### PR TITLE
Fix video thumbnails

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -122,8 +122,6 @@ async function save(path: string, name: string, type: string, hash: string, size
 	} else if (type.startsWith('video/')) {
 		try {
 			thumbnail = await GenerateVideoThumbnail(path);
-			thumbnailExt = 'png';
-			thumbnailType = 'image/png';
 		} catch (e) {
 			console.log(`GenerateVideoThumbnail failed: ${e}`);
 		}

--- a/src/services/drive/generate-video-thumbnail.ts
+++ b/src/services/drive/generate-video-thumbnail.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as tmp from 'tmp';
-import sharp = require('sharp');
+import * as sharp from 'sharp';
 const ThumbnailGenerator = require('video-thumbnail-generator').default;
 
 export async function GenerateVideoThumbnail(path: string): Promise<Buffer> {

--- a/src/services/drive/generate-video-thumbnail.ts
+++ b/src/services/drive/generate-video-thumbnail.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as tmp from 'tmp';
+import sharp = require('sharp');
 const ThumbnailGenerator = require('video-thumbnail-generator').default;
 
 export async function GenerateVideoThumbnail(path: string): Promise<Buffer> {
@@ -15,18 +16,27 @@ export async function GenerateVideoThumbnail(path: string): Promise<Buffer> {
 		thumbnailPath: outDir,
 	});
 
-	await tg.generateOneByPercent(10, {
-		size: '498x280',
+	await tg.generateOneByPercent(5, {
+		size: '100%',
 		filename: 'output.png',
 	});
 
 	const outPath = `${outDir}/output.png`;
 
-	const buffer = fs.readFileSync(outPath);
+	const thumbnail = await sharp(outPath)
+		.resize(498, 280, {
+			fit: 'inside',
+			withoutEnlargement: true
+		})
+		.jpeg({
+			quality: 85,
+			progressive: true
+		})
+		.toBuffer();
 
 	// cleanup
 	fs.unlinkSync(outPath);
 	cleanup();
 
-	return buffer;
+	return thumbnail;
 }


### PR DESCRIPTION
# Summary
動画のサムネイル作成 (#4084) の修正
- アスペクト比が保持されないのを修正
- PNGではなくJPEGで生成するように
- 10%地点は先すぎる気がしたので5%地点に
