### PR TITLE
Supports toggle password in SMTP settings

### DIFF
--- a/src/client/app/admin/views/instance.vue
+++ b/src/client/app/admin/views/instance.vue
@@ -54,7 +54,7 @@
 			</ui-horizon-group>
 			<ui-horizon-group inputs>
 				<ui-input v-model="smtpUser" :disabled="!enableEmail">{{ $t('smtp-user') }}</ui-input>
-				<ui-input v-model="smtpPass" type="password" :disabled="!enableEmail">{{ $t('smtp-pass') }}</ui-input>
+				<ui-input v-model="smtpPass" type="password" :withPasswordToggle="true" :disabled="!enableEmail">{{ $t('smtp-pass') }}</ui-input>
 			</ui-horizon-group>
 			<ui-switch v-model="smtpSecure" :disabled="!enableEmail">{{ $t('smtp-secure') }}<span slot="desc">{{ $t('smtp-secure-info') }}</span></ui-switch>
 		</section>


### PR DESCRIPTION
# Summary
管理画面のSMTP設定でパスワードの表示非表示を切り替えられるようにしています
Related #3861, #3865