### PR TITLE
Fix huge close icon of friends-maker

### DIFF
--- a/src/client/app/desktop/views/components/friends-maker.vue
+++ b/src/client/app/desktop/views/components/friends-maker.vue
@@ -160,6 +160,7 @@ export default Vue.extend({
 			color #222
 
 		> [data-icon]
+			box-sizing initial
 			padding 14px
 
 </style>

--- a/src/client/app/mobile/views/components/friends-maker.vue
+++ b/src/client/app/mobile/views/components/friends-maker.vue
@@ -124,6 +124,7 @@ export default Vue.extend({
 			color #222
 
 		> [data-icon]
+			box-sizing initial
 			padding 10px
 
 </style>


### PR DESCRIPTION
I wonder if this method is the best..

-- | Before | After
--|--|--
desktop | ![screenshot from 2019-02-14 03-23-00](https://user-images.githubusercontent.com/27640522/52735010-ea954200-3009-11e9-9ca9-cc2ee992d076.png) | ![screenshot from 2019-02-14 03-34-17](https://user-images.githubusercontent.com/27640522/52735020-f08b2300-3009-11e9-8f02-c84ffa5606d6.png)
mobile | ![screenshot from 2019-02-14 03-26-20](https://user-images.githubusercontent.com/27640522/52735016-ecf79c00-3009-11e9-9f0c-92f6723d7d54.png) | ![screenshot from 2019-02-14 03-33-57](https://user-images.githubusercontent.com/27640522/52735019-ef59f600-3009-11e9-9a84-140f544354bb.png)
