### PR TITLE
ダイレクト投稿でユーザーが指定されていなかったらrejectする

### DIFF
--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -188,6 +188,11 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 				data.visibleUsers.push(u);
 			}
 		}
+
+		// ダイレクト投稿でユーザーが指定されていなかったらreject
+		if (data.visibleUsers.length === 0) {
+			return rej('Target user is not specified');
+		}
 	}
 
 	const note = await insertNote(user, data, tags, emojis, mentionedUsers);


### PR DESCRIPTION
# Summary
ダイレクト投稿で、ユーザーを追加でもメンションでもユーザーが指定されていなかった時は
今までと同じように投稿に失敗するようにする。

https://github.com/syuilo/misskey/pull/3722#issuecomment-449590867
> リプライもメンションもユーザーを追加もせずダイレクト投稿した場合、このPR以後はサーバー側で出ていたエラーも出なくなるので、むしろ #3719 のようにクライアント側で補う必要があると思うのですがどうでしょう？(送信の際にメンション=MFMの解析が必要そうですが)