### PR TITLE
ActivityPub Note/Outbox の公開範囲の修正

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -54,7 +54,8 @@ router.get('/notes/:note', async (ctx, next) => {
 	if (!isActivityPubReq(ctx)) return await next();
 
 	const note = await Note.findOne({
-		_id: new mongo.ObjectID(ctx.params.note)
+		_id: new mongo.ObjectID(ctx.params.note),
+		$or: [ { visibility: 'public' }, { visibility: 'home' } ]
 	});
 
 	if (note === null) {
@@ -62,7 +63,7 @@ router.get('/notes/:note', async (ctx, next) => {
 		return;
 	}
 
-	ctx.body = pack(await renderNote(note));
+	ctx.body = pack(await renderNote(note, false));
 });
 
 // outbox

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -83,7 +83,7 @@ export default async (ctx: Koa.Context) => {
 
 		if (sinceId) notes.reverse();
 
-		const renderedNotes = await Promise.all(notes.map(note => renderNote(note)));
+		const renderedNotes = await Promise.all(notes.map(note => renderNote(note, false)));
 		const rendered = renderOrderedCollectionPage(
 			`${partOf}?page=true${sinceId ? `&since_id=${sinceId}` : ''}${untilId ? `&until_id=${untilId}` : ''}`,
 			user.notesCount, renderedNotes, partOf,


### PR DESCRIPTION
以下の問題の修正
- ActivityPubから Noteを参照(/notes/xxxxx)すると非公開等であっても内容が見れてしまう
- ActivityPubから 非公開等にリプライした投稿を参照(/notes/xxxxx, Outbox)すると、リプライ元の内容が見れてしまう
