### PR TITLE
 On remote notes, not use content for detecting mentions

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -82,7 +82,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	}
 	//#endergion
 
-	const mentions = await extractMentionedUsers(actor, note.to, note.cc, resolver);
+	const apMentions = await extractMentionedUsers(actor, note.to, note.cc, resolver);
 
 	// 添付ファイル
 	// TODO: attachmentは必ずしもImageではない
@@ -119,7 +119,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 		geo: undefined,
 		visibility,
 		visibleUsers,
-		mentions,
+		apMentions,
 		uri: note.id
 	}, silent);
 }
@@ -189,9 +189,9 @@ async function extractMentionedUsers(actor: IRemoteUser, to: string[], cc: strin
 	uris = uris.filter(x => x !== `${actor.uri}/followers`);
 	uris = unique(uris);
 
-	return await Promise.all(
-		uris.map(async uri => {
-			return await resolvePerson(uri, null, resolver);
-		})
+	const users = await Promise.all(
+		uris.map(async uri => await resolvePerson(uri, null, resolver).catch(() => null))
 	);
+
+	return users.filter(x => x != null);
 }

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -13,6 +13,7 @@ import htmlToMFM from '../../../mfm/html-to-mfm';
 import Emoji from '../../../models/emoji';
 import { ITag } from './tag';
 import { toUnicode } from 'punycode';
+import { unique } from '../../../prelude/array';
 
 const log = debug('misskey:activitypub');
 
@@ -81,6 +82,8 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 	}
 	//#endergion
 
+	const mentions = await extractMentionedUsers(actor, note.to, note.cc, resolver);
+
 	// 添付ファイル
 	// TODO: attachmentは必ずしもImageではない
 	// TODO: attachmentは必ずしも配列ではない
@@ -116,6 +119,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 		geo: undefined,
 		visibility,
 		visibleUsers,
+		mentions,
 		uri: note.id
 	}, silent);
 }
@@ -171,6 +175,23 @@ async function extractEmojis(tags: ITag[], host_: string) {
 				url: tag.icon.url,
 				aliases: [],
 			});
+		})
+	);
+}
+
+async function extractMentionedUsers(actor: IRemoteUser, to: string[], cc: string[], resolver: Resolver ) {
+	let uris = [] as string[];
+
+	if (to) uris.concat(to);
+	if (cc) uris.concat(cc);
+
+	uris = uris.filter(x => x !== 'https://www.w3.org/ns/activitystreams#Public');
+	uris = uris.filter(x => x !== `${actor.uri}/followers`);
+	uris = unique(uris);
+
+	return await Promise.all(
+		uris.map(async uri => {
+			return await resolvePerson(uri, null, resolver);
 		})
 	);
 }

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -98,6 +98,7 @@ type Option = {
 	cw?: string;
 	visibility?: string;
 	visibleUsers?: IUser[];
+	apMentions?: IUser[];
 	uri?: string;
 	app?: IApp;
 };
@@ -149,7 +150,7 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 	const emojis = extractEmojis(tokens);
 
-	const mentionedUsers = await extractMentionedUsers(tokens);
+	const mentionedUsers = data.apMentions || await extractMentionedUsers(tokens);
 
 	if (data.reply && !user._id.equals(data.reply.userId) && !mentionedUsers.some(u => u._id.equals(data.reply.userId))) {
 		mentionedUsers.push(await User.findOne({ _id: data.reply.userId }));


### PR DESCRIPTION
リモートから到着した投稿に対しては、メンション対象を取得するために本文を使用しない。

現状は、メンション対象を認識する際に
ローカルもリモート分も本文の`@なんたら`をパースして認識していますが
リモートから到着した分に関しては本文をパースよりもto, ccを参照したほうがベターなため
それを使用するようにしています。

つまりリモートからのAP Note においては、以下の本文パースではなく
```
content: '<p>:<span class="h-card"><a href="https://example.com/@USER" class="u-url mention">@<span>USER</span></a></sp  an>:</p>',
```
以下のURIから取得するようにしています(#Public, followers は特殊なので除外)
```
to: [ 'https://www.w3.org/ns/activitystreams#Public' ],
cc:
  [ 'https://example.com/users/user/followers',
    'https://example.com/users/user' ],
```

これにより発信インスタンスが意図しているメンションが誤爆なく受け取れるようになるはず。