### PR TITLE
production環境のログに出てくる妙に長いリクエストエラーメッセージを短くする

### DIFF
--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -55,6 +55,8 @@ export default class Resolver {
 				Accept: 'application/activity+json, application/ld+json'
 			},
 			json: true
+		}).catch(e => {
+			throw new Error(`request error: ${e.message}`);
 		});
 
 		if (object === null || (


### PR DESCRIPTION
外部のAPオブジェクトの取得でエラーが発生した時に
無駄に長い(関連オブジェクトの全ダンプみたいなのが入ってる)ログが出てくるのを修正。
```
{ StatusCodeError: 404 - undefined
    :      
  name: 'StatusCodeError',
  statusCode: 404,
  message: '404 - undefined',
  error: undefined,
  options:
    :  (あと300行くらい)
```
↓
```
Error: request error 404 - undefined
    at request.catch.e (/home/xxx/misskey/built/remote/activitypub/resolver.js:46:19)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```