### PR TITLE
Fix: URLプレビューのthumbnailで()を含むURLを提示されると表示できない

### DIFF
--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -185,7 +185,6 @@ export default Vue.extend({
 				this.title = info.title;
 				this.description = info.description;
 				this.thumbnail = info.thumbnail;
-				console.log(info.thumbnail);
 				this.icon = info.icon;
 				this.sitename = info.sitename;
 				this.fetching = false;

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -9,7 +9,7 @@
 </div>
 <div v-else class="mk-url-preview">
 	<a :class="{ mini, compact }" :href="url" target="_blank" :title="url" v-if="!fetching">
-		<div class="thumbnail" v-if="thumbnail" :style="`background-image: url(${thumbnail})`"></div>
+		<div class="thumbnail" v-if="thumbnail" :style="`background-image: url('${thumbnail}')`"></div>
 		<article>
 			<header>
 				<h1 :title="title">{{ title }}</h1>
@@ -185,6 +185,7 @@ export default Vue.extend({
 				this.title = info.title;
 				this.description = info.description;
 				this.thumbnail = info.thumbnail;
+				console.log(info.thumbnail);
 				this.icon = info.icon;
 				this.sitename = info.sitename;
 				this.fetching = false;


### PR DESCRIPTION
# Summary
URLプレビューのthumbnailで、`(`, `)`を含むURLを提示されると表示できないのを修正