### PR TITLE
Improve relative time detection

### DIFF
--- a/src/client/app/common/views/components/time.vue
+++ b/src/client/app/common/views/components/time.vue
@@ -53,8 +53,8 @@ export default Vue.extend({
 				ago >= 3600     ? this.$t('@.time.hours_ago')  .replace('{}', (~~(ago / 3600)).toString()) :
 				ago >= 60       ? this.$t('@.time.minutes_ago').replace('{}', (~~(ago / 60)).toString()) :
 				ago >= 10       ? this.$t('@.time.seconds_ago').replace('{}', (~~(ago % 60)).toString()) :
-				ago >= 0        ? this.$t('@.time.just_now') :
-				ago <  0        ? this.$t('@.time.future') :
+				ago >= -1       ? this.$t('@.time.just_now') :
+				ago <  -1       ? this.$t('@.time.future') :
 				this.$t('@.time.unknown'));
 		}
 	},


### PR DESCRIPTION
時刻表示であまり`未来`が出現しないようにする

現状、クライアント側の時計が0.1秒遅れているだけでも`たった今`ではなく`未来`になってしまうので
`たった今`と判定する範囲に余裕をもたせています。