### PR TITLE
Tune AP URL negotiating with Accept

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -83,7 +83,7 @@ router.get('/notes/:note', async (ctx, next) => {
 	}
 
 	ctx.body = pack(await renderNote(note, false));
-	ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
+	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });
 
@@ -162,7 +162,9 @@ async function userInfo(ctx: Router.IRouterContext, user: IUser) {
 	setResponseType(ctx);
 }
 
-router.get('/users/:user', async ctx => {
+router.get('/users/:user', async (ctx, next) => {
+	if (!isActivityPubReq(ctx)) return await next();
+
 	if (!ObjectID.isValid(ctx.params.user)) {
 		ctx.status = 404;
 		return;


### PR DESCRIPTION
# Summary
AP/WebでAcceptヘッダによりResponseを出し分けているURL周辺の各種修正

Fix #3665 
Webから (APでなく) `/users/:user` にアクセスした際は `/@:user` にリダイレクトするように

`/notes/note` (AP/Web) もキャッシュするように

これを適用する際
フロントエンドやCDNでキャッシュしている場合は、キャッシュがVaryに対応している必要があります
https://github.com/syuilo/misskey/issues/3665#issuecomment-448308460 
- nginx でキャッシュをしている場合→基本的に対応しているので問題なし
- CloudFlare でキャッシュをしている場合
  - デフォルト設定でキャッシュをしている場合→該当URLはキャッシュされないので問題なし
  - Page RulesなどでCache Everything 等で上書き設定している場合 (xyzのことです)→Offにする必要あり