### PR TITLE
Filter hidden replies / mentions

### DIFF
--- a/src/server/api/endpoints/notes/mentions.ts
+++ b/src/server/api/endpoints/notes/mentions.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy'; import ID, { transform } from '../../../../misc/cafy-id';
 import Note from '../../../../models/note';
-import { getFriendIds } from '../../common/get-friends';
+import { getFriendIds, getFriends } from '../../common/get-friends';
 import { packMany } from '../../../../models/note';
 import define from '../../define';
 import read from '../../../../services/note/read';
@@ -47,6 +47,9 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 		return rej('cannot set sinceId and untilId');
 	}
 
+	// フォローを取得
+	const followings = await getFriends(user._id);
+
 	const visibleQuery = [{
 		visibility: { $in: [ 'public', 'home' ] }
 	}, {
@@ -55,6 +58,9 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 	}, {
 		// to me (for specified)
 		visibleUserIds: { $in: [ user._id ] }
+	}, {
+		visibility: 'followers',
+		userId: { $in: followings.map(f => f.id) }
 	}];
 
 	const query = {

--- a/src/server/api/endpoints/notes/mentions.ts
+++ b/src/server/api/endpoints/notes/mentions.ts
@@ -47,8 +47,24 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 		return rej('cannot set sinceId and untilId');
 	}
 
+	const visibleQuery = user == null ? [{
+		visibility: { $in: [ 'public', 'home' ] }
+	}] : [{
+		visibility: { $in: [ 'public', 'home' ] }
+	}, {
+		// myself (for specified/private)
+		userId: user._id
+	}, {
+		// to me (for specified)
+		visibleUserIds: { $in: [ user._id ] }
+	}];
+
 	const query = {
-		deletedAt: null,
+		$and: [{
+			deletedAt: null,
+		}, {
+			$or: visibleQuery,
+		}],
 
 		$or: [{
 			mentions: user._id

--- a/src/server/api/endpoints/notes/mentions.ts
+++ b/src/server/api/endpoints/notes/mentions.ts
@@ -47,9 +47,7 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 		return rej('cannot set sinceId and untilId');
 	}
 
-	const visibleQuery = user == null ? [{
-		visibility: { $in: [ 'public', 'home' ] }
-	}] : [{
+	const visibleQuery = [{
 		visibility: { $in: [ 'public', 'home' ] }
 	}, {
 		// myself (for specified/private)

--- a/src/server/api/endpoints/notes/replies.ts
+++ b/src/server/api/endpoints/notes/replies.ts
@@ -39,8 +39,21 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 		muterId: user._id
 	})).map(m => m.muteeId) : null;
 
+	const visibleQuery = user == null ? [{
+		visibility: { $in: [ 'public', 'home' ] }
+	}] : [{
+		visibility: { $in: [ 'public', 'home' ] }
+	}, {
+		// myself (for specified/private)
+		userId: user._id
+	}, {
+		// to me (for specified)
+		visibleUserIds: { $in: [ user._id ] }
+	}];
+
 	const q = {
-		replyId: ps.noteId
+		replyId: ps.noteId,
+		$or: visibleQuery
 	} as any;
 
 	if (mutedUserIds && mutedUserIds.length > 0) {

--- a/src/server/api/endpoints/notes/timeline.ts
+++ b/src/server/api/endpoints/notes/timeline.ts
@@ -141,7 +141,7 @@ export default define(meta, (ps, user) => new Promise(async (res, rej) => {
 	const visibleQuery = user == null ? [{
 		visibility: { $in: [ 'public', 'home' ] }
 	}] : [{
-		visibility: { $in: [ 'public', 'home' ] }
+		visibility: { $in: [ 'public', 'home', 'followers' ] }
 	}, {
 		// myself (for specified/private)
 		userId: user._id

--- a/src/server/api/stream/channels/main.ts
+++ b/src/server/api/stream/channels/main.ts
@@ -19,6 +19,11 @@ export default class extends Channel {
 			switch (type) {
 				case 'notification': {
 					if (mutedUserIds.includes(body.userId)) return;
+					if (body.note && body.note.isHidden) return;
+					break;
+				}
+				case 'mention': {
+					if (body.isHidden) return;
 					break;
 				}
 			}


### PR DESCRIPTION
# Summary
1. 返信一覧を取得すると非公開投稿も取得されてしまう (API notes/replies)
2. メンション一覧を取得すると非公開投稿も取得されてしまう (API notes/mentions)
3. メンション一覧に非公開投稿がpushされてしまう
4. 通知に非公開投稿がpushされてしまう
5. ホームにフォロワー限定投稿が表示されない (API notes/timeline)

を修正

2 は #3973 かもしれない