### PR TITLE
Return 404 for invalid Object ID

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -65,7 +65,7 @@ router.get('/notes/:note', async (ctx, next) => {
 	if (!isActivityPubReq(ctx)) return await next();
 
 	if (!ObjectID.isValid(ctx.params.note)) {
-		ctx.status = 400;
+		ctx.status = 404;
 		return;
 	}
 
@@ -88,7 +88,7 @@ router.get('/notes/:note', async (ctx, next) => {
 // note activity
 router.get('/notes/:note/activity', async ctx => {
 	if (!ObjectID.isValid(ctx.params.note)) {
-		ctx.status = 400;
+		ctx.status = 404;
 		return;
 	}
 
@@ -123,7 +123,7 @@ router.get('/users/:user/collections/featured', Featured);
 // publickey
 router.get('/users/:user/publickey', async ctx => {
 	if (!ObjectID.isValid(ctx.params.user)) {
-		ctx.status = 400;
+		ctx.status = 404;
 		return;
 	}
 
@@ -161,10 +161,8 @@ async function userInfo(ctx: Router.IRouterContext, user: IUser) {
 }
 
 router.get('/users/:user', async ctx => {
-	if (!isActivityPubReq(ctx)) ctx.redirect(`/@${ctx.params.user}`);
-
 	if (!ObjectID.isValid(ctx.params.user)) {
-		ctx.status = 400;
+		ctx.status = 404;
 		return;
 	}
 
@@ -180,11 +178,6 @@ router.get('/users/:user', async ctx => {
 
 router.get('/@:user', async (ctx, next) => {
 	if (!isActivityPubReq(ctx)) return await next();
-
-	if (!ObjectID.isValid(ctx.params.user)) {
-		ctx.status = 400;
-		return;
-	}
 
 	const user = await User.findOne({
 		usernameLower: ctx.params.user.toLowerCase(),

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -1,4 +1,4 @@
-import * as mongo from 'mongodb';
+import { ObjectID } from 'mongodb';
 import * as Router from 'koa-router';
 const json = require('koa-json-body');
 const httpSignature = require('http-signature');
@@ -64,8 +64,13 @@ router.post('/users/:user/inbox', json(), inbox);
 router.get('/notes/:note', async (ctx, next) => {
 	if (!isActivityPubReq(ctx)) return await next();
 
+	if (!ObjectID.isValid(ctx.params.note)) {
+		ctx.status = 400;
+		return;
+	}
+
 	const note = await Note.findOne({
-		_id: new mongo.ObjectID(ctx.params.note),
+		_id: new ObjectID(ctx.params.note),
 		visibility: { $in: ['public', 'home'] },
 		localOnly: { $ne: true }
 	});
@@ -82,8 +87,13 @@ router.get('/notes/:note', async (ctx, next) => {
 
 // note activity
 router.get('/notes/:note/activity', async ctx => {
+	if (!ObjectID.isValid(ctx.params.note)) {
+		ctx.status = 400;
+		return;
+	}
+
 	const note = await Note.findOne({
-		_id: new mongo.ObjectID(ctx.params.note),
+		_id: new ObjectID(ctx.params.note),
 		visibility: { $in: ['public', 'home'] },
 		localOnly: { $ne: true }
 	});
@@ -112,7 +122,12 @@ router.get('/users/:user/collections/featured', Featured);
 
 // publickey
 router.get('/users/:user/publickey', async ctx => {
-	const userId = new mongo.ObjectID(ctx.params.user);
+	if (!ObjectID.isValid(ctx.params.user)) {
+		ctx.status = 400;
+		return;
+	}
+
+	const userId = new ObjectID(ctx.params.user);
 
 	const user = await User.findOne({
 		_id: userId,
@@ -146,7 +161,14 @@ async function userInfo(ctx: Router.IRouterContext, user: IUser) {
 }
 
 router.get('/users/:user', async ctx => {
-	const userId = new mongo.ObjectID(ctx.params.user);
+	if (!isActivityPubReq(ctx)) ctx.redirect(`/@${ctx.params.user}`);
+
+	if (!ObjectID.isValid(ctx.params.user)) {
+		ctx.status = 400;
+		return;
+	}
+
+	const userId = new ObjectID(ctx.params.user);
 
 	const user = await User.findOne({
 		_id: userId,
@@ -158,6 +180,11 @@ router.get('/users/:user', async ctx => {
 
 router.get('/@:user', async (ctx, next) => {
 	if (!isActivityPubReq(ctx)) return await next();
+
+	if (!ObjectID.isValid(ctx.params.user)) {
+		ctx.status = 400;
+		return;
+	}
 
 	const user = await User.findOne({
 		usernameLower: ctx.params.user.toLowerCase(),

--- a/src/server/activitypub/followers.ts
+++ b/src/server/activitypub/followers.ts
@@ -1,4 +1,4 @@
-import * as mongo from 'mongodb';
+import { ObjectID } from 'mongodb';
 import * as Router from 'koa-router';
 import config from '../../config';
 import $ from 'cafy'; import ID, { transform } from '../../misc/cafy-id';
@@ -11,7 +11,12 @@ import renderFollowUser from '../../remote/activitypub/renderer/follow-user';
 import { setResponseType } from '../activitypub';
 
 export default async (ctx: Router.IRouterContext) => {
-	const userId = new mongo.ObjectID(ctx.params.user);
+	if (!ObjectID.isValid(ctx.params.user)) {
+		ctx.status = 404;
+		return;
+	}
+
+	const userId = new ObjectID(ctx.params.user);
 
 	// Get 'cursor' parameter
 	const [cursor = null, cursorErr] = $.type(ID).optional.get(ctx.request.query.cursor);

--- a/src/server/activitypub/following.ts
+++ b/src/server/activitypub/following.ts
@@ -1,7 +1,8 @@
-import * as mongo from 'mongodb';
+import { ObjectID } from 'mongodb';
 import * as Router from 'koa-router';
 import config from '../../config';
-import $ from 'cafy'; import ID, { transform } from '../../misc/cafy-id';
+import $ from 'cafy';
+import ID, { transform } from '../../misc/cafy-id';
 import User from '../../models/user';
 import Following from '../../models/following';
 import pack from '../../remote/activitypub/renderer';
@@ -11,7 +12,12 @@ import renderFollowUser from '../../remote/activitypub/renderer/follow-user';
 import { setResponseType } from '../activitypub';
 
 export default async (ctx: Router.IRouterContext) => {
-	const userId = new mongo.ObjectID(ctx.params.user);
+	if (!ObjectID.isValid(ctx.params.note)) {
+		ctx.status = 404;
+		return;
+	}
+
+	const userId = new ObjectID(ctx.params.user);
 
 	// Get 'cursor' parameter
 	const [cursor = null, cursorErr] = $.type(ID).optional.get(ctx.request.query.cursor);

--- a/src/server/activitypub/following.ts
+++ b/src/server/activitypub/following.ts
@@ -12,7 +12,7 @@ import renderFollowUser from '../../remote/activitypub/renderer/follow-user';
 import { setResponseType } from '../activitypub';
 
 export default async (ctx: Router.IRouterContext) => {
-	if (!ObjectID.isValid(ctx.params.note)) {
+	if (!ObjectID.isValid(ctx.params.user)) {
 		ctx.status = 404;
 		return;
 	}

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -16,7 +16,7 @@ import renderAnnounce from '../../remote/activitypub/renderer/announce';
 import { countIf } from '../../prelude/array';
 
 export default async (ctx: Router.IRouterContext) => {
-	if (!ObjectID.isValid(ctx.params.note)) {
+	if (!ObjectID.isValid(ctx.params.user)) {
 		ctx.status = 404;
 		return;
 	}

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -1,7 +1,8 @@
-import * as mongo from 'mongodb';
+import { ObjectID } from 'mongodb';
 import * as Router from 'koa-router';
 import config from '../../config';
-import $ from 'cafy'; import ID, { transform } from '../../misc/cafy-id';
+import $ from 'cafy';
+import ID, { transform } from '../../misc/cafy-id';
 import User from '../../models/user';
 import pack from '../../remote/activitypub/renderer';
 import renderOrderedCollection from '../../remote/activitypub/renderer/ordered-collection';
@@ -15,7 +16,12 @@ import renderAnnounce from '../../remote/activitypub/renderer/announce';
 import { countIf } from '../../prelude/array';
 
 export default async (ctx: Router.IRouterContext) => {
-	const userId = new mongo.ObjectID(ctx.params.user);
+	if (!ObjectID.isValid(ctx.params.note)) {
+		ctx.status = 404;
+		return;
+	}
+
+	const userId = new ObjectID(ctx.params.user);
 
 	// Get 'sinceId' parameter
 	const [sinceId, sinceIdErr] = $.type(ID).optional.get(ctx.request.query.since_id);


### PR DESCRIPTION
Resolve #3625
関連 #3621

ActibityPubで
以下のURIのように不正なObjectIDで要求された時に500でなく404を返すように修正しています
```
/notes/InvaliedID
/notes/InvaliedID/activity
/users/InvaliedID
/users/InvaliedID/publickey
/users/InvaliedID/followers
/users/InvaliedID/following
/users/InvaliedID/outbox
/users/InvaliedID/collections/featured
```