### PR TITLE
/api/ 下の存在しないURL対しては404を返すようにする

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -46,6 +46,11 @@ router.post('/signin', require('./private/signin').default);
 router.use(require('./service/github').routes());
 router.use(require('./service/twitter').routes());
 
+// Return 404 for unknown API
+router.all('*', async ctx => {
+	ctx.status = 404;
+});
+
 // Register router
 app.use(router.routes());
 


### PR DESCRIPTION
/api/ 下の存在しないにURL対しては
200でベースHTMLを返すのではなく 404を返すようにします。

Fediverseなクローラーは、よくこのあたりにある存在しないAPIを叩いてくるみたい
#128 の一部修正