### PR TITLE
Complement file extension from MIME

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -37,7 +37,13 @@ async function save(path: string, name: string, type: string, hash: string, size
 	if (config.drive && config.drive.storage == 'minio') {
 		const minio = new Minio.Client(config.drive.config);
 
-		const [ext] = (name.match(/\.([a-zA-Z0-9_-]+)$/) || ['']);
+		let [ext] = (name.match(/\.([a-zA-Z0-9_-]+)$/) || ['']);
+
+		if (ext === '') {
+			if (type === 'image/jpeg') ext = '.jpg';
+			if (type === 'image/png') ext = '.png';
+			if (type === 'image/webp') ext = '.webp';
+		}
 
 		const key = `${config.drive.prefix}/${uuid.v4()}${ext}`;
 		const thumbnailKey = `${config.drive.prefix}/${uuid.v4()}.jpg`;


### PR DESCRIPTION
ドライブファイルをオブジェクトストレージ保存時にファイル名が提供されていなくても、MIMEから拡張子を付ける。

非オブジェクトストレージ使用のMisskey→Misskeyに行った際に
全て拡張子が付かないままで
https://support.cloudflare.com/hc/en-us/articles/200172516-What-file-extensions-does-CloudFlare-cache-for-static-content-
のキャッシュ条件にあてはまらない状態になってしまうため。