### PR TITLE
Fix follow processing icon

### DIFF
--- a/src/client/app/common/views/components/follow-button.vue
+++ b/src/client/app/common/views/components/follow-button.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
 		iconAndText(): any[] {
 			return (
 				(this.hasPendingFollowRequestFromYou && this.user.isLocked) ? ['hourglass-half', this.$t('request-pending')] :
-				(this.hasPendingFollowRequestFromYou && !this.user.isLocked) ? ['hourglass-start', this.$t('follow-processing')] :
+				(this.hasPendingFollowRequestFromYou && !this.user.isLocked) ? ['spinner', this.$t('follow-processing')] :
 				(this.isFollowing) ? ['minus', this.$t('following')] :
 				(!this.isFollowing && this.user.isLocked) ? ['plus', this.$t('follow-request')] :
 				(!this.isFollowing && !this.user.isLocked) ? ['plus', this.$t('follow')] :

--- a/src/client/app/common/views/pages/follow.vue
+++ b/src/client/app/common/views/pages/follow.vue
@@ -22,7 +22,7 @@
 			:disabled="followWait">
 		<template v-if="!followWait">
 			<template v-if="user.hasPendingFollowRequestFromYou && user.isLocked"><fa icon="hourglass-half"/> {{ $t('request-pending') }}</template>
-			<template v-else-if="user.hasPendingFollowRequestFromYou && !user.isLocked"><fa icon="hourglass-start"/> {{ $t('follow-processing') }}</template>
+			<template v-else-if="user.hasPendingFollowRequestFromYou && !user.isLocked"><fa icon="spinner"/> {{ $t('follow-processing') }}</template>
 			<template v-else-if="user.isFollowing"><fa icon="minus"/> {{ $t('following') }}</template>
 			<template v-else-if="!user.isFollowing && user.isLocked"><fa icon="plus"/> {{ $t('follow-request') }}</template>
 			<template v-else-if="!user.isFollowing && !user.isLocked"><fa icon="plus"/> {{ $t('follow') }}</template>

--- a/src/client/app/init.ts
+++ b/src/client/app/init.ts
@@ -123,6 +123,7 @@ import {
 	faArrowLeft,
 	faMapMarker,
 	faRobot,
+	faHourglassHalf,
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -253,6 +254,7 @@ library.add(
 	faArrowLeft,
 	faMapMarker,
 	faRobot,
+	faHourglassHalf,
 
 	farBell,
 	farEnvelope,


### PR DESCRIPTION
# Summary
フォロー 処理中/承認待ち アイコンが欠けているのを修正

処理待ち/承認待ちアイコンがどっちも砂時計で見分けづらいので
(実は砂の位置が違う 処理待ちは砂が全部上にある / 承認待ちは砂が半分落ちてる)

処理待ちはくるくる
![image](https://user-images.githubusercontent.com/30769358/50300161-e562bd80-04c6-11e9-8168-fb8f9aedc266.png)

承認待ちは砂時計
![image](https://user-images.githubusercontent.com/30769358/50300169-ef84bc00-04c6-11e9-8d07-82e36a7d4248.png)

にしてます

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
