### PR TITLE
Fix following from Preroma does not complete

### DIFF
--- a/src/models/follow-request.ts
+++ b/src/models/follow-request.ts
@@ -12,6 +12,7 @@ export type IFollowRequest = {
 	createdAt: Date;
 	followeeId: mongo.ObjectID;
 	followerId: mongo.ObjectID;
+	requestId?: string;	// id of Follow Activity
 
 	// 非正規化
 	_followee: {

--- a/src/remote/activitypub/kernel/follow.ts
+++ b/src/remote/activitypub/kernel/follow.ts
@@ -23,5 +23,5 @@ export default async (actor: IRemoteUser, activity: IFollow): Promise<void> => {
 		throw new Error('フォローしようとしているユーザーはローカルユーザーではありません');
 	}
 
-	await follow(actor, followee);
+	await follow(actor, followee, activity.id);
 };

--- a/src/remote/activitypub/renderer/accept.ts
+++ b/src/remote/activitypub/renderer/accept.ts
@@ -1,4 +1,8 @@
-export default (object: any) => ({
+import config from '../../../config';
+import { ILocalUser } from '../../../models/user';
+
+export default (object: any, user: ILocalUser) => ({
 	type: 'Accept',
+	actor: `${config.url}/users/${user._id}`,
 	object
 });

--- a/src/remote/activitypub/renderer/follow.ts
+++ b/src/remote/activitypub/renderer/follow.ts
@@ -1,8 +1,14 @@
 import config from '../../../config';
 import { IUser, isLocalUser } from '../../../models/user';
 
-export default (follower: IUser, followee: IUser) => ({
-	type: 'Follow',
-	actor: isLocalUser(follower) ? `${config.url}/users/${follower._id}` : follower.uri,
-	object: isLocalUser(followee) ? `${config.url}/users/${followee._id}` : followee.uri
-});
+export default (follower: IUser, followee: IUser, requestId?: string) => {
+	const follow = {
+		type: 'Follow',
+		actor: isLocalUser(follower) ? `${config.url}/users/${follower._id}` : follower.uri,
+		object: isLocalUser(followee) ? `${config.url}/users/${followee._id}` : followee.uri
+	} as any;
+
+	if (requestId) follow.id = requestId;
+
+	return follow;
+};

--- a/src/remote/activitypub/renderer/reject.ts
+++ b/src/remote/activitypub/renderer/reject.ts
@@ -1,4 +1,8 @@
-export default (object: any) => ({
+import config from '../../../config';
+import { ILocalUser } from '../../../models/user';
+
+export default (object: any, user: ILocalUser) => ({
 	type: 'Reject',
+	actor: `${config.url}/users/${user._id}`,
 	object
 });

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -10,13 +10,13 @@ import renderAccept from '../../remote/activitypub/renderer/accept';
 import { deliver } from '../../queue';
 import createFollowRequest from './requests/create';
 
-export default async function(follower: IUser, followee: IUser) {
+export default async function(follower: IUser, followee: IUser, requestId?: string) {
 	// フォロー対象が鍵アカウントである or
 	// フォロワーがBotであり、フォロー対象がBotからのフォローに慎重である or
 	// フォロワーがローカルユーザーであり、フォロー対象がリモートユーザーである
 	// 上記のいずれかに当てはまる場合はすぐフォローせずにフォローリクエストを発行しておく
 	if (followee.isLocked || (followee.carefulBot && follower.isBot) || (isLocalUser(follower) && isRemoteUser(followee))) {
-		await createFollowRequest(follower, followee);
+		await createFollowRequest(follower, followee, requestId);
 		return;
 	}
 
@@ -79,7 +79,7 @@ export default async function(follower: IUser, followee: IUser) {
 	}
 
 	if (isRemoteUser(follower) && isLocalUser(followee)) {
-		const content = pack(renderAccept(renderFollow(follower, followee)));
+		const content = pack(renderAccept(renderFollow(follower, followee, requestId)));
 		deliver(followee, content, follower.inbox);
 	}
 }

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -79,7 +79,7 @@ export default async function(follower: IUser, followee: IUser, requestId?: stri
 	}
 
 	if (isRemoteUser(follower) && isLocalUser(followee)) {
-		const content = pack(renderAccept(renderFollow(follower, followee, requestId)));
+		const content = pack(renderAccept(renderFollow(follower, followee, requestId), followee));
 		deliver(followee, content, follower.inbox);
 	}
 }

--- a/src/services/following/requests/accept.ts
+++ b/src/services/following/requests/accept.ts
@@ -34,7 +34,7 @@ export default async function(followee: IUser, follower: IUser) {
 			followerId: follower._id
 		});
 
-		const content = pack(renderAccept(renderFollow(follower, followee, request.requestId)));
+		const content = pack(renderAccept(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 

--- a/src/services/following/requests/accept.ts
+++ b/src/services/following/requests/accept.ts
@@ -29,7 +29,12 @@ export default async function(followee: IUser, follower: IUser) {
 	});
 
 	if (isRemoteUser(follower)) {
-		const content = pack(renderAccept(renderFollow(follower, followee)));
+		const request = await FollowRequest.findOne({
+			followeeId: followee._id,
+			followerId: follower._id
+		});
+
+		const content = pack(renderAccept(renderFollow(follower, followee, request.requestId)));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -6,11 +6,12 @@ import renderFollow from '../../../remote/activitypub/renderer/follow';
 import { deliver } from '../../../queue';
 import FollowRequest from '../../../models/follow-request';
 
-export default async function(follower: IUser, followee: IUser) {
+export default async function(follower: IUser, followee: IUser, requestId?: string) {
 	await FollowRequest.insert({
 		createdAt: new Date(),
 		followerId: follower._id,
 		followeeId: followee._id,
+		requestId,
 
 		// 非正規化
 		_follower: {

--- a/src/services/following/requests/reject.ts
+++ b/src/services/following/requests/reject.ts
@@ -13,7 +13,7 @@ export default async function(followee: IUser, follower: IUser) {
 			followerId: follower._id
 		});
 
-		const content = pack(renderReject(renderFollow(follower, followee, request.requestId)));
+		const content = pack(renderReject(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 

--- a/src/services/following/requests/reject.ts
+++ b/src/services/following/requests/reject.ts
@@ -8,7 +8,12 @@ import { publishMainStream } from '../../../stream';
 
 export default async function(followee: IUser, follower: IUser) {
 	if (isRemoteUser(follower)) {
-		const content = pack(renderReject(renderFollow(follower, followee)));
+		const request = await FollowRequest.findOne({
+			followeeId: followee._id,
+			followerId: follower._id
+		});
+
+		const content = pack(renderReject(renderFollow(follower, followee, request.requestId)));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 


### PR DESCRIPTION
Resolve #2812, #2904

Pleromaからのフォローが完了しなくなっているのを修正

0a61edf
送信されるAccept/Rejectにactorがないのを修正

95bf585
送信されるAccept/RejectのFollow objectに 対象のFollow idがない(#2812)のを修正
リモートからFollowを受け取った時にそのActivity idを保存しておき、
Accept/Rejectを返す際に保存しているものがあれば送り返すようにしています。