### PR TITLE
Trim notifications text

### DIFF
--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -217,7 +217,7 @@ export default Vue.extend({
 		> div
 			> .notification
 				margin 0
-				padding 12px 16px
+				padding 16px
 				overflow-wrap break-word
 				font-size 12px
 				border-bottom solid 1px var(--faceDivider)
@@ -228,7 +228,7 @@ export default Vue.extend({
 				> .mk-time
 					display inline
 					position absolute
-					top 12px
+					top 16px
 					right 12px
 					vertical-align top
 					color var(--noteHeaderInfo)

--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -271,7 +271,7 @@ export default Vue.extend({
 					display inline-block
 					width: 100%
 					overflow hidden
-					white-space: nowrap
+					white-space nowrap
 					text-overflow ellipsis
 
 					[data-icon]

--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -20,7 +20,7 @@
 								<mk-reaction-icon :reaction="notification.reaction"/>
 								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id">{{ notification.user | userName }}</router-link>
 							</p>
-							<router-link class="note-ref" :to="notification.note | notePage">
+							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
 							</router-link>
 						</div>
@@ -32,7 +32,7 @@
 							<p><fa icon="retweet"/>
 								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">{{ notification.note.user | userName }}</router-link>
 							</p>
-							<router-link class="note-ref" :to="notification.note | notePage">
+							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
 								<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
 							</router-link>
 						</div>
@@ -44,7 +44,7 @@
 							<p><fa icon="quote-left"/>
 								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">{{ notification.note.user | userName }}</router-link>
 							</p>
-							<router-link class="note-preview" :to="notification.note | notePage">{{ getNoteSummary(notification.note) }}</router-link>
+							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</router-link>
 						</div>
 					</template>
 
@@ -72,7 +72,7 @@
 							<p><fa icon="reply"/>
 								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">{{ notification.note.user | userName }}</router-link>
 							</p>
-							<router-link class="note-preview" :to="notification.note | notePage">{{ getNoteSummary(notification.note) }}</router-link>
+							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</router-link>
 						</div>
 					</template>
 
@@ -82,7 +82,7 @@
 							<p><fa icon="at"/>
 								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">{{ notification.note.user | userName }}</router-link>
 							</p>
-							<a class="note-preview" :href="notification.note | notePage">{{ getNoteSummary(notification.note) }}</a>
+							<a class="note-preview" :href="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</a>
 						</div>
 					</template>
 
@@ -90,7 +90,7 @@
 						<mk-avatar class="avatar" :user="notification.user"/>
 						<div class="text">
 							<p><fa icon="chart-pie"/><a :href="notification.user | userPage" v-user-preview="notification.user.id">{{ notification.user | userName }}</a></p>
-							<router-link class="note-ref" :to="notification.note | notePage">
+							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
 							</router-link>
 						</div>
@@ -217,9 +217,9 @@ export default Vue.extend({
 		> div
 			> .notification
 				margin 0
-				padding 16px
+				padding 12px 16px
 				overflow-wrap break-word
-				font-size 13px
+				font-size 12px
 				border-bottom solid 1px var(--faceDivider)
 
 				&:last-child
@@ -228,7 +228,7 @@ export default Vue.extend({
 				> .mk-time
 					display inline
 					position absolute
-					top 16px
+					top 12px
 					right 12px
 					vertical-align top
 					color var(--noteHeaderInfo)
@@ -262,9 +262,17 @@ export default Vue.extend({
 
 				.note-preview
 					color var(--noteText)
+					display inline-block
+					overflow hidden
+					max-height 48px
 
 				.note-ref
 					color var(--noteText)
+					display inline-block
+					width: 100%
+					overflow hidden
+					white-space: nowrap
+					text-overflow ellipsis
 
 					[data-icon]
 						font-size 1em

--- a/src/client/app/desktop/views/pages/deck/deck.notification.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notification.vue
@@ -153,7 +153,7 @@ export default Vue.extend({
 				display inline-block
 				width: 100%
 				overflow hidden
-				white-space: nowrap
+				white-space nowrap
 				text-overflow ellipsis
 
 				[data-icon]

--- a/src/client/app/desktop/views/pages/deck/deck.notification.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notification.vue
@@ -8,7 +8,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}
 				<fa icon="quote-right"/>
 			</router-link>
@@ -23,7 +23,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -59,7 +59,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -111,8 +111,8 @@ export default Vue.extend({
 <style lang="stylus" scoped>
 .dsfykdcjpuwfvpefwufddclpjhzktmpw
 	> .notification
-		padding 16px
-		font-size 13px
+		padding 12px 16px
+		font-size 12px
 		overflow-wrap break-word
 
 		&:after
@@ -150,6 +150,11 @@ export default Vue.extend({
 
 			> .note-ref
 				color var(--noteText)
+				display inline-block
+				width: 100%
+				overflow hidden
+				white-space: nowrap
+				text-overflow ellipsis
 
 				[data-icon]
 					font-size 1em

--- a/src/client/app/desktop/views/pages/deck/deck.notification.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notification.vue
@@ -111,7 +111,7 @@ export default Vue.extend({
 <style lang="stylus" scoped>
 .dsfykdcjpuwfvpefwufddclpjhzktmpw
 	> .notification
-		padding 12px 16px
+		padding 16px
 		font-size 12px
 		overflow-wrap break-word
 

--- a/src/client/app/mobile/views/components/notification.vue
+++ b/src/client/app/mobile/views/components/notification.vue
@@ -165,7 +165,7 @@ export default Vue.extend({
 				display inline-block
 				width: 100%
 				overflow hidden
-				white-space: nowrap
+				white-space nowrap
 				text-overflow ellipsis
 
 				[data-icon]

--- a/src/client/app/mobile/views/components/notification.vue
+++ b/src/client/app/mobile/views/components/notification.vue
@@ -8,7 +8,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}
 				<fa icon="quote-right"/>
 			</router-link>
@@ -23,7 +23,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -59,7 +59,7 @@
 				<router-link :to="notification.user | userPage">{{ notification.user | userName }}</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
-			<router-link class="note-ref" :to="notification.note | notePage">
+			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -107,7 +107,7 @@ export default Vue.extend({
 <style lang="stylus" scoped>
 .mk-notification
 	> .notification
-		padding 16px
+		padding 12px 16px
 		font-size 12px
 		overflow-wrap break-word
 
@@ -162,6 +162,11 @@ export default Vue.extend({
 
 			> .note-ref
 				color var(--noteText)
+				display inline-block
+				width: 100%
+				overflow hidden
+				white-space: nowrap
+				text-overflow ellipsis
 
 				[data-icon]
 					font-size 1em

--- a/src/client/app/mobile/views/components/notification.vue
+++ b/src/client/app/mobile/views/components/notification.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
 <style lang="stylus" scoped>
 .mk-notification
 	> .notification
-		padding 12px 16px
+		padding 16px
 		font-size 12px
 		overflow-wrap break-word
 

--- a/src/misc/get-note-summary.ts
+++ b/src/misc/get-note-summary.ts
@@ -31,7 +31,7 @@ const summarize = (note: any): string => {
 		if (note.reply) {
 			summary += `\n\nRE: ${summarize(note.reply)}`;
 		} else {
-			summary += "\n\nRE: ...";
+			summary += '\n\nRE: ...';
 		}
 	}
 
@@ -40,7 +40,7 @@ const summarize = (note: any): string => {
 		if (note.renote) {
 			summary += `\n\nRN: ${summarize(note.renote)}`;
 		} else {
-			summary += "\n\nRN: ...";
+			summary += '\n\nRN: ...';
 		}
 	}
 

--- a/src/misc/get-note-summary.ts
+++ b/src/misc/get-note-summary.ts
@@ -29,18 +29,18 @@ const summarize = (note: any): string => {
 	// 返信のとき
 	if (note.replyId) {
 		if (note.reply) {
-			summary += ` RE: ${summarize(note.reply)}`;
+			summary += `\n\nRE: ${summarize(note.reply)}`;
 		} else {
-			summary += ' RE: ...';
+			summary += "\n\nRE: ...";
 		}
 	}
 
 	// Renoteのとき
 	if (note.renoteId) {
 		if (note.renote) {
-			summary += ` RN: ${summarize(note.renote)}`;
+			summary += `\n\nRN: ${summarize(note.renote)}`;
 		} else {
-			summary += ' RN: ...';
+			summary += "\n\nRN: ...";
 		}
 	}
 


### PR DESCRIPTION
Resolve #3407 
長い投稿のNotificationsがあまりスペースをとらないようにしています

Reaction / Renote (desktop-home / deck / mobile)
1行表示 + ツールチップ
![image](https://user-images.githubusercontent.com/30769358/49250472-3cdeb200-f462-11e8-81e4-9542bbe969b7.png)

Reply / Mention / Quote (desktop-home only)
高さ制限 + ツールチップ
![image](https://user-images.githubusercontent.com/30769358/49250525-5d0e7100-f462-11e8-8676-3656ddfbb658.png)

