### PR TITLE
非承認制アカウントのリモートフォローではフォロー許可待ちと表示しない

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -439,6 +439,7 @@ common/views/pages/follow.vue:
   following: "Following"
   follow: "Follow"
   request-pending: "Pending follow request"
+  follow-processing: "Processing follow"
   follow-request: "Follow request"
 desktop:
   banner-crop-title: "Crop the part that appears as a banner"
@@ -565,6 +566,7 @@ desktop/views/components/follow-button.vue:
   following: "Following"
   follow: "Follow"
   request-pending: "Pending follow request"
+  follow-processing: "Processing follow"
   follow-request: "Follow request"
 desktop/views/components/followers-window.vue:
   followers: "{}'s followers"
@@ -1044,6 +1046,7 @@ mobile/views/components/follow-button.vue:
   following: "Following"
   follow: "Follow"
   request-pending: "Pending follow request"
+  follow-processing: "Processing follow"
   follow-request: "Follow request"
 mobile/views/components/friends-maker.vue:
   title: "Let's follow them"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -514,6 +514,7 @@ common/views/pages/follow.vue:
   following: "フォロー中"
   follow: "フォロー"
   request-pending: "フォロー許可待ち"
+  follow-processing: "フォロー処理中"
   follow-request: "フォロー申請"
 
 desktop:
@@ -656,6 +657,7 @@ desktop/views/components/follow-button.vue:
   following: "フォロー中"
   follow: "フォロー"
   request-pending: "フォロー許可待ち"
+  follow-processing: "フォロー処理中"
   follow-request: "フォロー申請"
 
 desktop/views/components/followers-window.vue:
@@ -1232,6 +1234,7 @@ mobile/views/components/follow-button.vue:
   following: "フォロー中"
   follow: "フォロー"
   request-pending: "フォロー許可待ち"
+  follow-processing: "フォロー処理中"
   follow-request: "フォロー申請"
 
 mobile/views/components/friends-maker.vue:

--- a/src/client/app/common/views/pages/follow.vue
+++ b/src/client/app/common/views/pages/follow.vue
@@ -19,7 +19,8 @@
 			@click="onClick"
 			:disabled="followWait">
 		<template v-if="!followWait">
-			<template v-if="user.hasPendingFollowRequestFromYou">%fa:hourglass-half% %i18n:@request-pending%</template>
+			<template v-if="user.hasPendingFollowRequestFromYou && user.isLocked">%fa:hourglass-half% %i18n:@request-pending%</template>
+			<template v-else-if="user.hasPendingFollowRequestFromYou && !user.isLocked">%fa:hourglass-start% %i18n:@follow-processing%</template>
 			<template v-else-if="user.isFollowing">%fa:minus% %i18n:@following%</template>
 			<template v-else-if="!user.isFollowing && user.isLocked">%fa:plus% %i18n:@follow-request%</template>
 			<template v-else-if="!user.isFollowing && !user.isLocked">%fa:plus% %i18n:@follow%</template>

--- a/src/client/app/desktop/views/components/follow-button.vue
+++ b/src/client/app/desktop/views/components/follow-button.vue
@@ -5,7 +5,8 @@
 	:disabled="wait"
 >
 	<template v-if="!wait">
-		<template v-if="u.hasPendingFollowRequestFromYou">%fa:hourglass-half%<template v-if="size == 'big'"> %i18n:@request-pending%</template></template>
+		<template v-if="u.hasPendingFollowRequestFromYou && u.isLocked">%fa:hourglass-half%<template v-if="size == 'big'"> %i18n:@request-pending%</template></template>
+		<template v-else-if="u.hasPendingFollowRequestFromYou && !u.isLocked">%fa:hourglass-start%<template v-if="size == 'big'"> %i18n:@follow-processing%</template></template>
 		<template v-else-if="u.isFollowing">%fa:minus%<template v-if="size == 'big'"> %i18n:@following%</template></template>
 		<template v-else-if="!u.isFollowing && u.isLocked">%fa:plus%<template v-if="size == 'big'"> %i18n:@follow-request%</template></template>
 		<template v-else-if="!u.isFollowing && !u.isLocked">%fa:plus%<template v-if="size == 'big'"> %i18n:@follow%</template></template>

--- a/src/client/app/mobile/views/components/follow-button.vue
+++ b/src/client/app/mobile/views/components/follow-button.vue
@@ -5,7 +5,8 @@
 	:disabled="wait"
 >
 	<template v-if="!wait">
-		<template v-if="u.hasPendingFollowRequestFromYou">%fa:hourglass-half% %i18n:@request-pending%</template>
+		<template v-if="u.hasPendingFollowRequestFromYou && u.isLocked">%fa:hourglass-half% %i18n:@request-pending%</template>
+		<template v-else-if="u.hasPendingFollowRequestFromYou && !u.isLocked">%fa:hourglass-start% %i18n:@follow-processing%</template>
 		<template v-else-if="u.isFollowing">%fa:minus% %i18n:@following%</template>
 		<template v-else-if="!u.isFollowing && u.isLocked">%fa:plus% %i18n:@follow-request%</template>
 		<template v-else-if="!u.isFollowing && !u.isLocked">%fa:plus% %i18n:@follow%</template>


### PR DESCRIPTION
Resolve #2777 

非承認制アカウントのリモートフォローでは、「フォロー許可待ち」ではなく「フォロー処理中」と表示するようにしてます。
承認制アカウントのリモートフォローでは、今までどおり「フォロー許可待ち」と表示します。
![image](https://user-images.githubusercontent.com/30769358/46281831-c54bee00-c5aa-11e8-90ca-180f6ffcdef7.png)
![image](https://user-images.githubusercontent.com/30769358/46281937-2378d100-c5ab-11e8-80c2-aefa4990a1c6.png)
![image](https://user-images.githubusercontent.com/30769358/46281910-fdebc780-c5aa-11e8-9384-3aec87ac866e.png)

なお、案にあった以下の挙動は採用していません。
> 「数秒間は"待機のマーク"を表示し、待っても許可が確認できなかったらフォロー許可待ちを表示」

おそらく某Mastodonの挙動と思われますが、
Misskeyではフォロー完了時にUI側にイベントを受け取って処理できるので待機処理は不要  
非承認制アカウントで「フォロー許可待ち」に遷移するの自体間違いと思われる
ため。

フォローが完了した際に自動的に「フォロー中」になり、  
非承認制アカウントで処理が滞っている場合は「フォロー処理中」のままとなります。