### PR TITLE
削除された投稿はタイムライン上で表示しないようにする

### DIFF
--- a/src/client/app/desktop/views/components/notes.note.vue
+++ b/src/client/app/desktop/views/components/notes.note.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="note" :class="{ deleted: p.deletedAt != null }" tabindex="-1" v-hotkey="keymap" :title="title">
+<div class="note" v-show="p.deletedAt == null" tabindex="-1" v-hotkey="keymap" :title="title">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -239,9 +239,6 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
-.note.deleted
-	display none
-
 .note
 	margin 0
 	padding 0

--- a/src/client/app/desktop/views/components/notes.note.vue
+++ b/src/client/app/desktop/views/components/notes.note.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="note" tabindex="-1" v-hotkey="keymap" :title="title">
+<div class="note" :class="{ deleted: p.deletedAt != null }" tabindex="-1" v-hotkey="keymap" :title="title">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -239,6 +239,9 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
+.note.deleted
+	display none
+
 .note
 	margin 0
 	padding 0

--- a/src/client/app/desktop/views/pages/deck/deck.note.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.note.vue
@@ -1,5 +1,5 @@
 <template>
-<div v-if="!mediaView" class="zyjjkidcqjnlegkqebitfviomuqmseqk" :class="{ renote: isRenote, deleted: p.deletedAt != null }">
+<div v-if="!mediaView" v-show="p.deletedAt == null" class="zyjjkidcqjnlegkqebitfviomuqmseqk" :class="{ renote: isRenote }">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -163,9 +163,6 @@ export default Vue.extend({
 
 	&:last-child
 		margin-bottom 12px
-
-.zyjjkidcqjnlegkqebitfviomuqmseqk.deleted
-	display none
 
 .zyjjkidcqjnlegkqebitfviomuqmseqk
 	font-size 13px

--- a/src/client/app/desktop/views/pages/deck/deck.note.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.note.vue
@@ -1,5 +1,5 @@
 <template>
-<div v-if="!mediaView" class="zyjjkidcqjnlegkqebitfviomuqmseqk" :class="{ renote: isRenote }">
+<div v-if="!mediaView" class="zyjjkidcqjnlegkqebitfviomuqmseqk" :class="{ renote: isRenote, deleted: p.deletedAt != null }">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -163,6 +163,9 @@ export default Vue.extend({
 
 	&:last-child
 		margin-bottom 12px
+
+.zyjjkidcqjnlegkqebitfviomuqmseqk.deleted
+	display none
 
 .zyjjkidcqjnlegkqebitfviomuqmseqk
 	font-size 13px

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="note" :class="{ renote: isRenote, smart: $store.state.device.postStyle == 'smart', deleted: p.deletedAt != null }">
+<div class="note" v-show="p.deletedAt == null" :class="{ renote: isRenote, smart: $store.state.device.postStyle == 'smart' }">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -150,9 +150,6 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
-.note.deleted
-	display: none
-
 .note
 	font-size 12px
 	border-bottom solid 1px var(--faceDivider)

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="note" :class="{ renote: isRenote, smart: $store.state.device.postStyle == 'smart' }">
+<div class="note" :class="{ renote: isRenote, smart: $store.state.device.postStyle == 'smart', deleted: p.deletedAt != null }">
 	<div class="reply-to" v-if="p.reply && (!$store.getters.isSignedIn || $store.state.settings.showReplyTarget)">
 		<x-sub :note="p.reply"/>
 	</div>
@@ -150,6 +150,9 @@ export default Vue.extend({
 </script>
 
 <style lang="stylus" scoped>
+.note.deleted
+	display: none
+
 .note
 	font-size 12px
 	border-bottom solid 1px var(--faceDivider)

--- a/src/server/api/endpoints/notes/global-timeline.ts
+++ b/src/server/api/endpoints/notes/global-timeline.ts
@@ -58,6 +58,8 @@ export default async (params: any, user: ILocalUser) => {
 	};
 
 	const query = {
+		deletedAt: null,
+
 		// public only
 		visibility: 'public',
 

--- a/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -129,6 +129,8 @@ export default async (params: any, user: ILocalUser) => {
 
 	const query = {
 		$and: [{
+			deletedAt: null,
+
 			$or: [{
 				// フォローしている人の投稿
 				$or: followQuery

--- a/src/server/api/endpoints/notes/local-timeline.ts
+++ b/src/server/api/endpoints/notes/local-timeline.ts
@@ -71,6 +71,8 @@ export default async (params: any, user: ILocalUser) => {
 	};
 
 	const query = {
+		deletedAt: null,
+
 		// public only
 		visibility: 'public',
 

--- a/src/server/api/endpoints/notes/mentions.ts
+++ b/src/server/api/endpoints/notes/mentions.ts
@@ -45,6 +45,8 @@ export default (params: any, user: ILocalUser) => new Promise(async (res, rej) =
 
 	// Construct query
 	const query = {
+		deletedAt: null,
+
 		$or: [{
 			mentions: user._id
 		}, {

--- a/src/server/api/endpoints/notes/timeline.ts
+++ b/src/server/api/endpoints/notes/timeline.ts
@@ -132,6 +132,8 @@ export default async (params: any, user: ILocalUser) => {
 
 	const query = {
 		$and: [{
+			deletedAt: null,
+
 			// フォローしている人の投稿
 			$or: followQuery,
 

--- a/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -137,6 +137,8 @@ export default async (params: any, user: ILocalUser) => {
 
 	const query = {
 		$and: [{
+			deletedAt: null,
+
 			// リストに入っている人のタイムラインへの投稿
 			$or: listQuery,
 

--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -136,6 +136,7 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 	};
 
 	const query = {
+		deletedAt: null,
 		userId: user._id
 	} as any;
 


### PR DESCRIPTION
削除された投稿はタイムライン上で表示しないようにしています。
- タイムライン系のAPI(DBクエリ)で、削除された投稿はなるべく返さないようにする。
- UI上でも、削除された投稿は非表示にする。（表示後にイベント等で消された場合のため）

以下の部分はとりあえず今までどおりです。
- 投稿詳細では「削除されました」で残る。
- リプライ先が削除されている場合は「削除されました」で残る。
- 引用先が削除されている場合は「削除されました」で残る。