### PR TITLE
Fix error in profile

### DIFF
--- a/src/mfm/html-to-mfm.ts
+++ b/src/mfm/html-to-mfm.ts
@@ -43,7 +43,7 @@ export default function(html: string): string {
 				if ((rel && rel.value.match('tag') !== null) || !href || href.value == txt) {
 					text += txt;
 				// メンション
-				} else if (txt.startsWith('@') && !rel || !rel.value.match(/^me /)) {
+				} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {
 					const part = txt.split('@');
 
 					if (part.length == 2) {


### PR DESCRIPTION
リモートMisskeyユーザーの情報取得が失敗することがあるのを修正

自己紹介にメンション (Misskey の場合はrelがないリンク) がある場合エラーになってしまう
`TypeError: Cannot read property 'value' of undefined`