### PR TITLE
オブジェクトストレージ格納時にContent-Typeを指定する

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -25,7 +25,7 @@ async function save(readable: stream.Readable, name: string, type: string, hash:
 		const minio = new Minio.Client(config.drive.config);
 		const id = uuid.v4();
 		const obj = `${config.drive.prefix}/${id}`;
-		await minio.putObject(config.drive.bucket, obj, readable);
+		await minio.putObject(config.drive.bucket, obj, readable, size, { 'Content-Type': type });
 
 		Object.assign(metadata, {
 			withoutChunks: true,


### PR DESCRIPTION
S3に画像を格納してもapplication/octet-streamになってしまって、URL直接アクセスでダウンロードになってしまったりするため、Content-Type付きで格納するようにしてます。