### PR TITLE
Hide warned contents in welcome timeline

### DIFF
--- a/src/client/app/common/views/components/welcome-timeline.vue
+++ b/src/client/app/common/views/components/welcome-timeline.vue
@@ -16,7 +16,7 @@
 					</div>
 				</header>
 				<div class="text">
-					<misskey-flavored-markdown v-if="note.text" :text="note.text" :author="note.user" :custom-emojis="note.emojis"/>
+					<misskey-flavored-markdown v-if="note.text" :text="note.cw != null ? note.cw : note.text" :author="note.user" :custom-emojis="note.emojis"/>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
# Summary
Fix #3605 

cwがある時はcontentsじゃなくてcwだけを表示するように。
空cwで空白投稿になってしまうけど、メディアだけ投稿とかも空白投稿になるのでまあいいかなと。
