### PR TITLE
url-previewに失敗した場合、クライアントやプロキシでキャッシュできるようにする

### DIFF
--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -104,13 +104,15 @@ export default Vue.extend({
 		}
 		fetch('/url?url=' + encodeURIComponent(this.url)).then(res => {
 			res.json().then(info => {
-				this.title = info.title;
-				this.description = info.description;
-				this.thumbnail = info.thumbnail;
-				this.icon = info.icon;
-				this.sitename = info.sitename;
+				if (info.url != null) {
+					this.title = info.title;
+					this.description = info.description;
+					this.thumbnail = info.thumbnail;
+					this.icon = info.icon;
+					this.sitename = info.sitename;
 
-				this.fetching = false;
+					this.fetching = false;
+				}
 			});
 		});
 	}

--- a/src/server/web/url-preview.ts
+++ b/src/server/web/url-preview.ts
@@ -14,7 +14,9 @@ module.exports = async (ctx: Koa.Context) => {
 
 		ctx.body = summary;
 	} catch (e) {
-		ctx.status = 500;
+		ctx.status = 200;
+		ctx.set('Cache-Control', 'max-age=86400, immutable');
+		ctx.body = '{}';
 	}
 };
 


### PR DESCRIPTION
url-previewで失敗した場合、クライアントでもプロキシでもキャッシュされずに  
表示毎にサーバー経由でプレビュー対象URLにリクエストしてしまう件の修正。

url-preview失敗応答を、クライアントやプロキシ(構成されている場合)で
キャッシュされるように修正しています。

サーバーからの応答は  
ステータスコード: 異常系や204はあまり積極的にキャッシュしてくれなかったので200  
コンテンツ: 空コンテンツ等を返すと後の処理が面倒なので空JSON  
にしています。
