### PR TITLE
Fix translation location

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -805,6 +805,7 @@ desktop/views/components/settings.vue:
   update-settings: "Advanced settings"
   prevent-update: "Postpone updates (not recommended)"
   prevent-update-desc: "Even if you turn this setting on, updates may apply. This setting is enabled only for this device."
+  mark-as-read-all-unread-notes: "Mark all posts as read"
   no-updates: "No updates available"
   no-updates-desc: "Your Misskey is up to date."
   update-available: "A new version is available"
@@ -1430,7 +1431,6 @@ mobile/views/pages/settings.vue:
   signout: "Sign out"
   sound: "Sounds"
   enable-sounds: "Enable sounds"
-  mark-as-read-all-unread-notes: "Mark all posts as read"
   password: "Password"
 mobile/views/pages/user.vue:
   follows-you: "Follows you"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -838,6 +838,7 @@ desktop/views/components/settings.vue:
   2fa: "二段階認証"
   other: "その他"
   license: "ライセンス"
+  mark-as-read-all-unread-notes: "すべての投稿を既読にする"
   theme: "テーマ"
 
   behaviour: "動作"
@@ -1641,7 +1642,6 @@ mobile/views/pages/settings.vue:
   signout: "サインアウト"
   sound: "サウンド"
   enable-sounds: "サウンドを有効にする"
-  mark-as-read-all-unread-notes: "すべての投稿を既読にする"
   password: "パスワード"
 
 mobile/views/pages/user.vue:


### PR DESCRIPTION
# Summary
`mark-as-read-all-unread-notes` is used in `src/client/app/desktop/views/components/settings.vue` only.