### PR TITLE
Restore web max-age to 5 minutes

### DIFF
--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -237,7 +237,7 @@ router.get('*', async ctx => {
 	await ctx.render('base', {
 		img: meta.bannerUrl
 	});
-	ctx.set('Cache-Control', 'public, max-age=86400');
+	ctx.set('Cache-Control', 'public, max-age=300');
 });
 
 // Register router


### PR DESCRIPTION
# Summary
ベースHTMLのキャッシュを1日→5分に戻す

いつのまにか1日になってたのと、長くてもさほど効果が見込めないのと、更新があったときに問題が発生するため