### PR TITLE
リプライで元の公開範囲を引き継ぐ

### DIFF
--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -178,6 +178,10 @@ export default Vue.extend({
 			});
 		}
 
+		if (this.reply && ['home', 'followers'].includes(this.reply.visibility)) {
+			this.visibility = this.reply.visibility;
+		}
+
 		this.$nextTick(() => {
 			// 書きかけの投稿を復元
 			if (!this.instant) {

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -178,14 +178,13 @@ export default Vue.extend({
 			});
 		}
 
-		if (this.reply && ['home', 'followers'].includes(this.reply.visibility)) {
+		// 公開以外へのリプライ時は元の公開範囲を引き継ぐ
+		if (this.reply && ['home', 'followers', 'specified', 'private'].includes(this.reply.visibility)) {
 			this.visibility = this.reply.visibility;
 		}
 
 		// ダイレクトへのリプライはリプライ先ユーザーを初期設定
 		if (this.reply && this.reply.visibility === 'specified') {
-			this.visibility = this.reply.visibility;
-
 			(this as any).api('users/show', {	userId: this.reply.userId }).then(user => {
 				this.visibleUsers.push(user);
 			});

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -182,6 +182,15 @@ export default Vue.extend({
 			this.visibility = this.reply.visibility;
 		}
 
+		// ダイレクトへのリプライはリプライ先ユーザーを初期設定
+		if (this.reply && this.reply.visibility === 'specified') {
+			this.visibility = this.reply.visibility;
+
+			(this as any).api('users/show', {	userId: this.reply.userId }).then(user => {
+				this.visibleUsers.push(user);
+			});
+		}
+
 		this.$nextTick(() => {
 			// 書きかけの投稿を復元
 			if (!this.instant) {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -173,6 +173,10 @@ export default Vue.extend({
 			});
 		}
 
+		if (this.reply && ['home', 'followers'].includes(this.reply.visibility)) {
+			this.visibility = this.reply.visibility;
+		}
+
 		this.focus();
 
 		this.$nextTick(() => {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -177,6 +177,15 @@ export default Vue.extend({
 			this.visibility = this.reply.visibility;
 		}
 
+		// ダイレクトへのリプライはリプライ先ユーザーを初期設定
+		if (this.reply && this.reply.visibility === 'specified') {
+			this.visibility = this.reply.visibility;
+
+			(this as any).api('users/show', {	userId: this.reply.userId }).then(user => {
+				this.visibleUsers.push(user);
+			});
+		}
+
 		this.focus();
 
 		this.$nextTick(() => {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -173,14 +173,13 @@ export default Vue.extend({
 			});
 		}
 
-		if (this.reply && ['home', 'followers'].includes(this.reply.visibility)) {
+		// 公開以外へのリプライ時は元の公開範囲を引き継ぐ
+		if (this.reply && ['home', 'followers', 'specified', 'private'].includes(this.reply.visibility)) {
 			this.visibility = this.reply.visibility;
 		}
 
 		// ダイレクトへのリプライはリプライ先ユーザーを初期設定
 		if (this.reply && this.reply.visibility === 'specified') {
-			this.visibility = this.reply.visibility;
-
 			(this as any).api('users/show', {	userId: this.reply.userId }).then(user => {
 				this.visibleUsers.push(user);
 			});


### PR DESCRIPTION
#2684
リプライ時に、投稿フォームでリプライ先の公開範囲を初期設定するようにしています。

ホーム/フォロワー限定/非公開にリプライ → それぞれ元の公開範囲を初期設定
ダイレクトにリプライ → 公開範囲ダイレクト&リプライ先ユーザーを初期設定
公開にリプライ → 制御なし(そのユーザーの投稿設定を使用)