### PR TITLE
Docker関連の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM alpine:edge AS base
+FROM alpine:3.8 AS base
 
 ENV NODE_ENV=production
 
-RUN apk add --no-cache nodejs nodejs-npm
-RUN apk add vips fftw --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+RUN apk add --no-cache nodejs nodejs-npm zlib
 WORKDIR /misskey
 COPY . ./
 
 FROM base AS builder
 
-RUN apk add --no-cache	gcc g++ python autoconf automake file make nasm
-RUN apk add vips-dev fftw-dev --update-cache --repository https://dl-3.alpinelinux.org/alpine/edge/testing/
+RUN apk add --no-cache \
+    gcc \
+    g++ \
+    libc-dev \
+    python \
+    autoconf \
+    automake \
+    file \
+    make \
+    nasm \
+    pkgconfig \
+    libtool \
+    zlib-dev
 RUN npm install \
     && npm install -g node-gyp \
     && node-gyp configure \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   mongo:
     restart: always
-    image: mongo:4.1-bionic
+    image: mongo:4.1
     networks:
       - internal_network
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: always
     links:
       - mongo
-      - redis
+#      - redis
 #      - es
     ports:
       - "127.0.0.1:3000:3000"
@@ -14,14 +14,14 @@ services:
       - internal_network
       - external_network
 
-  redis:
-    restart: always
-    image: redis:4.0-alpine
-    networks:
-      - internal_network
+#  redis:
+#    restart: always
+#    image: redis:4.0-alpine
+#    networks:
+#      - internal_network
 ### Uncomment to enable Redis persistance
-#    volumes:
-#      - ./redis:/data
+##    volumes:
+##      - ./redis:/data
 
   mongo:
     restart: always

--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -7,23 +7,29 @@ This guide describes how to install and setup Misskey with Docker.
 
 ----------------------------------------------------------------
 
-*1.* Make configuration files
+*1.* Download Misskey
+----------------------------------------------------------------
+1. `git clone -b master git://github.com/syuilo/misskey.git` Clone Misskey repository's master branch.
+2. `cd misskey` Move to misskey directory.
+3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
+
+*2.* Make configuration files
 ----------------------------------------------------------------
 1. `cp .config/example.yml .config/default.yml` Copy the `.config/example.yml` and rename it to `default.yml`.
 2. `cp .config/mongo_initdb_example.js .config/mongo_initdb.js` Copy the `.config/mongo_initdb_example.js` and rename it to `mongo_initdb.js`.
 2. Edit `default.yml` and `mongo_initdb.js`.
 
-*2.* Configure Docker
+*3.* Configure Docker
 ----------------------------------------------------------------
 Edit `docker-compose.yml`.
 
-*3.* Build Misskey
+*4.* Build Misskey
 ----------------------------------------------------------------
 Build misskey with the following:
 
 `docker-compose build`
 
-*4.* That is it.
+*5.* That is it.
 ----------------------------------------------------------------
 Well done! Now, you have an environment that run to Misskey.
 

--- a/docs/docker.ja.md
+++ b/docs/docker.ja.md
@@ -7,23 +7,29 @@ Dockerを使ったMisskey構築方法
 
 ----------------------------------------------------------------
 
-*1.* 設定ファイルを作成する
+*1.* Misskeyのダウンロード
+----------------------------------------------------------------
+1. `git clone -b master git://github.com/syuilo/misskey.git` masterブランチからMisskeyレポジトリをクローン
+2. `cd misskey` misskeyディレクトリに移動
+3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+
+*2.* 設定ファイルを作成する
 ----------------------------------------------------------------
 1. `cp .config/example.yml .config/default.yml` `.config/example.yml`をコピーし名前を`default.yml`にする
 2. `cp .config/mongo_initdb_example.js .config/mongo_initdb.js` `.config/mongo_initdb_example.js`をコピーし名前を`mongo_initdb.js`にする
 3. `default.yml`と`mongo_initdb.js`を編集する
 
-*2.* Dockerの設定
+*3.* Dockerの設定
 ----------------------------------------------------------------
 `docker-compose.yml`を編集してください。
 
-*3.* Misskeyのビルド
+*4.* Misskeyのビルド
 ----------------------------------------------------------------
 次のコマンドでMisskeyをビルドしてください:
 
 `docker-compose build`
 
-*4.* 以上です！
+*5.* 以上です！
 ----------------------------------------------------------------
 お疲れ様でした。これでMisskeyを動かす準備は整いました。
 


### PR DESCRIPTION
* なぜかMongoDBに接続できなかったのを修正(Alpine Linuxが不安定版だから発生？)
* ベースイメージにalpine:edgeの代わりにalpine:3.8を使うように変更(バージョン固定のため)
* MongoDBのイメージのタグ名を"4.1-bionic"から"4.1"に修正
* インストールするパッケージを変更
* docker-compose.ymlでもredisをオプションに変更
* ドキュメントに「Misskeyのダウンロード」という段落を追加