### PR TITLE
Toggle show/hide password

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -132,6 +132,8 @@ common:
   line-width-thin: "細い"
   line-width-normal: "普通"
   line-width-thick: "太い"
+  hide-password: "パスワードを隠す"
+  show-password: "パスワードを表示する"
 
   do-not-use-in-production: "これは開発ビルドです。本番環境で使用しないでください。"
   user-suspended: "このユーザーは凍結されています。"

--- a/src/client/app/common/views/components/signin.vue
+++ b/src/client/app/common/views/components/signin.vue
@@ -6,7 +6,7 @@
 		<span slot="prefix">@</span>
 		<span slot="suffix">@{{ host }}</span>
 	</ui-input>
-	<ui-input v-model="password" type="password" :withPasswordToggle="true" required styl="fill">
+	<ui-input v-model="password" type="password" :with-password-toggle="true" required styl="fill">
 		<span>{{ $t('password') }}</span>
 		<span slot="prefix"><fa icon="lock"/></span>
 	</ui-input>

--- a/src/client/app/common/views/components/signin.vue
+++ b/src/client/app/common/views/components/signin.vue
@@ -6,7 +6,7 @@
 		<span slot="prefix">@</span>
 		<span slot="suffix">@{{ host }}</span>
 	</ui-input>
-	<ui-input v-model="password" type="password" required styl="fill">
+	<ui-input v-model="password" type="password" :withPasswordToggle="true" required styl="fill">
 		<span>{{ $t('password') }}</span>
 		<span slot="prefix"><fa icon="lock"/></span>
 	</ui-input>

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -383,6 +383,7 @@ root(fill)
 
 		> a
 			color var(--inputLabel)
+			text-decoration none
 
 	> .desc
 		margin 6px 0

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -39,6 +39,12 @@
 		</template>
 		<div class="suffix" ref="suffix"><slot name="suffix"></slot></div>
 	</div>
+	<div class="toggle" v-if="withPasswordToggle">
+		<a @click='togglePassword'>
+			<span v-if="type == 'password'"><fa :icon="['fa', 'eye']"/> {{ $t('@.show-password') }}</span>
+			<span v-if="type != 'password'"><fa :icon="['far', 'eye-slash']"/> {{ $t('@.hide-password') }}</span>
+		</a>
+	</div>
 	<div class="desc"><slot name="desc"></slot></div>
 </div>
 </template>
@@ -93,6 +99,11 @@ export default Vue.extend({
 			required: false
 		},
 		withPasswordMeter: {
+			type: Boolean,
+			required: false,
+			default: false
+		},
+		withPasswordToggle: {
 			type: Boolean,
 			required: false,
 			default: false
@@ -177,6 +188,13 @@ export default Vue.extend({
 	methods: {
 		focus() {
 			this.$refs.input.focus();
+		},
+		togglePassword() {
+			if(this.type == 'password') {
+				this.type = 'text'
+			} else {
+				this.type = 'password'
+			}
 		},
 		chooseFile() {
 			this.$refs.file.click();
@@ -355,6 +373,16 @@ root(fill)
 
 			if fill
 				padding-right 12px
+
+	> .toggle
+		cursor pointer
+		padding-left 0.5em
+		font-size 0.7em
+		opacity 0.7
+		text-align left
+
+		> a
+			color var(--inputLabel)
 
 	> .desc
 		margin 6px 0


### PR DESCRIPTION
# Summary
ui-inputにパスワードの表示/非表示を切り替えられるオプションを追加

![image](https://user-images.githubusercontent.com/30769358/50914793-b82c7e00-147a-11e9-9761-3b9aa5d2ec4c.png)

![image](https://user-images.githubusercontent.com/30769358/50914794-b9f64180-147a-11e9-9372-ae9c06ff5b4a.png)

ここではログインフォームに適用しているが #3861 などでも使うかも