### PR TITLE
Fix: default order of users/notes

### DIFF
--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -180,6 +180,8 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 		query.createdAt = {
 			$lt: new Date(ps.untilDate)
 		};
+	} else {
+		sort._id = -1;
 	}
 
 	if (!ps.includeReplies) {


### PR DESCRIPTION
users/notes のパラメータなし時のソート順が未定義になってしまってたのを修正してます。
https://github.com/syuilo/misskey/pull/3210#issuecomment-438620588