### PR TITLE
Fix: time tooltip overlaps with others

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -76,7 +76,7 @@ export default (opts: Opts = {}) => ({
 		},
 
 		title(): string {
-			return new Date(this.appearNote.createdAt).toLocaleString();
+			return '';
 		},
 
 		urls(): string[] {

--- a/src/client/app/common/views/components/time.vue
+++ b/src/client/app/common/views/components/time.vue
@@ -1,5 +1,5 @@
 <template>
-<time class="mk-time">
+<time class="mk-time" :title="absolute">
 	<span v-if=" mode == 'relative' ">{{ relative }}</span>
 	<span v-if=" mode == 'absolute' ">{{ absolute }}</span>
 	<span v-if=" mode == 'detail' ">{{ absolute }} ({{ relative }})</span>


### PR DESCRIPTION
# Summary
ノート領域全体に設定されている時間のツールチップが
他のツールチップと被ったり、変なとこで出てくるのを修正。
![image](https://user-images.githubusercontent.com/30769358/51265069-364ccf80-19fb-11e9-9d25-d10718c44041.png)

ツールチップを出すのは時間の上だけに変更
