### PR TITLE
フォロー申請結果とフォロー申請解除の処理の修正

### DIFF
--- a/src/remote/activitypub/kernel/accept/follow.ts
+++ b/src/remote/activitypub/kernel/accept/follow.ts
@@ -5,7 +5,7 @@ import accept from '../../../../services/following/requests/accept';
 import { IFollow } from '../../type';
 
 export default async (actor: IRemoteUser, activity: IFollow): Promise<void> => {
-	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+	const id = typeof activity.actor == 'string' ? activity.actor : activity.actor.id;
 
 	if (!id.startsWith(config.url + '/')) {
 		return null;

--- a/src/remote/activitypub/kernel/reject/follow.ts
+++ b/src/remote/activitypub/kernel/reject/follow.ts
@@ -5,7 +5,7 @@ import reject from '../../../../services/following/requests/reject';
 import { IFollow } from '../../type';
 
 export default async (actor: IRemoteUser, activity: IFollow): Promise<void> => {
-	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+	const id = typeof activity.actor == 'string' ? activity.actor : activity.actor.id;
 
 	if (!id.startsWith(config.url + '/')) {
 		return null;

--- a/src/remote/activitypub/kernel/undo/follow.ts
+++ b/src/remote/activitypub/kernel/undo/follow.ts
@@ -31,7 +31,7 @@ export default async (actor: IRemoteUser, activity: IFollow): Promise<void> => {
 	});
 
 	if (req) {
-		await cancelRequest(actor, followee);
+		await cancelRequest(followee, actor);
 	} else {
 		await unfollow(actor, followee);
 	}


### PR DESCRIPTION
#1869 #1870 の修正

#1870 の方は最悪Misskeyインスタンス間でActivityPubが無限ループする  
関係するどちらかの一方のインスタンスが対処済みならば無限ループまではしない

無限ループの修正を含むのは undo/follow.ts の方