### PR TITLE
Use Node.js official Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8 AS base
+FROM alpine:edge AS base
 
 ENV NODE_ENV=production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:edge AS base
+FROM node:11-alpine AS base
 
 ENV NODE_ENV=production
 
-RUN apk add --no-cache nodejs nodejs-npm zlib
 RUN npm i -g npm@latest
 
 WORKDIR /misskey


### PR DESCRIPTION
Alpine Linux 3.8 の Node.js バージョンが古く、動作環境の条件を満たしていない。
Related to #2997 

Resolve #3242

ref: https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.8