### PR TITLE
 Make max allowed text length configurable 

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -164,3 +164,6 @@ drive:
 #  external: true
 #  engine: http://vinayaka.distsn.org/cgi-bin/vinayaka-user-match-misskey-api.cgi?{{host}}+{{user}}+{{limit}}+{{offset}}
 #  timeout: 300000
+
+# Max allowed note text length in charactors
+maxNoteTextLength: 1000

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -156,7 +156,7 @@ export default Vue.extend({
 		canPost(): boolean {
 			return !this.posting &&
 				(1 <= this.text.length || 1 <= this.files.length || this.poll || this.renote) &&
-				(length(this.text.trim()) <= 1000);
+				(length(this.text.trim()) <= this.maxNoteTextLength);
 		}
 	},
 

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -45,7 +45,7 @@
 		<span v-if="visibility === 'specified'">%fa:envelope%</span>
 		<span v-if="visibility === 'private'">%fa:lock%</span>
 	</button>
-	<p class="text-count" :class="{ over: this.trimmedLength(text) > 1000 }">{{ 1000 - this.trimmedLength(text) }}</p>
+	<p class="text-count" :class="{ over: this.trimmedLength(text) > this.maxNoteTextLength }">{{ this.maxNoteTextLength - this.trimmedLength(text) }}</p>
 	<button :class="{ posting }" class="submit" :disabled="!canPost" @click="post">
 		{{ posting ? '%i18n:@posting%' : submitText }}<mk-ellipsis v-if="posting"/>
 	</button>
@@ -107,8 +107,15 @@ export default Vue.extend({
 			visibleUsers: [],
 			autocomplete: null,
 			draghover: false,
-			recentHashtags: JSON.parse(localStorage.getItem('hashtags') || '[]')
+			recentHashtags: JSON.parse(localStorage.getItem('hashtags') || '[]'),
+			maxNoteTextLength: 1000
 		};
+	},
+
+	created() {
+		(this as any).os.getMeta().then(meta => {
+			this.maxNoteTextLength = meta.maxNoteTextLength;
+		});
 	},
 
 	computed: {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -4,7 +4,7 @@
 		<header>
 			<button class="cancel" @click="cancel">%fa:times%</button>
 			<div>
-				<span class="text-count" :class="{ over: trimmedLength(text) > 1000 }">{{ 1000 - trimmedLength(text) }}</span>
+				<span class="text-count" :class="{ over: trimmedLength(text) > this.maxNoteTextLength }">{{ this.maxNoteTextLength - trimmedLength(text) }}</span>
 				<span class="geo" v-if="geo">%fa:map-marker-alt%</span>
 				<button class="submit" :disabled="!canPost" @click="post">{{ submitText }}</button>
 			</div>
@@ -102,8 +102,15 @@ export default Vue.extend({
 			visibleUsers: [],
 			useCw: false,
 			cw: null,
-			recentHashtags: JSON.parse(localStorage.getItem('hashtags') || '[]')
+			recentHashtags: JSON.parse(localStorage.getItem('hashtags') || '[]'),
+			maxNoteTextLength: 1000
 		};
+	},
+
+	created() {
+		(this as any).os.getMeta().then(meta => {
+			this.maxNoteTextLength = meta.maxNoteTextLength;
+		});
 	},
 
 	computed: {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -151,7 +151,7 @@ export default Vue.extend({
 		canPost(): boolean {
 			return !this.posting &&
 				(1 <= this.text.length || 1 <= this.files.length || this.poll || this.renote) &&
-				(this.text.trim().length <= 1000);
+				(this.text.trim().length <= this.maxNoteTextLength);
 		}
 	},
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -49,6 +49,8 @@ export default function load() {
 	if (config.localDriveCapacityMb == null) config.localDriveCapacityMb = 256;
 	if (config.remoteDriveCapacityMb == null) config.remoteDriveCapacityMb = 8;
 
+	if (config.maxNoteTextLength == null) config.maxNoteTextLength = 1000;
+
 	if (config.name == null) config.name = 'Misskey';
 
 	return Object.assign(config, mixin);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -103,6 +103,8 @@ export type Source = {
 		engine: string;
 		timeout: number;
 	};
+
+	maxNoteTextLength?: number;
 };
 
 /**

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -14,6 +14,7 @@ import NoteReaction from './note-reaction';
 import Favorite, { deleteFavorite } from './favorite';
 import Notification, { deleteNotification } from './notification';
 import Following from './following';
+import config from '../config';
 
 const Note = db.get<INote>('notes');
 Note.createIndex('uri', { sparse: true, unique: true });
@@ -29,7 +30,7 @@ Note.createIndex({
 export default Note;
 
 export function isValidText(text: string): boolean {
-	return length(text.trim()) <= 1000 && text.trim() != '';
+	return length(text.trim()) <= config.maxNoteTextLength && text.trim() != '';
 }
 
 export function isValidCw(text: string): boolean {

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -49,6 +49,7 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 		swPublickey: config.sw ? config.sw.public_key : null,
 		hidedTags: (me && me.isAdmin) ? meta.hidedTags : undefined,
 		bannerUrl: meta.bannerUrl,
+		maxNoteTextLength: config.maxNoteTextLength,
 
 		features: {
 			registration: !meta.disableRegistration,


### PR DESCRIPTION
投稿本文の最大文字数をconfigから設定可能にしてます

インスタンスの設定値は、meta API から`maxNoteTextLength`で取得可能