### PR TITLE
 Do not import as pack from AP renderer 

### DIFF
--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -1,7 +1,7 @@
 import config from '../../../config';
 import * as uuid from 'uuid';
 
-export default (x: any) => {
+export const renderActivity = (x: any) => {
 	if (x == null) return null;
 
 	if (x !== null && typeof x === 'object' && x.id == null) {

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -4,7 +4,7 @@ const json = require('koa-json-body');
 const httpSignature = require('http-signature');
 
 import { createHttpJob } from '../queue';
-import pack from '../remote/activitypub/renderer';
+import { renderActivity } from '../remote/activitypub/renderer';
 import Note from '../models/note';
 import User, { isLocalUser, ILocalUser, IUser } from '../models/user';
 import Emoji from '../models/emoji';
@@ -83,7 +83,7 @@ router.get('/notes/:note', async (ctx, next) => {
 		return;
 	}
 
-	ctx.body = pack(await renderNote(note, false));
+	ctx.body = renderActivity(await renderNote(note, false));
 	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });
@@ -106,7 +106,7 @@ router.get('/notes/:note/activity', async ctx => {
 		return;
 	}
 
-	ctx.body = pack(await packActivity(note));
+	ctx.body = renderActivity(await packActivity(note));
 	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });
@@ -137,7 +137,7 @@ router.get('/questions/:question', async (ctx, next) => {
 			_id: poll.userId
 	});
 
-	ctx.body = pack(await renderQuestion(user as ILocalUser, poll));
+	ctx.body = renderActivity(await renderQuestion(user as ILocalUser, poll));
 	setResponseType(ctx);
 });
 
@@ -173,7 +173,7 @@ router.get('/users/:user/publickey', async ctx => {
 	}
 
 	if (isLocalUser(user)) {
-		ctx.body = pack(renderKey(user));
+		ctx.body = renderActivity(renderKey(user));
 		ctx.set('Cache-Control', 'public, max-age=180');
 		setResponseType(ctx);
 	} else {
@@ -188,7 +188,7 @@ async function userInfo(ctx: Router.IRouterContext, user: IUser) {
 		return;
 	}
 
-	ctx.body = pack(await renderPerson(user as ILocalUser));
+	ctx.body = renderActivity(await renderPerson(user as ILocalUser));
 	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 }
@@ -235,7 +235,7 @@ router.get('/emojis/:emoji', async ctx => {
 		return;
 	}
 
-	ctx.body = pack(await renderEmoji(emoji));
+	ctx.body = renderActivity(await renderEmoji(emoji));
 	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });

--- a/src/server/activitypub/featured.ts
+++ b/src/server/activitypub/featured.ts
@@ -2,7 +2,7 @@ import { ObjectID } from 'mongodb';
 import * as Router from 'koa-router';
 import config from '../../config';
 import User from '../../models/user';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderOrderedCollection from '../../remote/activitypub/renderer/ordered-collection';
 import { setResponseType } from '../activitypub';
 import Note from '../../models/note';
@@ -38,7 +38,7 @@ export default async (ctx: Router.IRouterContext) => {
 		renderedNotes.length, null, null, renderedNotes
 	);
 
-	ctx.body = pack(rendered);
+	ctx.body = renderActivity(rendered);
 	ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 	setResponseType(ctx);
 };

--- a/src/server/activitypub/followers.ts
+++ b/src/server/activitypub/followers.ts
@@ -4,7 +4,7 @@ import config from '../../config';
 import $ from 'cafy'; import ID, { transform } from '../../misc/cafy-id';
 import User from '../../models/user';
 import Following from '../../models/following';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderOrderedCollection from '../../remote/activitypub/renderer/ordered-collection';
 import renderOrderedCollectionPage from '../../remote/activitypub/renderer/ordered-collection-page';
 import renderFollowUser from '../../remote/activitypub/renderer/follow-user';
@@ -77,12 +77,12 @@ export default async (ctx: Router.IRouterContext) => {
 			inStock ? `${partOf}?page=true&cursor=${followings[followings.length - 1]._id}` : null
 		);
 
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		setResponseType(ctx);
 	} else {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followersCount, `${partOf}?page=true`, null);
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}

--- a/src/server/activitypub/following.ts
+++ b/src/server/activitypub/following.ts
@@ -5,7 +5,7 @@ import $ from 'cafy';
 import ID, { transform } from '../../misc/cafy-id';
 import User from '../../models/user';
 import Following from '../../models/following';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderOrderedCollection from '../../remote/activitypub/renderer/ordered-collection';
 import renderOrderedCollectionPage from '../../remote/activitypub/renderer/ordered-collection-page';
 import renderFollowUser from '../../remote/activitypub/renderer/follow-user';
@@ -78,12 +78,12 @@ export default async (ctx: Router.IRouterContext) => {
 			inStock ? `${partOf}?page=true&cursor=${followings[followings.length - 1]._id}` : null
 		);
 
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		setResponseType(ctx);
 	} else {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followingCount, `${partOf}?page=true`, null);
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -4,7 +4,7 @@ import config from '../../config';
 import $ from 'cafy';
 import ID, { transform } from '../../misc/cafy-id';
 import User from '../../models/user';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderOrderedCollection from '../../remote/activitypub/renderer/ordered-collection';
 import renderOrderedCollectionPage from '../../remote/activitypub/renderer/ordered-collection-page';
 import { setResponseType } from '../activitypub';
@@ -94,7 +94,7 @@ export default async (ctx: Router.IRouterContext) => {
 			notes.length > 0 ? `${partOf}?page=true&until_id=${notes[notes.length - 1]._id}` : null
 		);
 
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	} else {
@@ -103,7 +103,7 @@ export default async (ctx: Router.IRouterContext) => {
 			`${partOf}?page=true`,
 			`${partOf}?page=true&since_id=000000000000000000000000`
 		);
-		ctx.body = pack(rendered);
+		ctx.body = renderActivity(rendered);
 		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	}

--- a/src/server/api/endpoints/users/lists/push.ts
+++ b/src/server/api/endpoints/users/lists/push.ts
@@ -2,7 +2,7 @@ import $ from 'cafy'; import ID, { transform } from '../../../../../misc/cafy-id
 import UserList from '../../../../../models/user-list';
 import User, { pack as packUser, isRemoteUser, fetchProxyAccount } from '../../../../../models/user';
 import { publishUserListStream } from '../../../../../stream';
-import ap from '../../../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../../../remote/activitypub/renderer';
 import renderFollow from '../../../../../remote/activitypub/renderer/follow';
 import { deliver } from '../../../../../queue';
 import define from '../../../define';
@@ -72,7 +72,7 @@ export default define(meta, (ps, me) => new Promise(async (res, rej) => {
 	// このインスタンス内にこのリモートユーザーをフォローしているユーザーがいなくても投稿を受け取るためにダミーのユーザーがフォローしたということにする
 	if (isRemoteUser(user)) {
 		const proxy = await fetchProxyAccount();
-		const content = ap(renderFollow(proxy, user));
+		const content = renderActivity(renderFollow(proxy, user));
 		deliver(proxy, content, user.inbox);
 	}
 }));

--- a/src/services/blocking/create.ts
+++ b/src/services/blocking/create.ts
@@ -2,7 +2,7 @@ import User, { isLocalUser, isRemoteUser, pack as packUser, IUser } from '../../
 import Following from '../../models/following';
 import FollowRequest from '../../models/follow-request';
 import { publishMainStream } from '../../stream';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderFollow from '../../remote/activitypub/renderer/follow';
 import renderUndo from '../../remote/activitypub/renderer/undo';
 import renderBlock from '../../remote/activitypub/renderer/block';
@@ -27,7 +27,7 @@ export default async function(blocker: IUser, blockee: IUser) {
 	});
 
 	if (isLocalUser(blocker) && isRemoteUser(blockee)) {
-		const content = pack(renderBlock(blocker, blockee));
+		const content = renderActivity(renderBlock(blocker, blockee));
 		deliver(blocker, content, blockee.inbox);
 	}
 }
@@ -67,13 +67,13 @@ async function cancelRequest(follower: IUser, followee: IUser) {
 
 	// リモートにフォローリクエストをしていたらUndoFollow送信
 	if (isLocalUser(follower) && isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		const content = renderActivity(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower, content, followee.inbox);
 	}
 
 	// リモートからフォローリクエストを受けていたらReject送信
 	if (isRemoteUser(follower) && isLocalUser(followee)) {
-		const content = pack(renderReject(renderFollow(follower, followee, request.requestId), followee));
+		const content = renderActivity(renderReject(renderFollow(follower, followee, request.requestId), followee));
 		deliver(followee, content, follower.inbox);
 	}
 }
@@ -119,7 +119,7 @@ async function unFollow(follower: IUser, followee: IUser) {
 
 	// リモートにフォローをしていたらUndoFollow送信
 	if (isLocalUser(follower) && isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		const content = renderActivity(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower, content, followee.inbox);
 	}
 }

--- a/src/services/blocking/delete.ts
+++ b/src/services/blocking/delete.ts
@@ -1,6 +1,6 @@
 import { isLocalUser, isRemoteUser, IUser } from '../../models/user';
 import Blocking from '../../models/blocking';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderBlock from '../../remote/activitypub/renderer/block';
 import renderUndo from '../../remote/activitypub/renderer/undo';
 import { deliver } from '../../queue';
@@ -22,7 +22,7 @@ export default async function(blocker: IUser, blockee: IUser) {
 
 	// deliver if remote bloking
 	if (isLocalUser(blocker) && isRemoteUser(blockee)) {
-		const content = pack(renderUndo(renderBlock(blocker, blockee), blocker));
+		const content = renderActivity(renderUndo(renderBlock(blocker, blockee), blocker));
 		deliver(blocker, content, blockee.inbox);
 	}
 }

--- a/src/services/following/create.ts
+++ b/src/services/following/create.ts
@@ -3,7 +3,7 @@ import Following from '../../models/following';
 import Blocking from '../../models/blocking';
 import { publishMainStream } from '../../stream';
 import notify from '../../notify';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderFollow from '../../remote/activitypub/renderer/follow';
 import renderAccept from '../../remote/activitypub/renderer/accept';
 import renderReject from '../../remote/activitypub/renderer/reject';
@@ -26,7 +26,7 @@ export default async function(follower: IUser, followee: IUser, requestId?: stri
 
 	if (isRemoteUser(follower) && isLocalUser(followee) && blocked) {
 		// リモートフォローを受けてブロックしていた場合は、エラーにするのではなくRejectを送り返しておしまい。
-		const content = pack(renderReject(renderFollow(follower, followee, requestId), followee));
+		const content = renderActivity(renderReject(renderFollow(follower, followee, requestId), followee));
 		deliver(followee , content, follower.inbox);
 		return;
 	} else if (isRemoteUser(follower) && isLocalUser(followee) && blocking) {
@@ -115,7 +115,7 @@ export default async function(follower: IUser, followee: IUser, requestId?: stri
 	}
 
 	if (isRemoteUser(follower) && isLocalUser(followee)) {
-		const content = pack(renderAccept(renderFollow(follower, followee, requestId), followee));
+		const content = renderActivity(renderAccept(renderFollow(follower, followee, requestId), followee));
 		deliver(followee, content, follower.inbox);
 	}
 }

--- a/src/services/following/delete.ts
+++ b/src/services/following/delete.ts
@@ -1,7 +1,7 @@
 import User, { isLocalUser, isRemoteUser, pack as packUser, IUser } from '../../models/user';
 import Following from '../../models/following';
 import { publishMainStream } from '../../stream';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import renderFollow from '../../remote/activitypub/renderer/follow';
 import renderUndo from '../../remote/activitypub/renderer/undo';
 import { deliver } from '../../queue';
@@ -48,7 +48,7 @@ export default async function(follower: IUser, followee: IUser) {
 	}
 
 	if (isLocalUser(follower) && isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		const content = renderActivity(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower, content, followee.inbox);
 	}
 }

--- a/src/services/following/requests/accept.ts
+++ b/src/services/following/requests/accept.ts
@@ -1,6 +1,6 @@
 import User, { IUser, isRemoteUser, ILocalUser, pack as packUser, isLocalUser } from '../../../models/user';
 import FollowRequest from '../../../models/follow-request';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import renderAccept from '../../../remote/activitypub/renderer/accept';
 import { deliver } from '../../../queue';
@@ -42,7 +42,7 @@ export default async function(followee: IUser, follower: IUser) {
 			followerId: follower._id
 		});
 
-		const content = pack(renderAccept(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
+		const content = renderActivity(renderAccept(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 

--- a/src/services/following/requests/cancel.ts
+++ b/src/services/following/requests/cancel.ts
@@ -1,6 +1,6 @@
 import User, { IUser, isRemoteUser, ILocalUser, pack as packUser } from '../../../models/user';
 import FollowRequest from '../../../models/follow-request';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import renderUndo from '../../../remote/activitypub/renderer/undo';
 import { deliver } from '../../../queue';
@@ -8,7 +8,7 @@ import { publishMainStream } from '../../../stream';
 
 export default async function(followee: IUser, follower: IUser) {
 	if (isRemoteUser(followee)) {
-		const content = pack(renderUndo(renderFollow(follower, followee), follower));
+		const content = renderActivity(renderUndo(renderFollow(follower, followee), follower));
 		deliver(follower as ILocalUser, content, followee.inbox);
 	}
 

--- a/src/services/following/requests/create.ts
+++ b/src/services/following/requests/create.ts
@@ -1,7 +1,7 @@
 import User, { isLocalUser, isRemoteUser, pack as packUser, IUser } from '../../../models/user';
 import { publishMainStream } from '../../../stream';
 import notify from '../../../notify';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import { deliver } from '../../../queue';
 import FollowRequest from '../../../models/follow-request';
@@ -61,7 +61,7 @@ export default async function(follower: IUser, followee: IUser, requestId?: stri
 	}
 
 	if (isLocalUser(follower) && isRemoteUser(followee)) {
-		const content = pack(renderFollow(follower, followee));
+		const content = renderActivity(renderFollow(follower, followee));
 		deliver(follower, content, followee.inbox);
 	}
 }

--- a/src/services/following/requests/reject.ts
+++ b/src/services/following/requests/reject.ts
@@ -1,6 +1,6 @@
 import User, { IUser, isRemoteUser, ILocalUser, pack as packUser } from '../../../models/user';
 import FollowRequest from '../../../models/follow-request';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import renderFollow from '../../../remote/activitypub/renderer/follow';
 import renderReject from '../../../remote/activitypub/renderer/reject';
 import { deliver } from '../../../queue';
@@ -13,7 +13,7 @@ export default async function(followee: IUser, follower: IUser) {
 			followerId: follower._id
 		});
 
-		const content = pack(renderReject(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
+		const content = renderActivity(renderReject(renderFollow(follower, followee, request.requestId), followee as ILocalUser));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}
 

--- a/src/services/i/pin.ts
+++ b/src/services/i/pin.ts
@@ -5,7 +5,7 @@ import Note, { packMany } from '../../models/note';
 import Following from '../../models/following';
 import renderAdd from '../../remote/activitypub/renderer/add';
 import renderRemove from '../../remote/activitypub/renderer/remove';
-import packAp from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import { deliver } from '../../queue';
 
 /**
@@ -100,7 +100,7 @@ export async function deliverPinnedChange(userId: mongo.ObjectID, noteId: mongo.
 	const target = `${config.url}/users/${user._id}/collections/featured`;
 
 	const item = `${config.url}/notes/${noteId}`;
-	const content = packAp(isAddition ? renderAdd(user, target, item) : renderRemove(user, target, item));
+	const content = renderActivity(isAddition ? renderAdd(user, target, item) : renderRemove(user, target, item));
 	for (const inbox of queue) {
 		deliver(user, content, inbox);
 	}

--- a/src/services/i/update.ts
+++ b/src/services/i/update.ts
@@ -3,7 +3,7 @@ import User, { isLocalUser, isRemoteUser } from '../../models/user';
 import Following from '../../models/following';
 import renderPerson from '../../remote/activitypub/renderer/person';
 import renderUpdate from '../../remote/activitypub/renderer/update';
-import packAp from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import { deliver } from '../../queue';
 
 export async function publishToFollowers(userId: mongo.ObjectID) {
@@ -29,7 +29,7 @@ export async function publishToFollowers(userId: mongo.ObjectID) {
 		}
 
 		if (queue.length > 0) {
-			const content = packAp(renderUpdate(await renderPerson(user), user));
+			const content = renderActivity(renderUpdate(await renderPerson(user), user));
 			for (const inbox of queue) {
 				deliver(user, content, inbox);
 			}

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -7,7 +7,7 @@ import { deliver } from '../../queue';
 import renderNote from '../../remote/activitypub/renderer/note';
 import renderCreate from '../../remote/activitypub/renderer/create';
 import renderAnnounce from '../../remote/activitypub/renderer/announce';
-import packAp from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import DriveFile, { IDriveFile } from '../../models/drive-file';
 import notify from '../../notify';
 import NoteWatching from '../../models/note-watching';
@@ -283,7 +283,7 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 	createMentionedEvents(mentionedUsers, note, nm);
 
-	const noteActivity = await renderActivity(data, note);
+	const noteActivity = await renderActivity_(data, note);
 
 	if (isLocalUser(user)) {
 		deliverNoteToMentionedRemoteUsers(mentionedUsers, user, noteActivity);
@@ -341,14 +341,14 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 	index(note);
 });
 
-async function renderActivity(data: Option, note: INote) {
+async function renderActivity_(data: Option, note: INote) {
 	if (data.localOnly) return null;
 
 	const content = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0)
 		? renderAnnounce(data.renote.uri ? data.renote.uri : `${config.url}/notes/${data.renote._id}`, note)
 		: renderCreate(await renderNote(note, false), note);
 
-	return packAp(content);
+	return renderActivity(content);
 }
 
 function incRenoteCount(renote: INote) {

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -283,7 +283,7 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 
 	createMentionedEvents(mentionedUsers, note, nm);
 
-	const noteActivity = await renderActivity_(data, note);
+	const noteActivity = await renderNoteOrRenoteActivity(data, note);
 
 	if (isLocalUser(user)) {
 		deliverNoteToMentionedRemoteUsers(mentionedUsers, user, noteActivity);
@@ -341,7 +341,7 @@ export default async (user: IUser, data: Option, silent = false) => new Promise<
 	index(note);
 });
 
-async function renderActivity_(data: Option, note: INote) {
+async function renderNoteOrRenoteActivity(data: Option, note: INote) {
 	if (data.localOnly) return null;
 
 	const content = data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length == 0)

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -2,7 +2,7 @@ import Note, { INote } from '../../models/note';
 import { IUser, isLocalUser } from '../../models/user';
 import { publishNoteStream } from '../../stream';
 import renderDelete from '../../remote/activitypub/renderer/delete';
-import pack from '../../remote/activitypub/renderer';
+import { renderActivity } from '../../remote/activitypub/renderer';
 import { deliver } from '../../queue';
 import Following from '../../models/following';
 import renderTombstone from '../../remote/activitypub/renderer/tombstone';
@@ -75,7 +75,7 @@ export default async function(user: IUser, note: INote) {
 
 	//#region ローカルの投稿なら削除アクティビティを配送
 	if (isLocalUser(user)) {
-		const content = pack(renderDelete(renderTombstone(`${config.url}/notes/${note._id}`), user));
+		const content = renderActivity(renderDelete(renderTombstone(`${config.url}/notes/${note._id}`), user));
 
 		const followings = await Following.find({
 			followeeId: user._id,

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -7,7 +7,7 @@ import NoteWatching from '../../../models/note-watching';
 import watch from '../watch';
 import renderLike from '../../../remote/activitypub/renderer/like';
 import { deliver } from '../../../queue';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import perUserReactionsChart from '../../../chart/per-user-reactions';
 
 export default async (user: IUser, note: INote, reaction: string) => new Promise(async (res, rej) => {
@@ -86,7 +86,7 @@ export default async (user: IUser, note: INote, reaction: string) => new Promise
 	//#region 配信
 	// リアクターがローカルユーザーかつリアクション対象がリモートユーザーの投稿なら配送
 	if (isLocalUser(user) && isRemoteUser(note._user)) {
-		const content = pack(renderLike(user, note, reaction));
+		const content = renderActivity(renderLike(user, note, reaction));
 		deliver(user, content, note._user.inbox);
 	}
 	//#endregion

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -4,7 +4,7 @@ import Reaction from '../../../models/note-reaction';
 import { publishNoteStream } from '../../../stream';
 import renderLike from '../../../remote/activitypub/renderer/like';
 import renderUndo from '../../../remote/activitypub/renderer/undo';
-import pack from '../../../remote/activitypub/renderer';
+import { renderActivity } from '../../../remote/activitypub/renderer';
 import { deliver } from '../../../queue';
 
 export default async (user: IUser, note: INote) => new Promise(async (res, rej) => {
@@ -42,7 +42,7 @@ export default async (user: IUser, note: INote) => new Promise(async (res, rej) 
 	//#region 配信
 	// リアクターがローカルユーザーかつリアクション対象がリモートユーザーの投稿なら配送
 	if (isLocalUser(user) && isRemoteUser(note._user)) {
-		const content = pack(renderUndo(renderLike(user, note, exist.reaction), user));
+		const content = renderActivity(renderUndo(renderLike(user, note, exist.reaction), user));
 		deliver(user, content, note._user.inbox);
 	}
 	//#endregion


### PR DESCRIPTION
# Summary
AP rendererがrootのだけなぜか`pack`という名前でimportされていて
modelの`pack`と被っててややこしかったり、たまに違う名前でimportされててややこしかったり
するのを修正。