### PR TITLE
Return 404 for undefined .well-known

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -59,6 +59,11 @@ const router = new Router();
 router.use(activityPub.routes());
 router.use(webFinger.routes());
 
+// Return 404 for other .well-known
+router.all('/.well-known/*', async ctx => {
+	ctx.status = 404;
+});
+
 // Register router
 app.use(router.routes());
 


### PR DESCRIPTION
`/.well-known/nodeinfo`など、
`/.well-known/webfinger`以外の実装していない`/.well-known/`以下のリクエストには404を返す