### PR TITLE
Fix several file processings

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -190,7 +190,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 	].map(img =>
 		img == null
 			? Promise.resolve(null)
-			: resolveImage(user, img)
+			: resolveImage(user, img).catch(() => null)
 	)));
 
 	const avatarId = avatar ? avatar._id : null;
@@ -276,7 +276,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 	].map(img =>
 		img == null
 			? Promise.resolve(null)
-			: resolveImage(exist, img)
+			: resolveImage(exist, img).catch(() => null)
 	)));
 
 	// Update user

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -185,6 +185,10 @@ export default async function(
 					// 種類が同定できなかったら application/octet-stream にする
 					res(['application/octet-stream', null]);
 				}
+			})
+			.on('end', () => {
+				// maybe 0 bytes
+				res(['application/octet-stream', null]);
 			});
 	});
 


### PR DESCRIPTION
リモートユーザー取得/更新時に、アバター画像等の処理に失敗しても無視して継続するように。
0バイトファイルを処理すると返ってこなくなるのを修正。