### PR TITLE
Fix "About" url error

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -358,7 +358,8 @@ common/views/components/messaging-room.message.vue:
   deleted: "このメッセージは削除されました"
 
 common/views/components/nav.vue:
-  about: "Misskeyについて"
+  about_jp: "Misskeyについて(日本語)"
+  about_en: "About Misskey(English)"
   stats: "統計"
   status: "ステータス"
   wiki: "Wiki"
@@ -1576,7 +1577,8 @@ mobile/views/components/ui.nav.vue:
   darkmode: "ダークモード"
   settings: "設定"
   admin: "管理"
-  about: "Misskeyについて"
+  about_jp: "Misskeyについて(日本語)"
+  about_en: "About Misskey(English)"
 
 mobile/views/components/user-timeline.vue:
   no-notes: "このユーザーは投稿していないようです。"

--- a/src/client/app/common/views/components/nav.vue
+++ b/src/client/app/common/views/components/nav.vue
@@ -1,6 +1,8 @@
 <template>
 <span class="mk-nav">
-	<a :href="aboutUrl">{{ $t('about') }}</a>
+	<a :href="enAboutUrl">{{ $t('about_en') }}</a>
+	<i>・</i>
+	<a :href="jpAboutUrl">{{ $t('about_jp') }}</a>
 	<i>・</i>
 	<a :href="repositoryUrl">{{ $t('repository') }}</a>
 	<i>・</i>
@@ -19,7 +21,8 @@ export default Vue.extend({
 	i18n: i18n('common/views/components/nav.vue'),
 	data() {
 		return {
-			aboutUrl: `/docs/${lang}/about`,
+			enAboutUrl: `/docs/en-US/about`,
+			jpAboutUrl: `/docs/ja-JP/about`,
 			repositoryUrl: 'https://github.com/syuilo/misskey',
 			feedbackUrl: 'https://github.com/syuilo/misskey/issues/new'
 		}

--- a/src/client/app/mobile/views/components/ui.nav.vue
+++ b/src/client/app/mobile/views/components/ui.nav.vue
@@ -40,7 +40,8 @@
 					<div v-html="announcement.text"></div>
 				</article>
 			</div>
-			<a :href="aboutUrl"><p class="about">{{ $t('about') }}</p></a>
+			<a :href="enAboutUrl"><p class="about">{{ $t('about_en') }}</p></a>
+			<a :href="jpAboutUrl"><p class="about">{{ $t('about_jp') }}</p></a>
 		</div>
 	</transition>
 </div>
@@ -59,7 +60,8 @@ export default Vue.extend({
 		return {
 			hasGameInvitation: false,
 			connection: null,
-			aboutUrl: `/docs/${lang}/about`,
+			enAboutUrl: `/docs/en-US/about`,
+			jpAboutUrl: `/docs/ja-JP/about`,
 			announcements: [],
 			searching: false,
 		};


### PR DESCRIPTION
Currently there are only English and Japanese About pages. In other languages user will see 404 error.
So I change the url "/docs/${lang}/about" into 2 urls: "/docs/en-US/about" and "/docs/ja-JP/about"