### PR TITLE
Fix ActivityPub CW

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -103,6 +103,8 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 		quote = await resolveNote(note._misskey_quote).catch(() => null);
 	}
 
+	const cw = note.summary === '' ? null : note.summary;
+
 	// テキストのパース
 	const text = note._misskey_content ? note._misskey_content : htmlToMFM(note.content);
 
@@ -120,7 +122,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 		files: files,
 		reply,
 		renote: quote,
-		cw: note.summary,
+		cw: cw,
 		text: text,
 		viaMobile: false,
 		localOnly: false,

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -106,6 +106,8 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		text += `\n\nRE: ${url}`;
 	}
 
+	const summary = note.cw === '' ? String.fromCharCode(0x200B) : note.cw;
+
 	const content = toHtml(Object.assign({}, note, { text }));
 
 	const emojis = await getEmojis(note.emojis);
@@ -121,7 +123,7 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 		id: `${config.url}/notes/${note._id}`,
 		type: 'Note',
 		attributedTo,
-		summary: note.cw,
+		summary,
 		content,
 		_misskey_content: text,
 		_misskey_quote: quote,


### PR DESCRIPTION
Resolve #3439, Resolve #3444 

CWを送る際に、`''` (Mastodon/PleromaだとCW扱いにならない) の場合は、
`U+200B zero width space`で送るように。

CWが来た時に、`''` (PleromaだとCWのつもりではない) の場合は、
非CWと解釈するように。

Mastodon / Pleroma / 新旧Misskey を対象に確認済み。