### PR TITLE
Fix overlap of birthday label on datepicker

### DIFF
--- a/src/client/app/common/views/components/profile-editor.vue
+++ b/src/client/app/common/views/components/profile-editor.vue
@@ -24,7 +24,7 @@
 			</ui-input>
 
 			<ui-input v-model="birthday" type="date">
-				<span>{{ $t('birthday') }}</span>
+				<span slot="title">{{ $t('birthday') }}</span>
 				<span slot="prefix"><fa icon="birthday-cake"/></span>
 			</ui-input>
 

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -6,6 +6,7 @@
 			<div class="value" ref="passwordMetar"></div>
 		</div>
 		<span class="label" ref="label"><slot></slot></span>
+		<span class="title" ref="title"><slot name="title"></slot></span>
 		<div class="prefix" ref="prefix"><slot name="prefix"></slot></div>
 		<template v-if="type != 'file'">
 			<input ref="input"
@@ -280,6 +281,20 @@ root(fill)
 			//will-change transform
 			transform-origin top left
 			transform scale(1)
+
+		> .title
+			position absolute
+			z-index 1
+			top fill ? -24px : -17px
+			left 0 !important
+			pointer-events none
+			font-size 16px
+			line-height 32px
+			color var(--inputLabel)
+			pointer-events none
+			//will-change transform
+			transform-origin top left
+			transform scale(.75)
 
 		> input
 			display block


### PR DESCRIPTION
# Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
Fix #3696

Adds a new "title" slot that works like the expanded label.
This means birthday will always be expanded out with no animation, so it cannot overlap the date picker
<img width="415" alt="image" src="https://user-images.githubusercontent.com/7827846/50271648-71ee8b00-0489-11e9-9eaf-44352e42bec7.png">

