### PR TITLE
Mastodon等からとどく投稿の公開範囲(フォロワー/ダイレクト)判定の修正

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -69,12 +69,13 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	if (!note.to.includes('https://www.w3.org/ns/activitystreams#Public')) {
 		if (note.cc.includes('https://www.w3.org/ns/activitystreams#Public')) {
 			visibility = 'home';
+		} else if (note.to.includes(`${actor.uri}/followers`)) {	// TODO: person.followerと照合するべき？
+			visibility = 'followers';
 		} else {
 			visibility = 'specified';
 			visibleUsers = await Promise.all(note.to.map(uri => resolvePerson(uri)));
 		}
 	}
-	if (note.cc.length == 0) visibility = 'followers';
 	//#endergion
 
 	// 添付メディア


### PR DESCRIPTION
Resolve #2170, #2171 

```
Public
"to":["https://www.w3.org/ns/activitystreams#Public"],
"cc":["https://SRC/users/1/followers"],

Unlisted
"to":["https://SRC/users/1/followers"],
"cc":["https://www.w3.org/ns/activitystreams#Public"],

Follower
"to":["https://SRC/users/1/followers"],
"cc":[],

Direct
"to":["https://DST/users/ID"],
"cc":[],
```
において

- `https://SRC/users/1/followers` を 実ユーザーとして解決を試みてしまうの修正  
- ccが空の場合followers判定してしまうのを修正