### PR TITLE
Fix build error for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest AS base
+FROM alpine:edge AS base
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
`Dockerfile`の記述にミスがあり、`docker-compose build`が失敗するようになっていました。  
ベースのイメージを`alpine:latest`から`alpine:edge`にすることで正常にビルドできるようになります。

エラーメッセージ:  
```
$ sudo docker-compose build
redis uses an image, skipping
mongo uses an image, skipping
Building web
Step 1/16 : FROM alpine:latest AS base
 ---> 196d12cf6ab1
Step 2/16 : ENV NODE_ENV=production
 ---> Using cache
 ---> df7572b2e01a
Step 3/16 : RUN apk add --no-cache nodejs nodejs-npm
 ---> Using cache
 ---> da92549ef957
Step 4/16 : RUN apk add vips fftw --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
 ---> Using cache
 ---> e296dcc59a6a
Step 5/16 : WORKDIR /misskey
 ---> Using cache
 ---> 2d1baaeae644
Step 6/16 : COPY . ./
 ---> Using cache
 ---> c69b3beae549
Step 7/16 : FROM base AS builder
 ---> c69b3beae549
Step 8/16 : RUN apk add --no-cache	gcc g++ python autoconf automake file make nasm
 ---> Using cache
 ---> 56c980153ac1
Step 9/16 : RUN apk add vips-dev fftw-dev --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
 ---> Running in ec15b6a3d0c9
fetch https://dl-3.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  pc:fftw3 (missing):
    required by: vips-dev-8.7.0-r0[pc:fftw3]
                 vips-dev-8.7.0-r0[pc:fftw3]
                 vips-dev-8.7.0-r0[pc:fftw3]
ERROR: Service 'web' failed to build: The command '/bin/sh -c apk add vips-dev fftw-dev --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/' returned a non-zero code: 2
```

お忙しいところ申し訳ございませんが、ご対応よろしくお願いします。