### PR TITLE
Hide unavailable admin menus

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1069,6 +1069,7 @@ admin/views/index.vue:
   announcements: "お知らせ"
   hashtags: "ハッシュタグ"
   back-to-misskey: "Misskeyに戻る"
+  you-are-not-an-admin: "あなたは管理者でもモデレーターでもないため、いくつかのメニューは隠されています。"
 
 admin/views/dashboard.vue:
   dashboard: "ダッシュボード"

--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -37,7 +37,7 @@
 		</div>
 	</nav>
 	<main>
-		<p class="warn" v-if="!perm()">{{ $t('you-are-not-an-admin') }}</p>
+		<p class="warn" v-if="!perm()"><fa icon="exclamation-triangle"/> {{ $t('you-are-not-an-admin') }}</p>
 		<div class="page">
 			<div v-if="page == 'dashboard'"><x-dashboard/></div>
 			<div v-if="page == 'instance'"><x-instance/></div>

--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -13,21 +13,21 @@
 		<div class="mi">
 			<img svg-inline src="../assets/header-icon.svg"/>
 		</div>
-		<div class="me">
+		<div v-if="$store.state.i" class="me">
 			<img class="avatar" :src="$store.state.i.avatarUrl" alt="avatar"/>
 			<p class="name">{{ $store.state.i | userName }}</p>
 		</div>
 		<ul>
-			<li @click="nav('dashboard')" :class="{ active: page == 'dashboard' }"><fa icon="home" fixed-width/>{{ $t('dashboard') }}</li>
-			<li @click="nav('instance')" :class="{ active: page == 'instance' }"><fa icon="cog" fixed-width/>{{ $t('instance') }}</li>
-			<li @click="nav('moderators')" :class="{ active: page == 'moderators' }"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</li>
-			<li @click="nav('users')" :class="{ active: page == 'users' }"><fa icon="users" fixed-width/>{{ $t('users') }}</li>
-			<!-- <li @click="nav('federation')" :class="{ active: page == 'federation' }"><fa :icon="faShareAlt" fixed-width/>{{ $t('federation') }}</li> -->
-			<li @click="nav('emoji')" :class="{ active: page == 'emoji' }"><fa :icon="faGrin" fixed-width/>{{ $t('emoji') }}</li>
-			<li @click="nav('announcements')" :class="{ active: page == 'announcements' }"><fa icon="broadcast-tower" fixed-width/>{{ $t('announcements') }}</li>
-			<li @click="nav('hashtags')" :class="{ active: page == 'hashtags' }"><fa icon="hashtag" fixed-width/>{{ $t('hashtags') }}</li>
+			<li v-if="perm('dashboard')" @click="nav('dashboard')" :class="{ active: page == 'dashboard' }"><fa icon="home" fixed-width/>{{ $t('dashboard') }}</li>
+			<li v-if="perm('instance')" @click="nav('instance')" :class="{ active: page == 'instance' }"><fa icon="cog" fixed-width/>{{ $t('instance') }}</li>
+			<li v-if="perm('moderators')" @click="nav('moderators')" :class="{ active: page == 'moderators' }"><fa :icon="faHeadset" fixed-width/>{{ $t('moderators') }}</li>
+			<li v-if="perm('users')" @click="nav('users')" :class="{ active: page == 'users' }"><fa icon="users" fixed-width/>{{ $t('users') }}</li>
+			<!-- <li v-if="perm('federation')" @click="nav('federation')" :class="{ active: page == 'federation' }"><fa :icon="faShareAlt" fixed-width/>{{ $t('federation') }}</li> -->
+			<li v-if="perm('emoji')" @click="nav('emoji')" :class="{ active: page == 'emoji' }"><fa :icon="faGrin" fixed-width/>{{ $t('emoji') }}</li>
+			<li v-if="perm('announcements')" @click="nav('announcements')" :class="{ active: page == 'announcements' }"><fa icon="broadcast-tower" fixed-width/>{{ $t('announcements') }}</li>
+			<li v-if="perm('hashtags')" @click="nav('hashtags')" :class="{ active: page == 'hashtags' }"><fa icon="hashtag" fixed-width/>{{ $t('hashtags') }}</li>
 
-			<!-- <li @click="nav('drive')" :class="{ active: page == 'drive' }"><fa icon="cloud" fixed-width/>{{ $t('@.drive') }}</li> -->
+			<!-- <li v-if="perm('drive')" @click="nav('drive')" :class="{ active: page == 'drive' }"><fa icon="cloud" fixed-width/>{{ $t('@.drive') }}</li> -->
 		</ul>
 		<div class="back-to-misskey">
 			<a href="/"><fa :icon="faArrowLeft"/> {{ $t('back-to-misskey') }}</a>
@@ -99,6 +99,10 @@ export default Vue.extend({
 	methods: {
 		nav(page: string) {
 			this.page = page;
+		},
+		perm(page: string): boolean {
+			if (page === 'dashboard') return true;
+			return this.$store.state.i && (this.$store.state.i.isAdmin || this.$store.state.i.isModerator);
 		}
 	}
 });

--- a/src/client/app/admin/views/index.vue
+++ b/src/client/app/admin/views/index.vue
@@ -37,6 +37,7 @@
 		</div>
 	</nav>
 	<main>
+		<p class="warn" v-if="!perm()">{{ $t('you-are-not-an-admin') }}</p>
 		<div class="page">
 			<div v-if="page == 'dashboard'"><x-dashboard/></div>
 			<div v-if="page == 'instance'"><x-instance/></div>
@@ -269,6 +270,17 @@ export default Vue.extend({
 	> main
 		width 100%
 		padding 0 0 0 250px
+
+		> .warn
+			display block
+			margin 0
+			padding 4px
+			text-align center
+			font-size 12px
+			color #000
+			background-size auto auto
+			background-color rgba(255, 225, 0, 1)
+			background-image repeating-linear-gradient(45deg, transparent, transparent 20px, rgba(245, 216, 0, 1) 20px, rgba(245, 216, 0, 1) 40px )
 
 		> .page
 			max-width 1150px


### PR DESCRIPTION
関連 #3526
Resolve #3331

/admin で権限がないメニュー (開けても動かない) は隠してます
未ログインだとエラーで何も表示されないのを修正しています
メニューが隠されてる場合は警告を表示します

管理者/モデレーター
![image](https://user-images.githubusercontent.com/30769358/49604832-4c19ae80-f9d2-11e8-8aca-5834eaa3fa15.png)

一般ユーザー
![image](https://user-images.githubusercontent.com/30769358/49604858-5d62bb00-f9d2-11e8-8622-a7b5efb2cfe9.png)

未ログイン
![image](https://user-images.githubusercontent.com/30769358/49604884-6b184080-f9d2-11e8-9881-83d1195fa46a.png)
