### PR TITLE
HTTP Signature ホスト検証エラーメッセージの調整

### DIFF
--- a/src/queue/processors/http/process-inbox.ts
+++ b/src/queue/processors/http/process-inbox.ts
@@ -38,7 +38,7 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 		try {
 			ValidateActivity(activity, host);
 		} catch (e) {
-			console.warn(e);
+			console.warn(e.message);
 			done();
 			return;
 		}
@@ -55,7 +55,7 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 		try {
 			ValidateActivity(activity, host);
 		} catch (e) {
-			console.warn(e);
+			console.warn(e.message);
 			done();
 			return;
 		}
@@ -100,7 +100,10 @@ function ValidateActivity(activity: any, host: string) {
 	// id (if exists)
 	if (typeof activity.id === 'string') {
 		const uriHost = toUnicode(new URL(activity.id).hostname.toLowerCase());
-		if (host !== uriHost) throw new Error('activity.id has different host');
+		if (host !== uriHost) {
+			const diag = activity.signature ? '. Has LD-Signature. Forwarded?' : '';
+			throw new Error(`activity.id(${activity.id}) has different host(${host})${diag}`);
+		}
 	}
 
 	// actor (if exists)


### PR DESCRIPTION
#2547 の修正で出てくるエラーメッセージの調整

現状、以下のメッセージが多めに出てくるため
```
Error: activity.id has different host
    at ValidateActivity (/home/misskey/misskey/built/queue/processors/http/process-inbox.js:94:19)
    at exports.default (/home/misskey/misskey/built/queue/processors/http/process-inbox.js:50:13)
    at Object.exports.default (/home/misskey/misskey/built/queue/processors/http/index.js:12:9)
    at Object.createHttpJob (/home/misskey/misskey/built/queue/index.js:5:26)
    at inbox (/home/misskey/misskey/built/server/activitypub.js:30:13)
    at dispatch (/home/misskey/misskey/node_modules/koa-router/node_modules/koa-compose/index.js:44:32)
    at next (/home/misskey/misskey/node_modules/koa-router/node_modules/koa-compose/index.js:45:18)
    at body.json.then (/home/misskey/misskey/node_modules/koa-json-body/lib/index.js:25:14)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
スタックトレースなどは出さずにして、変わりに追加情報を出すように変更してます。

```
activity.id(https://forward.example.com/users/USER/statuses/123/activity) has different host(origin.example.com). Has LD-Signature. Forwarded?
```

なお現状`activity.id has different host`が出てくること自体は、
ほぼMastodonの以下のActivityによるものと思われるので、さほど問題なさそう。

**Mastodon の forward_for_reply（正式名称不明）**

誰かが誰かにリプライした時に、
(リプライした人が(自分のフォロワーに)配信するだけではなく)
リプライされた人が(自分のフォロワーに)リプライした人の投稿を配信する挙動
https://github.com/tootsuite/mastodon/blob/dddf022aae4ddeabfc329f8adb75867bb2abf5fb/app/lib/activitypub/activity/create.rb#L24

この場合、他人の投稿を配信することになるので、
これが行われるのは、リプライにLinked Data Signatureという別のSignatureが付いてた場合に限定される。

このActivityは、HTTP Signatureが投稿者とは違う人で署名されていて
Linked Data Signatureが投稿者のものになっている。

現状、Linked Data Signatureはサポートしてないので、このActivityの検証手段はなく、常にvalidateエラー扱いになる。