### PR TITLE
管理者がサインイン履歴を参照できるツール

### DIFF
--- a/src/tools/show-signin-history.ts
+++ b/src/tools/show-signin-history.ts
@@ -1,0 +1,59 @@
+// node built/tools/show-signin-history username
+//  => {Success} {Date} {IPAddrsss}
+
+// node built/tools/show-signin-history username user-agent,x-forwarded-for
+//  with user-agent and x-forwarded-for
+
+// node built/tools/show-signin-history username all
+//  with full request headers
+
+import User from '../models/user';
+import Signin from '../models/signin';
+
+async function main(username: string, headers: string[]) {
+	const user = await User.findOne({
+		host: null,
+		usernameLower: username.toLowerCase(),
+	});
+
+	if (user === null) throw 'User not found';
+
+	const history = await Signin.find({
+		userId: user._id
+	});
+
+	console.log(headers);
+
+	for (const signin of history) {
+		console.log(`${signin.success ? 'OK' : 'NG'} ${signin.createdAt ? signin.createdAt.toISOString() : 'Unknown'} ${signin.ip}`);
+
+		// headers
+		if (headers != null) {
+			for (const key of Object.keys(signin.headers)) {
+				if (headers.includes('all') || headers.includes(key)) {
+					console.log(`   ${key}: ${signin.headers[key]}`);
+				}
+			}
+		}
+	}
+}
+
+// get args
+const args = process.argv.slice(2);
+
+let username = args[0];
+let headers: string[];
+
+if (args[1] != null) {
+	headers = args[1].split(/,/).map(header => header.toLowerCase());
+}
+
+// normalize args
+username = username.replace(/^@/, '');
+
+main(username, headers).then(() => {
+	process.exit(0);
+}).catch(e => {
+	console.warn(e);
+	process.exit(1);
+});

--- a/src/tools/show-signin-history.ts
+++ b/src/tools/show-signin-history.ts
@@ -22,8 +22,6 @@ async function main(username: string, headers: string[]) {
 		userId: user._id
 	});
 
-	console.log(headers);
-
 	for (const signin of history) {
 		console.log(`${signin.success ? 'OK' : 'NG'} ${signin.createdAt ? signin.createdAt.toISOString() : 'Unknown'} ${signin.ip}`);
 


### PR DESCRIPTION
# Summary
Related #3864 

サーバー管理者がサインイン履歴を参照できるツール

```
node built/tools/show-signin-history username
 => 「成否 日付 IPアドレス」を列挙

node built/tools/show-signin-history username user-agent,x-forwarded-for
 => リクエストヘッダ (user-agent and x-forwarded-for) 付き

node built/tools/show-signin-history username all
 => すべてのリクエストヘッダ付き
```

