### PR TITLE
fix(package): update @fortawesome/free-brands-svg-icons to version 5.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-svg-core": "1.2.4",
-		"@fortawesome/free-brands-svg-icons": "5.3.1",
+		"@fortawesome/free-brands-svg-icons": "5.4.1",
 		"@fortawesome/free-regular-svg-icons": "5.3.1",
 		"@fortawesome/free-solid-svg-icons": "5.3.1",
 		"@koa/cors": "2.2.2",


### PR DESCRIPTION
Closes #2859