### PR TITLE
Do not show duplicate url-preview

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -1,5 +1,5 @@
 import parse from '../../../../mfm/parse';
-import { sum } from '../../../../prelude/array';
+import { sum, unique } from '../../../../prelude/array';
 import shouldMuteNote from './should-mute-note';
 import MkNoteMenu from '../views/components/note-menu.vue';
 import MkReactionPicker from '../views/components/reaction-picker.vue';
@@ -78,9 +78,9 @@ export default (opts: Opts = {}) => ({
 		urls(): string[] {
 			if (this.appearNote.text) {
 				const ast = parse(this.appearNote.text);
-				return ast
+				return unique(ast
 					.filter(t => (t.type == 'url' || t.type == 'link') && !t.silent)
-					.map(t => t.url);
+					.map(t => t.url));
 			} else {
 				return null;
 			}

--- a/src/client/app/common/views/components/messaging-room.message.vue
+++ b/src/client/app/common/views/components/messaging-room.message.vue
@@ -34,6 +34,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import parse from '../../../../../mfm/parse';
+import { unique } from '../../../../../prelude/array';
 
 export default Vue.extend({
 	i18n: i18n('common/views/components/messaging-room.message.vue'),
@@ -49,9 +50,9 @@ export default Vue.extend({
 		urls(): string[] {
 			if (this.message.text) {
 				const ast = parse(this.message.text);
-				return ast
+				return unique(ast
 					.filter(t => (t.type == 'url' || t.type == 'link') && !t.silent)
-					.map(t => t.url);
+					.map(t => t.url));
 			} else {
 				return null;
 			}

--- a/src/client/app/desktop/views/components/note-detail.vue
+++ b/src/client/app/desktop/views/components/note-detail.vue
@@ -94,7 +94,7 @@ import MkRenoteFormWindow from './renote-form-window.vue';
 import MkNoteMenu from '../../../common/views/components/note-menu.vue';
 import MkReactionPicker from '../../../common/views/components/reaction-picker.vue';
 import XSub from './note.sub.vue';
-import { sum } from '../../../../../prelude/array';
+import { sum, unique } from '../../../../../prelude/array';
 import noteSubscriber from '../../../common/scripts/note-subscriber';
 
 export default Vue.extend({
@@ -149,9 +149,9 @@ export default Vue.extend({
 		urls(): string[] {
 			if (this.p.text) {
 				const ast = parse(this.p.text);
-				return ast
+				return unique(ast
 					.filter(t => (t.type == 'url' || t.type == 'link') && !t.silent)
-					.map(t => t.url);
+					.map(t => t.url));
 			} else {
 				return null;
 			}

--- a/src/client/app/mobile/views/components/note-detail.vue
+++ b/src/client/app/mobile/views/components/note-detail.vue
@@ -92,7 +92,7 @@ import parse from '../../../../../mfm/parse';
 import MkNoteMenu from '../../../common/views/components/note-menu.vue';
 import MkReactionPicker from '../../../common/views/components/reaction-picker.vue';
 import XSub from './note.sub.vue';
-import { sum } from '../../../../../prelude/array';
+import { sum, unique } from '../../../../../prelude/array';
 import noteSubscriber from '../../../common/scripts/note-subscriber';
 
 export default Vue.extend({
@@ -143,9 +143,9 @@ export default Vue.extend({
 		urls(): string[] {
 			if (this.p.text) {
 				const ast = parse(this.p.text);
-				return ast
+				return unique(ast
 					.filter(t => (t.type == 'url' || t.type == 'link') && !t.silent)
-					.map(t => t.url);
+					.map(t => t.url));
 			} else {
 				return null;
 			}


### PR DESCRIPTION
同じURLが2つ以上あった際、同じURLプレビューを複数表示しないようにしてます。

Vueにおこられたりもするので
`[Vue warn]: Duplicate keys detected: 'https://example.com/aaa'.`