### PR TITLE
Docker: Remove unnecessary workaround for BusyBox's "free" (#4199)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ WORKDIR /misskey
 
 FROM base AS builder
 
-RUN unlink /usr/bin/free
 RUN apk add --no-cache \
     autoconf \
     automake \
@@ -20,7 +19,6 @@ RUN apk add --no-cache \
     make \
     nasm \
     pkgconfig \
-    procps \
     python \
     zlib-dev
 RUN npm i -g node-gyp


### PR DESCRIPTION
> # Summary
> 
> systeminformationは`free`コマンドではなく`/proc/meminfo`を使うようになったので、このワークアラウンドは不要ですよね。
> # 動作確認
> 
> 10.83.0に差分を適用して、Docker環境で動作確認しました。
> 
>     * [x]  起動すること
> 
>     * [x]  投稿できること
> 
>     * [x]  「サーバー情報」ウィジェットがメモリ容量を正しく読み取っていること
> 
> 
> ![スクリーンショット](https://user-images.githubusercontent.com/11152868/52516253-ef08d600-2c6a-11e9-90d1-6bb0c2f1883c.png)
> 
> ```
> $ docker-compose exec web cat /proc/meminfo
> MemTotal:       16158560 kB
> MemFree:         1113024 kB
> MemAvailable:    9694468 kB
> Buffers:         4946992 kB
> Cached:          2547508 kB
> SwapCached:            0 kB
> Active:          5828820 kB
> Inactive:        6441924 kB
> Active(anon):    2661212 kB
> Inactive(anon):  3156264 kB
> Active(file):    3167608 kB
> Inactive(file):  3285660 kB
> Unevictable:           4 kB
> Mlocked:               4 kB
> SwapTotal:             0 kB
> SwapFree:              0 kB
> Dirty:             24936 kB
> Writeback:             0 kB
> AnonPages:       4776608 kB
> Mapped:           387900 kB
> Shmem:           1041232 kB
> Slab:            2539104 kB
> SReclaimable:    2466416 kB
> SUnreclaim:        72688 kB
> KernelStack:       15376 kB
> PageTables:        53100 kB
> NFS_Unstable:          0 kB
> Bounce:                0 kB
> WritebackTmp:          0 kB
> CommitLimit:     8079280 kB
> Committed_AS:   10958972 kB
> VmallocTotal:   34359738367 kB
> VmallocUsed:      564904 kB
> VmallocChunk:   34358423548 kB
> HardwareCorrupted:     0 kB
> AnonHugePages:   1159168 kB
> CmaTotal:              0 kB
> CmaFree:               0 kB
> HugePages_Total:       0
> HugePages_Free:        0
> HugePages_Rsvd:        0
> HugePages_Surp:        0
> Hugepagesize:       2048 kB
> DirectMap4k:      233776 kB
> DirectMap2M:    16435200 kB
> ```
> 
> 5828820 / 16158560 ≒ 0.36
>
> _Originally posted by @khws4v1 in https://github.com/syuilo/misskey/pull/4199#issue-251651904_
