### PR TITLE
Emojify friends username of desktop user page

### DIFF
--- a/src/client/app/desktop/views/pages/user/user.friends.vue
+++ b/src/client/app/desktop/views/pages/user/user.friends.vue
@@ -6,7 +6,7 @@
 		<div class="user" v-for="friend in users">
 			<mk-avatar class="avatar" :user="friend"/>
 			<div class="body">
-				<router-link class="name" :to="friend | userPage" v-user-preview="friend.id">{{ friend.name }}</router-link>
+				<router-link class="name" :to="friend | userPage" v-user-preview="friend.id"><mk-user-name :user="friend"/></router-link>
 				<p class="username">@{{ friend | acct }}</p>
 			</div>
 		</div>


### PR DESCRIPTION
デスクトップのユーザーページのよく話すユーザー欄の名前の絵文字が平文になっていたため emojify しました。

![image](https://user-images.githubusercontent.com/27640522/52738941-22ed4e00-3013-11e9-9c68-1282fa713a6f.png)
