### PR TITLE
Add double underscore syntax for bold markdown

### DIFF
--- a/src/mfm/parser.ts
+++ b/src/mfm/parser.ts
@@ -154,7 +154,7 @@ const mfm = P.createLanguage({
 
 	//#region Bold
 	bold: r =>
-		P.regexp(/\*\*([\s\S]+?)\*\*/, 1)
+		P.regexp(/(\*\*|__)([\s\S]+?)\1/, 2)
 		.map(x => createTree('bold', P.alt(
 			r.strike,
 			r.italic,

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -177,6 +177,29 @@ describe('MFM', () => {
 					text('bar'),
 				]);
 			});
+
+			it('with underscores', () => {
+				const tokens = analyze('__foo__');
+				assert.deepStrictEqual(tokens, [
+					tree('bold', [
+						text('foo')
+					], {}),
+				]);
+			});
+
+			it('mixed syntax', () => {
+				const tokens = analyze('**foo__');
+				assert.deepStrictEqual(tokens, [
+						text('**foo__'),
+				]);
+			});
+
+			it('mixed syntax', () => {
+				const tokens = analyze('__foo**');
+				assert.deepStrictEqual(tokens, [
+						text('__foo**'),
+				]);
+			});
 		});
 
 		it('big', () => {


### PR DESCRIPTION
# Summary
see https://github.com/syuilo/misskey/pull/3732
this allows bold text through either `**text**` or `__text__`

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
