### PR TITLE
Fix various darkmode elements on user pages

### DIFF
--- a/src/client/app/desktop/views/pages/user/user.friends.vue
+++ b/src/client/app/desktop/views/pages/user/user.friends.vue
@@ -43,7 +43,7 @@ export default Vue.extend({
 root(isDark)
 .friends
 	background isDark ? #282C37 : #fff
-	border solid 1px isDark ? #21242f : rgba(#000, 0.075)
+	border solid 1px rgba(#000, 0.075)
 	border-radius 6px
 
 	> .title

--- a/src/client/app/desktop/views/pages/user/user.friends.vue
+++ b/src/client/app/desktop/views/pages/user/user.friends.vue
@@ -45,6 +45,7 @@ root(isDark)
 	background isDark ? #282C37 : #fff
 	border solid 1px rgba(#000, 0.075)
 	border-radius 6px
+	overflow hidden
 
 	> .title
 		z-index 1

--- a/src/client/app/desktop/views/pages/user/user.friends.vue
+++ b/src/client/app/desktop/views/pages/user/user.friends.vue
@@ -40,9 +40,10 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
+root(isDark)
 .friends
-	background #fff
-	border solid 1px rgba(#000, 0.075)
+	background isDark ? #282C37 : #fff
+	border solid 1px isDark ? #21242f : rgba(#000, 0.075)
 	border-radius 6px
 
 	> .title
@@ -52,7 +53,8 @@ export default Vue.extend({
 		line-height 42px
 		font-size 0.9em
 		font-weight bold
-		color #888
+		background isDark ? #313543 : inherit
+		color isDark ? #e3e5e8 : #888
 		box-shadow 0 1px rgba(#000, 0.07)
 
 		> i
@@ -70,7 +72,7 @@ export default Vue.extend({
 
 	> .user
 		padding 16px
-		border-bottom solid 1px #eee
+		border-bottom solid 1px isDark ? #21242f : #eee
 
 		&:last-child
 			border-bottom none
@@ -96,18 +98,24 @@ export default Vue.extend({
 				margin 0
 				font-size 16px
 				line-height 24px
-				color #555
+				color isDark ? #ccc : #555
 
 			> .username
 				display block
 				margin 0
 				font-size 15px
 				line-height 16px
-				color #ccc
+				color isDark ? #555 : #ccc
 
 		> .mk-follow-button
 			position absolute
 			top 16px
 			right 16px
+
+.friends[data-darkmode]
+	root(true)
+
+.friends:not([data-darkmode])
+	root(false)
 
 </style>

--- a/src/client/app/desktop/views/pages/user/user.photos.vue
+++ b/src/client/app/desktop/views/pages/user/user.photos.vue
@@ -44,6 +44,7 @@ root(isDark)
 	background isDark ? #282C37 : #fff
 	border solid 1px rgba(#000, 0.075)
 	border-radius 6px
+	overflow hidden
 
 	> .title
 		z-index 1

--- a/src/client/app/desktop/views/pages/user/user.photos.vue
+++ b/src/client/app/desktop/views/pages/user/user.photos.vue
@@ -39,8 +39,9 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
+root(isDark)
 .photos
-	background #fff
+	background isDark ? #282C37 : #fff
 	border solid 1px rgba(#000, 0.075)
 	border-radius 6px
 
@@ -51,7 +52,8 @@ export default Vue.extend({
 		line-height 42px
 		font-size 0.9em
 		font-weight bold
-		color #888
+		background: isDark ? #313543 : inherit
+		color isDark ? #e3e5e8 : #888
 		box-shadow 0 1px rgba(#000, 0.07)
 
 		> i
@@ -84,5 +86,11 @@ export default Vue.extend({
 
 		> i
 			margin-right 4px
+
+.photos[data-darkmode]
+	root(true)
+
+.photos:not([data-darkmode])
+	root(false)
 
 </style>

--- a/src/client/app/desktop/views/pages/user/user.vue
+++ b/src/client/app/desktop/views/pages/user/user.vue
@@ -138,7 +138,7 @@ root(isDark)
 				padding 16px
 				font-size 12px
 				color #aaa
-				background #fff
+				background isDark ? #21242f : #fff
 				border solid 1px rgba(#000, 0.075)
 				border-radius 6px
 


### PR DESCRIPTION
Dark mode on user pages was not being applied to some elements in the sidebar (Photos, Friends/Frequent mentions/bottom navbar)

Original:
![chrome_2018-08-27_16-10-15](https://user-images.githubusercontent.com/2767514/44667875-e487b680-aa13-11e8-8c65-96ce7027c115.png)

Updated:
![nvidia share_2018-08-27_16-09-27](https://user-images.githubusercontent.com/2767514/44667879-e8b3d400-aa13-11e8-8b79-430ad05914f8.png)
