### PR TITLE
sort user timeline by date

### DIFF
--- a/src/client/app/desktop/views/pages/deck/deck.user-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.user-column.vue
@@ -155,7 +155,8 @@ export default Vue.extend({
 			this.$root.api('users/notes', {
 				userId: this.user.id,
 				fileType: image,
-				limit: 9
+				limit: 9,
+				untilDate: new Date().getTime() + 1000 * 86400 * 365
 			}).then(notes => {
 				notes.forEach(note => {
 					note.files.forEach(file => {
@@ -254,6 +255,7 @@ export default Vue.extend({
 				this.$root.api('users/notes', {
 					userId: this.user.id,
 					limit: fetchLimit + 1,
+					untilDate: new Date().getTime() + 1000 * 86400 * 365,
 					withFiles: this.withFiles,
 					includeMyRenotes: this.$store.state.settings.showMyRenotes,
 					includeRenotedMyNotes: this.$store.state.settings.showRenotedMyNotes,
@@ -274,7 +276,7 @@ export default Vue.extend({
 			const promise = this.$root.api('users/notes', {
 				userId: this.user.id,
 				limit: fetchLimit + 1,
-				untilId: (this.$refs.timeline as any).tail().id,
+				untilDate: new Date((this.$refs.timeline as any).tail().createdAt).getTime(),
 				withFiles: this.withFiles,
 				includeMyRenotes: this.$store.state.settings.showMyRenotes,
 				includeRenotedMyNotes: this.$store.state.settings.showRenotedMyNotes,

--- a/src/client/app/desktop/views/pages/user/user.photos.vue
+++ b/src/client/app/desktop/views/pages/user/user.photos.vue
@@ -27,7 +27,8 @@ export default Vue.extend({
 		this.$root.api('users/notes', {
 			userId: this.user.id,
 			withFiles: true,
-			limit: 9
+			limit: 9,
+			untilDate: new Date().getTime() + 1000 * 86400 * 365
 		}).then(notes => {
 			notes.forEach(note => {
 				note.files.forEach(file => {

--- a/src/client/app/desktop/views/pages/user/user.timeline.vue
+++ b/src/client/app/desktop/views/pages/user/user.timeline.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
 				this.$root.api('users/notes', {
 					userId: this.user.id,
 					limit: fetchLimit + 1,
-					untilDate: this.date ? this.date.getTime() : undefined,
+					untilDate: this.date ? this.date.getTime() : new Date().getTime() + 1000 * 86400 * 365,
 					includeReplies: this.mode == 'with-replies',
 					withFiles: this.mode == 'with-media'
 				}).then(notes => {
@@ -86,7 +86,7 @@ export default Vue.extend({
 				limit: fetchLimit + 1,
 				includeReplies: this.mode == 'with-replies',
 				withFiles: this.mode == 'with-media',
-				untilId: (this.$refs.timeline as any).tail().id
+				untilDate: new Date((this.$refs.timeline as any).tail().createdAt).getTime()
 			});
 
 			promise.then(notes => {

--- a/src/client/app/mobile/views/components/user-timeline.vue
+++ b/src/client/app/mobile/views/components/user-timeline.vue
@@ -44,7 +44,8 @@ export default Vue.extend({
 				this.$root.api('users/notes', {
 					userId: this.user.id,
 					withFiles: this.withMedia,
-					limit: fetchLimit + 1
+					limit: fetchLimit + 1,
+					untilDate: new Date().getTime() + 1000 * 86400 * 365
 				}).then(notes => {
 					if (notes.length == fetchLimit + 1) {
 						notes.pop();
@@ -66,7 +67,7 @@ export default Vue.extend({
 				userId: this.user.id,
 				withFiles: this.withMedia,
 				limit: fetchLimit + 1,
-				untilId: (this.$refs.timeline as any).tail().id
+				untilDate: new Date((this.$refs.timeline as any).tail().createdAt).getTime()
 			});
 
 			promise.then(notes => {

--- a/src/client/app/mobile/views/pages/user/home.notes.vue
+++ b/src/client/app/mobile/views/pages/user/home.notes.vue
@@ -22,7 +22,8 @@ export default Vue.extend({
 	},
 	mounted() {
 		this.$root.api('users/notes', {
-			userId: this.user.id
+			userId: this.user.id,
+			untilDate: new Date().getTime() + 1000 * 86400 * 365
 		}).then(notes => {
 			this.notes = notes;
 			this.fetching = false;

--- a/src/client/app/mobile/views/pages/user/home.photos.vue
+++ b/src/client/app/mobile/views/pages/user/home.photos.vue
@@ -29,7 +29,8 @@ export default Vue.extend({
 		this.$root.api('users/notes', {
 			userId: this.user.id,
 			withFiles: true,
-			limit: 6
+			limit: 6,
+			untilDate: new Date().getTime() + 1000 * 86400 * 365
 		}).then(notes => {
 			notes.forEach(note => {
 				note.media.forEach(media => {

--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -153,9 +153,7 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 	}
 
 	//#region Construct query
-	const sort = {
-		_id: -1
-	};
+	const sort = { } as any;
 
 	const query = {
 		deletedAt: null,
@@ -168,15 +166,17 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 			$gt: ps.sinceId
 		};
 	} else if (ps.untilId) {
+		sort._id = -1;
 		query._id = {
 			$lt: ps.untilId
 		};
 	} else if (ps.sinceDate) {
-		sort._id = 1;
+		sort.createdAt = 1;
 		query.createdAt = {
 			$gt: new Date(ps.sinceDate)
 		};
 	} else if (ps.untilDate) {
+		sort.createdAt = -1;
 		query.createdAt = {
 			$lt: new Date(ps.untilDate)
 		};


### PR DESCRIPTION
~~Resolve #<span></span>3207~~ ?
UI上でユーザーのタイムラインをid順ではなくdate順に並べるようにしています
それに伴い、API(users/notes)でDateを指定したときのソート順を日付順にしています(#3209)

users/notesのuntileDateで
`new Date().getTime() + 1000 * 86400 * 365`のような1年後の値を入れているのは、
初期のソート順をdate順にするためになります。