### PR TITLE
互換ストリーム / に main streamの内容も流す

### DIFF
--- a/src/server/api/streaming.ts
+++ b/src/server/api/streaming.ts
@@ -44,6 +44,10 @@ module.exports = (server: http.Server) => {
 				request.resourceURL.pathname === '/local-timeline' ? channels.localTimeline :
 				request.resourceURL.pathname === '/hybrid-timeline' ? channels.hybridTimeline :
 				request.resourceURL.pathname === '/global-timeline' ? channels.globalTimeline : null);
+
+			if (request.resourceURL.pathname === '/') {
+				main.connectChannel(Math.random().toString(), null, channels.main);
+			}
 		}
 
 		connection.once('close', () => {


### PR DESCRIPTION
v10において、旧 /  のストリームの`mention`等を利用しているアプリのためにmain streamの内容を流すようにしてます。

これでちゃんと機能するようになっているが、妥当かは自信なし。