### PR TITLE
Fix mention links

### DIFF
--- a/src/client/app/common/views/components/mention.vue
+++ b/src/client/app/common/views/components/mention.vue
@@ -1,5 +1,5 @@
 <template>
-<router-link class="ldlomzub" :to="`/@${ canonical }`" v-user-preview="canonical">
+<router-link class="ldlomzub" :to="`/${ canonical }`" v-user-preview="canonical">
 	<span class="me" v-if="isMe">{{ $t('@.you') }}</span>
 	<span class="main">
 		<span class="username">@{{ username }}</span>


### PR DESCRIPTION
# Summary
`canonical` already starts with `@`, remove the extra `@`.

```ts
computed: {
	canonical(): string {
		return `@${this.username}@${toUnicode(this.host)}`;
	},
```