### PR TITLE
 Remote custom emojis 

### DIFF
--- a/src/client/app/common/views/components/misskey-flavored-markdown.ts
+++ b/src/client/app/common/views/components/misskey-flavored-markdown.ts
@@ -24,6 +24,9 @@ export default Vue.component('misskey-flavored-markdown', {
 		i: {
 			type: Object,
 			default: null
+		},
+		customEmojis: {
+			required: false,
 		}
 	},
 
@@ -186,17 +189,18 @@ export default Vue.component('misskey-flavored-markdown', {
 
 				case 'emoji': {
 					//#region カスタム絵文字
-					const customEmojis = (this.os.getMetaSync() || { emojis: [] }).emojis || [];
-					const customEmoji = customEmojis.find(e => e.name == token.emoji || (e.aliases || []).includes(token.emoji));
-					if (customEmoji) {
-						return [createElement('img', {
-							attrs: {
-								src: customEmoji.url,
-								alt: token.emoji,
-								title: token.emoji,
-								style: 'height: 2.5em; vertical-align: middle;'
-							}
-						})];
+					if (this.customEmojis != null) {
+						const customEmoji = this.customEmojis.find(e => e.name == token.emoji || (e.aliases || []).includes(token.emoji));
+						if (customEmoji) {
+							return [createElement('img', {
+								attrs: {
+									src: customEmoji.url,
+									alt: token.emoji,
+									title: token.emoji,
+									style: 'height: 2.5em; vertical-align: middle;'
+								}
+							})];
+						}
 					}
 					//#endregion
 

--- a/src/client/app/common/views/components/welcome-timeline.vue
+++ b/src/client/app/common/views/components/welcome-timeline.vue
@@ -14,7 +14,7 @@
 					</div>
 				</header>
 				<div class="text">
-					<misskey-flavored-markdown v-if="note.text" :text="note.text"/>
+					<misskey-flavored-markdown v-if="note.text" :text="note.text" :customEmojis="p.emojis"/>
 				</div>
 			</div>
 		</div>

--- a/src/client/app/desktop/views/components/note-detail.vue
+++ b/src/client/app/desktop/views/components/note-detail.vue
@@ -45,7 +45,7 @@
 				<div class="text">
 					<span v-if="p.isHidden" style="opacity: 0.5">%i18n:@private%</span>
 					<span v-if="p.deletedAt" style="opacity: 0.5">%i18n:@deleted%</span>
-					<misskey-flavored-markdown v-if="p.text" :text="p.text" :i="$store.state.i"/>
+					<misskey-flavored-markdown v-if="p.text" :text="p.text" :i="$store.state.i" :customEmojis="p.emojis" />
 				</div>
 				<div class="files" v-if="p.files.length > 0">
 					<mk-media-list :media-list="p.files" :raw="true"/>

--- a/src/client/app/desktop/views/components/note.vue
+++ b/src/client/app/desktop/views/components/note.vue
@@ -34,7 +34,7 @@
 					<div class="text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">%i18n:@private%</span>
 						<a class="reply" v-if="appearNote.reply">%fa:reply%</a>
-						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text"/>
+						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text" :customEmojis="appearNote.emojis"/>
 						<a class="rp" v-if="appearNote.renote">RN:</a>
 					</div>
 					<div class="files" v-if="appearNote.files.length > 0">

--- a/src/client/app/desktop/views/components/sub-note-content.vue
+++ b/src/client/app/desktop/views/components/sub-note-content.vue
@@ -4,7 +4,7 @@
 		<span v-if="note.isHidden" style="opacity: 0.5">%i18n:@private%</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">%i18n:@deleted%</span>
 		<a class="reply" v-if="note.replyId">%fa:reply%</a>
-		<misskey-flavored-markdown v-if="note.text" :text="note.text" :i="$store.state.i"/>
+		<misskey-flavored-markdown v-if="note.text" :text="note.text" :i="$store.state.i" :customEmojis="note.emojis"/>
 		<a class="rp" v-if="note.renoteId" :href="`/notes/${note.renoteId}`">RN: ...</a>
 	</div>
 	<details v-if="note.files.length > 0">

--- a/src/client/app/mobile/views/components/note-detail.vue
+++ b/src/client/app/mobile/views/components/note-detail.vue
@@ -43,7 +43,7 @@
 				<div class="text">
 					<span v-if="p.isHidden" style="opacity: 0.5">(%i18n:@private%)</span>
 					<span v-if="p.deletedAt" style="opacity: 0.5">(%i18n:@deleted%)</span>
-					<misskey-flavored-markdown v-if="p.text" :text="p.text" :i="$store.state.i"/>
+					<misskey-flavored-markdown v-if="p.text" :text="p.text" :i="$store.state.i" :customEmojis="p.emojis"/>
 				</div>
 				<div class="files" v-if="p.files.length > 0">
 					<mk-media-list :media-list="p.files" :raw="true"/>

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -30,7 +30,7 @@
 					<div class="text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">(%i18n:@private%)</span>
 						<a class="reply" v-if="appearNote.reply">%fa:reply%</a>
-						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text" :customEmojis="p.emojis"/>
+						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text" :customEmojis="appearNote.emojis"/>
 						<a class="rp" v-if="appearNote.renote != null">RN:</a>
 					</div>
 					<div class="files" v-if="appearNote.files.length > 0">

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -30,7 +30,7 @@
 					<div class="text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">(%i18n:@private%)</span>
 						<a class="reply" v-if="appearNote.reply">%fa:reply%</a>
-						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text"/>
+						<misskey-flavored-markdown v-if="appearNote.text" :text="appearNote.text" :i="$store.state.i" :class="$style.text" :customEmojis="p.emojis"/>
 						<a class="rp" v-if="appearNote.renote != null">RN:</a>
 					</div>
 					<div class="files" v-if="appearNote.files.length > 0">

--- a/src/client/app/mobile/views/components/sub-note-content.vue
+++ b/src/client/app/mobile/views/components/sub-note-content.vue
@@ -4,7 +4,7 @@
 		<span v-if="note.isHidden" style="opacity: 0.5">(%i18n:@private%)</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">(%i18n:@deleted%)</span>
 		<a class="reply" v-if="note.replyId">%fa:reply%</a>
-		<misskey-flavored-markdown v-if="note.text" :text="note.text" :i="$store.state.i"/>
+		<misskey-flavored-markdown v-if="note.text" :text="note.text" :i="$store.state.i" :customEmojis="note.emojis"/>
 		<a class="rp" v-if="note.renoteId">RN: ...</a>
 	</div>
 	<details v-if="note.files.length > 0">

--- a/src/models/emoji.ts
+++ b/src/models/emoji.ts
@@ -1,0 +1,22 @@
+import db from '../db/mongodb';
+
+const Emoji = db.get<IEmoji>('emoji');
+
+Emoji.createIndex(['name', 'host'], { unique: true });
+
+export default Emoji;
+
+export type IEmoji = {
+	name: string;
+	host: string;
+	url: string;
+	aliases?: string[];
+	updatedAt?: Date;
+};
+
+export const packEmojis = async (
+	host: string,
+	// MeiTODO: filter
+) => {
+	return await Emoji.find({ host });
+};

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -12,6 +12,7 @@ import { packMany as packFileMany, IDriveFile } from './drive-file';
 import Favorite from './favorite';
 import Following from './following';
 import config from '../config';
+import { packEmojis } from './emoji';
 
 const Note = db.get<INote>('notes');
 Note.createIndex('uri', { sparse: true, unique: true });
@@ -227,6 +228,11 @@ export const pack = async (
 	}
 
 	const id = _note._id;
+
+	// _note._userを消す前か、_note.userを解決した後でないとホストがわからない
+	if (_note._user) {
+		_note.emojis = packEmojis(_note._user.host);
+	}
 
 	// Rename _id to id
 	_note.id = _note._id;

--- a/src/remote/activitypub/misc/get-emoji-names.ts
+++ b/src/remote/activitypub/misc/get-emoji-names.ts
@@ -1,0 +1,6 @@
+import parse from '../../../mfm/parse';
+
+export default function(text: string) {
+	if (!text) return [];
+	return parse(text).filter(t => t.type === 'emoji').map(t => (t as any).emoji);
+}

--- a/src/remote/activitypub/models/icon.ts
+++ b/src/remote/activitypub/models/icon.ts
@@ -1,0 +1,5 @@
+export type IIcon = {
+	type: string;
+	mediaType?: string;
+	url?: string;
+};

--- a/src/remote/activitypub/models/tag.ts
+++ b/src/remote/activitypub/models/tag.ts
@@ -1,0 +1,12 @@
+import { IIcon } from "./icon";
+
+/***
+ * tag (ActivityPub)
+ */
+export type ITag = {
+	id: string;
+	type: string;
+	name?: string;
+	updated?: Date;
+	icon?: IIcon;
+};

--- a/src/remote/activitypub/renderer/emoji.ts
+++ b/src/remote/activitypub/renderer/emoji.ts
@@ -1,0 +1,14 @@
+import { IEmoji } from '../../../models/emoji';
+import config from '../../../config';
+
+export default (emoji: IEmoji) => ({
+	id: `${config.url}/emojis/${emoji.name}`,
+	type: 'Emoji',
+	name: `:${emoji.name}:`,
+	updated: emoji.updatedAt != null ? emoji.updatedAt.toISOString() : new Date().toISOString,
+	icon: {
+		type: 'Image',
+		mediaType: 'image/png',	//Mei-TODO
+		url: emoji.url
+	}
+});

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import config from '../../../config';
 import Meta from '../../../models/meta';
 import { ILocalUser } from '../../../models/user';
+import Emoji from '../../../models/emoji';
 
 const pkg = require('../../../../package.json');
 const client = require('../../../../built/client/meta.json');
@@ -21,6 +22,8 @@ export const meta = {
 
 export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => {
 	const meta: any = (await Meta.findOne()) || {};
+
+	const emojis = await Emoji.find({ host: null });
 
 	res({
 		maintainer: config.maintainer,
@@ -50,7 +53,7 @@ export default (params: any, me: ILocalUser) => new Promise(async (res, rej) => 
 		hidedTags: (me && me.isAdmin) ? meta.hidedTags : undefined,
 		bannerUrl: meta.bannerUrl,
 		maxNoteTextLength: config.maxNoteTextLength,
-		emojis: meta.emojis,
+		emojis: emojis,
 
 		features: {
 			registration: !meta.disableRegistration,

--- a/src/tools/add-emoji.ts
+++ b/src/tools/add-emoji.ts
@@ -1,0 +1,31 @@
+import * as debug from 'debug';
+import Emoji from "../models/emoji";
+
+debug.enable('*');
+
+async function main(name: string, url: string, alias?: string): Promise<any> {
+	const aliases = alias != null ? [ alias ] : [];
+
+	await Emoji.insert({
+		host: null,
+		name,
+		url,
+		aliases,
+		updatedAt: new Date()
+	});
+}
+
+const args = process.argv.slice(2);
+const name = args[0];
+const url = args[1];
+
+if (!name) throw 'require name';
+if (!url) throw 'require url';
+
+main(name, url).then(() => {
+	console.log('success');
+	process.exit(0);
+}).catch(e => {
+	console.warn(e);
+	process.exit(1);
+});


### PR DESCRIPTION
リモート絵文字を表示できるようにしています。
また、ローカル絵文字をリモートに連携できるようにしています。
ローカル絵文字のDB格納場所が変更されてます。
ローカル絵文字を、`node built/tools/add-emoji.js <name> <url>`で追加できるようにしています。

変更内容は主に以下の通り
- AP リモートからの絵文字を受信時にローカルDBに格納するようにしています
- AP ローカル投稿をリモートに送信する際に絵文字情報を送信するようにしています
- ローカル絵文字DB格納箇所をMeta→Emojiに変更しています
  (meta APIに互換は持たせてますが、Metaに登録済みの絵文字は再登録が必要です)

先にプルリクがありはするのですが・・・
- 個々の絵文字コンポーネントがAPIにリクエスト→リモートにリクエストしているが、このアプローチだと結果的に絵文字の数だけリモートリクエストが発生していけない。
- クライアント側でAPIから`:name@host:`の形式でAPIからリモート絵文字が返ってくることを期待して実装しているが、その部分がまだ未実装なのでまだ追加が必要そう。
- 通常の文字をパースするとmfm Emoji部分でエラーになってしまう。

などの問題があるため使わない形で実装してしまってます、ごめんなのだわ。ごめんなさい。

※なお、先のプルリクの絵文字一覧を返すAPIあたりは競合しないため(DB取得先をEmojiコレクションに変更すれば)再利用可能と思われます。