### PR TITLE
Resolve #3537

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -980,6 +980,7 @@ common/views/components/password-settings.vue:
   enter-new-password-again: "もう一度新しいパスワードを入力してください"
   not-match: "新しいパスワードが一致しません"
   changed: "パスワードを変更しました"
+  failed: "パスワード変更に失敗しました"
 
 desktop/views/components/sub-note-content.vue:
   private: "この投稿は非公開です"

--- a/src/client/app/common/views/components/password-settings.vue
+++ b/src/client/app/common/views/components/password-settings.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
 			}
 			this.$root.api('i/change_password', {
 				currentPassword,
-				newPassword: newPassword
+				newPassword
 			}).then(() => {
 				this.$root.dialog({
 					type: 'success',

--- a/src/client/app/common/views/components/password-settings.vue
+++ b/src/client/app/common/views/components/password-settings.vue
@@ -44,10 +44,18 @@ export default Vue.extend({
 				return;
 			}
 			this.$root.api('i/change_password', {
-				currentPasword: currentPassword,
+				currentPassword,
 				newPassword: newPassword
 			}).then(() => {
-				this.$notify(this.$t('changed'));
+				this.$root.dialog({
+					type: 'success',
+					text: this.$t('changed')
+				});
+			}).catch(() => {
+				this.$root.dialog({
+					type: 'error',
+					text: this.$t('failed')
+				});
 			});
 		}
 	}


### PR DESCRIPTION
Resolve #3537 
- TypoでAPIリクエスト自体が動いてないのを修正
- 失敗時にエラーを表示するように
- 枠外でnotifyが出ても気づかないのでdialogに変更