### PR TITLE
リモートにNSFWが効かないのを修正

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -81,7 +81,9 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	// 添付メディア
 	// TODO: attachmentは必ずしもImageではない
 	// TODO: attachmentは必ずしも配列ではない
+	// Noteがsensitiveなら添付もsensitiveにする
 	const media = note.attachment
+		.map(attach => attach.sensitive = note.sensitive)
 		? await Promise.all(note.attachment.map(x => resolveImage(actor, x)))
 		: [];
 

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -79,6 +79,8 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		...mentionTags,
 	];
 
+	const files = await promisedFiles;
+
 	return {
 		id: `${config.url}/notes/${note._id}`,
 		type: 'Note',
@@ -89,7 +91,8 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		to,
 		cc,
 		inReplyTo,
-		attachment: (await promisedFiles).map(renderDocument),
+		attachment: files.map(renderDocument),
+		sensitive: files.some(file => file.metadata.isSensitive),
 		tag
 	};
 }

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -16,6 +16,7 @@ export interface IObject {
 	image?: any;
 	url?: string;
 	tag?: any[];
+	sensitive?: boolean;
 }
 
 export interface IActivity extends IObject {


### PR DESCRIPTION
https://github.com/syuilo/misskey/issues/2238, https://github.com/syuilo/misskey/issues/2326 の修正

Misskey <=> Mastodon で伝わらないのは、
Misskey: sensitiveはAttachmentに付けてる のに対して、
Mastodon: sensitiveはNote全体に付けてる ため。
→AP送信時に、どれか1つの添付ファイルがsensitiveなら Noteにsensitiveを付けるように変更
→AP受信時に、Noteがsensitiveなら 全部の添付ファイルにsensitiveを付けるように変更

Misskey => Misskey で伝わらないのは、
別の理由(Imageにはsensitive付けてるがDocumentには付けてない)だが
上の修正で包括されるのでこの部分は未修正。

NSFW, 非NSFWが混在している場合に、
リモートへは(Misskey向けでも)全ファイルNSFWで伝わるが
通信相手がMastodonかMisskeyを区別できないので仕方ない。

新しく送受信したものからNSFWが反映される