### PR TITLE
Resolve #3786

### DIFF
--- a/src/docs/api/entities/note.yaml
+++ b/src/docs/api/entities/note.yaml
@@ -75,6 +75,20 @@ props:
       ja-JP: "この投稿に対する自分の<a href='/docs/api/reactions'>リアクション</a>"
       en-US: "The your <a href='/docs/api/reactions'>reaction</a> of this note"
 
+  renoteCount:
+    type: "number"
+    optional: false
+    desc:
+      ja-JP: "この投稿がRenoteされた数"
+      en-US: "The number of renotes for this post"
+
+  repliesCount:
+    type: "number"
+    optional: false
+    desc:
+      ja-JP: "この投稿に返信された数"
+      en-US: "The number of replies to this post"
+
   reactionCounts:
     type: "object"
     optional: false

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -273,6 +273,11 @@ export const pack = async (
 	// Populate files
 	_note.files = packFileMany(_note.fileIds || []);
 
+	// Some counts
+	_note.renoteCount = _note.renoteCount || 0;
+	_note.repliesCount = _note.repliesCount || 0;
+	_note.reactionCounts = _note.reactionCounts || {};
+
 	// 後方互換性のため
 	_note.mediaIds = _note.fileIds;
 	_note.media = _note.files;


### PR DESCRIPTION
# Summary
Resolve #3786 

renoteCount, repliesCount がドキュメントされてないので追加
reactionCounts が optional でないのに optional になってるので、ない時は空の {} を返すように
renoteCount, repliesCount もない時は 0 を返すように
