### PR TITLE
Fix: notes/create hangs when rejected

### DIFF
--- a/src/server/api/call.ts
+++ b/src/server/api/call.ts
@@ -56,7 +56,7 @@ export default (endpoint: string, user: IUser, app: IApp, data: any, file?: any)
 			console.warn(`SLOW API CALL DETECTED: ${ep.name} (${time}ms)`);
 		}
 	} catch (e) {
-		if (e.name == 'INVALID_PARAM') {
+		if (e && e.name == 'INVALID_PARAM') {
 			rej({
 				code: e.name,
 				param: e.param,

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -216,7 +216,7 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 	}
 
 	// 投稿を作成
-	const note = await create(user, {
+	create(user, {
 		createdAt: new Date(),
 		files: files,
 		poll: ps.poll,
@@ -229,12 +229,14 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 		visibility: ps.visibility,
 		visibleUsers,
 		geo: ps.geo
-	});
-
-	const noteObj = await pack(note, user);
-
-	// Reponse
-	res({
-		createdNote: noteObj
+	})
+	.then(note => pack(note, user))
+	.then(noteObj => {
+		res({
+			createdNote: noteObj
+		});
+	})
+	.catch(e => {
+		rej(e);
 	});
 }));

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -116,27 +116,27 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 	// リプライ対象が削除された投稿だったらreject
 	if (data.reply && data.reply.deletedAt != null) {
-		return rej();
+		return rej('Reply target has been deleted');
 	}
 
 	// Renote対象が削除された投稿だったらreject
 	if (data.renote && data.renote.deletedAt != null) {
-		return rej();
+		return rej('Renote target has been deleted');
 	}
 
 	// Renote対象が「ホームまたは全体」以外の公開範囲ならreject
 	if (data.renote && data.renote.visibility != 'public' && data.renote.visibility != 'home') {
-		return rej();
+		return rej('Renote target is not public or home');
 	}
 
 	// リプライ対象が自分以外の非公開の投稿なら禁止
 	if (data.reply && data.reply.visibility == 'private' && !data.reply.userId.equals(user._id)) {
-		return rej();
+		return rej('Reply target is private of others');
 	}
 
 	// Renote対象が自分以外の非公開の投稿なら禁止
 	if (data.renote && data.renote.visibility == 'private' && !data.renote.userId.equals(user._id)) {
-		return rej();
+		return rej('Renote target is private of others');
 	}
 
 	if (data.text) {


### PR DESCRIPTION
- notes/createで禁止される操作(非公開をRenoteなど)を行った際に応答が返ってこないのを修正
- notes/createで拒否された時に禁止された操作の内容を返すように修正
- API全般でendpoints以下から`rej()`で戻ってきた時に応答しなくなりそうなのを修正

してます