### PR TITLE
adds ko-KR な to にゃ

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -372,7 +372,12 @@ export const pack = async (
 	//#endregion
 
 	if (_note.user.isCat && _note.text) {
-		_note.text = _note.text.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ');
+		_note.text = (_note.text
+			// ja-JP
+			.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
+			// ko-KR
+			.replace(/[나-낳]/g, (match: string) => String.fromCharCode(match.codePointAt(0) + 56))
+		);
 	}
 
 	if (!opts.skipHide) {

--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -376,7 +376,9 @@ export const pack = async (
 			// ja-JP
 			.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
 			// ko-KR
-			.replace(/[나-낳]/g, (match: string) => String.fromCharCode(match.codePointAt(0) + 56))
+			.replace(/[나-낳]/g, (match: string) => String.fromCharCode(
+				match.codePointAt(0)  + '냐'.charCodeAt(0) - '나'.charCodeAt(0)
+			))
 		);
 	}
 


### PR DESCRIPTION
# Summary

adds ko-KR な to にゃ

Making sentences like a cat in korean in natural korean way might be considered hard thing; but I wish this feature ("na" to "nya") also work in korean. so I put only 'na' to 'nya', which are not a natural way but seems to be profitable point of compromize.

- this only take consider pre-composed "Hangul Syllables", not composable area "Hangul Jamo" which are not used commonly. (first one becomes 2-byte but second one becomes 3-byte, thus it is not used commonly)
- 56 is '냐'(nya) - '나'(na). korean precomposed letters (in unicode) are in serial order which makes possible of easy-calculation

this does not solve any issues.