### PR TITLE
Compact URL preview

### DIFF
--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -14,7 +14,7 @@
 			<header>
 				<h1 :title="title">{{ title }}</h1>
 			</header>
-			<p v-if="description" :title="description">{{ description.length > 85 ? description.slice(0, 85) + '…' : description }}</p>
+			<p v-if="description" :title="description">{{ description.length > 1000 ? description.slice(0, 1000) + '…' : description }}</p>
 			<footer>
 				<img class="icon" v-if="icon" :src="icon"/>
 				<p :title="sitename">{{ sitename }}</p>

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -8,16 +8,16 @@
 	</blockquote>
 </div>
 <div v-else class="mk-url-preview">
-	<a :class="{ mini }" :href="url" target="_blank" :title="url" v-if="!fetching">
+	<a :class="{ mini, compact }" :href="url" target="_blank" :title="url" v-if="!fetching">
 		<div class="thumbnail" v-if="thumbnail" :style="`background-image: url(${thumbnail})`"></div>
 		<article>
 			<header>
-				<h1>{{ title }}</h1>
+				<h1 :title="title">{{ title }}</h1>
 			</header>
-			<p v-if="description">{{ description.length > 85 ? description.slice(0, 85) + '…' : description }}</p>
+			<p v-if="description" :title="description">{{ description.length > 85 ? description.slice(0, 85) + '…' : description }}</p>
 			<footer>
 				<img class="icon" v-if="icon" :src="icon"/>
-				<p>{{ sitename }}</p>
+				<p :title="sitename">{{ sitename }}</p>
 			</footer>
 		</article>
 	</a>
@@ -115,6 +115,12 @@ export default Vue.extend({
 		},
 
 		detail: {
+			type: Boolean,
+			required: false,
+			default: false
+		},
+
+		compact: {
 			type: Boolean,
 			required: false,
 			default: false
@@ -302,6 +308,23 @@ export default Vue.extend({
 						width 12px
 						height 12px
 
+			&.compact
+				> .thumbnail
+					position: absolute
+					width 56px
+					height 100%
+
+				> article
+					left 56px
+					width calc(100% - 56px)
+					padding 4px
+
+					> header
+						margin-bottom 2px
+
+					> footer
+						margin-top 2px
+
 		&.mini
 			font-size 10px
 
@@ -325,4 +348,27 @@ export default Vue.extend({
 						width 12px
 						height 12px
 
+			&.compact
+				> .thumbnail
+					position: absolute
+					width 56px
+					height 100%
+
+				> article
+					left 56px
+					width calc(100% - 56px)
+					padding 4px
+
+					> header
+						margin-bottom 2px
+
+					> footer
+						margin-top 2px
+
+		&.compact
+			> article
+				> header, p, footer
+					overflow: hidden;
+					white-space: nowrap;
+					text-overflow: ellipsis;
 </style>

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -367,7 +367,7 @@ export default Vue.extend({
 
 		&.compact
 			> article
-				> header, p, footer
+				> header h1, p, footer
 					overflow: hidden;
 					white-space: nowrap;
 					text-overflow: ellipsis;

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -14,7 +14,7 @@
 			<header>
 				<h1 :title="title">{{ title }}</h1>
 			</header>
-			<p v-if="description" :title="description">{{ description.length > 1000 ? description.slice(0, 1000) + '…' : description }}</p>
+			<p v-if="description" :title="description">{{ description.length > 85 ? description.slice(0, 85) + '…' : description }}</p>
 			<footer>
 				<img class="icon" v-if="icon" :src="icon"/>
 				<p :title="sitename">{{ sitename }}</p>

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -14,7 +14,7 @@
 			<header>
 				<h1 :title="title">{{ title }}</h1>
 			</header>
-			<p v-if="description" :title="description">{{ description.length > 1000 ? description.slice(0, 1000) + '…' : description }}</p>
+			<p v-if="description" :title="description">{{ description }}</p>
 			<footer>
 				<img class="icon" v-if="icon" :src="icon"/>
 				<p :title="sitename">{{ sitename }}</p>
@@ -183,7 +183,7 @@ export default Vue.extend({
 			res.json().then(info => {
 				if (info.url == null) return;
 				this.title = info.title;
-				this.description = info.description;
+				this.description = info.description && info.description.length > 505 ? info.description.slice(0, 505) + '…' : info.description;
 				this.thumbnail = info.thumbnail;
 				this.icon = info.icon;
 				this.sitename = info.sitename;

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -14,7 +14,7 @@
 			<header>
 				<h1 :title="title">{{ title }}</h1>
 			</header>
-			<p v-if="description" :title="description">{{ description }}</p>
+			<p v-if="description" :title="description">{{ description.length > 1000 ? description.slice(0, 1000) + '…' : description }}</p>
 			<footer>
 				<img class="icon" v-if="icon" :src="icon"/>
 				<p :title="sitename">{{ sitename }}</p>
@@ -183,7 +183,7 @@ export default Vue.extend({
 			res.json().then(info => {
 				if (info.url == null) return;
 				this.title = info.title;
-				this.description = info.description && info.description.length > 505 ? info.description.slice(0, 505) + '…' : info.description;
+				this.description = info.description;
 				this.thumbnail = info.thumbnail;
 				this.icon = info.icon;
 				this.sitename = info.sitename;

--- a/src/client/app/desktop/views/components/note.vue
+++ b/src/client/app/desktop/views/components/note.vue
@@ -36,7 +36,7 @@
 					<mk-poll v-if="appearNote.poll" :note="appearNote" ref="pollViewer"/>
 					<a class="location" v-if="appearNote.geo" :href="`https://maps.google.com/maps?q=${appearNote.geo.coordinates[1]},${appearNote.geo.coordinates[0]}`" target="_blank"><fa icon="map-marker-alt"/> 位置情報</a>
 					<div class="renote" v-if="appearNote.renote"><mk-note-preview :note="appearNote.renote" :mini="mini"/></div>
-					<mk-url-preview v-for="url in urls" :url="url" :key="url" :mini="mini"/>
+					<mk-url-preview v-for="url in urls" :url="url" :key="url" :mini="mini" :compact="compact"/>
 				</div>
 			</div>
 			<footer v-if="appearNote.deletedAt == null">
@@ -98,6 +98,11 @@ export default Vue.extend({
 			required: true
 		},
 		detail: {
+			type: Boolean,
+			required: false,
+			default: false
+		},
+		compact: {
 			type: Boolean,
 			required: false,
 			default: false

--- a/src/client/app/desktop/views/components/notes.vue
+++ b/src/client/app/desktop/views/components/notes.vue
@@ -15,7 +15,7 @@
 	<!-- トランジションを有効にするとなぜかメモリリークする -->
 	<component :is="!$store.state.device.reduceMotion ? 'transition-group' : 'div'" name="mk-notes" class="notes transition" tag="div" ref="notes">
 		<template v-for="(note, i) in _notes">
-			<x-note :note="note" :key="note.id" @update:note="onNoteUpdated(i, $event)" ref="note"/>
+			<x-note :note="note" :key="note.id" @update:note="onNoteUpdated(i, $event)" :compact="true" ref="note"/>
 			<p class="date" :key="note.id + '_date'" v-if="i != notes.length - 1 && note._date != _notes[i + 1]._date">
 				<span><fa icon="angle-up"/>{{ note._datetext }}</span>
 				<span><fa icon="angle-down"/>{{ _notes[i + 1]._datetext }}</span>

--- a/src/client/app/desktop/views/pages/deck/deck.notes.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notes.vue
@@ -18,6 +18,7 @@
 				:key="note.id"
 				@update:note="onNoteUpdated(i, $event)"
 				:media-view="mediaView"
+				:compact="true"
 				:mini="true"/>
 			<p class="date" :key="note.id + '_date'" v-if="i != notes.length - 1 && note._date != _notes[i + 1]._date">
 				<span><fa icon="angle-up"/>{{ note._datetext }}</span>

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -30,7 +30,7 @@
 						<mk-media-list :media-list="appearNote.files"/>
 					</div>
 					<mk-poll v-if="appearNote.poll" :note="appearNote" ref="pollViewer"/>
-					<mk-url-preview v-for="url in urls" :url="url" :key="url"/>
+					<mk-url-preview v-for="url in urls" :url="url" :key="url" :compact="compact"/>
 					<a class="location" v-if="appearNote.geo" :href="`https://maps.google.com/maps?q=${appearNote.geo.coordinates[1]},${appearNote.geo.coordinates[0]}`" target="_blank"><fa icon="map-marker-alt"/> {{ $t('location') }}</a>
 					<div class="renote" v-if="appearNote.renote"><mk-note-preview :note="appearNote.renote"/></div>
 				</div>
@@ -90,6 +90,11 @@ export default Vue.extend({
 		note: {
 			type: Object,
 			required: true
+		},
+		compact: {
+			type: Boolean,
+			required: false,
+			default: false
 		}
 	}
 });

--- a/src/client/app/mobile/views/components/notes.vue
+++ b/src/client/app/mobile/views/components/notes.vue
@@ -15,7 +15,7 @@
 	<!-- トランジションを有効にするとなぜかメモリリークする -->
 	<component :is="!$store.state.device.reduceMotion ? 'transition-group' : 'div'" name="mk-notes" class="transition" tag="div">
 		<template v-for="(note, i) in _notes">
-			<mk-note :note="note" :key="note.id" @update:note="onNoteUpdated(i, $event)"/>
+			<mk-note :note="note" :key="note.id" @update:note="onNoteUpdated(i, $event)" :compact="true"/>
 			<p class="date" :key="note.id + '_date'" v-if="i != notes.length - 1 && note._date != _notes[i + 1]._date">
 				<span><fa icon="angle-up"/>{{ note._datetext }}</span>
 				<span><fa icon="angle-down"/>{{ _notes[i + 1]._datetext }}</span>


### PR DESCRIPTION
# Summary
タイムライン上のURLプレビューをコンパクト (縦をあまり専有しないように) にしています

- url-previewにcompactオプションを追加してタイムライン上表示で適用するように
  - description等は1行表示にしてツールチップを追加
  - サムネイルは常に脇に表示するように
- 詳細表示はそのまま
  - (取り消し) ~~ただし文字数のリミットを緩めています
    (500+αにしてますが、200程度でトリムされてくるようなので実際は200文字程度になるはず)~~

**desktop**
![image](https://user-images.githubusercontent.com/30769358/50722870-21c62880-1119-11e9-8054-76168e0d46c1.png)
↓
![image](https://user-images.githubusercontent.com/30769358/50722868-1e32a180-1119-11e9-8725-df12085b869a.png)

**deck (mobileも似たような感じ)**
![image](https://user-images.githubusercontent.com/30769358/50722862-12df7600-1119-11e9-81ca-2743a7c4350b.png)
↓
![image](https://user-images.githubusercontent.com/30769358/50722859-0e1ac200-1119-11e9-8054-6050d8c294cb.png)
