### PR TITLE
Prevent setting non-image files as avatar/banner

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -411,6 +411,7 @@ desktop:
   uploading-avatar: "Uploading a new avatar"
   avatar-updated: "Successfully updated the avatar"
   choose-avatar: "Select an image for the avatar"
+  invalid-filetype: "This filetype is not acceptable here"
 desktop/views/components/activity.chart.vue:
   total: "Black ... Total"
   notes: "Blue ... Notes"

--- a/src/client/app/desktop/api/update-avatar.ts
+++ b/src/client/app/desktop/api/update-avatar.ts
@@ -6,6 +6,19 @@ import ProgressDialog from '../views/components/progress-dialog.vue';
 export default (os: OS) => {
 
 	const cropImage = file => new Promise((resolve, reject) => {
+		
+		var regex = RegExp('\.(jpg|jpeg|png|gif|webp|bmp|tiff)$')
+		if(!regex.test(file.name) ) {
+			os.apis.dialog({
+				title: '%fa:info-circle% %i18n:desktop.invalid-filetype%',
+				text: null,
+				actions: [{
+					text: '%i18n:common.got-it%'
+				}]
+			});
+			reject
+		}
+		
 		const w = os.new(CropWindow, {
 			image: file,
 			title: '%i18n:desktop.avatar-crop-title%',

--- a/src/client/app/desktop/api/update-avatar.ts
+++ b/src/client/app/desktop/api/update-avatar.ts
@@ -3,9 +3,9 @@ import { apiUrl } from '../../config';
 import CropWindow from '../views/components/crop-window.vue';
 import ProgressDialog from '../views/components/progress-dialog.vue';
 
-export default (os: OS) => (cb, file = null) => {
-	const fileSelected = file => {
+export default (os: OS) => {
 
+	const cropImage = file => new Promise((resolve, reject) => {
 		const w = os.new(CropWindow, {
 			image: file,
 			title: '%i18n:desktop.avatar-crop-title%',
@@ -19,27 +19,29 @@ export default (os: OS) => (cb, file = null) => {
 
 			os.api('drive/folders/find', {
 				name: '%i18n:desktop.avatar%'
-			}).then(iconFolder => {
-				if (iconFolder.length === 0) {
+			}).then(avatarFolder => {
+				if (avatarFolder.length === 0) {
 					os.api('drive/folders/create', {
 						name: '%i18n:desktop.avatar%'
 					}).then(iconFolder => {
-						upload(data, iconFolder);
+						resolve(upload(data, iconFolder));
 					});
 				} else {
-					upload(data, iconFolder[0]);
+					resolve(upload(data, avatarFolder[0]));
 				}
 			});
 		});
 
 		w.$once('skipped', () => {
-			set(file);
+			resolve(file);
 		});
 
-		document.body.appendChild(w.$el);
-	};
+		w.$once('cancelled', reject);
 
-	const upload = (data, folder) => {
+		document.body.appendChild(w.$el);
+	});
+
+	const upload = (data, folder) => new Promise((resolve, reject) => {
 		const dialog = os.new(ProgressDialog, {
 			title: '%i18n:desktop.uploading-avatar%'
 		});
@@ -52,18 +54,19 @@ export default (os: OS) => (cb, file = null) => {
 		xhr.onload = e => {
 			const file = JSON.parse((e.target as any).response);
 			(dialog as any).close();
-			set(file);
+			resolve(file);
 		};
+		xhr.onerror = reject;
 
 		xhr.upload.onprogress = e => {
 			if (e.lengthComputable) (dialog as any).update(e.loaded, e.total);
 		};
 
 		xhr.send(data);
-	};
+	});
 
-	const set = file => {
-		os.api('i/update', {
+	const setAvatar = file => {
+		return os.api('i/update', {
 			avatarId: file.id
 		}).then(i => {
 			os.store.commit('updateIKeyValue', {
@@ -83,18 +86,21 @@ export default (os: OS) => (cb, file = null) => {
 				}]
 			});
 
-			if (cb) cb(i);
+			return i;
 		});
 	};
 
-	if (file) {
-		fileSelected(file);
-	} else {
-		os.apis.chooseDriveFile({
-			multiple: false,
-			title: '%fa:image% %i18n:desktop.choose-avatar%'
-		}).then(file => {
-			fileSelected(file);
-		});
-	}
+	return (file = null) => {
+		const selectedFile = file
+			? Promise.resolve(file)
+			: os.apis.chooseDriveFile({
+				multiple: false,
+				title: '%fa:image% %i18n:desktop.choose-avatar%'
+			});
+
+		return selectedFile
+			.then(cropImage)
+			.then(setAvatar)
+			.catch(err => err && console.warn(err));
+	};
 };

--- a/src/client/app/desktop/api/update-banner.ts
+++ b/src/client/app/desktop/api/update-banner.ts
@@ -6,6 +6,20 @@ import ProgressDialog from '../views/components/progress-dialog.vue';
 export default (os: OS) => {
 
 	const cropImage = file => new Promise((resolve, reject) => {
+		
+		var regex = RegExp('\.(jpg|jpeg|png|gif|webp|bmp|tiff)$')
+
+		if(!regex.test(file.name) ) {
+			os.apis.dialog({
+				title: '%fa:info-circle% %i18n:desktop.invalid-filetype%',
+				text: null,
+				actions: [{
+					text: '%i18n:common.got-it%'
+				}]
+			});
+			reject
+		}
+		
 		const w = os.new(CropWindow, {
 			image: file,
 			title: '%i18n:desktop.banner-crop-title%',


### PR DESCRIPTION
Depends on/includes previous PR: syuilo/misskey/pull/2509

This PR prevents using file extensions other than commonly used image extensions as an avatar or banner. This does not stop files with incorrect extensions, but does prevent accidental changes.

Submitting as a fix for syuilo/misskey/issues/2096, however will require additional localisation