### PR TITLE
send/receive user hashtags via AP

### DIFF
--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -48,6 +48,7 @@ type IUserBase = {
 	lang?: string;
 	pinnedNoteIds: mongo.ObjectID[];
 	emojis?: string[];
+	tags?: string[];
 
 	/**
 	 * 凍結されているか否か

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -11,7 +11,7 @@ import { resolveImage } from './image';
 import { IRemoteUser, IUser } from '../../../models/user';
 import { fromHtml } from '../../../mfm/fromHtml';
 import Emoji, { IEmoji } from '../../../models/emoji';
-import { ITag } from './tag';
+import { ITag, extractHashtags } from './tag';
 import { toUnicode } from 'punycode';
 import { unique, concat, difference } from '../../../prelude/array';
 import { extractPollFromQuestion } from './question';
@@ -238,15 +238,4 @@ async function extractMentionedUsers(actor: IRemoteUser, to: string[], cc: strin
 	);
 
 	return users.filter(x => x != null);
-}
-
-function extractHashtags(tags: ITag[]) {
-	if (!tags) return [];
-
-	const hashtags = tags.filter(tag => tag.type === 'Hashtag' && typeof tag.name == 'string');
-
-	return hashtags.map(tag => {
-		const m = tag.name.match(/^#(.+)/);
-		return m ? m[1] : null;
-	}).filter(x => x != null);
 }

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -17,7 +17,7 @@ import registerInstance from '../../../services/register-instance';
 import Instance from '../../../models/instance';
 import getDriveFileUrl from '../../../misc/get-drive-file-url';
 import { IEmoji } from '../../../models/emoji';
-import { ITag } from './tag';
+import { ITag, extractHashtags } from './tag';
 import Following from '../../../models/following';
 import { IIdentifier } from './identifier';
 
@@ -140,6 +140,8 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 
 	const { fields, services } = analyzeAttachments(person.attachment);
 
+	const tags = extractHashtags(person.tag);
+
 	const isBot = object.type == 'Service';
 
 	// Create user
@@ -171,6 +173,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<IU
 			url: person.url,
 			fields,
 			...services,
+			tags,
 			isBot,
 			isCat: (person as any).isCat === true
 		}) as IRemoteUser;
@@ -334,6 +337,8 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 
 	const { fields, services } = analyzeAttachments(person.attachment);
 
+	const tags = extractHashtags(person.tag);
+
 	const updates = {
 		lastFetchedAt: new Date(),
 		inbox: person.inbox,
@@ -349,6 +354,7 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 		endpoints: person.endpoints,
 		fields,
 		...services,
+		tags,
 		isBot: object.type == 'Service',
 		isCat: (person as any).isCat === true,
 		isLocked: person.manuallyApprovesFollowers,

--- a/src/remote/activitypub/models/tag.ts
+++ b/src/remote/activitypub/models/tag.ts
@@ -13,3 +13,14 @@ export type ITag = {
 	icon?: IIcon;
 	identifier?: IIdentifier;
 };
+
+export function extractHashtags(tags: ITag[]) {
+	if (!tags) return [];
+
+	const hashtags = tags.filter(tag => tag.type === 'Hashtag' && typeof tag.name == 'string');
+
+	return hashtags.map(tag => {
+		const m = tag.name.match(/^#(.+)/);
+		return m ? m[1] : null;
+	}).filter(x => x != null);
+}

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -8,6 +8,7 @@ import DriveFile from '../../../models/drive-file';
 import { getEmojis } from './note';
 import renderEmoji from './emoji';
 import { IIdentifier } from '../models/identifier';
+import renderHashtag from './hashtag';
 
 export default async (user: ILocalUser) => {
 	const id = `${config.url}/users/${user._id}`;
@@ -67,8 +68,11 @@ export default async (user: ILocalUser) => {
 	const emojis = await getEmojis(user.emojis);
 	const apemojis = emojis.map(emoji => renderEmoji(emoji));
 
+	const hashtagTags = (user.tags || []).map(tag => renderHashtag(tag));
+
 	const tag = [
 		...apemojis,
+		...hashtagTags,
 	];
 
 	return {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -8,6 +8,7 @@ import define from '../../define';
 import getDriveFileUrl from '../../../../misc/get-drive-file-url';
 import { parse, parsePlain } from '../../../../mfm/parse';
 import extractEmojis from '../../../../misc/extract-emojis';
+import extractHashtags from '../../../../misc/extract-hashtags';
 const langmap = require('langmap');
 
 export const meta = {
@@ -201,9 +202,10 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 		}
 	}
 
-	//#region emojis
+	//#region emojis/tags
 	if (updates.name != null || updates.description != null) {
 		let emojis = [] as string[];
+		let tags = [] as string[];
 
 		if (updates.name != null) {
 			const tokens = parsePlain(updates.name);
@@ -213,9 +215,11 @@ export default define(meta, (ps, user, app) => new Promise(async (res, rej) => {
 		if (updates.description != null) {
 			const tokens = parse(updates.description);
 			emojis = emojis.concat(extractEmojis(tokens));
+			tags = extractHashtags(tokens);
 		}
 
 		updates.emojis = emojis;
+		updates.tags = tags;
 	}
 	//#endregion
 


### PR DESCRIPTION
# Summary
Related #758

Mastodonのディレクトリ機能 ( https://mastodon.social/explore ) で
ユーザーがbioに載せたハッシュタグをAPで公開するようになったので
それを送受信するようにする。

- MastodonからAP経由で来るユーザーのハッシュタグをDB保存する
- ローカルユーザーのdescriptionからハッシュタグを抽出しDB保存する、またAPで公開する