### PR TITLE
プレビューで自分のアカウントの場合はフォローボタンを表示しないように修正

### DIFF
--- a/src/client/app/desktop/views/components/user-preview.vue
+++ b/src/client/app/desktop/views/components/user-preview.vue
@@ -19,7 +19,7 @@
 				<p>%i18n:@followers%</p><a>{{ u.followersCount }}</a>
 			</div>
 		</div>
-		<mk-follow-button v-if="$store.getters.isSignedIn && user.id != $store.state.i.id" :user="u"/>
+		<mk-follow-button v-if="$store.getters.isSignedIn && u.id != $store.state.i.id" :user="u"/>
 	</template>
 </div>
 </template>


### PR DESCRIPTION
![screenshot from 2018-07-26 21-09-39](https://user-images.githubusercontent.com/14953122/43261685-95dfc798-9118-11e8-9350-557b5e3038a5.png)
↑の画像のように、自分のアカウントにも関わらずフォローボタンが表示されてしまう問題を修正しました。