### PR TITLE
Update translation placeholder

### DIFF
--- a/src/client/app/common/views/components/messaging-room.form.vue
+++ b/src/client/app/common/views/components/messaging-room.form.vue
@@ -85,7 +85,7 @@ export default Vue.extend({
 				}
 			} else {
 				if (items[0].kind == 'file') {
-					alert('%i18n:only-one-file-attached%');
+					alert(this.$t('only-one-file-attached'));
 				}
 			}
 		},
@@ -107,7 +107,7 @@ export default Vue.extend({
 				return;
 			} else if (e.dataTransfer.files.length > 1) {
 				e.preventDefault();
-				alert('%i18n:only-one-file-attached%');
+				alert(this.$t('only-one-file-attached'));
 				return;
 			}
 


### PR DESCRIPTION
# Summary
Copied from `messaging-room.vue`. Fixes the alert message when dragging multiple files into the messaging form.

![alert](https://user-images.githubusercontent.com/14329097/50385888-fda82780-06d4-11e9-8c87-de92aad87c76.png)
