### PR TITLE
本文からメンション等を展開しないオプション

### DIFF
--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -82,6 +82,30 @@ export const meta = {
 			}
 		},
 
+		noExtractMentions: {
+			validator: $.bool.optional,
+			default: false,
+			desc: {
+				'ja-JP': '本文からメンションを展開しないか否か。'
+			}
+		},
+
+		noExtractHashtags: {
+			validator: $.bool.optional,
+			default: false,
+			desc: {
+				'ja-JP': '本文からハッシュタグを展開しないか否か。'
+			}
+		},
+
+		noExtractEmojis: {
+			validator: $.bool.optional,
+			default: false,
+			desc: {
+				'ja-JP': '本文からカスタム絵文字を展開しないか否か。'
+			}
+		},
+
 		geo: {
 			validator: $.obj({
 				coordinates: $.arr().length(2)
@@ -237,6 +261,9 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 		localOnly: ps.localOnly,
 		visibility: ps.visibility,
 		visibleUsers,
+		apMentions: ps.noExtractMentions ? [] : undefined,
+		apHashtags: ps.noExtractHashtags ? [] : undefined,
+		apEmojis: ps.noExtractEmojis ? [] : undefined,
 		geo: ps.geo
 	})
 	.then(note => pack(note, user))


### PR DESCRIPTION
# Summary
1. 本文にメンションのようなシーケンスがあっても、メンションにしないオプション
    通知やリモート配信等がされなくなる
2. 本文にハッシュタグのようなシーケンスがあっても、ハッシュタグにしないオプション
    タグタイムライン等にのらなくなる
3. 本文にカスタム絵文字のようなシーケンスがあっても、カスタム絵文字にしないオプション

botとか自動生成系メンション等飛ばしたくない時に使うかも