### PR TITLE
Feature flags feature

### DIFF
--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -39,6 +39,15 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 		recaptchaSitekey: config.recaptcha ? config.recaptcha.site_key : null,
 		swPublickey: config.sw ? config.sw.public_key : null,
 		hidedTags: (me && me.isAdmin) ? meta.hidedTags : undefined,
-		bannerUrl: meta.bannerUrl
+		bannerUrl: meta.bannerUrl,
+		features: {
+			registration: !meta.disableRegistration,
+			localTimeLine: !meta.disableLocalTimeline,
+			elasticsearch: config.elasticsearch ? true : false,
+			recaptcha: config.recaptcha ? true : false,
+			objectStorage: config.drive && config.drive.storage === 'minio',
+			twitter: config.twitter ? true : false,
+			serviceWorker: config.sw ? true : false
+		}
 	});
 });


### PR DESCRIPTION
#2794 とりあえず
meta APIで機能フラグを提供するようにしています

```yml
features:
  registration: 新規登録を受け付けているか
  localTimeLine: ローカルタイムラインがあるか
  elasticsearch: 全文検索を提供しているか
  recaptcha: 新規登録にreCAPTCHAが必要か
  objectStorage: ドライブファイルをオブジェクトストレージに格納しているか
  twitter: ツイッターでログインに対応しているか
  serviceWorker: ServiceWorkerに対応しているか
```

- `disableRegistration`, `disableLocalTimeline` などreversedではあるが同等のプロパティ
- `recaptchaSitekey`, `swPublickey`など内部向けだが頑張れば機能フラグとして解釈できそうなもの

が既にあって利用できないこともなかったのですが
reversedだったり、一部は内部向けプロパティの様相があったので
あくまでも、外部に機能の有無を公開するためのプロパティ(features配下)として新設しました。