### PR TITLE
Fix: can not update remote Misskey user

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -165,7 +165,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 				publicKeyPem: person.publicKey.publicKeyPem
 			},
 			inbox: person.inbox,
-			sharedInbox: person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined,
+			sharedInbox: person.sharedInbox || (person.endpoints ? person.endpoints.sharedInbox : undefined),
 			featured: person.featured,
 			endpoints: person.endpoints,
 			uri: person.id,
@@ -341,7 +341,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		$set: {
 			lastFetchedAt: new Date(),
 			inbox: person.inbox,
-			sharedInbox: person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined,
+			sharedInbox: person.sharedInbox || (person.endpoints ? person.endpoints.sharedInbox : undefined),
 			featured: person.featured,
 			avatarId: avatar ? avatar._id : null,
 			bannerId: banner ? banner._id : null,
@@ -374,7 +374,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		followerId: exist._id
 	}, {
 		$set: {
-			'_follower.sharedInbox': person.sharedInbox || person.endpoints ? person.endpoints.sharedInbox : undefined
+			'_follower.sharedInbox': person.sharedInbox || (person.endpoints ? person.endpoints.sharedInbox : undefined)
 		}
 	});
 


### PR DESCRIPTION
# Summary
先のsharedInboxの修正で、
リモートMisskeyユーザーの情報が登録/更新出来なくなっていたのを修正してます

`TypeError: Cannot read property 'sharedInbox' of undefined`