### PR TITLE
Misskey => Misskey で renote 出来ない件修正

### DIFF
--- a/src/remote/activitypub/kernel/announce/note.ts
+++ b/src/remote/activitypub/kernel/announce/note.ts
@@ -40,11 +40,13 @@ export default async function(resolver: Resolver, actor: IRemoteUser, activity: 
 	if (!note.to.includes('https://www.w3.org/ns/activitystreams#Public')) {
 		if (note.cc.includes('https://www.w3.org/ns/activitystreams#Public')) {
 			visibility = 'home';
+		} else if (note.to.includes(`${actor.uri}/followers`)) {	// TODO: person.followerと照合するべき？
+			visibility = 'followers';
 		} else {
 			visibility = 'specified';
 			visibleUsers = await Promise.all(note.to.map(uri => resolvePerson(uri)));
 		}
-	}	if (activity.cc.length == 0) visibility = 'followers';
+	}
 	//#endergion
 
 	await post(actor, {

--- a/src/remote/activitypub/renderer/announce.ts
+++ b/src/remote/activitypub/renderer/announce.ts
@@ -1,5 +1,15 @@
-export default (id: string, object: any) => ({
-	type: 'Announce',
-	id,
-	object
-});
+import config from '../../../config';
+import { INote } from '../../../models/note';
+
+export default (object: any, note: INote) => {
+	const attributedTo = `${config.url}/users/${note.userId}`;
+
+	return {
+		id: `${config.url}/notes/${note._id}`,
+		type: 'Announce',
+		published: note.createdAt.toISOString(),
+		to: ['https://www.w3.org/ns/activitystreams#Public'],
+		cc: [attributedTo, `${attributedTo}/followers`],
+		object
+	};
+};

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -235,8 +235,8 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 async function renderActivity(data: Option, note: INote) {
 	const content = data.renote && data.text == null
-	? renderAnnounce(data.renote.uri ? data.renote.uri : await renderNote(data.renote), note)
-	: renderCreate(await renderNote(note));
+		? renderAnnounce(data.renote.uri ? data.renote.uri : await renderNote(data.renote), note)
+		: renderCreate(await renderNote(note));
 
 	return packAp(content);
 }

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -235,8 +235,8 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 async function renderActivity(data: Option, note: INote) {
 	const content = data.renote && data.text == null
-		? renderAnnounce(note._id.toHexString(), data.renote.uri ? data.renote.uri : await renderNote(data.renote))
-		: renderCreate(await renderNote(note));
+	? renderAnnounce(data.renote.uri ? data.renote.uri : await renderNote(data.renote), note)
+	: renderCreate(await renderNote(note));
 
 	return packAp(content);
 }


### PR DESCRIPTION
Resolve #1543 

src/remote/activitypub/kernel/announce/note.ts
主にここ
x activity.cc
o note.cc

判定方法もCreate noteと同様に修正

src/remote/activitypub/renderer/announce.ts
idにURLを使用するように、他の項目も送るように修正

Mastodon => Misskey
Misskey => Misskey
Misskey => Mastodon 
のパターンで確認済みです