### PR TITLE
ベースHTMLは immutableキャッシュしないようにする

### DIFF
--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -122,8 +122,7 @@ router.get('/notes/:note', async ctx => {
 router.get('*', async ctx => {
 	await send(ctx, `app/base.html`, {
 		root: client,
-		maxage: ms('3 days'),
-		immutable: true
+		maxage: ms('5m')
 	});
 });
 


### PR DESCRIPTION
Resolve #2398
キャッシュ期間はとりあえず5分にしてます