### PR TITLE
起動時のDB接続チェックでエラーを検出できないのを修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import * as portscanner from 'portscanner';
 import isRoot = require('is-root');
 import Xev from 'xev';
 import * as program from 'commander';
+import mongo from './db/mongodb';
 
 import Logger from './misc/logger';
 import ProgressBar from './misc/cli/progressbar';
@@ -158,8 +159,13 @@ function checkMongoDb(config: Config) {
 	const p = config.mongodb.pass ? encodeURIComponent(config.mongodb.pass) : null;
 	const uri = `mongodb://${u && p ? `${u}:****@` : ''}${config.mongodb.host}:${config.mongodb.port}/${config.mongodb.db}`;
 	mongoDBLogger.info(`Connecting to ${uri}`);
-	require('./db/mongodb');
-	mongoDBLogger.succ('Connectivity confirmed');
+
+	mongo.then(() => {
+		mongoDBLogger.succ('Connectivity confirmed');
+	})
+	.catch(err => {
+		mongoDBLogger.error(err.message);
+	});
 }
 
 function spawnWorkers(limit: number) {


### PR DESCRIPTION
Resolve #2387 

![image](https://user-images.githubusercontent.com/30769358/44435072-3c27bb80-a5e9-11e8-886a-81456b0ba976.png)
のようにエラー時にメッセージが出るようにする

