### PR TITLE
delete unnecessary key

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -311,6 +311,7 @@ export const pack = (
 		delete _user.password;
 		delete _user.token;
 		delete _user.twoFactorTempSecret;
+		delete _user.two_factor_temp_secret;
 		delete _user.twoFactorSecret;
 		if (_user.twitter) {
 			delete _user.twitter.accessToken;

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -311,7 +311,7 @@ export const pack = (
 		delete _user.password;
 		delete _user.token;
 		delete _user.twoFactorTempSecret;
-		delete _user.two_factor_temp_secret;
+		delete _user.two_factor_temp_secret; // 後方互換性のため
 		delete _user.twoFactorSecret;
 		if (_user.twitter) {
 			delete _user.twitter.accessToken;


### PR DESCRIPTION
# Summary
なんか漏れているのを修正

https://misskey.xyz/notes/5c518be8472b9f0032d8edf9
ユーザーによっては`User`Entityで`two_factor_temp_secret`が漏れている

`two_factor_temp_secret`はリファクタかバグ修正でリネームする前のkey
https://github.com/syuilo/misskey/commit/bfc193d8cd9aecdb82d585e8b4e101deac60a5bb#diff-50791f332d02141d1ab47453c462a3ad
https://github.com/syuilo/misskey/commit/bfc193d8cd9aecdb82d585e8b4e101deac60a5bb#diff-e2e2acdeb7536f5bfd8c409345bbb824

古い方のkeyを消し忘れている