### PR TITLE
リアクション一覧のマージンを調整

### DIFF
--- a/src/client/app/common/views/components/reactions-viewer.vue
+++ b/src/client/app/common/views/components/reactions-viewer.vue
@@ -148,7 +148,8 @@ export default Vue.extend({
 	> span
 		display inline-block
 		height 32px
-		margin-right 6px
+		margin-right 4px
+		margin-bottom 4px
 		padding 0 6px
 		border-radius 4px
 		cursor pointer


### PR DESCRIPTION
# Summary
リアクション一覧で以下を修正
- リアクションの1行目と2行目がくっつく
- Firefox deckだと5列ではなく4列表示になる

![image](https://user-images.githubusercontent.com/30769358/52288566-cdc89100-29af-11e9-877f-2fd596d42d34.png)
↓
![image](https://user-images.githubusercontent.com/30769358/52288568-cf925480-29af-11e9-9590-132698482562.png)

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
