### PR TITLE
Add example nginx configuration

### DIFF
--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -1,8 +1,8 @@
 # Sample nginx configuration for Misskey
 #
 # 1. Replace example.tld to your domain
-# 2. Copy to /etc/nginx/sites-enabled
-#    or copy to /etc/nginx/sites-available and then symlink from /etc/nginx/sites-ebabled
+# 2. Copy to /etc/nginx/sites-available/ and then symlink from /etc/nginx/sites-ebabled/
+#    or copy to /etc/nginx/conf.d/
 
 # For WebSocket
 map $http_upgrade $connection_upgrade {

--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -1,0 +1,70 @@
+# Sample Nginx configuration for Misskey
+#
+# 1. Replace example.tld to your domain
+# 2. Copy to /etc/nginx/sites-enabled
+#    or copy to /etc/nginx/sites-available and then symlink from /etc/nginx/sites-ebabled
+
+# For WebSocket
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+proxy_cache_path /tmp/nginx_cache levels=1:2 keys_zone=cache1:16m max_size=1g inactive=720m use_temp_path=off;
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name example.tld;
+
+    # For SSL domain validation
+    root /var/www/html;
+    location /.well-known/acme-challenge/ { allow all; }
+    location /.well-known/pki-validation/ { allow all; }
+    location / { return 301 https://$server_name$request_uri; }
+}
+
+server {
+    listen 443 http2;
+    listen [::]:443 http2;
+    server_name example.tld;
+    ssl on;
+		ssl_session_cache shared:ssl_session_cache:10m;
+
+    # To use Let's Encrypt certificate
+    ssl_certificate     /etc/letsencrypt/live/example.tld/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/example.tld/privkey.pem;
+
+    # To use Debian/Ubuntu's self-signed certificate (For testing or before issuing a certificate)
+    #ssl_certificate     /etc/ssl/certs/ssl-cert-snakeoil.pem;
+    #ssl_certificate_key /etc/ssl/private/ssl-cert-snakeoil.key;
+
+    # SSL protocol settings
+    ssl_protocols TLSv1 TLSv1.2;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:AES128-SHA;
+    ssl_prefer_server_ciphers on;
+
+    # Change to your upload limit
+    client_max_body_size 80m;
+
+    # Proxy to Node
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+
+        # For WebSocket
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # Cache settings
+        proxy_cache cache1;
+        proxy_cache_lock on;
+        proxy_cache_use_stale updating;
+        add_header X-Cache $upstream_cache_status;
+    }
+}

--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -1,4 +1,4 @@
-# Sample Nginx configuration for Misskey
+# Sample nginx configuration for Misskey
 #
 # 1. Replace example.tld to your domain
 # 2. Copy to /etc/nginx/sites-enabled


### PR DESCRIPTION
Resolve #3654

nginx でリバースプロキシする設定例

- SSLを終端してNodeにProxyする
- WebSocketに対応する
- Cache-Controlに従ってキャッシュする

主に Debian / Ubuntu / CentOS あたりのディストリを想定してます。