### PR TITLE
Supports emoji in notifications

### DIFF
--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -23,7 +23,9 @@
 								</router-link>
 							</p>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-								<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
+								<fa icon="quote-left"/>
+									<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+								<fa icon="quote-right"/>
 							</router-link>
 						</div>
 					</template>
@@ -37,7 +39,9 @@
 								</router-link>
 							</p>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
-								<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
+								<fa icon="quote-left"/>
+									<misskey-flavored-markdown :text="getNoteSummary(notification.note.renote)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.renote.emojis"/>
+								<fa icon="quote-right"/>
 							</router-link>
 						</div>
 					</template>
@@ -50,7 +54,9 @@
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
 							</p>
-							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</router-link>
+							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
+								<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+							</router-link>
 						</div>
 					</template>
 
@@ -84,7 +90,9 @@
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
 							</p>
-							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</router-link>
+							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
+								<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+							</router-link>
 						</div>
 					</template>
 
@@ -96,7 +104,9 @@
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
 							</p>
-							<a class="note-preview" :href="notification.note | notePage" :title="getNoteSummary(notification.note)">{{ getNoteSummary(notification.note) }}</a>
+							<a class="note-preview" :href="notification.note | notePage" :title="getNoteSummary(notification.note)">
+								<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+							</a>
 						</div>
 					</template>
 
@@ -107,7 +117,9 @@
 								<mk-user-name :user="notification.user"/>
 							</a></p>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-								<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
+								<fa icon="quote-left"/>
+									<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+								<fa icon="quote-right"/>
 							</router-link>
 						</div>
 					</template>

--- a/src/client/app/desktop/views/pages/deck/deck.notification.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notification.vue
@@ -11,7 +11,8 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
 				<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -28,7 +29,9 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note.renote)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.renote.emojis"/>
+				<fa icon="quote-right"/>
 			</router-link>
 		</div>
 	</div>
@@ -70,7 +73,9 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+				<fa icon="quote-right"/>
 			</router-link>
 		</div>
 	</div>

--- a/src/client/app/mobile/views/components/notification.vue
+++ b/src/client/app/mobile/views/components/notification.vue
@@ -9,7 +9,8 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
 				<fa icon="quote-right"/>
 			</router-link>
 		</div>
@@ -24,7 +25,9 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note.renote) }}<fa icon="quote-right"/>
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note.renote)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.renote.emojis"/>
+				<fa icon="quote-right"/>
 			</router-link>
 		</div>
 	</div>
@@ -60,7 +63,9 @@
 				<mk-time :time="notification.createdAt"/>
 			</header>
 			<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
-				<fa icon="quote-left"/>{{ getNoteSummary(notification.note) }}<fa icon="quote-right"/>
+				<fa icon="quote-left"/>
+					<misskey-flavored-markdown :text="getNoteSummary(notification.note)" :should-break="false" :plain-text="true" :custom-emojis="notification.note.emojis"/>
+				<fa icon="quote-right"/>
 			</router-link>
 		</div>
 	</div>


### PR DESCRIPTION
# Summary
Notifications で Emoji (Custom, Twemoji) を表示できるようにしてます

(desktop, deck, mobile) x (reaction, renote, quote, reply, mention, poll_vote) を対応
ただし、desktop x (quote, reply) x custom-emojis は対応不可