### PR TITLE
Make activity view in admin scrollable

### DIFF
--- a/src/client/app/admin/views/ap-log.vue
+++ b/src/client/app/admin/views/ap-log.vue
@@ -69,7 +69,7 @@ export default Vue.extend({
 	display block
 	padding 12px 16px 16px 16px
 	height 250px
-	overflow hidden
+	overflow auto
 	box-shadow 0 2px 4px rgba(0, 0, 0, 0.1)
 	background var(--adminDashboardCardBg)
 	border-radius 8px


### PR DESCRIPTION

# Summary
I can't think of any reason why this isnt currently the case as the extra lines are still there, just not displayed, meaning theres no difference in performance/memory usage
Also means that sometimes entries are cut off which is weird
Also, sometimes there is reason to wish to view older entries that may have scrolled off the page/keep reading something which was pushed too far down.

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
