### PR TITLE
Update setup.ja.md

### DIFF
--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -109,6 +109,7 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 ```
+CentOSで1024以下のポートを使用してMisskeyを使用する場合は`ExecStart=/usr/bin/sudo /usr/bin/npm start`に変更する必要があります。
 
 3. `systemctl daemon-reload ; systemctl enable misskey` systemdを再読み込みしmisskeyサービスを有効化
 4. `systemctl start misskey` misskeyサービスの起動


### PR DESCRIPTION
CentOS7 でsystemctl にて動かす場合に`sudo`を使用する必要があったので、マニュアルに追加しました。