### PR TITLE
Fix: ap/show does not return on error

### DIFF
--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -25,11 +25,10 @@ export const meta = {
 	},
 };
 
-export default define(meta, (ps) => new Promise(async (res, rej) => {
-	const object = await fetchAny(ps.uri);
-	if (object == null) return rej('object not found');
-
-	res(object);
+export default define(meta, (ps) => new Promise((res, rej) => {
+	fetchAny(ps.uri)
+		.then(object => object != null ? res(object) : rej('object not found'))
+		.catch(e => rej(e));
 }));
 
 /***


### PR DESCRIPTION
# Summary
ap/showでエラーが発生すると応答が返ってこない
検索窓にAPオブジェクト以外のURLを入れると読み込み中のままになる
を修正

https://github.com/syuilo/misskey/issues/3686#issuecomment-449021033