### PR TITLE
via の表示を改善 (issue/3075)

### DIFF
--- a/src/client/app/desktop/views/components/note-detail.vue
+++ b/src/client/app/desktop/views/components/note-detail.vue
@@ -60,6 +60,7 @@
 			</div>
 		</div>
 		<footer>
+			<span class="app" v-if="note.app">via <b>{{ note.app.name }}</b></span>
 			<mk-reactions-viewer :note="p"/>
 			<button class="replyButton" @click="reply" title="">
 				<template v-if="p.reply"><fa icon="reply-all"/></template>
@@ -388,6 +389,12 @@ export default Vue.extend({
 
 		> footer
 			font-size 1.2em
+
+			> .app
+				display block
+				font-size 0.8em
+				margin-left 0.5em
+				color var(--noteHeaderInfo)
 
 			> button
 				margin 0 28px 0 0

--- a/src/client/app/desktop/views/components/note.vue
+++ b/src/client/app/desktop/views/components/note.vue
@@ -24,7 +24,7 @@
 	<article>
 		<mk-avatar class="avatar" :user="appearNote.user"/>
 		<div class="main">
-			<mk-note-header class="header" :note="appearNote"/>
+			<mk-note-header class="header" :note="appearNote" :mini="mini"/>
 			<div class="body">
 				<p v-if="appearNote.cw != null" class="cw">
 					<span class="text" v-if="appearNote.cw != ''">{{ appearNote.cw }}</span>
@@ -47,6 +47,7 @@
 				</div>
 			</div>
 			<footer>
+				<span class="app" v-if="appearNote.app && mini">via <b>{{ appearNote.app.name }}</b></span>
 				<mk-reactions-viewer :note="appearNote" ref="reactionsViewer"/>
 				<button class="replyButton" @click="reply()" title="%i18n:@reply%">
 					<template v-if="appearNote.reply"><fa icon="reply-all"/></template>
@@ -318,6 +319,12 @@ export default Vue.extend({
 							border-radius 8px
 
 			> footer
+				> .app
+					display block
+					margin-top 0.5em
+					margin-left 0.5em
+					color var(--noteHeaderInfo)
+					font-size 0.8em
 				> button
 					margin 0 28px 0 0
 					padding 0 8px


### PR DESCRIPTION
Issue: #3075 

Deck および詳細表示時、ノートのvia表示を以下のようにレイアウトするようにしました

<img width="300" alt="2018-11-08 13 45 08" src="https://user-images.githubusercontent.com/7106976/48178525-73db0f80-e35d-11e8-896e-6d6603ff1245.png">


<img width="300" alt="2018-11-08 13 44 45" src="https://user-images.githubusercontent.com/7106976/48178526-73db0f80-e35d-11e8-932d-c1fa733aabaf.png">

