### PR TITLE
Fix some image processing

### DIFF
--- a/src/client/app/common/views/components/image-viewer.vue
+++ b/src/client/app/common/views/components/image-viewer.vue
@@ -65,5 +65,6 @@ export default Vue.extend({
 		max-height 100%
 		margin auto
 		cursor zoom-out
+		image-orientation from-image
 
 </style>


### PR DESCRIPTION
Resolve #2973, #2612
#3306 を一部修正

**サムネイル生成品質の修正(#2973)**
1. withoutEnlargement: サムネイルの方が大きい場合は拡大しないように
2. width=300 => 498x280 touch from inside: 常に幅を300にするのではなく、498x280の枠に収まる最大サイズにするように
3. JPEG Quolity 50=>85: 80以下は劣化の割に大して小さくならないので85%に
4. PNGのThumbnailはPNGで生成するように(サイズがでかくなる可能性はあるが他もそんな感じなのでいいのでは)

**#3306 の一部修正**
これはExifのOrientationを見て回転させる必要あり
- サムネイルについては生成時に回転させるように
- オリジナルについては、オリジナルを改変する必要があるのでサーバー上対応は一旦保留。
  - iOS(Safari, Firefox, Chrome)では、ブラウザで回転してくれるはずなので元から起きないと思われる
  - Windows/Linux(Firefox)は`CSS(image-orientation: from-image)`でブラウザで補正させることで対処済み
  - Windows/Linux(Chrome)は未対応
    (なお今のimgタグで表示ではなく画像を直接表示に戻せば解決できる)
  - Edgeは何をやってもダメ(サーバー上対応が必要)

#3306 を完全に解決させるには #106 などと合わせて
OriginalとThumbmailの中間の(Exif等のカット/Orientationの解決/あまりにでかいサイズの縮小)
などを行ったWeb公開用の画像を定義する必要がありそうなので後々…