### PR TITLE
Fix #4152

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -1,5 +1,5 @@
 type Locale = { [key: string]: string };
 
-declare const locales: { [lang: string]: Locale };
+declare const locales: { [lang: string]: any };
 
-export default locales;
+export = locales;

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -1,5 +1,3 @@
-type Locale = { [key: string]: string };
-
 declare const locales: { [lang: string]: any };
 
 export = locales;

--- a/src/server/web/docs.ts
+++ b/src/server/web/docs.ts
@@ -16,7 +16,7 @@ import config from '../../config';
 import { licenseHtml } from '../../misc/license';
 import { copyright } from '../../const.json';
 import endpoints from '../api/endpoints';
-import locales from '../../../locales';
+const locales = require('../../../locales');
 import * as nestedProperty from 'nested-property';
 
 function getLang(lang: string): string {

--- a/src/server/web/docs.ts
+++ b/src/server/web/docs.ts
@@ -16,7 +16,7 @@ import config from '../../config';
 import { licenseHtml } from '../../misc/license';
 import { copyright } from '../../const.json';
 import endpoints from '../api/endpoints';
-const locales = require('../../../locales');
+import * as locales from '../../../locales';
 import * as nestedProperty from 'nested-property';
 
 function getLang(lang: string): string {


### PR DESCRIPTION
# Summary
Fix #4152 
ドキュメントが参照できるようにしています

`import * as locales from '../../../locales';` にすると以下のエラー出てしまうのでしてない

`src/server/web/docs.ts(66,53): error TS7017: Element implicitly has an 'any' type because type 'typeof import("misskey/locales/index")' has no index signature.`