### PR TITLE
Use cache with RSS

### DIFF
--- a/src/client/app/common/views/widgets/rss.vue
+++ b/src/client/app/common/views/widgets/rss.vue
@@ -44,7 +44,6 @@ export default define({
 		},
 		fetch() {
 			fetch(`https://api.rss2json.com/v1/api.json?rss_url=${this.props.url}`, {
-				cache: 'no-cache'
 			}).then(res => {
 				res.json().then(feed => {
 					this.items = feed.items;


### PR DESCRIPTION
Resolve #2399 ?

RSS API でブラウザのキャッシュが利用できるように変更

ホームを開いている間RSSのAPIに1分間隔でリクエスト(キャッシュ使用なし)
↓
ブラウザのキャッシュを利用する

RSS APIから返る`Cache-Control: public, max-age=1800`を使用するようになるので
リクエスト数は1/30以下になるはず。