### PR TITLE
Fix sharedInbox recovery code

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -376,6 +376,8 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		$set: {
 			'_follower.sharedInbox': person.sharedInbox || (person.endpoints ? person.endpoints.sharedInbox : undefined)
 		}
+	}, {
+		multi: true
 	});
 
 	await updateFeatured(exist._id).catch(err => console.log(err));


### PR DESCRIPTION
# Summary
#3711 の sharedInbox のリカバリコードが不完全で、完全にリカバリされないのを修正。
