### PR TITLE
ActivityPubのHTTPリクエストの強化

### DIFF
--- a/src/queue/processors/http/deliver.ts
+++ b/src/queue/processors/http/deliver.ts
@@ -7,19 +7,18 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 		await request(job.data.user, job.data.to, job.data.content);
 		done();
 	} catch (res) {
-		if (res == null || !res.hasOwnProperty('statusCode')) {
-			console.warn(`deliver failed (unknown): ${res}`);
-			return done();
-		}
-
-		if (res.statusCode == null) return done();
-		if (res.statusCode >= 400 && res.statusCode < 500) {
-			// HTTPステータスコード4xxはクライアントエラーであり、それはつまり
-			// 何回再送しても成功することはないということなのでエラーにはしないでおく
-			done();
+		if (res != null && res.hasOwnProperty('statusCode')) {
+			if (res.statusCode >= 400 && res.statusCode < 500) {
+				// HTTPステータスコード4xxはクライアントエラーであり、それはつまり
+				// 何回再送しても成功することはないということなのでエラーにはしないでおく
+				done();
+			} else {
+				console.warn(`deliver failed: ${res.statusCode} ${res.statusMessage} to=${job.data.to}`);
+				done(res.statusMessage);
+			}
 		} else {
-			console.warn(`deliver failed: ${res.statusMessage}`);
-			done(res.statusMessage);
+			console.warn(`deliver failed: ${res} to=${job.data.to}`);
+			done();
 		}
 	}
 };

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -7,7 +7,7 @@ const log = debug('misskey:activitypub:resolver');
 
 export default class Resolver {
 	private history: Set<string>;
-	private timeout: number = 10 * 1000;
+	private timeout = 10 * 1000;
 
 	constructor() {
 		this.history = new Set();

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -7,6 +7,7 @@ const log = debug('misskey:activitypub:resolver');
 
 export default class Resolver {
 	private history: Set<string>;
+	private timeout: number = 10 * 1000;
 
 	constructor() {
 		this.history = new Set();
@@ -50,6 +51,7 @@ export default class Resolver {
 
 		const object = await request({
 			url: value,
+			timeout: this.timeout,
 			headers: {
 				'User-Agent': config.user_agent,
 				Accept: 'application/activity+json, application/ld+json'


### PR DESCRIPTION
ActivityPubのHTTPリクエストで、タイムアウトの追加とログの出し方を修正しています。

AP deliver (push配信)
- タイムアウトを追加
- 4xx, 5xx エラーが`deliver failed (unknown)`として処理されてしまうのを修正
- ソケット系エラー(DNS/接続/証明書エラー)がかなり長めのログを出してしまうのを修正
- エラー時にどこへのリクエストだったかを表示するように

AP resolve (object取得)
- タイムアウトを追加