### PR TITLE
Show locked mark in account

### DIFF
--- a/src/client/app/common/views/components/acct.vue
+++ b/src/client/app/common/views/components/acct.vue
@@ -2,6 +2,7 @@
 <span class="mk-acct">
 	<span class="name">@{{ user.username }}</span>
 	<span class="host" :class="{ fade: $store.state.settings.contrastedAcct }" v-if="user.host || detail || $store.state.settings.showFullAcct">@{{ user.host || host }}</span>
+	<fa v-if="user.isLocked == true" class="locked" icon="lock" fixed-width/>
 </span>
 </template>
 
@@ -23,4 +24,8 @@ export default Vue.extend({
 .mk-acct
 	> .host.fade
 		opacity 0.5
+
+	> .locked
+		opacity 0.8
+		margin-left 0.5em
 </style>

--- a/src/client/app/desktop/views/components/user-card.vue
+++ b/src/client/app/desktop/views/components/user-card.vue
@@ -7,7 +7,8 @@
 		<router-link :to="user | userPage" class="name">
 			<mk-user-name :user="user"/>
 		</router-link>
-		<span class="username">@{{ user | acct }}</span>
+		<span class="username">@{{ user | acct }} <fa v-if="user.isLocked == true" class="locked" icon="lock" fixed-width/></span>
+		
 		<div class="description">
 			<misskey-flavored-markdown v-if="user.description" :text="user.description" :author="user" :i="$store.state.i" :custom-emojis="user.emojis"/>
 		</div>
@@ -74,6 +75,9 @@ export default Vue.extend({
 		> .username
 			display block
 			opacity 0.7
+
+			> .locked
+				opacity 0.8
 
 		> .description
 			margin 8px 0 16px 0

--- a/src/client/app/desktop/views/pages/deck/deck.user-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.user-column.vue
@@ -19,7 +19,7 @@
 				<span class="name">
 					<mk-user-name :user="user"/>
 				</span>
-				<span class="acct">@{{ user | acct }}</span>
+				<span class="acct">@{{ user | acct }} <fa v-if="user.isLocked == true" class="locked" icon="lock" fixed-width/></span>
 			</div>
 		</header>
 		<div class="info">
@@ -410,6 +410,9 @@ export default Vue.extend({
 				font-size 14px
 				opacity 0.7
 				text-shadow 0 0 8px #000
+
+				> .locked
+					opacity 0.8
 
 	> .info
 		padding 16px


### PR DESCRIPTION
# Summary
Resolve #3706

アカウント (`@user`) の脇に鍵マークを表示するようにしてます
ユーザー詳細ページやフォローボタンが表示されそうな場所を対象にしています