### PR TITLE
ユーザーヘッダーのボットアイコンのタイトル設定先が間違えているのを修正

### DIFF
--- a/src/client/app/desktop/views/pages/user/user.header.vue
+++ b/src/client/app/desktop/views/pages/user/user.header.vue
@@ -9,7 +9,7 @@
 			</p>
 			<div>
 				<span class="username"><mk-acct :user="user" :detail="true" /></span>
-				<span v-if="user.isBot" :title="$t('title')"><fa icon="robot"/></span>
+				<span v-if="user.isBot" :title="$t('is-bot')"><fa icon="robot"/></span>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
ref:
https://github.com/syuilo/misskey/blob/93c3f34813027954af3e4e8a29aa631e9872d87b/locales/ja-JP.yml#L1497-L1501