### PR TITLE
show self host in unicode

### DIFF
--- a/src/client/app/admin/views/instance.vue
+++ b/src/client/app/admin/views/instance.vue
@@ -83,12 +83,13 @@
 import Vue from 'vue';
 import i18n from '../../i18n';
 import { host } from '../../config';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('admin/views/instance.vue'),
 	data() {
 		return {
-			host,
+			host: toUnicode(host),
 			maintainerName: null,
 			maintainerEmail: null,
 			disableRegistration: false,

--- a/src/client/app/common/views/components/acct.vue
+++ b/src/client/app/common/views/components/acct.vue
@@ -8,11 +8,12 @@
 <script lang="ts">
 import Vue from 'vue';
 import { host } from '../../../config';
+import { toUnicode } from 'punycode';
 export default Vue.extend({
 	props: ['user', 'detail'],
 	data() {
 		return {
-			host
+			host: toUnicode(host)
 		};
 	}
 });

--- a/src/client/app/common/views/components/profile-editor.vue
+++ b/src/client/app/common/views/components/profile-editor.vue
@@ -73,12 +73,13 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import { apiUrl, host } from '../../../config';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('common/views/components/profile-editor.vue'),
 	data() {
 		return {
-			host,
+			host: toUnicode(host),
 			name: null,
 			username: null,
 			location: null,

--- a/src/client/app/common/views/components/signin.vue
+++ b/src/client/app/common/views/components/signin.vue
@@ -21,6 +21,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import { apiUrl, host } from '../../../config';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('common/views/components/signin.vue'),
@@ -39,7 +40,7 @@ export default Vue.extend({
 			password: '',
 			token: '',
 			apiUrl,
-			host
+			host: toUnicode(host)
 		};
 	},
 	methods: {

--- a/src/client/app/common/views/components/signup.vue
+++ b/src/client/app/common/views/components/signup.vue
@@ -46,12 +46,13 @@ import Vue from 'vue';
 import i18n from '../../../i18n';
 const getPasswordStrength = require('syuilo-password-strength');
 import { host, url } from '../../../config';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('common/views/components/signup.vue'),
 	data() {
 		return {
-			host,
+			host: toUnicode(host),
 			username: '',
 			password: '',
 			retypedPassword: '',

--- a/src/client/app/desktop/views/pages/welcome.vue
+++ b/src/client/app/desktop/views/pages/welcome.vue
@@ -151,6 +151,7 @@ import Vue from 'vue';
 import i18n from '../../../i18n';
 import { host, copyright } from '../../../config';
 import { concat } from '../../../../../prelude/array';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('desktop/views/pages/welcome.vue'),
@@ -160,7 +161,7 @@ export default Vue.extend({
 			stats: null,
 			banner: null,
 			copyright,
-			host,
+			host: toUnicode(host),
 			name: 'Misskey',
 			description: '',
 			announcements: [],

--- a/src/client/app/mobile/views/pages/welcome.vue
+++ b/src/client/app/mobile/views/pages/welcome.vue
@@ -76,6 +76,7 @@ import Vue from 'vue';
 import i18n from '../../../i18n';
 import { copyright, host } from '../../../config';
 import { concat } from '../../../../../prelude/array';
+import { toUnicode } from 'punycode';
 
 export default Vue.extend({
 	i18n: i18n('mobile/views/pages/welcome.vue'),
@@ -85,7 +86,7 @@ export default Vue.extend({
 			copyright,
 			stats: null,
 			banner: null,
-			host,
+			host: toUnicode(host),
 			name: 'Misskey',
 			description: '',
 			photos: [],


### PR DESCRIPTION
非ASCIIのホスト上で運用されている際に、
自ホスト名がUI上でpunycodeで表示されてしまう(他のMisskeyからはUnicodeで見えるにもかかわらず)
のを修正しています。
