### PR TITLE
Increase slightly the font size of replies

### DIFF
--- a/src/client/app/desktop/views/components/note.sub.vue
+++ b/src/client/app/desktop/views/components/note.sub.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
 
 	&.mini
 		padding 16px
-		font-size 14px
+		font-size 13px
 
 		> .avatar
 			margin 0 8px 0 0
@@ -99,6 +99,6 @@ export default Vue.extend({
 
 					pre
 						max-height 120px
-						font-size 82%
+						font-size 80%
 
 </style>

--- a/src/client/app/desktop/views/components/note.sub.vue
+++ b/src/client/app/desktop/views/components/note.sub.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
 
 	&.mini
 		padding 16px
-		font-size 13px
+		font-size 12px
 
 		> .avatar
 			margin 0 8px 0 0

--- a/src/client/app/desktop/views/components/note.sub.vue
+++ b/src/client/app/desktop/views/components/note.sub.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
 
 	&.mini
 		padding 16px
-		font-size 10px
+		font-size 14px
 
 		> .avatar
 			margin 0 8px 0 0
@@ -99,6 +99,6 @@ export default Vue.extend({
 
 					pre
 						max-height 120px
-						font-size 80%
+						font-size 82%
 
 </style>


### PR DESCRIPTION
# Summary

<!--
  -
Attempts to fix the very small, and hard-to-read font-size of replies, wjich is the case now, as shown bellow:
<img width="319" alt="screenshot 2019-02-21 at 13 11 29" src="https://user-images.githubusercontent.com/45913977/53168506-0c2e9480-35db-11e9-8f63-fc244674d917.png">

<img width="327" alt="screenshot 2019-02-21 at 13 10 37" src="https://user-images.githubusercontent.com/45913977/53168539-24061880-35db-11e9-856f-a846bde85e66.png">


  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
