### PR TITLE
Improve setDifference

### DIFF
--- a/src/prelude/array.ts
+++ b/src/prelude/array.ts
@@ -18,8 +18,8 @@ export function erase<T>(x: T, xs: T[]): T[] {
 	return xs.filter(y => x !== y);
 }
 
-export function setDifference<T>(xs: T[], ys: T[]): T[] {
-	return xs.filter(x => !ys.includes(x));
+export function setDifference<T>(includes: T[], excludes: T[]): T[] {
+	return unique(includes).filter(inc => !excludes.includes(inc));
 }
 
 export function unique<T>(xs: T[]): T[] {


### PR DESCRIPTION
Array setDifference を改良しています

**定義から引数の用途が推測できるように引数名を修正**
以下を全て満たしていて、使用時に実装先のfunctionの中を見に行く必要が出てしまうため。
- 2つの引数の位置づけが違うので使用時に用途を把握する必要がある
- JSDocコメントがない
- 引数名(`xy`, `ys`)から2つの引数の位置づけが推測できない
- 2つの引数の型も同じ
- `setDifference`があまり知られてなさそう

**1つ目の配列をuniqueするように修正**
mongoDB等はそういう仕様らしいためそちらに寄せてます
https://docs.mongodb.com/manual/reference/operator/aggregation/setDifference/
