### PR TITLE
Hide NSFW in user images

### DIFF
--- a/src/client/app/desktop/views/pages/deck/deck.user-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.user-column.vue
@@ -169,6 +169,7 @@ export default Vue.extend({
 			this.$root.api('users/notes', {
 				userId: this.user.id,
 				fileType: image,
+				excludeNsfw: !this.$store.state.device.alwaysShowNsfw,
 				limit: 9,
 				untilDate: new Date().getTime() + 1000 * 86400 * 365
 			}).then(notes => {

--- a/src/client/app/desktop/views/pages/user/user.photos.vue
+++ b/src/client/app/desktop/views/pages/user/user.photos.vue
@@ -29,9 +29,11 @@ export default Vue.extend({
 			'image/png',
 			'image/gif'
 		];
+
 		this.$root.api('users/notes', {
 			userId: this.user.id,
 			fileType: image,
+			excludeNsfw: !this.$store.state.device.alwaysShowNsfw,
 			limit: 9,
 			untilDate: new Date().getTime() + 1000 * 86400 * 365
 		}).then(notes => {

--- a/src/client/app/mobile/views/pages/user/home.photos.vue
+++ b/src/client/app/mobile/views/pages/user/home.photos.vue
@@ -34,6 +34,7 @@ export default Vue.extend({
 		this.$root.api('users/notes', {
 			userId: this.user.id,
 			fileType: image,
+			excludeNsfw: !this.$store.state.device.alwaysShowNsfw,
 			limit: 9,
 			untilDate: new Date().getTime() + 1000 * 86400 * 365
 		}).then(notes => {

--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -124,6 +124,14 @@ export const meta = {
 				'ja-JP': '指定された種類のファイルが添付された投稿のみを取得します'
 			}
 		},
+
+		excludeNsfw: {
+			validator: $.bool.optional,
+			default: false,
+			desc: {
+				'ja-JP': 'true にすると、NSFW指定されたファイルを除外します(fileTypeが指定されている場合のみ有効)'
+			}
+		},
 	}
 };
 
@@ -233,6 +241,12 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 		query['_files.contentType'] = {
 			$in: ps.fileType
 		};
+
+		if (ps.excludeNsfw) {
+			query['_files.metadata.isSensitive'] = {
+				$ne: true
+			};
+		}
 	}
 	//#endregion
 


### PR DESCRIPTION
# Summary
Resolve #3853 

ユーザーの画像一覧でNSFWなメディアは表示しないように (一覧に出ない)
ただし「常に閲覧注意のメディアを表示する」が有効なユーザーが見たら表示する