### PR TITLE
Improve tags settings

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -990,6 +990,12 @@ desktop/views/components/sub-note-content.vue:
   media-count: "{}つのメディア"
   poll: "アンケート"
 
+desktop/views/components/settings.tags.vue:
+  title: "タグ"
+  query: "クエリ (省略可)"
+  add: "追加"
+  save: "保存"
+
 desktop/views/components/taskmanager.vue:
   title: "タスクマネージャ"
 

--- a/src/client/app/common/views/components/ui/textarea.vue
+++ b/src/client/app/common/views/components/ui/textarea.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="ui-textarea" :class="{ focused, filled, tall }">
+<div class="ui-textarea" :class="{ focused, filled, tall, pre }">
 	<div class="input">
 		<span class="label" ref="label"><slot></slot></span>
 		<textarea ref="input"
@@ -42,6 +42,11 @@ export default Vue.extend({
 			required: false
 		},
 		tall: {
+			type: Boolean,
+			required: false,
+			default: false
+		},
+		pre: {
 			type: Boolean,
 			required: false,
 			default: false
@@ -174,6 +179,11 @@ root(fill)
 		> .input
 			> textarea
 				min-height 200px
+
+	&.pre
+		> .input
+			> textarea
+				white-space pre
 
 .ui-textarea.fill
 	root(true)

--- a/src/client/app/desktop/views/components/settings.tags.vue
+++ b/src/client/app/desktop/views/components/settings.tags.vue
@@ -1,15 +1,15 @@
 <template>
 <div class="vfcitkilproprqtbnpoertpsziierwzi">
-	<div v-for="timeline in timelines" class="timeline">
+	<div v-for="timeline in timelines" class="timeline" :key="timeline.id">
 		<ui-input v-model="timeline.title" @change="save">
 			<span>{{ $t('title') }}</span>
 		</ui-input>
-		<ui-textarea :value="timeline.query ? timeline.query.map(tags => tags.join(' ')).join('\n') : ''" @input="onQueryChange(timeline, $event)">
+		<ui-textarea :value="timeline.query ? timeline.query.map(tags => tags.join(' ')).join('\n') : ''" :pre="true" @input="onQueryChange(timeline, $event)">
 			<span>{{ $t('query') }}</span>
 		</ui-textarea>
-		<ui-button class="save" @click="save">{{ $t('save') }}</ui-button>
 	</div>
 	<ui-button class="add" @click="add">{{ $t('add') }}</ui-button>
+	<ui-button class="save" @click="save">{{ $t('save') }}</ui-button>
 </div>
 </template>
 
@@ -33,12 +33,19 @@ export default Vue.extend({
 				title: '',
 				query: ''
 			});
-
-			this.save();
 		},
 
 		save() {
-			this.$store.dispatch('settings/set', { key: 'tagTimelines', value: this.timelines });
+			const timelines = this.timelines
+				.filter(timeline => timeline.title)
+				.map(timeline => {
+					if (!(timeline.query && timeline.query[0] && timeline.query[0][0])) {
+						timeline.query = timeline.title.split('\n').map(tags => tags.split(' '));
+					}
+					return timeline;
+				});
+
+			this.$store.dispatch('settings/set', { key: 'tagTimelines', value: timelines });
 		},
 
 		onQueryChange(timeline, value) {


### PR DESCRIPTION
ハッシュタグ設定をいろいろ修正しています

addした時点で空アイテムが登録されてしまう
→ addでは保存しないように

saveボタンが各アイテムに付いてるがどれを押しても全更新される
→ saveボタンは一番下に1つだけに

消す方法がない / titleが空でも登録できてしまう
→ titleが空なら登録しないようにする

ぱっと見queryの書き方がわからない / queryが空でも登録できてしまう
→ queryはオプションにして、queryが空ならtitleをqueryとして登録するように

queryのtextareaが表示時に改行されてしまうことがあるため意味が変わってしまう
→ 改行しないように

ローカライズされていない
→ ローカライズした