### PR TITLE
リモートフォローは必ず承認待ち状態を挟むように変更

### DIFF
--- a/src/client/app/common/views/pages/follow.vue
+++ b/src/client/app/common/views/pages/follow.vue
@@ -83,7 +83,7 @@ export default Vue.extend({
 						userId: this.user.id
 					});
 				} else {
-					if (this.user.isLocked && this.user.hasPendingFollowRequestFromYou) {
+					if (this.user.hasPendingFollowRequestFromYou) {
 						this.user = await (this as any).api('following/requests/cancel', {
 							userId: this.user.id
 						});

--- a/src/client/app/desktop/views/components/follow-button.vue
+++ b/src/client/app/desktop/views/components/follow-button.vue
@@ -55,13 +55,15 @@ export default Vue.extend({
 	methods: {
 		onFollow(user) {
 			if (user.id == this.u.id) {
-				this.user.isFollowing = user.isFollowing;
+				this.u.isFollowing = user.isFollowing;
+				this.u.hasPendingFollowRequestFromYou = user.hasPendingFollowRequestFromYou;
 			}
 		},
 
 		onUnfollow(user) {
 			if (user.id == this.u.id) {
-				this.user.isFollowing = user.isFollowing;
+				this.u.isFollowing = user.isFollowing;
+				this.u.hasPendingFollowRequestFromYou = user.hasPendingFollowRequestFromYou;
 			}
 		},
 
@@ -74,7 +76,7 @@ export default Vue.extend({
 						userId: this.u.id
 					});
 				} else {
-					if (this.u.isLocked && this.u.hasPendingFollowRequestFromYou) {
+					if (this.u.hasPendingFollowRequestFromYou) {
 						this.u = await (this as any).api('following/requests/cancel', {
 							userId: this.u.id
 						});

--- a/src/client/app/mobile/views/components/follow-button.vue
+++ b/src/client/app/mobile/views/components/follow-button.vue
@@ -48,12 +48,14 @@ export default Vue.extend({
 		onFollow(user) {
 			if (user.id == this.u.id) {
 				this.u.isFollowing = user.isFollowing;
+				this.u.hasPendingFollowRequestFromYou = user.hasPendingFollowRequestFromYou;
 			}
 		},
 
 		onUnfollow(user) {
 			if (user.id == this.u.id) {
 				this.u.isFollowing = user.isFollowing;
+				this.u.hasPendingFollowRequestFromYou = user.hasPendingFollowRequestFromYou;
 			}
 		},
 
@@ -66,7 +68,7 @@ export default Vue.extend({
 						userId: this.u.id
 					});
 				} else {
-					if (this.u.isLocked && this.u.hasPendingFollowRequestFromYou) {
+					if (this.u.hasPendingFollowRequestFromYou) {
 						this.u = await (this as any).api('following/requests/cancel', {
 							userId: this.u.id
 						});

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -432,10 +432,10 @@ export const pack = (
 				followerId: _user.id,
 				followeeId: meId
 			}),
-			_user.isLocked ? FollowRequest.findOne({
+			FollowRequest.findOne({
 				followerId: meId,
 				followeeId: _user.id
-			}) : Promise.resolve(null),
+			}),
 			FollowRequest.findOne({
 				followerId: _user.id,
 				followeeId: meId

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -11,7 +11,7 @@ import { deliver } from '../../queue';
 import createFollowRequest from './requests/create';
 
 export default async function(follower: IUser, followee: IUser) {
-	if (followee.isLocked) {
+	if (followee.isLocked || isLocalUser(follower) && isRemoteUser(followee)) {
 		await createFollowRequest(follower, followee);
 	} else {
 		const following = await Following.insert({
@@ -70,11 +70,6 @@ export default async function(follower: IUser, followee: IUser) {
 
 			// 通知を作成
 			notify(followee._id, follower._id, 'follow');
-		}
-
-		if (isLocalUser(follower) && isRemoteUser(followee)) {
-			const content = pack(renderFollow(follower, followee));
-			deliver(follower, content, followee.inbox);
 		}
 
 		if (isRemoteUser(follower) && isLocalUser(followee)) {

--- a/src/services/following/requests/accept.ts
+++ b/src/services/following/requests/accept.ts
@@ -75,4 +75,6 @@ export default async function(followee: IUser, follower: IUser) {
 	packUser(followee, followee, {
 		detail: true
 	}).then(packed => publishUserStream(followee._id, 'meUpdated', packed));
+
+	packUser(followee, follower).then(packed => publishUserStream(follower._id, 'follow', packed));
 }

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -7,8 +7,6 @@ import { deliver } from '../../../queue';
 import FollowRequest from '../../../models/follow-request';
 
 export default async function(follower: IUser, followee: IUser) {
-	if (!followee.isLocked) throw '対象のアカウントは鍵アカウントではありません';
-
 	await FollowRequest.insert({
 		createdAt: new Date(),
 		followerId: follower._id,

--- a/src/services/following/requests/reject.ts
+++ b/src/services/following/requests/reject.ts
@@ -1,9 +1,10 @@
-import User, { IUser, isRemoteUser, ILocalUser } from '../../../models/user';
+import User, { IUser, isRemoteUser, ILocalUser, pack as packUser } from '../../../models/user';
 import FollowRequest from '../../../models/follow-request';
 import pack from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import renderReject from '../../../remote/activitypub/renderer/reject';
 import { deliver } from '../../../queue';
+import { publishUserStream } from '../../../stream';
 
 export default async function(followee: IUser, follower: IUser) {
 	if (isRemoteUser(follower)) {
@@ -21,4 +22,6 @@ export default async function(followee: IUser, follower: IUser) {
 			pendingReceivedFollowRequestsCount: -1
 		}
 	});
+
+	packUser(followee, follower).then(packed => publishUserStream(follower._id, 'unfollow', packed));
 }


### PR DESCRIPTION
Resolve #2604, #2605 

リモートフォロー時は、ローカルで鍵と認識している否かを問わず
必ず一旦フォローリクエストにするように変更しています。
（即時フォロー済みに変更するのではなく）

UIやisLockedを見てる部分も変更しています。

### 変更前
相手がリモートの場合、鍵垢と認識している場合のみフォローリクエスト

### 変更後
相手がリモートの場合、常にフォローリクエスト

一時的にスタータスは承認待ちになる（DBもUIも）

リモートから Accept/Rejectが返ってきたタイミングで
→DBを承認待ちから変更(フォロー済み/未フォローへ)
→publish follow/unfollow event
→eventを受けてUIのフォローボタンが変わる