### PR TITLE
オブジェクトストレージの参照URLを上書きできるようにする

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -68,6 +68,29 @@ drive:
   #   accessKey:
   #   secretKey:
 
+  # S3 example
+  # storage: 'minio'
+  # bucket: bucket-name
+  # prefix: files
+  # config:
+  #   endPoint: s3-us-west-2.amazonaws.com
+  #   region: us-west-2
+  #   secure: true
+  #   accessKey: XXX
+  #   secretKey: YYY
+
+  # S3 example (with CDN, custom domain)
+  # storage: 'minio'
+  # bucket: drive.example.com
+  # prefix: files
+  # baseUrl: https://drive.example.com
+  # config:
+  #   endPoint: s3-us-west-2.amazonaws.com
+  #   region: us-west-2
+  #   secure: true
+  #   accessKey: XXX
+  #   secretKey: YYY
+
 #
 # Below settings are optional
 #

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -53,6 +53,7 @@ export type Source = {
 		storage: string;
 		bucket?: string;
 		prefix?: string;
+		baseUrl?: string;
 		config?: any;
 	};
 

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -25,7 +25,7 @@ async function save(readable: stream.Readable, name: string, type: string, hash:
 		const minio = new Minio.Client(config.drive.config);
 		const id = uuid.v4();
 		const obj = `${config.drive.prefix}/${id}`;
-		await minio.putObject(config.drive.bucket, obj, readable, size, { 'Content-Type': type });
+		await minio.putObject(config.drive.bucket, obj, readable, size, { 'Content-Type': type, 'Cache-Control': 'max-age=31536000, immutable' });
 
 		Object.assign(metadata, {
 			withoutChunks: true,

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -25,6 +25,8 @@ async function save(readable: stream.Readable, name: string, type: string, hash:
 		const minio = new Minio.Client(config.drive.config);
 		const id = uuid.v4();
 		const obj = `${config.drive.prefix}/${id}`;
+		const baseUrl = config.drive.baseUrl
+			|| `${ config.drive.config.secure ? 'https' : 'http' }://${ config.drive.config.endPoint }${ config.drive.config.port ? ':' + config.drive.config.port : '' }/${ config.drive.bucket }`;
 		await minio.putObject(config.drive.bucket, obj, readable, size, { 'Content-Type': type, 'Cache-Control': 'max-age=31536000, immutable' });
 
 		Object.assign(metadata, {
@@ -33,7 +35,7 @@ async function save(readable: stream.Readable, name: string, type: string, hash:
 			storageProps: {
 				id: id
 			},
-			url: `${ config.drive.config.secure ? 'https' : 'http' }://${ config.drive.config.endPoint }${ config.drive.config.port ? ':' + config.drive.config.port : '' }/${ config.drive.bucket }/${ obj }`
+			url: `${ baseUrl }/${ obj }`
 		});
 
 		const file = await DriveFile.insert({


### PR DESCRIPTION
オブジェクトストレージの参照URLとして
直接アクセスの`https://[エンドポイント]/[バケット]/[オブジェクト]`以外に
CDN・カスタムドメインを利用した`https://[カスタムドメイン]/[オブジェクト]`という構成も考えられるため
既定の`https://[エンドポイント]/[バケット]`部分をコンフィグで置き換えられるようにしています。

また、S3でそれぞれの構成を行う場合の設定例を追加しています。