### PR TITLE
ActivityPubオブジェクトCache-Controlを追加

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -75,6 +75,7 @@ router.get('/notes/:note', async (ctx, next) => {
 	}
 
 	ctx.body = pack(await renderNote(note, false));
+	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });
 
@@ -91,6 +92,7 @@ router.get('/notes/:note/activity', async ctx => {
 	}
 
 	ctx.body = pack(await packActivity(note));
+	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });
 
@@ -122,6 +124,7 @@ router.get('/users/:user/publickey', async ctx => {
 
 	if (isLocalUser(user)) {
 		ctx.body = pack(renderKey(user));
+		ctx.set('Cache-Control', 'public, max-age=180');
 		setResponseType(ctx);
 	} else {
 		ctx.status = 400;
@@ -136,6 +139,7 @@ async function userInfo(ctx: Router.IRouterContext, user: IUser) {
 	}
 
 	ctx.body = pack(await renderPerson(user as ILocalUser));
+	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 }
 

--- a/src/server/activitypub/featured.ts
+++ b/src/server/activitypub/featured.ts
@@ -34,5 +34,6 @@ export default async (ctx: Router.IRouterContext) => {
 	);
 
 	ctx.body = pack(rendered);
+	ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 	setResponseType(ctx);
 };

--- a/src/server/activitypub/followers.ts
+++ b/src/server/activitypub/followers.ts
@@ -78,6 +78,7 @@ export default async (ctx: Router.IRouterContext) => {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followersCount, `${partOf}?page=true`, null);
 		ctx.body = pack(rendered);
+		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}
 };

--- a/src/server/activitypub/following.ts
+++ b/src/server/activitypub/following.ts
@@ -78,6 +78,7 @@ export default async (ctx: Router.IRouterContext) => {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followingCount, `${partOf}?page=true`, null);
 		ctx.body = pack(rendered);
+		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}
 };

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -88,6 +88,7 @@ export default async (ctx: Router.IRouterContext) => {
 		);
 
 		ctx.body = pack(rendered);
+		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	} else {
 		// index page
@@ -96,6 +97,7 @@ export default async (ctx: Router.IRouterContext) => {
 			`${partOf}?page=true&since_id=000000000000000000000000`
 		);
 		ctx.body = pack(rendered);
+		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}
 };


### PR DESCRIPTION
GETで取得できるActivityPubオブジェクトに明示的にCache-Controlを付加してます  
設定値はMastodonに寄せています
```
OK: https://misskey.example.com/users/xxxxx
OK: https://misskey.example.com/users/xxxxx/publickey
NG: https://misskey.example.com/users/xxxxx/outbox
NG: https://misskey.example.com/users/xxxxx/followers
NG: https://misskey.example.com/users/xxxxx/following
NG: https://misskey.example.com/users/xxxxx/collections/featured
OK: https://misskey.example.com/notes/xxxxx
OK: https://misskey.example.com/notes/xxxxx/activity
```
```
OK => public, max-age=180
NG => private, max-age=0, must-revalidate
```