### PR TITLE
ユーザー/ノート詳細ページにAPオブジェクト等へのmeta linkを追加

### DIFF
--- a/src/server/web/views/note.pug
+++ b/src/server/web/views/note.pug
@@ -23,3 +23,6 @@ block meta
 		link(rel='prev' href=`${config.url}/notes/${note.prev}`)
 	if note.next
 		link(rel='next' href=`${config.url}/notes/${note.next}`)
+
+	if !user.host
+		link(rel='alternate' href=url type='application/activity+json')

--- a/src/server/web/views/user.pug
+++ b/src/server/web/views/user.pug
@@ -18,3 +18,10 @@ block meta
 	meta(property='og:description' content= user.description)
 	meta(property='og:url'         content= url)
 	meta(property='og:image'       content= img)
+	
+	if !user.host
+		link(rel='alternate' href=`${config.url}/users/${user._id}` type='application/activity+json')
+	if user.uri
+		link(rel='alternate' href=user.uri type='application/activity+json')
+	if user.url
+		link(rel='alternate' href=user.url type='text/html')


### PR DESCRIPTION
ユーザー/ノート詳細ページを直接参照した時に以下のmetaタグを追加しています

- ユーザー詳細ページにActivityPubオブジェクトへのlink
- ユーザー詳細ページにリモートユーザーの場合プロフィールページへのlink
- ノート詳細ページにActivityPubオブジェクトへのlink(ローカルのみ)

利点は、
API経由じゃないと取得できないユーザーのオブジェクトIDが、
比較的楽に取得できるようになるのでデバッグが楽になる・・・とか

User page (Local user)
```html
<link rel="alternate" href="https://local-misskey/users/ID" type="application/activity+json">
```

User page (Remote Misskey user)
```html
<link rel="alternate" href="https://remote-misskey/users/ID" type="application/activity+json">
<link rel="alternate" href="https://remote-misskey/@USER" type="text/html">
```

User page (Remote Mastodon user)
```html
<link rel="alternate" href="https://remote-mastodon/users/USER" type="application/activity+json">
<link rel="alternate" href="https://remote-mastodon/@USER" type="text/html">
```

Note page (Local user)
```html
<link rel="alternate" href="https://local-misskey/notes/ID" type="application/activity+json">
```
Note page (Remote user)
no change
