### PR TITLE
Implement /api/v1/instance/peers

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -45,6 +45,7 @@ router.post('/signin', require('./private/signin').default);
 
 router.use(require('./service/github').routes());
 router.use(require('./service/twitter').routes());
+router.use(require('./service/v1').routes());
 
 // Return 404 for unknown API
 router.all('*', async ctx => {

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -45,7 +45,8 @@ router.post('/signin', require('./private/signin').default);
 
 router.use(require('./service/github').routes());
 router.use(require('./service/twitter').routes());
-router.use(require('./service/v1').routes());
+
+router.use(require('./mastodon').routes());
 
 // Return 404 for unknown API
 router.all('*', async ctx => {

--- a/src/server/api/mastodon.ts
+++ b/src/server/api/mastodon.ts
@@ -1,5 +1,5 @@
 import * as Router from 'koa-router';
-import User from '../../../models/user';
+import User from '../../models/user';
 import { toASCII } from 'punycode';
 
 // Init router

--- a/src/server/api/service/v1.ts
+++ b/src/server/api/service/v1.ts
@@ -8,7 +8,6 @@ const router = new Router();
 router.get('/v1/instance/peers', async ctx => {
 	const peers = await User.distinct('host', { host: { $ne: null } }) as any as string[];
 	const punyCodes = peers.map(peer => toASCII(peer));
-	ctx.set('Cache-Control', 'public, max-age=3600');
 	ctx.body = punyCodes;
 });
 

--- a/src/server/api/service/v1.ts
+++ b/src/server/api/service/v1.ts
@@ -1,0 +1,13 @@
+import * as Router from 'koa-router';
+import User from '../../../models/user';
+
+// Init router
+const router = new Router();
+
+router.get('/v1/instance/peers', async ctx => {
+	const peers = await User.distinct('host', { host: { $ne: null } });
+	ctx.set('Cache-Control', 'public, max-age=3600');
+	ctx.body = peers;
+});
+
+module.exports = router;

--- a/src/server/api/service/v1.ts
+++ b/src/server/api/service/v1.ts
@@ -1,13 +1,15 @@
 import * as Router from 'koa-router';
 import User from '../../../models/user';
+import { toASCII } from 'punycode';
 
 // Init router
 const router = new Router();
 
 router.get('/v1/instance/peers', async ctx => {
-	const peers = await User.distinct('host', { host: { $ne: null } });
+	const peers = await User.distinct('host', { host: { $ne: null } }) as any as string[];
+	const punyCodes = peers.map(peer => toASCII(peer));
 	ctx.set('Cache-Control', 'public, max-age=3600');
-	ctx.body = peers;
+	ctx.body = punyCodes;
 });
 
 module.exports = router;


### PR DESCRIPTION
Mastodon/Pleromaとかにある、認知済みリモートインスタンス一覧を返すAPIがあると
他のインスタンスを探すのに少し役に立つみたいです。

例: https://misskey.m544.net/api/v1/instance/peers