### PR TITLE
リクエストにUser-Agentを付ける

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -7,6 +7,7 @@ import { URL } from 'url';
 import * as yaml from 'js-yaml';
 import { Source, Mixin } from './types';
 import isUrl = require('is-url');
+const pkg = require('../../package.json');
 
 /**
  * Path of configuration directory
@@ -43,6 +44,7 @@ export default function load() {
 	mixin.stats_url = `${mixin.scheme}://${mixin.host}/stats`;
 	mixin.status_url = `${mixin.scheme}://${mixin.host}/status`;
 	mixin.drive_url = `${mixin.scheme}://${mixin.host}/files`;
+	mixin.user_agent = `Misskey/${pkg.version} (${config.url})`;
 
 	if (config.localDriveCapacityMb == null) config.localDriveCapacityMb = 256;
 	if (config.remoteDriveCapacityMb == null) config.remoteDriveCapacityMb = 8;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -114,6 +114,7 @@ export type Mixin = {
 	status_url: string;
 	dev_url: string;
 	drive_url: string;
+	user_agent: string;
 };
 
 export type Config = Source & Mixin;

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -27,6 +27,7 @@ export default (user: ILocalUser, url: string, object: any) => new Promise((reso
 		method: 'POST',
 		path: pathname + search,
 		headers: {
+			'User-Agent': config.user_agent,
 			'Content-Type': 'application/activity+json',
 			'Digest': `SHA-256=${hash}`
 		}

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -1,7 +1,7 @@
 import * as request from 'request-promise-native';
 import * as debug from 'debug';
 import { IObject } from './type';
-//import config from '../../config';
+import config from '../../config';
 
 const log = debug('misskey:activitypub:resolver');
 
@@ -51,6 +51,7 @@ export default class Resolver {
 		const object = await request({
 			url: value,
 			headers: {
+				'User-Agent': config.user_agent,
 				Accept: 'application/activity+json, application/ld+json'
 			},
 			json: true

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -34,7 +34,12 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 	// write content at URL to temp file
 	await new Promise((res, rej) => {
 		const writable = fs.createWriteStream(path);
-		request(url)
+		request({
+			url,
+			headers: {
+				'User-Agent': config.user_agent
+			}
+		})
 			.on('error', rej)
 			.on('end', () => {
 				writable.close();


### PR DESCRIPTION
Resolve #2580
ActivityPub等のリクエストにUser-Agentを付けるようにしてます

- ActivityPub Activity送信
- ActivityPub followersコレクション等の取得
- リモート画像の取得

に`User-Agent: Misskey/8.23.0 (https://example.com)`のようなものが付くようになってます。

WebFingerは変更できなかったので、未対応です。