### PR TITLE
Fix: emoji regex

### DIFF
--- a/src/mfm/parse/elements/emoji.ts
+++ b/src/mfm/parse/elements/emoji.ts
@@ -9,7 +9,7 @@ export type TextElementEmoji = {
 };
 
 export default function(text: string) {
-	const match = text.match(/^:([a-zA-Z0-9+-_]+?):/);
+	const match = text.match(/^:([a-zA-Z0-9+_-]+):/);
 	if (!match) return null;
 	const emoji = match[0];
 	return {


### PR DESCRIPTION
絵文字判定の正規表現を修正
- `+-_`が文字コードの範囲扱いになって`+(0x2B)`～`_(0x5F)`が全部マッチしてしまうのを修正
- 上が正しくマッチすれば`?`はもういらないので削除