### PR TITLE
プロフィール上ボタンの表示の問題を修正

### DIFF
--- a/src/client/app/desktop/views/pages/user/user.profile.vue
+++ b/src/client/app/desktop/views/pages/user/user.profile.vue
@@ -1,6 +1,6 @@
 <template>
-<div class="profile">
-	<div class="friend-form" v-if="$store.getters.isSignedIn && $store.state.i.id != user.id">
+<div class="profile" v-if="$store.getters.isSignedIn">
+	<div class="friend-form" v-if="$store.state.i.id != user.id">
 		<mk-follow-button :user="user" size="big"/>
 		<p class="followed" v-if="user.isFollowed">%i18n:@follows-you%</p>
 		<p class="stalk" v-if="user.isFollowing">
@@ -9,7 +9,7 @@
 		</p>
 	</div>
 	<div class="action-form">
-		<button class="mute ui" @click="user.isMuted ? unmute() : mute()">
+		<button class="mute ui" @click="user.isMuted ? unmute() : mute()" v-if="$store.state.i.id != user.id">
 			<span v-if="user.isMuted">%fa:eye% %i18n:@unmute%</span>
 			<span v-if="!user.isMuted">%fa:eye-slash% %i18n:@mute%</span>
 		</button>


### PR DESCRIPTION
fix #1963 

### Before

|未ログイン|ログイン中:自分|ログイン中:他人|
|:--:|:--:|:--:|
|![image](https://user-images.githubusercontent.com/14953122/43262700-11fc15c2-911c-11e8-87bf-544893d2aad0.png)|(未ログイン時と同様)|![image](https://user-images.githubusercontent.com/14953122/43262903-a745a9d6-911c-11e8-9d1e-3f1426037f29.png)|

### After
|未ログイン|ログイン中:自分|ログイン中:他人|
|:--:|:--:|:--:|
|(非表示)|![image](https://user-images.githubusercontent.com/14953122/43262762-3f4c7d32-911c-11e8-8fd7-79b9ba2020a9.png)|![image](https://user-images.githubusercontent.com/14953122/43262785-4f40c266-911c-11e8-8a2a-f33e6926e35f.png)|