### PR TITLE
ActivityPub送信時の公開範囲の実装

### DIFF
--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -50,9 +50,21 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		? note.mentionedRemoteUsers.map(x => x.uri)
 		: [];
 
-	const cc = ['public', 'home', 'followers'].includes(note.visibility)
-		? [`${attributedTo}/followers`].concat(mentions)
-		: [];
+	let to: string[] = [];
+	let cc: string[] = [];
+
+	if (note.visibility == 'public') {
+		to = ['https://www.w3.org/ns/activitystreams#Public'];
+		cc = [`${attributedTo}/followers`].concat(mentions);
+	} else if (note.visibility == 'home') {
+		to = [`${attributedTo}/followers`];
+		cc = ['https://www.w3.org/ns/activitystreams#Public'].concat(mentions);
+	} else if (note.visibility == 'followers') {
+		to = [`${attributedTo}/followers`];
+		cc = mentions;
+	} else {
+		to = mentions;
+	}
 
 	const mentionedUsers = note.mentions ? await User.find({
 		_id: {
@@ -74,7 +86,7 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		summary: note.cw,
 		content: toHtml(note),
 		published: note.createdAt.toISOString(),
-		to: 'https://www.w3.org/ns/activitystreams#Public',
+		to,
 		cc,
 		inReplyTo,
 		attachment: (await promisedFiles).map(renderDocument),

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -19,6 +19,8 @@ export default async (user: ILocalUser) => {
 		id,
 		inbox: `${id}/inbox`,
 		outbox: `${id}/outbox`,
+		followers: `${id}/followers`,
+		following: `${id}/following`,
 		sharedInbox: `${config.url}/inbox`,
 		url: `${config.url}/@${user.username}`,
 		preferredUsername: user.username,

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -89,6 +89,48 @@ router.get('/users/:user/outbox', async ctx => {
 	ctx.body = pack(rendered);
 });
 
+// followers
+router.get('/users/:user/followers', async ctx => {
+	const userId = new mongo.ObjectID(ctx.params.user);
+
+	const user = await User.findOne({
+		_id: userId,
+		host: null
+	});
+
+	if (user === null) {
+		ctx.status = 404;
+		return;
+	}
+
+	// TODO: Implement fetch and render
+
+	const rendered = renderOrderedCollection(`${config.url}/users/${userId}/followers`, 0, []);
+
+	ctx.body = pack(rendered);
+});
+
+// following
+router.get('/users/:user/following', async ctx => {
+	const userId = new mongo.ObjectID(ctx.params.user);
+
+	const user = await User.findOne({
+		_id: userId,
+		host: null
+	});
+
+	if (user === null) {
+		ctx.status = 404;
+		return;
+	}
+
+	// TODO: Implement fetch and render
+
+	const rendered = renderOrderedCollection(`${config.url}/users/${userId}/following`, 0, []);
+
+	ctx.body = pack(rendered);
+});
+
 // publickey
 router.get('/users/:user/publickey', async ctx => {
 	const userId = new mongo.ObjectID(ctx.params.user);


### PR DESCRIPTION
今まで、ActivityPub送信時に全て公開扱いになっていたのを
Mastodonと同様の公開範囲で送信するようにしています。

- src/remote/activitypub/renderer/person.ts
AP Personに、Followers/Following collectionが定義されてないとフォロー系が効かないため追加してます。
- src/server/activitypub.ts
AP Followers/Following collectionは、実データは返さずに常に0件を返します（後日実装予定）。
Mastodonでも、オプションによってはここが0件を返すようになるのでとりあえず大丈夫かなと。
- src/remote/activitypub/renderer/note.ts
toとccをMastodonと同様の組み合わせで送信するようにしています。

Mastodon宛てのフォロワー限定投稿については、これを反映後実際にできるようになるまでに最大24時間かかります。
今までPersonで Followers/Following collectionを定義してなかったのですが
その古いPersonを持ってるMastodonインスタンスに対して送ると
to, cc の followers 指定の部分が無視されてしまうため。