### PR TITLE
ap/showが返ってこないことがあるのを修正

### DIFF
--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -24,15 +24,15 @@ export const meta = {
 	},
 };
 
-export default (params: any) => new Promise(async (res, rej) => {
+export default async (params: any) => {
 	const [ps, psErr] = getParams(meta, params);
-	if (psErr) return rej(psErr);
+	if (psErr) throw psErr;
 
 	const object = await fetchAny(ps.uri);
-	if (object !== null) return res(object);
+	if (object !== null) return object;
 
-	return rej('object not found');
-});
+	throw new Error('object not found');
+};
 
 /***
  * URIからUserかNoteを解決する


### PR DESCRIPTION
ap/show APIでエラーとなる時に返ってこないことがあるのを修正しています
https://github.com/syuilo/misskey/pull/2832#issuecomment-427670933

`export default (params: any) => new Promise(async (res, rej) => {` の中で
awaitしている先で例外が発生すると戻ってこないようなので修正しています。

1. awaitの後ろにcatchを付ける
https://github.com/syuilo/misskey/commit/cad2f2e9cde866b7a5ee75fdd532d7bab0cd5bf4
2. Promiseを使わない
https://github.com/syuilo/misskey/commit/15395686aa980c0eab55436d81b7a80ce86a6b7e

の2つを検討して2にしています