### PR TITLE
Send original URL for quote

### DIFF
--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -102,10 +102,9 @@ export default async function renderNote(note: INote, dive = true): Promise<any>
 
 	let apText = text;
 
-	if (note.renoteId != null) {
+	if (quote) {
 		if (apText == null) apText = '';
-		const url = `${config.url}/notes/${note.renoteId}`;
-		apText += `\n\nRE: ${url}`;
+		apText += `\n\nRE: ${quote}`;
 	}
 
 	const summary = note.cw === '' ? String.fromCharCode(0x200B) : note.cw;


### PR DESCRIPTION
Resolve #3468

引用投稿時にオリジナルのURLを送るようにしています

AP用のURLでWeb用のURLとは違う可能性はありますが
Misskey / Mastodon / Pleroma を見た感じこのURLでもWeb用のコンテンツを出力してくれたり
リダイレクトしてくれたりするので問題なさそう。