### PR TITLE
ユーザー詳細ページのアカウント名はローカルユーザーでもホストも表示するようにする

### DIFF
--- a/src/client/app/common/views/components/acct.vue
+++ b/src/client/app/common/views/components/acct.vue
@@ -1,14 +1,20 @@
 <template>
 <span class="mk-acct">
 	<span class="name">@{{ user.username }}</span>
-	<span class="host" v-if="user.host">@{{ user.host }}</span>
+	<span class="host" v-if="user.host || detail">@{{ user.host || host }}</span>
 </span>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { host } from '../../../config';
 export default Vue.extend({
-	props: ['user']
+	props: ['user', 'detail'],
+	data() {
+		return {
+			host
+		};
+	}
 });
 </script>
 

--- a/src/client/app/desktop/views/pages/user/user.header.vue
+++ b/src/client/app/desktop/views/pages/user/user.header.vue
@@ -6,7 +6,7 @@
 		<div class="title">
 			<p class="name">{{ user | userName }}</p>
 			<div>
-				<span class="username"><mk-acct :user="user"/></span>
+				<span class="username"><mk-acct :user="user" :detail="true" /></span>
 				<span v-if="user.isBot" title="%i18n:@is-bot%">%fa:robot%</span>
 				<span class="location" v-if="user.host === null && user.profile.location">%fa:map-marker% {{ user.profile.location }}</span>
 				<span class="birthday" v-if="user.host === null && user.profile.birthday">%fa:birthday-cake% {{ user.profile.birthday.replace('-', '年').replace('-', '月') + '日' }} ({{ age }}歳)</span>

--- a/src/client/app/mobile/views/pages/user.vue
+++ b/src/client/app/mobile/views/pages/user.vue
@@ -16,7 +16,7 @@
 				</div>
 				<div class="title">
 					<h1>{{ user | userName }}</h1>
-					<span class="username"><mk-acct :user="user"/></span>
+					<span class="username"><mk-acct :user="user" :detail="true" /></span>
 					<span class="followed" v-if="user.isFollowed">%i18n:@follows-you%</span>
 				</div>
 				<div class="description">


### PR DESCRIPTION
ユーザー詳細ページ(`http://example.com/@user`)では
ローカルユーザーの場合はホスト名が省略されていますが、

インスタンス外のユーザーが
このページを閲覧後に、アカウントを自分の所属するインスタンスに入力してフォローする
ということがが考えられます。

現状では、フルアカウント名(`@user@example.com`)を取得しようとすると、
アドレスバー等からホストを補わないといけません。

ユーザー詳細ページのみ、ローカルアカウントであってもフルアカウント名を表示するようにして
容易にフルアカウント名が取得できるようにしてます。
（ユーザー詳細ページ以外は変更なし）