### PR TITLE
Add id to return of users/relation

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -217,6 +217,7 @@ export async function getRelation(me: mongo.ObjectId, target: mongo.ObjectId) {
 	]);
 
 	return {
+		id: target,
 		isFollowing: following1 !== null,
 		isStalking: following1 ? following1.stalk : false,
 		hasPendingFollowRequestFromYou: followReq1 !== null,


### PR DESCRIPTION
# Summary
Adds the user id of the relevant user to the return of /api/users/relation, making it much easier to deal with the response programmatically or asynchronously 