### PR TITLE
Fix: can't recognize rebirthed instance user

### DIFF
--- a/src/client/app/desktop/views/pages/user/user.vue
+++ b/src/client/app/desktop/views/pages/user/user.vue
@@ -62,10 +62,9 @@ export default Vue.extend({
 	},
 	methods: {
 		fetch() {
-			const params = Object.assign({ resync: true }, parseAcct(this.$route.params.user));
 			this.fetching = true;
 			Progress.start();
-			(this as any).api('users/show', params).then(user => {
+			(this as any).api('users/show', parseAcct(this.$route.params.user)).then(user => {
 				this.user = user;
 				this.fetching = false;
 				Progress.done();

--- a/src/client/app/desktop/views/pages/user/user.vue
+++ b/src/client/app/desktop/views/pages/user/user.vue
@@ -62,9 +62,10 @@ export default Vue.extend({
 	},
 	methods: {
 		fetch() {
+			const params = Object.assign({ resync: true }, parseAcct(this.$route.params.user));
 			this.fetching = true;
 			Progress.start();
-			(this as any).api('users/show', parseAcct(this.$route.params.user)).then(user => {
+			(this as any).api('users/show', params).then(user => {
 				this.user = user;
 				this.fetching = false;
 				Progress.done();

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -1,13 +1,18 @@
 import { toUnicode, toASCII } from 'punycode';
-import User, { IUser } from '../models/user';
+import User, { IUser, IRemoteUser } from '../models/user';
 import webFinger from './webfinger';
 import config from '../config';
-import { createPerson } from './activitypub/models/person';
+import { createPerson, updatePerson } from './activitypub/models/person';
+import { URL } from 'url';
+import * as debug from 'debug';
 
-export default async (username: string, _host: string, option?: any): Promise<IUser> => {
+const log = debug('misskey:remote:resolve-user');
+
+export default async (username: string, _host: string, option?: any, resync?: boolean): Promise<IUser> => {
 	const usernameLower = username.toLowerCase();
 
 	if (_host == null) {
+		log(`return local user: ${usernameLower}`);
 		return await User.findOne({ usernameLower, host: null });
 	}
 
@@ -15,22 +20,64 @@ export default async (username: string, _host: string, option?: any): Promise<IU
 	const host = toUnicode(hostAscii);
 
 	if (config.host == host) {
+		log(`return local user: ${usernameLower}`);
 		return await User.findOne({ usernameLower, host: null });
 	}
 
-	let user = await User.findOne({ usernameLower, host }, option);
+	const user = await User.findOne({ usernameLower, host }, option);
+
+	const acctLower = `${usernameLower}@${hostAscii}`;
 
 	if (user === null) {
-		const acctLower = `${usernameLower}@${hostAscii}`;
+		const self = await resolveSelf(acctLower);
 
-		const finger = await webFinger(acctLower);
-		const self = finger.links.find(link => link.rel && link.rel.toLowerCase() === 'self');
-		if (!self) {
-			throw new Error('self link not found');
-		}
-
-		user = await createPerson(self.href);
+		log(`return new remote user: ${acctLower}`);
+		return await createPerson(self.href);
 	}
 
+	if (resync) {
+		log(`try resync: ${acctLower}`);
+		const self = await resolveSelf(acctLower);
+
+		if ((user as IRemoteUser).uri !== self.href) {
+			// if uri mismatch, Fix (user@host <=> AP's Person id(IRemoteUser.uri)) mapping.
+			log(`uri missmatch: ${acctLower}`);
+			console.log(`recovery missmatch uri for (username=${username}, host=${host}) from ${(user as IRemoteUser).uri} to ${self.href}`);
+
+			// validate uri
+			const uri = new URL(self.href);
+			if (uri.hostname !== hostAscii) {
+				throw new Error(`Invalied uri`);
+			}
+
+			await User.update({
+				usernameLower,
+				host: host
+			 }, {
+				$set: {
+					uri: self.href
+				}
+			});
+
+			await updatePerson(self.href);
+
+			log(`return resynced remote user: ${acctLower}`);
+			return await User.findOne({ uri: self.href });
+		} else {
+			log(`uri is fine: ${acctLower}`);
+		}
+	}
+
+	log(`return existing remote user: ${acctLower}`);
 	return user;
 };
+
+async function resolveSelf(acctLower: string) {
+	log(`WebFinger for ${acctLower}`);
+	const finger = await webFinger(acctLower);
+	const self = finger.links.find(link => link.rel && link.rel.toLowerCase() === 'self');
+	if (!self) {
+		throw new Error('self link not found');
+	}
+	return self;
+}

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -58,15 +58,15 @@ export default async (username: string, _host: string, option?: any, resync?: bo
 					uri: self.href
 				}
 			});
-
-			await updatePerson(self.href);
-
-			log(`return resynced remote user: ${acctLower}`);
-			return await User.findOne({ uri: self.href });
 		} else {
 			log(`uri is fine: ${acctLower}`);
 		}
-	}
+
+		await updatePerson(self.href);
+
+		log(`return resynced remote user: ${acctLower}`);
+		return await User.findOne({ uri: self.href });
+}
 
 	log(`return existing remote user: ${acctLower}`);
 	return user;

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -26,6 +26,10 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 	const [host, hostErr] = $.str.optional.nullable.get(params.host);
 	if (hostErr) return rej('invalid host param');
 
+	// Get 'resync' parameter
+	const [resync = false, resyncErr] = $.bool.optional.get(params.resync);
+	if (resyncErr) return rej('invalid resync param');
+
 	if (userIds) {
 		const users = await User.find({
 			_id: {
@@ -40,7 +44,7 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 		// Lookup user
 		if (typeof host === 'string') {
 			try {
-				user = await resolveRemoteUser(username, host, cursorOption);
+				user = await resolveRemoteUser(username, host, cursorOption, resync);
 			} catch (e) {
 				console.warn(`failed to resolve remote user: ${e}`);
 				return rej('failed to resolve remote user');

--- a/src/tools/resync-remote-user.ts
+++ b/src/tools/resync-remote-user.ts
@@ -1,0 +1,32 @@
+import parseAcct from "../misc/acct/parse";
+import resolveUser from '../remote/resolve-user';
+import * as debug from 'debug';
+
+debug.enable('*');
+
+async function main(acct: string): Promise<any> {
+	const { username, host } = parseAcct(acct);
+	await resolveUser(username, host, {}, true);
+}
+
+// get args
+const args = process.argv.slice(2);
+let acct = args[0];
+
+// normalize args
+acct = acct.replace(/^@/, '');
+
+// check args
+if (!acct.match(/^\w+@\w/)) {
+	throw `Invalied acct format. Valied format are user@host`;
+}
+
+console.log(`resync ${acct}`);
+
+main(acct).then(() => {
+	console.log('success');
+	process.exit(0);
+}).catch(e => {
+	console.warn(e);
+	process.exit(1);
+});


### PR DESCRIPTION
Resolve #3022

## 事象の原因
まずリモートユーザーを特定するためのキーとしては主に以下の2つがあります。
1. user@example.com
2. ActivityPubのPerson object の URI (https://example.com/users/12345678)

1はインスタンスが飛んでも不変ですが、
2についてはMisskeyにおいてはインスタンスが転生した後は新しいIDが生成されます

Misskeyは連携に於いて2のIDを使用しているため、
インスタンス転生後は過去に存在した同名のユーザーは認識できなくなってしまいます。
(転生後インスタンスの該当URIをつっついても404でなにも(UpdateもRemoveもFollowも)できない)。

## 対応
これを解決するために、WebFinger参照により1と2の整合性を検証して
必要な場合に2のIDを更新する処理を追加しています。
(resolve-user.tsに`resync`オプションを追加して、指定されている場合はWebFingerからの更新～updatePersonを行う処理を追加)

上記の修復処理が実行されるトリガは、
管理者がツールで以下を実行した場合と
`node built/tools/resync-remote-user.js user@example.com`

API`users/show`が実行された後に、情報が古い場合にバックグラウンドで自動実行
の2種類になります。