### PR TITLE
tools/resync-remote-user で exit しないように

### DIFF
--- a/src/tools/resync-remote-user.ts
+++ b/src/tools/resync-remote-user.ts
@@ -24,9 +24,7 @@ if (!acct.match(/^\w+@\w/)) {
 console.log(`resync ${acct}`);
 
 main(acct).then(() => {
-	console.log('success');
-	process.exit(0);
+	console.log('Done');
 }).catch(e => {
 	console.warn(e);
-	process.exit(1);
 });


### PR DESCRIPTION
# Summary
tools/resync-remote-user で呼んでる処理にバックグラウンドで後処理が行われるものがあるので
自動でexitしないようにしています