### PR TITLE
ダイレクトを非公開のように使えるようにする

### DIFF
--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -183,11 +183,6 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 				data.visibleUsers.push(u);
 			}
 		}
-
-		// ダイレクト投稿でユーザーが指定されていなかったらreject
-		if (data.visibleUsers.length === 0) {
-			return rej('Target user is not specified');
-		}
 	}
 
 	const note = await insertNote(user, data, tags, emojis, mentionedUsers);


### PR DESCRIPTION
# Summary
Resolve #3803 

ダイレクト投稿でユーザーを指定しなくても投稿を許可するようにして、
以前の非公開のように使用できるようにしています。