### PR TITLE
Attempt to increase font size of notes in Deck for latin script

### DIFF
--- a/src/client/app/desktop/views/pages/deck/deck.notes.vue
+++ b/src/client/app/desktop/views/pages/deck/deck.notes.vue
@@ -211,7 +211,7 @@ export default Vue.extend({
 			display block
 			margin 0
 			line-height 28px
-			font-size 12px
+			font-size 15px
 			text-align center
 			color var(--dateDividerFg)
 			background var(--dateDividerBg)


### PR DESCRIPTION
It was too small to see well, especially for latin script languages, like English...

# Summary
This increases the font-size of notes in Deck view, which was too small for latin script languages.
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
