### PR TITLE
Hide unusable follow buttons

### DIFF
--- a/src/client/app/desktop/views/components/user-card.vue
+++ b/src/client/app/desktop/views/components/user-card.vue
@@ -2,7 +2,7 @@
 <div class="zvdbznxvfixtmujpsigoccczftvpiwqh">
 	<div class="banner" :style="bannerStyle"></div>
 	<mk-avatar class="avatar" :user="user" :disable-preview="true"/>
-	<mk-follow-button :user="user" class="follow" mini/>
+	<mk-follow-button v-if="$store.getters.isSignedIn && user.id != $store.state.i.id" :user="user" class="follow" mini/>
 	<div class="body">
 		<router-link :to="user | userPage" class="name">
 			<mk-user-name :user="user"/>

--- a/src/client/app/mobile/views/components/user-card.vue
+++ b/src/client/app/mobile/views/components/user-card.vue
@@ -7,7 +7,7 @@
 		<mk-user-name :user="user"/>
 	</a>
 	<p class="username"><mk-acct :user="user"/></p>
-	<mk-follow-button class="follow-button" :user="user"/>
+	<mk-follow-button v-if="$store.getters.isSignedIn && user.id != $store.state.i.id" class="follow-button" :user="user"/>
 </div>
 </template>
 


### PR DESCRIPTION
# Summary
以下の実際には使用できないのに表示されてしまうフォローボタンを隠しています

1. Desktop フォロー/フォロワー一覧
  1-1. 自分でもフォローボタンが表示される Resolve #4123
  1-2. 未ログインでもフォローボタンが表示される
2. Mobile よく会話するユーザー
  2-1. 自分でもフォローボタンが表示される Resolve #4123
  2-2. 未ログインでもフォローボタンが表示される
