### PR TITLE
User blocking (Following part)

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1203,6 +1203,9 @@ desktop/views/pages/user/user.profile.vue:
   mute: "ミュートする"
   muted: "ミュートしています"
   unmute: "ミュート解除"
+  block: "ブロックする"
+  unblock: "ブロック解除"
+  block-confirm: "このユーザーをブロックしますか？"
   push-to-a-list: "リストに追加"
   list-pushed: "{user}を{list}に追加しました。"
 

--- a/src/client/app/desktop/views/pages/user/user.profile.vue
+++ b/src/client/app/desktop/views/pages/user/user.profile.vue
@@ -13,6 +13,10 @@
 			<span v-if="user.isMuted">%fa:eye% %i18n:@unmute%</span>
 			<span v-if="!user.isMuted">%fa:eye-slash% %i18n:@mute%</span>
 		</ui-button>
+		<ui-button @click="user.isBlocking ? unblock() : block()" v-if="$store.state.i.id != user.id">
+			<span v-if="user.isBlocking">%fa:user% %i18n:@unblock%</span>
+			<span v-if="!user.isBlocking">%fa:user-slash% %i18n:@block%</span>
+		</ui-button>
 		<ui-button @click="list">%fa:list% %i18n:@push-to-a-list%</ui-button>
 	</div>
 </div>
@@ -61,6 +65,27 @@ export default Vue.extend({
 				userId: this.user.id
 			}).then(() => {
 				this.user.isMuted = false;
+			}, () => {
+				alert('error');
+			});
+		},
+
+		block() {
+			if (!window.confirm('%i18n:@block-confirm%')) return;
+			(this as any).api('blocking/create', {
+				userId: this.user.id
+			}).then(() => {
+				this.user.isBlocking = true;
+			}, () => {
+				alert('error');
+			});
+		},
+
+		unblock() {
+			(this as any).api('blocking/delete', {
+				userId: this.user.id
+			}).then(() => {
+				this.user.isBlocking = false;
 			}, () => {
 				alert('error');
 			});

--- a/src/models/blocking.ts
+++ b/src/models/blocking.ts
@@ -1,0 +1,41 @@
+import * as mongo from 'mongodb';
+import db from '../db/mongodb';
+import isObjectId from '../misc/is-objectid';
+
+const Blocking = db.get<IBlocking>('blocking');
+Blocking.createIndex(['blockerId', 'blockeeId'], { unique: true });
+export default Blocking;
+
+export type IBlocking = {
+	_id: mongo.ObjectID;
+	createdAt: Date;
+	blockeeId: mongo.ObjectID;
+	blockerId: mongo.ObjectID;
+};
+
+/**
+ * Blockingを物理削除します
+ */
+export async function deleteBlocking(blocking: string | mongo.ObjectID | IBlocking) {
+	let f: IBlocking;
+
+	// Populate
+	if (isObjectId(blocking)) {
+		f = await Blocking.findOne({
+			_id: blocking
+		});
+	} else if (typeof blocking === 'string') {
+		f = await Blocking.findOne({
+			_id: new mongo.ObjectID(blocking)
+		});
+	} else {
+		f = blocking as IBlocking;
+	}
+
+	if (f == null) return;
+
+	// このBlockingを削除
+	await Blocking.remove({
+		_id: f._id
+	});
+}

--- a/src/remote/activitypub/kernel/block/index.ts
+++ b/src/remote/activitypub/kernel/block/index.ts
@@ -1,0 +1,34 @@
+import * as mongo from 'mongodb';
+import User, { IRemoteUser } from '../../../../models/user';
+import config from '../../../../config';
+import * as debug from 'debug';
+import { IBlock } from '../../type';
+import block from '../../../../services/blocking/create';
+
+const log = debug('misskey:activitypub');
+
+export default async (actor: IRemoteUser, activity: IBlock): Promise<void> => {
+	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+
+	const uri = activity.id || activity;
+
+	log(`Block: ${uri}`);
+
+	if (!id.startsWith(config.url + '/')) {
+		return null;
+	}
+
+	const blockee = await User.findOne({
+		_id: new mongo.ObjectID(id.split('/').pop())
+	});
+
+	if (blockee === null) {
+		throw new Error('blockee not found');
+	}
+
+	if (blockee.host != null) {
+		throw new Error('ブロックしようとしているユーザーはローカルユーザーではありません');
+	}
+
+	block(actor, blockee);
+};

--- a/src/remote/activitypub/kernel/index.ts
+++ b/src/remote/activitypub/kernel/index.ts
@@ -10,6 +10,7 @@ import accept from './accept';
 import reject from './reject';
 import add from './add';
 import remove from './remove';
+import block from './block';
 
 const self = async (actor: IRemoteUser, activity: Object): Promise<void> => {
 	switch (activity.type) {
@@ -51,6 +52,10 @@ const self = async (actor: IRemoteUser, activity: Object): Promise<void> => {
 
 	case 'Undo':
 		await undo(actor, activity);
+		break;
+
+	case 'Block':
+		await block(actor, activity);
 		break;
 
 	case 'Collection':

--- a/src/remote/activitypub/kernel/undo/block.ts
+++ b/src/remote/activitypub/kernel/undo/block.ts
@@ -1,0 +1,34 @@
+import * as mongo from 'mongodb';
+import User, { IRemoteUser } from '../../../../models/user';
+import config from '../../../../config';
+import * as debug from 'debug';
+import { IBlock } from '../../type';
+import unBlock from '../../../../services/blocking/delete';
+
+const log = debug('misskey:activitypub');
+
+export default async (actor: IRemoteUser, activity: IBlock): Promise<void> => {
+	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
+
+	const uri = activity.id || activity;
+
+	log(`UnBlock: ${uri}`);
+
+	if (!id.startsWith(config.url + '/')) {
+		return null;
+	}
+
+	const blockee = await User.findOne({
+		_id: new mongo.ObjectID(id.split('/').pop())
+	});
+
+	if (blockee === null) {
+		throw new Error('blockee not found');
+	}
+
+	if (blockee.host != null) {
+		throw new Error('ブロック解除しようとしているユーザーはローカルユーザーではありません');
+	}
+
+	unBlock(actor, blockee);
+};

--- a/src/remote/activitypub/kernel/undo/block.ts
+++ b/src/remote/activitypub/kernel/undo/block.ts
@@ -3,7 +3,7 @@ import User, { IRemoteUser } from '../../../../models/user';
 import config from '../../../../config';
 import * as debug from 'debug';
 import { IBlock } from '../../type';
-import unBlock from '../../../../services/blocking/delete';
+import unblock from '../../../../services/blocking/delete';
 
 const log = debug('misskey:activitypub');
 
@@ -30,5 +30,5 @@ export default async (actor: IRemoteUser, activity: IBlock): Promise<void> => {
 		throw new Error('ブロック解除しようとしているユーザーはローカルユーザーではありません');
 	}
 
-	unBlock(actor, blockee);
+	unblock(actor, blockee);
 };

--- a/src/remote/activitypub/kernel/undo/index.ts
+++ b/src/remote/activitypub/kernel/undo/index.ts
@@ -1,8 +1,9 @@
 import * as debug from 'debug';
 
 import { IRemoteUser } from '../../../../models/user';
-import { IUndo, IFollow } from '../../type';
+import { IUndo, IFollow, IBlock } from '../../type';
 import unfollow from './follow';
+import unblock from './block';
 import Resolver from '../../resolver';
 
 const log = debug('misskey:activitypub');
@@ -30,6 +31,9 @@ export default async (actor: IRemoteUser, activity: IUndo): Promise<void> => {
 	switch (object.type) {
 		case 'Follow':
 			unfollow(actor, object as IFollow);
+			break;
+		case 'Block':
+			unblock(actor, object as IBlock);
 			break;
 	}
 

--- a/src/remote/activitypub/renderer/block.ts
+++ b/src/remote/activitypub/renderer/block.ts
@@ -1,0 +1,8 @@
+import config from '../../../config';
+import { ILocalUser, IRemoteUser } from "../../../models/user";
+
+export default (blocker?: ILocalUser, blockee?: IRemoteUser) => ({
+	type: 'Block',
+	actor: `${config.url}/users/${blocker._id}`,
+	object: blockee.uri
+});

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -108,6 +108,10 @@ export interface IAnnounce extends IActivity {
 	type: 'Announce';
 }
 
+export interface IBlock extends IActivity {
+	type: 'Block';
+}
+
 export type Object =
 	ICollection |
 	IOrderedCollection |
@@ -120,4 +124,5 @@ export type Object =
 	IAdd |
 	IRemove |
 	ILike |
-	IAnnounce;
+	IAnnounce |
+	IBlock;

--- a/src/server/api/endpoints/blocking/create.ts
+++ b/src/server/api/endpoints/blocking/create.ts
@@ -1,0 +1,75 @@
+import $ from 'cafy'; import ID from '../../../../misc/cafy-id';
+const ms = require('ms');
+import User, { pack, ILocalUser } from '../../../../models/user';
+import Blocking from '../../../../models/blocking';
+import create from '../../../../services/blocking/create';
+import getParams from '../../get-params';
+
+export const meta = {
+	stability: 'stable',
+
+	desc: {
+		'ja-JP': '指定したユーザーをブロックします。',
+		'en-US': 'Block a user.'
+	},
+
+	limit: {
+		duration: ms('1hour'),
+		max: 100
+	},
+
+	requireCredential: true,
+
+	kind: 'following-write',
+
+	params: {
+		userId: $.type(ID).note({
+			desc: {
+				'ja-JP': '対象のユーザーのID',
+				'en-US': 'Target user ID'
+			}
+		})
+	}
+};
+
+export default (params: any, user: ILocalUser) => new Promise(async (res, rej) => {
+	const [ps, psErr] = getParams(meta, params);
+	if (psErr) return rej(psErr);
+
+	const blocker = user;
+
+	// 自分自身
+	if (user._id.equals(ps.userId)) {
+		return rej('blockee is yourself');
+	}
+
+	// Get blockee
+	const blockee = await User.findOne({
+		_id: ps.userId
+	}, {
+		fields: {
+			data: false,
+			profile: false
+		}
+	});
+
+	if (blockee === null) {
+		return rej('user not found');
+	}
+
+	// Check if already blocking
+	const exist = await Blocking.findOne({
+		blockerId: blocker._id,
+		blockeeId: blockee._id
+	});
+
+	if (exist !== null) {
+		return rej('already blocking');
+	}
+
+	// Create blocking
+	await create(blocker, blockee);
+
+	// Send response
+	res(await pack(blockee._id, user));
+});

--- a/src/server/api/endpoints/blocking/delete.ts
+++ b/src/server/api/endpoints/blocking/delete.ts
@@ -1,0 +1,75 @@
+import $ from 'cafy'; import ID from '../../../../misc/cafy-id';
+const ms = require('ms');
+import User, { pack, ILocalUser } from '../../../../models/user';
+import Following from '../../../../models/following';
+import deleteFollowing from '../../../../services/following/delete';
+import getParams from '../../get-params';
+
+export const meta = {
+	stability: 'stable',
+
+	desc: {
+		'ja-JP': '指定したユーザーのフォローを解除します。',
+		'en-US': 'Unfollow a user.'
+	},
+
+	limit: {
+		duration: ms('1hour'),
+		max: 100
+	},
+
+	requireCredential: true,
+
+	kind: 'following-write',
+
+	params: {
+		userId: $.type(ID).note({
+			desc: {
+				'ja-JP': '対象のユーザーのID',
+				'en-US': 'Target user ID'
+			}
+		})
+	}
+};
+
+export default (params: any, user: ILocalUser) => new Promise(async (res, rej) => {
+	const [ps, psErr] = getParams(meta, params);
+	if (psErr) return rej(psErr);
+
+	const follower = user;
+
+	// Check if the followee is yourself
+	if (user._id.equals(ps.userId)) {
+		return rej('followee is yourself');
+	}
+
+	// Get followee
+	const followee = await User.findOne({
+		_id: ps.userId
+	}, {
+		fields: {
+			data: false,
+			'profile': false
+		}
+	});
+
+	if (followee === null) {
+		return rej('user not found');
+	}
+
+	// Check not following
+	const exist = await Following.findOne({
+		followerId: follower._id,
+		followeeId: followee._id
+	});
+
+	if (exist === null) {
+		return rej('already not following');
+	}
+
+	// Delete following
+	await deleteFollowing(follower, followee);
+
+	// Send response
+	res(await pack(followee._id, user));
+});

--- a/src/server/api/endpoints/blocking/delete.ts
+++ b/src/server/api/endpoints/blocking/delete.ts
@@ -1,16 +1,16 @@
 import $ from 'cafy'; import ID from '../../../../misc/cafy-id';
 const ms = require('ms');
 import User, { pack, ILocalUser } from '../../../../models/user';
-import Following from '../../../../models/following';
-import deleteFollowing from '../../../../services/following/delete';
+import Blocking from '../../../../models/blocking';
+import deleteBlocking from '../../../../services/blocking/delete';
 import getParams from '../../get-params';
 
 export const meta = {
 	stability: 'stable',
 
 	desc: {
-		'ja-JP': '指定したユーザーのフォローを解除します。',
-		'en-US': 'Unfollow a user.'
+		'ja-JP': '指定したユーザーのブロックを解除します。',
+		'en-US': 'Unblock a user.'
 	},
 
 	limit: {
@@ -36,15 +36,15 @@ export default (params: any, user: ILocalUser) => new Promise(async (res, rej) =
 	const [ps, psErr] = getParams(meta, params);
 	if (psErr) return rej(psErr);
 
-	const follower = user;
+	const blocker = user;
 
-	// Check if the followee is yourself
+	// Check if the blockee is yourself
 	if (user._id.equals(ps.userId)) {
-		return rej('followee is yourself');
+		return rej('blockee is yourself');
 	}
 
-	// Get followee
-	const followee = await User.findOne({
+	// Get blockee
+	const blockee = await User.findOne({
 		_id: ps.userId
 	}, {
 		fields: {
@@ -53,23 +53,23 @@ export default (params: any, user: ILocalUser) => new Promise(async (res, rej) =
 		}
 	});
 
-	if (followee === null) {
+	if (blockee === null) {
 		return rej('user not found');
 	}
 
-	// Check not following
-	const exist = await Following.findOne({
-		followerId: follower._id,
-		followeeId: followee._id
+	// Check not blocking
+	const exist = await Blocking.findOne({
+		blockerId: blocker._id,
+		blockeeId: blockee._id
 	});
 
 	if (exist === null) {
-		return rej('already not following');
+		return rej('already not blocking');
 	}
 
-	// Delete following
-	await deleteFollowing(follower, followee);
+	// Delete blocking
+	await deleteBlocking(blocker, blockee);
 
 	// Send response
-	res(await pack(followee._id, user));
+	res(await pack(blockee._id, user));
 });

--- a/src/server/api/endpoints/following/create.ts
+++ b/src/server/api/endpoints/following/create.ts
@@ -68,7 +68,11 @@ export default (params: any, user: ILocalUser) => new Promise(async (res, rej) =
 	}
 
 	// Create following
-	await create(follower, followee);
+	try {
+		await create(follower, followee);
+	} catch (e) {
+		return rej(e && e.message ? e.message : e);
+	}
 
 	// Send response
 	res(await pack(followee._id, user));

--- a/src/services/blocking/create.ts
+++ b/src/services/blocking/create.ts
@@ -1,0 +1,121 @@
+import User, { isLocalUser, isRemoteUser, pack as packUser, IUser } from '../../models/user';
+import Following from '../../models/following';
+import FollowRequest from '../../models/follow-request';
+import { publishMainStream } from '../../stream';
+import pack from '../../remote/activitypub/renderer';
+import renderFollow from '../../remote/activitypub/renderer/follow';
+import renderUndo from '../../remote/activitypub/renderer/undo';
+import renderBlock from '../../remote/activitypub/renderer/block';
+import { deliver } from '../../queue';
+import renderReject from '../../remote/activitypub/renderer/reject';
+import perUserFollowingChart from '../../chart/per-user-following';
+import Blocking from '../../models/blocking';
+
+export default async function(blocker: IUser, blockee: IUser) {
+
+	await Promise.all([
+		cancelRequest(blocker, blockee),
+		cancelRequest(blockee, blocker),
+		unFollow(blocker, blockee),
+		unFollow(blockee, blocker)
+	]);
+
+	await Blocking.insert({
+		createdAt: new Date(),
+		blockerId: blocker._id,
+		blockeeId: blockee._id,
+	});
+
+	if (isLocalUser(blocker) && isRemoteUser(blockee)) {
+		const content = pack(renderBlock(blocker, blockee));
+		deliver(blocker, content, blockee.inbox);
+	}
+}
+
+async function cancelRequest(follower: IUser, followee: IUser) {
+	const request = await FollowRequest.findOne({
+		followeeId: followee._id,
+		followerId: follower._id
+	});
+
+	if (request == null) {
+		return;
+	}
+
+	await FollowRequest.remove({
+		followeeId: followee._id,
+		followerId: follower._id
+	});
+
+	await User.update({ _id: followee._id }, {
+		$inc: {
+			pendingReceivedFollowRequestsCount: -1
+		}
+	});
+
+	if (isLocalUser(followee)) {
+		packUser(followee, followee, {
+			detail: true
+		}).then(packed => publishMainStream(followee._id, 'meUpdated', packed));
+	}
+
+	if (isLocalUser(follower)) {
+		packUser(followee, follower).then(packed => publishMainStream(follower._id, 'unfollow', packed));
+	}
+
+	// リモートにフォローリクエストをしていたらUndoFollow送信
+	if (isLocalUser(follower) && isRemoteUser(followee)) {
+		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		deliver(follower, content, followee.inbox);
+	}
+
+	// リモートからフォローリクエストを受けていたらReject送信
+	if (isRemoteUser(follower) && isLocalUser(followee)) {
+		const content = pack(renderReject(renderFollow(follower, followee, request.requestId), followee));
+		deliver(followee, content, follower.inbox);
+	}
+}
+
+async function unFollow(follower: IUser, followee: IUser) {
+	const following = await Following.findOne({
+		followerId: follower._id,
+		followeeId: followee._id
+	});
+
+	if (following == null) {
+		return;
+	}
+
+	Following.remove({
+		_id: following._id
+	});
+
+	//#region Decrement following count
+	User.update({ _id: follower._id }, {
+		$inc: {
+			followingCount: -1
+		}
+	});
+	//#endregion
+
+	//#region Decrement followers count
+	User.update({ _id: followee._id }, {
+		$inc: {
+			followersCount: -1
+		}
+	});
+	//#endregion
+
+	perUserFollowingChart.update(follower, followee, false);
+
+	// Publish unfollow event
+	if (isLocalUser(follower)) {
+		packUser(followee, follower).then(packed => publishMainStream(follower._id, 'unfollow', packed));
+	}
+
+	// リモートにフォローをしていたらUndoFollow送信
+	if (isLocalUser(follower) && isRemoteUser(followee)) {
+		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		deliver(follower, content, followee.inbox);
+	}
+}

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -24,14 +24,13 @@ export default async function(follower: IUser, followee: IUser, requestId?: stri
 		})
 	]);
 
-	// ブロック判定処理
 	if (isRemoteUser(follower) && isLocalUser(followee) && blocked) {
-		// リモートフォローを受けて(remote => local)ブロックしていた場合は、エラーにするのではなくRejectを送り返しておしまい。
+		// リモートフォローを受けてブロックしていた場合は、エラーにするのではなくRejectを送り返しておしまい。
 		const content = pack(renderReject(renderFollow(follower, followee, requestId), followee));
 		deliver(followee , content, follower.inbox);
 		return;
 	} else if (isRemoteUser(follower) && isLocalUser(followee) && blocking) {
-		// リモートフォローを受けて(remote => local)ブロックされているはずの場合だったら、ブロック解除しておく。
+		// リモートフォローを受けてブロックされているはずの場合だったら、ブロック解除しておく。
 		await Blocking.remove({
 			_id: blocking._id
 		});

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -1,15 +1,46 @@
 import User, { isLocalUser, isRemoteUser, pack as packUser, IUser } from '../../models/user';
 import Following from '../../models/following';
+import Blocking from '../../models/blocking';
 import { publishMainStream } from '../../stream';
 import notify from '../../notify';
 import pack from '../../remote/activitypub/renderer';
 import renderFollow from '../../remote/activitypub/renderer/follow';
 import renderAccept from '../../remote/activitypub/renderer/accept';
+import renderReject from '../../remote/activitypub/renderer/reject';
 import { deliver } from '../../queue';
 import createFollowRequest from './requests/create';
 import perUserFollowingChart from '../../chart/per-user-following';
 
 export default async function(follower: IUser, followee: IUser, requestId?: string) {
+	// check blocking
+	const [ blocking, blocked ] = await Promise.all([
+		await Blocking.findOne({
+			blockerId: follower._id,
+			blockeeId: followee._id,
+		}),
+		await Blocking.findOne({
+			blockerId: followee._id,
+			blockeeId: follower._id,
+		})
+	]);
+
+	// ブロック判定処理
+	if (isRemoteUser(follower) && isLocalUser(followee) && blocked) {
+		// リモートフォローを受けて(remote => local)ブロックしていた場合は、エラーにするのではなくRejectを送り返しておしまい。
+		const content = pack(renderReject(renderFollow(follower, followee, requestId), followee));
+		deliver(followee , content, follower.inbox);
+		return;
+	} else if (isRemoteUser(follower) && isLocalUser(followee) && blocking) {
+		// リモートフォローを受けて(remote => local)ブロックされているはずの場合だったら、ブロック解除しておく。
+		await Blocking.remove({
+			_id: blocking._id
+		});
+	} else {
+		// それ以外は単純に例外
+		if (blocking != null) throw new Error('blocking');
+		if (blocked != null) throw new Error('blocked');
+	}
+
 	// フォロー対象が鍵アカウントである or
 	// フォロワーがBotであり、フォロー対象がBotからのフォローに慎重である or
 	// フォロワーがローカルユーザーであり、フォロー対象がリモートユーザーである

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -14,11 +14,11 @@ import perUserFollowingChart from '../../chart/per-user-following';
 export default async function(follower: IUser, followee: IUser, requestId?: string) {
 	// check blocking
 	const [ blocking, blocked ] = await Promise.all([
-		await Blocking.findOne({
+		Blocking.findOne({
 			blockerId: follower._id,
 			blockeeId: followee._id,
 		}),
-		await Blocking.findOne({
+		Blocking.findOne({
 			blockerId: followee._id,
 			blockeeId: follower._id,
 		})

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -10,11 +10,11 @@ import Blocking from '../../../models/blocking';
 export default async function(follower: IUser, followee: IUser, requestId?: string) {
 	// check blocking
 	const [ blocking, blocked ] = await Promise.all([
-		await Blocking.findOne({
+		Blocking.findOne({
 			blockerId: follower._id,
 			blockeeId: followee._id,
 		}),
-		await Blocking.findOne({
+		Blocking.findOne({
 			blockerId: followee._id,
 			blockeeId: follower._id,
 		})

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -5,8 +5,23 @@ import pack from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import { deliver } from '../../../queue';
 import FollowRequest from '../../../models/follow-request';
+import Blocking from '../../../models/blocking';
 
 export default async function(follower: IUser, followee: IUser, requestId?: string) {
+	const [ blocking, blocked ] = await Promise.all([
+		await Blocking.findOne({
+			blockerId: follower._id,
+			blockeeId: followee._id,
+		}),
+		await Blocking.findOne({
+			blockerId: followee._id,
+			blockeeId: follower._id,
+		})
+	]);
+
+	if (blocking != null) throw new Error('blocking');
+	if (blocked != null) throw new Error('blocked');
+
 	await FollowRequest.insert({
 		createdAt: new Date(),
 		followerId: follower._id,

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -8,6 +8,7 @@ import FollowRequest from '../../../models/follow-request';
 import Blocking from '../../../models/blocking';
 
 export default async function(follower: IUser, followee: IUser, requestId?: string) {
+	// check blocking
 	const [ blocking, blocked ] = await Promise.all([
 		await Blocking.findOne({
 			blockerId: follower._id,


### PR DESCRIPTION
ブロック機能のフォロー制御部分のみ実装しています

API/UI(Desktop)からのBlock/Block解除(Remote送信も含む)
APから受けたBlock/UndoBlockの処理

Block処理は以下のようなFollow系処理のみ実装済み
- お互いのFollow/FollowRequestの解除
- Blockされている人をFollowできなくする
- Remoteも対応

以下のようなものは未実装です
- 投稿を見えなくする
- リアクション等をできなくする