### PR TITLE
Improve custom emoji parsing

### DIFF
--- a/src/mfm/parser.ts
+++ b/src/mfm/parser.ts
@@ -75,7 +75,7 @@ export const plainParser = P.createLanguage({
 	//#region Emoji
 	emoji: r =>
 		P.alt(
-			P.regexp(/:([a-z0-9_+-]+):/i, 1)
+			P.regexp(/:(\w+):/i, 1)
 			.map(x => makeNode('emoji', {
 				name: x
 			})),
@@ -190,7 +190,7 @@ const mfm = P.createLanguage({
 	//#region Emoji
 	emoji: r =>
 		P.alt(
-			P.regexp(/:([a-z0-9_+-]+):/i, 1)
+			P.regexp(/:(\w+):/i, 1)
 			.map(x => makeNode('emoji', {
 				name: x
 			})),

--- a/src/mfm/parser.ts
+++ b/src/mfm/parser.ts
@@ -75,7 +75,7 @@ export const plainParser = P.createLanguage({
 	//#region Emoji
 	emoji: r =>
 		P.alt(
-			P.regexp(/:(\w+):/i, 1)
+			P.regexp(/:([a-z0-9_+-]+):/i, 1)
 			.map(x => makeNode('emoji', {
 				name: x
 			})),
@@ -190,7 +190,7 @@ const mfm = P.createLanguage({
 	//#region Emoji
 	emoji: r =>
 		P.alt(
-			P.regexp(/:(\w+):/i, 1)
+			P.regexp(/:([a-z0-9_+-]+):/i, 1)
 			.map(x => makeNode('emoji', {
 				name: x
 			})),

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -198,8 +198,8 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 		let emojis = [] as string[];
 
 		if (updates.name != null) {
-			const match = updates.name.match(/:\w{1,100}:/g) as string[];
-			if (match) emojis = emojis.concat(match.map(m => m.replace(/:(\w+):/, '$1')));
+			const tokens = parse(updates.name, true);
+			emojis = emojis.concat(extractEmojis(tokens));
 		}
 
 		if (updates.description != null) {


### PR DESCRIPTION
プロフィール更新時の名前部分のカスタム絵文字抽出は
MFMパーサーのプレインテキスト版が使用できるのでそれを使用するように。

カスタム絵文字に使用可能な文字列は
MisskeyでもMastodonでも`[0-9A-Za-z_]`で`[+-]`は不要なはずなので正規表現パターンを修正。