### PR TITLE
Supports CSS Scrollbars

### DIFF
--- a/src/client/app/desktop/style.styl
+++ b/src/client/app/desktop/style.styl
@@ -10,6 +10,13 @@
 html
 	height 100%
 	background var(--bg)
+	scrollbar-color var(--scrollbarHandle) var(--scrollbarTrack)
+
+	&:hover
+		scrollbar-color var(--scrollbarHandleHover) var(--scrollbarTrack)
+
+	&:active
+		scrollbar-color var(--primary) var(--scrollbarTrack)
 
 	&, *
 		&::-webkit-scrollbar

--- a/src/client/app/desktop/style.styl
+++ b/src/client/app/desktop/style.styl
@@ -10,15 +10,16 @@
 html
 	height 100%
 	background var(--bg)
-	scrollbar-color var(--scrollbarHandle) var(--scrollbarTrack)
-
-	&:hover
-		scrollbar-color var(--scrollbarHandleHover) var(--scrollbarTrack)
-
-	&:active
-		scrollbar-color var(--primary) var(--scrollbarTrack)
 
 	&, *
+		scrollbar-color var(--scrollbarHandle) var(--scrollbarTrack)
+
+		&:hover
+			scrollbar-color var(--scrollbarHandleHover) var(--scrollbarTrack)
+
+		&:active
+			scrollbar-color var(--primary) var(--scrollbarTrack)
+
 		&::-webkit-scrollbar
 			width 6px
 			height 6px


### PR DESCRIPTION
# Summary
Resolve #3782

なお`:hover`の判定がwebkitのと違うっぽい
 - webkit: スクロールバー自体のhover
 - これ: ~~スクロールバーを表示させている領域に対するhover (window全体とか, divの領域とか)~~
  →スクロールバーを表示させている領域に対するhover と スクロールバー自体に対するhover で2段階で変わってるみたいなので問題なさそう

`scrollbar-width`も使いたかったのですが、
divとかのスクロールバーがなぜか消えてしまうので使ってません。
(通常のHTMLなら大丈夫だった)