### PR TITLE
Do not send needless emojis in note

### DIFF
--- a/src/models/emoji.ts
+++ b/src/models/emoji.ts
@@ -17,9 +17,17 @@ export type IEmoji = {
 
 export const packEmojis = async (
 	host: string,
-	// MeiTODO: filter
+	names?: string[]
 ) => {
-	return await Emoji.find({ host }, {
+	const query = {
+		host
+	} as any;
+
+	if (names != null) {
+		query.name = { $in: names };
+	}
+
+	return await Emoji.find(query, {
 		fields: {
 			_id: false
 		}


### PR DESCRIPTION
各Noteのペイロードとして絵文字情報を添付して送る際に
該当インスタンスの絵文字情報全部を送るのは無駄なので
Noteで使用されているもののみ送るように変更しています。