### PR TITLE
Cores => Logical cores

### DIFF
--- a/src/client/app/common/views/widgets/server.cpu.vue
+++ b/src/client/app/common/views/widgets/server.cpu.vue
@@ -3,7 +3,7 @@
 	<x-pie class="pie" :value="usage"/>
 	<div>
 		<p><fa icon="microchip"/>CPU</p>
-		<p>{{ meta.cpu.cores }} Cores</p>
+		<p>{{ meta.cpu.cores }} Logical cores</p>
 		<p>{{ meta.cpu.model }}</p>
 	</div>
 </div>


### PR DESCRIPTION
サーバー情報で、`logical CPU core`( https://nodejs.org/api/os.html#os_os_cpus )
の値を`Cores`と表記しているが、
単純に`Cores`と呼ぶと`physical CPU core`の方を指してしまうと思われるため
`Logical cores`の方が良さそう。


