### PR TITLE
Fix sharedInbox location

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -369,7 +369,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		}
 	});
 
-	// 該当ユーザーが既にフォロワーになっていた場合はsharedInboxもアップデートする
+	// 該当ユーザーが既にフォロワーになっていた場合はFollowingもアップデートする
 	await Following.update({
 		followerId: exist._id
 	}, {

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -18,6 +18,7 @@ import Instance from '../../../models/instance';
 import getDriveFileUrl from '../../../misc/get-drive-file-url';
 import { IEmoji } from '../../../models/emoji';
 import { ITag } from './tag';
+import Following from '../../../models/following';
 
 const log = debug('misskey:activitypub');
 
@@ -365,6 +366,15 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 				id: person.publicKey.id,
 				publicKeyPem: person.publicKey.publicKeyPem
 			},
+		}
+	});
+
+	// 該当ユーザーが既にフォロワーになっていた場合はsharedInboxもアップデートする
+	await Following.update({
+		followerId: exist._id
+	}, {
+		$set: {
+			'_follower.sharedInbox': person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined
 		}
 	});
 

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -164,7 +164,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 				publicKeyPem: person.publicKey.publicKeyPem
 			},
 			inbox: person.inbox,
-			sharedInbox: person.sharedInbox,
+			sharedInbox: person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined,
 			featured: person.featured,
 			endpoints: person.endpoints,
 			uri: person.id,
@@ -340,7 +340,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		$set: {
 			lastFetchedAt: new Date(),
 			inbox: person.inbox,
-			sharedInbox: person.sharedInbox,
+			sharedInbox: person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined,
 			featured: person.featured,
 			avatarId: avatar ? avatar._id : null,
 			bannerId: banner ? banner._id : null,

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -63,6 +63,7 @@ export default async (user: ILocalUser) => {
 		following: `${id}/following`,
 		featured: `${id}/collections/featured`,
 		sharedInbox: `${config.url}/inbox`,
+		endpoints: { sharedInbox: `${config.url}/inbox` },
 		url: `${config.url}/@${user.username}`,
 		preferredUsername: user.username,
 		name: user.name,

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -56,7 +56,7 @@ export interface IPerson extends IObject {
 	following: any;
 	featured?: any;
 	outbox: any;
-	endpoints: string[];
+	endpoints: any;
 }
 
 export const isCollection = (object: IObject): object is ICollection =>


### PR DESCRIPTION
# Summary
Fix #3709
sharedInbox の場所が間違っているのを修正
これにより、MastodonやPleromaのsharedInboxが正しく取得できるようになる。
また、Pleroma側のチェック強化によって配信できなくなるのが修正される。

ただ、リカバリするにはフォローされた時に作成される`Following`の非正規化項目のところもリカバリする必要があるので、ユーザー情報更新時に更新するようにしています。
https://github.com/syuilo/misskey/blob/95c4e4497e8a2529f7757f3a7274ae3b9c5a1513/src/models/following.ts#L23-L27