### PR TITLE
node-gypの警告を直す

### DIFF
--- a/src/crypto_key.cc
+++ b/src/crypto_key.cc
@@ -8,7 +8,7 @@
 
 NAN_METHOD(extractPublic)
 {
-	const auto sourceString = info[0]->ToString(Nan::GetCurrentContext()).FromMaybe(v8::Local<v8::String>());
+	const auto sourceString = info[0]->ToString(Nan::GetCurrentContext()).ToLocalChecked();
 	if (!sourceString->IsOneByte()) {
 		Nan::ThrowError("Malformed character found");
 		return;

--- a/src/crypto_key.cc
+++ b/src/crypto_key.cc
@@ -8,7 +8,7 @@
 
 NAN_METHOD(extractPublic)
 {
-	const auto sourceString = info[0]->ToString();
+	const auto sourceString = Nan::To<v8::String>(info[0]).ToLocalChecked();
 	if (!sourceString->IsOneByte()) {
 		Nan::ThrowError("Malformed character found");
 		return;

--- a/src/crypto_key.cc
+++ b/src/crypto_key.cc
@@ -8,7 +8,7 @@
 
 NAN_METHOD(extractPublic)
 {
-	const auto sourceString = Nan::To<v8::String>(info[0]).ToLocalChecked();
+	const auto sourceString = info[0]->ToString(Nan::GetCurrentContext()).FromMaybe(v8::Local<v8::String>());
 	if (!sourceString->IsOneByte()) {
 		Nan::ThrowError("Malformed character found");
 		return;


### PR DESCRIPTION
# Summary

Thanks to @ciffelia.

## Before

```bash
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/tmp/workspace/build'
  CXX(target) Release/obj.target/crypto_key/src/crypto_key.o
../src/crypto_key.cc: In function 'Nan::NAN_METHOD_RETURN_TYPE extractPublic(Nan::NAN_METHOD_ARGS_TYPE)':
../src/crypto_key.cc:11:46: warning: 'v8::Local<v8::String> v8::Value::ToString() const' is deprecated: Use maybe version [-Wdeprecated-declarations]
  const auto sourceString = info[0]->ToString();
                                              ^
In file included from /root/.node-gyp/11.6.0/include/node/node.h:63:0,
                 from ../node_modules/nan/nan.h:53,
                 from ../src/crypto_key.cc:1:
/root/.node-gyp/11.6.0/include/node/v8.h:10248:15: note: declared here
 Local<String> Value::ToString() const {
               ^~~~~
  SOLINK_MODULE(target) Release/obj.target/crypto_key.node
  COPY Release/crypto_key.node
make: Leaving directory '/tmp/workspace/build'
gyp info ok 
```

## After

```bash
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/tmp/workspace/build'
  CXX(target) Release/obj.target/crypto_key/src/crypto_key.o
  SOLINK_MODULE(target) Release/obj.target/crypto_key.node
  COPY Release/crypto_key.node
make: Leaving directory '/tmp/workspace/build'
gyp info ok 
```
