### PR TITLE
Renote visibility

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -788,6 +788,7 @@ desktop/views/components/renote-form.vue:
   quote: "引用する..."
   cancel: "キャンセル"
   renote: "Renote"
+  renote-home: "Renote (ホーム)"
   reposting: "しています..."
   success: "Renoteしました！"
   failure: "Renoteに失敗しました"

--- a/src/client/app/desktop/views/components/renote-form.vue
+++ b/src/client/app/desktop/views/components/renote-form.vue
@@ -5,7 +5,8 @@
 		<footer>
 			<a class="quote" v-if="!quote" @click="onQuote">{{ $t('quote') }}</a>
 			<ui-button class="button cancel" inline @click="cancel">{{ $t('cancel') }}</ui-button>
-			<ui-button class="button ok" inline primary @click="ok" :disabled="wait">{{ wait ? this.$t('reposting') : this.$t('renote') }}</ui-button>
+			<ui-button class="button home" inline :primary="visibility != 'public'" @click="ok('home')"   :disabled="wait">{{ wait ? this.$t('reposting') : this.$t('renote-home') }}</ui-button>
+			<ui-button class="button ok"   inline :primary="visibility == 'public'" @click="ok('public')" :disabled="wait">{{ wait ? this.$t('reposting') : this.$t('renote') }}</ui-button>
 		</footer>
 	</template>
 	<template v-if="quote">
@@ -24,14 +25,16 @@ export default Vue.extend({
 	data() {
 		return {
 			wait: false,
-			quote: false
+			quote: false,
+			visibility: this.$store.state.settings.defaultNoteVisibility
 		};
 	},
 	methods: {
-		ok() {
+		ok(v: string) {
 			this.wait = true;
 			this.$root.api('notes/create', {
-				renoteId: this.note.id
+				renoteId: this.note.id,
+				visibility: v || this.visibility
 			}).then(data => {
 				this.$emit('posted');
 				this.$notify(this.$t('success'));
@@ -81,7 +84,11 @@ export default Vue.extend({
 			height 40px
 
 			&.cancel
+				right 280px
+
+			&.home
 				right 148px
+				font-size 13px
 
 			&.ok
 				right 16px

--- a/src/remote/activitypub/renderer/announce.ts
+++ b/src/remote/activitypub/renderer/announce.ts
@@ -4,13 +4,26 @@ import { INote } from '../../../models/note';
 export default (object: any, note: INote) => {
 	const attributedTo = `${config.url}/users/${note.userId}`;
 
+	let to: string[] = [];
+	let cc: string[] = [];
+
+	if (note.visibility == 'public') {
+		to = ['https://www.w3.org/ns/activitystreams#Public'];
+		cc = [`${attributedTo}/followers`];
+	} else if (note.visibility == 'home') {
+		to = [`${attributedTo}/followers`];
+		cc = ['https://www.w3.org/ns/activitystreams#Public'];
+	} else {
+		return null;
+	}
+
 	return {
 		id: `${config.url}/notes/${note._id}/activity`,
 		actor: `${config.url}/users/${note.userId}`,
 		type: 'Announce',
 		published: note.createdAt.toISOString(),
-		to: ['https://www.w3.org/ns/activitystreams#Public'],
-		cc: [attributedTo, `${attributedTo}/followers`],
+		to,
+		cc,
 		object
 	};
 };

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -2,6 +2,8 @@ import config from '../../../config';
 import * as uuid from 'uuid';
 
 export default (x: any) => {
+	if (x == null) return null;
+
 	if (x !== null && typeof x === 'object' && x.id == null) {
 		x.id = `${config.url}/${uuid.v4()}`;
 	}


### PR DESCRIPTION
Resolve #2642 ?
元から裏技はあるので、リモート送受信での不整合の修正と少しUIの追加をしています。

変更点
- server
  - RenoteのAP送信時にPublic/Homeを区別して送るようにしています。(以前は常にPublic)
  - RenoteのAP送信時にFollower以下の公開範囲の場合は送信しないようにしてます。
    (Mastodon/旧Misskey等に送ってもFollowerにはならないため)
  - RenoteのAP受信時にRenoteの公開範囲を利用するようにしています。
    (以前はRenote対象の公開範囲を使用)
- client
  - DesktopのRenoteフォームに`Renote (ホーム)`を追加しています。
    Renoteする際にPublicかHomeかを選べるようになります。
    ユーザーの既定の公開範囲がPublicの場合はPublicが既定で、それ以外の場合はHomeが既定になります。

元からある裏技の部分はノータッチですので、Followerより狭いRenoteも依然として使えます。

結果的に
Public/Home/Public(localOnly)/Home(localOnly)でRenoteした場合はその通りの動作をします。
FollowerでRenoteした場合は、ローカルではその通りの動作をしますがリモートには伝わりません。
SpecifiedでRenoteは元々動かない模様。
PrivateでRenoteはその通りの動作をします。

※裏技：引用投稿で公開範囲を選択して本文も何もなしで投稿すると公開範囲を指定したRenoteが出来る