### PR TITLE
Fix missing username conversions

### DIFF
--- a/src/client/app/common/views/components/games/reversi/reversi.game.vue
+++ b/src/client/app/common/views/components/games/reversi/reversi.game.vue
@@ -4,8 +4,13 @@
 	<header><b><router-link :to="blackUser | userPage"><mk-user-name :user="blackUser"/></router-link></b>({{ $t('@.reversi.black') }}) vs <b><router-link :to="whiteUser | userPage"><mk-user-name :user="whiteUser"/></router-link></b>({{ $t('@.reversi.white') }})</header>
 
 	<div style="overflow: hidden; line-height: 28px;">
-		<p class="turn" v-if="!iAmPlayer && !game.isEnded">{{ $t('@.reversi.turn-of', { name: $options.filters.userName(turnUser) }) }}<mk-ellipsis/></p>
-		<p class="turn" v-if="logPos != logs.length">{{ $t('@.reversi.past-turn-of', { name: $options.filters.userName(turnUser) }) }}</p>
+		<p class="turn" v-if="!iAmPlayer && !game.isEnded">
+			<misskey-flavored-markdown :text="$t('@.reversi.turn-of', { name: $options.filters.userName(turnUser) })" :shouldBreak="false" :plainText="true" :custom-emojis="turnUser.emojis"/>
+			<mk-ellipsis/>
+		</p>
+		<p class="turn" v-if="logPos != logs.length">
+			<misskey-flavored-markdown :text="$t('@.reversi.past-turn-of', { name: $options.filters.userName(turnUser) })" :shouldBreak="false" :plainText="true" :custom-emojis="turnUser.emojis"/>
+		</p>
 		<p class="turn1" v-if="iAmPlayer && !game.isEnded && !isMyTurn">{{ $t('@.reversi.opponent-turn') }}<mk-ellipsis/></p>
 		<p class="turn2" v-if="iAmPlayer && !game.isEnded && isMyTurn" v-animate-css="{ classes: 'tada', iteration: 'infinite' }">{{ $t('@.reversi.my-turn') }}</p>
 		<p class="result" v-if="game.isEnded && logPos == logs.length">

--- a/src/client/app/common/views/pages/follow.vue
+++ b/src/client/app/common/views/pages/follow.vue
@@ -1,7 +1,8 @@
 <template>
 <div class="syxhndwprovvuqhmyvveewmbqayniwkv" v-if="!fetching">
-	<div class="signed-in-as" v-html="this.$t('signed-in-as').replace('{}', `<b>${myName}`)"></div>
-
+	<div class="signed-in-as">
+		<misskey-flavored-markdown :text="$t('signed-in-as').replace('{}', myName)" :shouldBreak="false" :plainText="true" :custom-emojis="$store.state.i.emojis"/>
+	</div>
 	<main>
 		<div class="banner" :style="bannerStyle"></div>
 		<mk-avatar class="avatar" :user="user" :disable-preview="true"/>
@@ -127,6 +128,7 @@ export default Vue.extend({
 	> .signed-in-as
 		margin-bottom 16px
 		font-size 14px
+		font-weight bold
 
 	> main
 		margin-bottom 16px

--- a/src/client/app/desktop/views/pages/deck/deck.note-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.note-column.vue
@@ -1,7 +1,7 @@
 <template>
 <x-column>
 	<span slot="header">
-		<fa :icon="['far', 'comment-alt']"/><span>{{ title }}</span>
+		<fa :icon="['far', 'comment-alt']"/><mk-user-name :user="note.user" v-if="note"/>
 	</span>
 
 	<div class="rvtscbadixhhbsczoorqoaygovdeecsx" v-if="note">
@@ -43,12 +43,6 @@ export default Vue.extend({
 			note: null,
 			fetching: true
 		};
-	},
-
-	computed: {
-		title(): string {
-			return this.note ? Vue.filter('userName')(this.note.user) : '';
-		}
 	},
 
 	created() {

--- a/src/client/app/desktop/views/pages/deck/deck.user-column.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.user-column.vue
@@ -1,7 +1,7 @@
 <template>
 <x-column>
 	<span slot="header">
-		<fa icon="user"/><span>{{ title }}</span>
+		<fa icon="user"/><mk-user-name :user="user" v-if="user"/>
 	</span>
 
 	<div class="zubukjlciycdsyynicqrnlsmdwmymzqu" v-if="user">
@@ -137,10 +137,6 @@ export default Vue.extend({
 	},
 
 	computed: {
-		title(): string {
-			return this.user ? Vue.filter('userName')(this.user) : '';
-		},
-
 		bannerStyle(): any {
 			if (this.user == null) return {};
 			if (this.user.bannerUrl == null) return {};

--- a/src/client/app/mobile/views/pages/followers.vue
+++ b/src/client/app/mobile/views/pages/followers.vue
@@ -1,7 +1,8 @@
 <template>
 <mk-ui>
 	<template slot="header" v-if="!fetching">
-		<img :src="user.avatarUrl" alt="">{{ $t('followers-of', { name }) }}
+		<img :src="user.avatarUrl" alt="">
+		<misskey-flavored-markdown :text="$t('followers-of', { name })" :shouldBreak="false" :plainText="true" :custom-emojis="user.emojis"/>
 	</template>
 	<mk-users-list
 		v-if="!fetching"

--- a/src/client/app/mobile/views/pages/following.vue
+++ b/src/client/app/mobile/views/pages/following.vue
@@ -1,7 +1,8 @@
 <template>
 <mk-ui>
 	<template slot="header" v-if="!fetching">
-		<img :src="user.avatarUrl" alt="">{{ $t('following-of', { name }) }}
+		<img :src="user.avatarUrl" alt="">
+		<misskey-flavored-markdown :text="$t('following-of', { name })" :shouldBreak="false" :plainText="true" :custom-emojis="user.emojis"/>
 	</template>
 	<mk-users-list
 		v-if="!fetching"

--- a/src/client/app/mobile/views/pages/settings.vue
+++ b/src/client/app/mobile/views/pages/settings.vue
@@ -2,8 +2,9 @@
 <mk-ui>
 	<span slot="header"><span style="margin-right:4px;"><fa icon="cog"/></span>{{ $t('settings') }}</span>
 	<main>
-		<div class="signin-as" v-html="this.$t('signed-in-as').replace('{}', `<b>${name}</b>`)"></div>
-
+		<div class="signed-in-as">
+			<misskey-flavored-markdown :text="$t('signed-in-as').replace('{}', name)" :shouldBreak="false" :plainText="true" :custom-emojis="$store.state.i.emojis"/>
+		</div>
 		<div>
 			<x-profile-editor/>
 
@@ -381,6 +382,7 @@ main
 		color var(--mobileSignedInAsFg)
 		background var(--mobileSignedInAsBg)
 		box-shadow 0 3px 1px -2px rgba(#000, 0.2), 0 2px 2px 0 rgba(#000, 0.14), 0 1px 5px 0 rgba(#000, 0.12)
+		font-weight bold
 
 	> .signout
 		margin 16px


### PR DESCRIPTION
# Summary
Fix #3920 

いくつかのユーザー名の絵文字変換の漏れを修正
- デッキのノート/ユーザーペイン
- authorize-follow画面のサインイン中のユーザー
- モバイルのフォロー/フォロワー画面
- モバイル設定画面のサインイン中のユーザー
- リバーシ観戦時の現在のターンユーザー
- リバーシバック時のターンユーザー