### PR TITLE
Change italic syntax to fit with other markdown implementations

### DIFF
--- a/src/mfm/parser.ts
+++ b/src/mfm/parser.ts
@@ -224,7 +224,7 @@ const mfm = P.createLanguage({
 
 	//#region Italic
 	italic: r =>
-		P.regexp(/<i>([\s\S]+?)<\/i>/, 1)
+		P.regexp(/(\*|_)([\s\S]+?)\1/, 2)
 		.map(x => createTree('italic', P.alt(
 			r.bold,
 			r.strike,


### PR DESCRIPTION
# Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
currently italics require an html <i> syntax, unlike every other formatter. this is very confusing, especially as there doesnt seem to be any documentation.
this change makes both _text_ and *text* work, both things that users would expect from other implementations of markdown such as pleroma, discord and github.

see:
https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet#emphasis
https://sourceforge.net/p/pleroma/wiki/markdown_syntax/#md_ex_text
https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-