### PR TITLE
 Feature to show only my posts in the user page 

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1374,6 +1374,7 @@ desktop/views/pages/user/user.timeline.vue:
   default: "投稿"
   with-replies: "投稿と返信"
   with-media: "メディア"
+  my-posts: "私の投稿"
   empty: "このユーザーはまだ何も投稿していないようです。"
 
 desktop/views/widgets/messaging.vue:

--- a/src/client/app/desktop/views/pages/user/user.timeline.vue
+++ b/src/client/app/desktop/views/pages/user/user.timeline.vue
@@ -4,6 +4,7 @@
 		<span :data-active="mode == 'default'" @click="mode = 'default'"><fa :icon="['far', 'comment-alt']"/> {{ $t('default') }}</span>
 		<span :data-active="mode == 'with-replies'" @click="mode = 'with-replies'"><fa icon="comments"/> {{ $t('with-replies') }}</span>
 		<span :data-active="mode == 'with-media'" @click="mode = 'with-media'"><fa :icon="['far', 'images']"/> {{ $t('with-media') }}</span>
+		<span :data-active="mode == 'my-posts'" @click="mode = 'my-posts'"><fa icon="user"/> {{ $t('my-posts') }}</span>
 	</header>
 	<mk-notes ref="timeline" :more="existMore ? more : null">
 		<p class="empty" slot="empty"><fa :icon="['far', 'comments']"/>{{ $t('empty') }}</p>
@@ -65,6 +66,7 @@ export default Vue.extend({
 					limit: fetchLimit + 1,
 					untilDate: this.date ? this.date.getTime() : new Date().getTime() + 1000 * 86400 * 365,
 					includeReplies: this.mode == 'with-replies',
+					includeMyRenotes: this.mode != 'my-posts',
 					withFiles: this.mode == 'with-media'
 				}).then(notes => {
 					if (notes.length == fetchLimit + 1) {
@@ -85,6 +87,7 @@ export default Vue.extend({
 				userId: this.user.id,
 				limit: fetchLimit + 1,
 				includeReplies: this.mode == 'with-replies',
+				includeMyRenotes: this.mode != 'my-posts',
 				withFiles: this.mode == 'with-media',
 				untilDate: new Date((this.$refs.timeline as any).tail().createdAt).getTime()
 			});

--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -156,6 +156,7 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 	const sort = { } as any;
 
 	const query = {
+		$and: [ {} ],
 		deletedAt: null,
 		userId: user._id
 	} as any;
@@ -186,6 +187,22 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 
 	if (!ps.includeReplies) {
 		query.replyId = null;
+	}
+
+	if (ps.includeMyRenotes === false) {
+		query.$and.push({
+			$or: [{
+				userId: { $ne: user._id }
+			}, {
+				renoteId: null
+			}, {
+				text: { $ne: null }
+			}, {
+				fileIds: { $ne: [] }
+			}, {
+				poll: { $ne: null }
+			}]
+		});
 	}
 
 	const withFiles = ps.withFiles != null ? ps.withFiles : ps.mediaOnly;


### PR DESCRIPTION
# Summary
Fix #3681
users/notes で includeMyRenotes が効くように
includeRenotedMyNotes, includeLocalRenotes はどうせユーザー指定では意味ないのでそのまま

Resolve #3674
ユーザーページでRenoteを除いたその人の投稿だけを表示する機能 (Desktopのみ)
![image](https://user-images.githubusercontent.com/30769358/50426880-4a118400-08dc-11e9-9cf9-d7b420d7f122.png)