### PR TITLE
Improve widget paging looks

### DIFF
--- a/src/client/app/desktop/views/widgets/polls.vue
+++ b/src/client/app/desktop/views/widgets/polls.vue
@@ -2,7 +2,10 @@
 <div class="mkw-polls">
 	<mk-widget-container :show-header="!props.compact">
 		<template slot="header"><fa icon="chart-pie"/>{{ $t('title') }}</template>
-		<button slot="func" :title="$t('title')" @click="fetch"><fa icon="sync"/></button>
+		<button slot="func" :title="$t('title')" @click="fetch">
+			<fa v-if="!fetching &&  more" icon="arrow-right"/>
+			<fa v-if="!fetching && !more" icon="sync"/>
+		</button> 
 
 		<div class="mkw-polls--body">
 			<div class="poll" v-if="!fetching && poll != null">
@@ -32,6 +35,7 @@ export default define({
 		return {
 			poll: null,
 			fetching: true,
+			more: true,
 			offset: 0
 		};
 	},
@@ -53,12 +57,18 @@ export default define({
 			}).then(notes => {
 				const poll = notes ? notes[0] : null;
 				if (poll == null) {
+					this.more = false;
 					this.offset = 0;
 				} else {
+					this.more = true;
 					this.offset++;
 				}
 				this.poll = poll;
 				this.fetching = false;
+			}).catch(() => {
+				this.poll = null;
+				this.fetching = false;
+				this.more = false;
 			});
 		}
 	}

--- a/src/client/app/desktop/views/widgets/users.vue
+++ b/src/client/app/desktop/views/widgets/users.vue
@@ -67,6 +67,7 @@ export default define({
 				this.users = [];
 				this.fetching = false;
 				this.more = false;
+				this.page = 0;
 			});
 		},
 		refresh() {

--- a/src/client/app/desktop/views/widgets/users.vue
+++ b/src/client/app/desktop/views/widgets/users.vue
@@ -2,7 +2,10 @@
 <div class="mkw-users">
 	<mk-widget-container :show-header="!props.compact">
 		<template slot="header"><fa icon="users"/>{{ $t('title') }}</template>
-		<button slot="func" :title="$t('title')" @click="refresh"><fa icon="sync"/></button>
+		<button slot="func" :title="$t('title')" @click="refresh">
+			<fa v-if="!fetching &&  more" icon="arrow-right"/>
+			<fa v-if="!fetching && !more" icon="sync"/>
+		</button>
 
 		<div class="mkw-users--body">
 			<p class="fetching" v-if="fetching"><fa icon="spinner" pulse fixed-width/>{{ $t('@.loading') }}<mk-ellipsis/></p>
@@ -38,6 +41,7 @@ export default define({
 		return {
 			users: [],
 			fetching: true,
+			more: true,
 			page: 0
 		};
 	},
@@ -59,12 +63,18 @@ export default define({
 			}).then(users => {
 				this.users = users;
 				this.fetching = false;
+			}).catch(() => {
+				this.users = [];
+				this.fetching = false;
+				this.more = false;
 			});
 		},
 		refresh() {
 			if (this.users.length < limit) {
+				this.more = false;
 				this.page = 0;
 			} else {
+				this.more = true;
 				this.page++;
 			}
 			this.fetch();


### PR DESCRIPTION
ウィジット (アンケート/おすすめユーザー) のページングアイコンが

常にsyncなのを
![image](https://user-images.githubusercontent.com/30769358/49378175-4b251a80-f74f-11e8-90e9-96e189281cb4.png)

次がある時はnextに
![image](https://user-images.githubusercontent.com/30769358/49378135-36488700-f74f-11e8-89bf-99eea1ae5123.png)

次がなくて最初にもどる時はsyncに
![image](https://user-images.githubusercontent.com/30769358/49378191-5415ec00-f74f-11e8-8c86-69db11cb1074.png)

取得中はなしにしてます
![image](https://user-images.githubusercontent.com/30769358/49378279-8889a800-f74f-11e8-8e42-d83a31101827.png)

また、エラー時に取得中のままになってしまうのを修正しています。