### PR TITLE
Fix fields

### DIFF
--- a/src/client/app/desktop/views/pages/deck/deck.user-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.user-column.vue
@@ -28,7 +28,9 @@
 			</div>
 			<div class="fields" v-if="user.fields">
 				<dl class="field" v-for="(field, i) in user.fields" :key="i">
-					<dt class="name">{{ field.name }}</dt>
+					<dt class="name">
+						<misskey-flavored-markdown :text="field.name" :shouldBreak="false" :plainText="true" :custom-emojis="user.emojis"/>
+					</dt>
 					<dd class="value">
 						<misskey-flavored-markdown :text="field.value" :author="user" :i="$store.state.i" :custom-emojis="user.emojis"/>
 					</dd>
@@ -431,6 +433,7 @@ export default Vue.extend({
 				display flex
 				padding 0
 				margin 0
+				align-items center
 
 				> .name
 					padding 4px

--- a/src/client/app/desktop/views/pages/user/user.header.vue
+++ b/src/client/app/desktop/views/pages/user/user.header.vue
@@ -20,7 +20,9 @@
 		</div>
 		<div class="fields" v-if="user.fields">
 			<dl class="field" v-for="(field, i) in user.fields" :key="i">
-				<dt class="name">{{ field.name }}</dt>
+				<dt class="name">
+					<misskey-flavored-markdown :text="field.name" :shouldBreak="false" :plainText="true" :custom-emojis="user.emojis"/>
+				</dt>
 				<dd class="value">
 					<misskey-flavored-markdown :text="field.value" :author="user" :i="$store.state.i" :custom-emojis="user.emojis"/>
 				</dd>
@@ -189,6 +191,7 @@ export default Vue.extend({
 				display flex
 				padding 0
 				margin 0
+				align-items center
 
 				> .name
 					border-right solid 1px var(--faceDivider)

--- a/src/client/app/mobile/views/pages/user.vue
+++ b/src/client/app/mobile/views/pages/user.vue
@@ -26,7 +26,9 @@
 				</div>
 				<div class="fields" v-if="user.fields">
 					<dl class="field" v-for="(field, i) in user.fields" :key="i">
-						<dt class="name">{{ field.name }}</dt>
+						<dt class="name">
+							<misskey-flavored-markdown :text="field.name" :shouldBreak="false" :plainText="true" :custom-emojis="user.emojis"/>
+						</dt>
 						<dd class="value">
 							<misskey-flavored-markdown :text="field.value" :author="user" :i="$store.state.i" :custom-emojis="user.emojis"/>
 						</dd>
@@ -316,6 +318,7 @@ main
 					display flex
 					padding 0
 					margin 0
+					align-items center
 
 					> .name
 						padding 4px


### PR DESCRIPTION
フィールドのマイナーな修正

- valueにカスタム絵文字が使用されると縦位置が揃わないのを修正
- nameにTwemojiが使用できるようにする

Before
![image](https://user-images.githubusercontent.com/30769358/49818914-5fa08d00-fdb7-11e8-9c91-3e80619c40c1.png)

After
![image](https://user-images.githubusercontent.com/30769358/49818708-c6717680-fdb6-11e8-9593-03a100819640.png)
