### PR TITLE
Ignore error in featuredNotes

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -441,7 +441,7 @@ export async function updateFeatured(userId: mongo.ObjectID) {
 
 	await User.update({ _id: user._id }, {
 		$set: {
-			pinnedNoteIds: featuredNotes.map(note => note._id)
+			pinnedNoteIds: featuredNotes.filter(note => note != null).map(note => note._id)
 		}
 	});
 }


### PR DESCRIPTION
# Summary
Related #3729
リモートユーザーの更新時に、各ピン留め投稿の取得失敗は無視するようにしています。

失敗自体の原因は、ピン留め投稿が消えているとかではないかと思われますが、
エラーを出してもしょうがないので無視するようにしています。