### PR TITLE
Fix: download file

### DIFF
--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -35,7 +35,6 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 	await new Promise((res, rej) => {
 		const writable = fs.createWriteStream(path);
 		writable.on('finish', () => {
-			console.log("writable finish");
 			res();
 		});
 
@@ -62,10 +61,6 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 		req.on('error', error => {
 			writable.close();
 			rej(error);
-		});
-		req.on('end', () => {
-			console.log("req end");
-			//res();
 		});
 	});
 

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -34,8 +34,13 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 	// write content at URL to temp file
 	await new Promise((res, rej) => {
 		const writable = fs.createWriteStream(path);
+
 		writable.on('finish', () => {
 			res();
+		});
+
+		writable.on('error', error => {
+			rej(error);
 		});
 
 		const requestUrl = URL.parse(url).pathname.match(/[^\u0021-\u00ff]/) ? encodeURI(url) : url;

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -58,7 +58,6 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 		});
 
 		req.on('end', () => {
-			writable.close();
 			res();
 		});
 	});

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -34,6 +34,11 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 	// write content at URL to temp file
 	await new Promise((res, rej) => {
 		const writable = fs.createWriteStream(path);
+		writable.on('finish', () => {
+			console.log("writable finish");
+			res();
+		});
+
 		const requestUrl = URL.parse(url).pathname.match(/[^\u0021-\u00ff]/) ? encodeURI(url) : url;
 
 		const req = request({
@@ -49,16 +54,18 @@ export default async (url: string, user: IUser, folderId: mongodb.ObjectID = nul
 
 		req.on('response', response => {
 			if (response.statusCode !== 200) {
+				writable.close();
 				rej(response.statusCode);
 			}
 		});
 
 		req.on('error', error => {
+			writable.close();
 			rej(error);
 		});
-
 		req.on('end', () => {
-			res();
+			console.log("req end");
+			//res();
 		});
 	});
 


### PR DESCRIPTION
リモートからのファイルダウンロードの修正

1. タイムアウトするようにする
2. エラー応答(!200)でも保存してしまうのを修正
3. Resolve #3111

3は、リクエスト完了時に`writable.close(); resolve()` ではなく
ファイル書き込み完了後に`writable.close(); resolve()`に変更しています。
なお v8以降は`autoClose`らしいので`writable finish/error`時の`close`は略