### PR TITLE
Remove unnecessary Renote check code

### DIFF
--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -136,11 +136,6 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 		return rej('Reply target is private of others');
 	}
 
-	// Renote対象が自分以外の非公開の投稿なら禁止
-	if (data.renote && data.renote.visibility == 'private' && !data.renote.userId.equals(user._id)) {
-		return rej('Renote target is private of others');
-	}
-
 	// ローカルのみをRenoteしたらローカルのみにする
 	if (data.renote && data.renote.localOnly) {
 		data.localOnly = true;


### PR DESCRIPTION
Renote 可否チェックの不要コードを削除してます

public/home 以外は Renote できないので
https://github.com/syuilo/misskey/blob/ade5055bc3b87ccf95e4cc4e353f1f86c6463bb1/src/services/note/create.ts#L129-L130

private 投稿での Renote チェックは不要
https://github.com/syuilo/misskey/blob/ade5055bc3b87ccf95e4cc4e353f1f86c6463bb1/src/services/note/create.ts#L139-L140