### PR TITLE
Add i18n when timelines are empty

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -862,6 +862,9 @@ desktop/views/components/renote-form.vue:
 desktop/views/components/renote-form-window.vue:
   title: "この投稿をRenoteしますか？"
 
+desktop/views/components/timeline.core.vue:
+  empty: "投稿がありません"
+
 desktop/views/pages/user-following-or-followers.vue:
   following: "{user}のフォロー"
   followers: "{user}のフォロワー"
@@ -1688,6 +1691,9 @@ mobile/views/pages/home.vue:
   global: "グローバル"
   mentions: "あなた宛て"
   messages: "メッセージ"
+
+mobile/views/pages/home.timeline.vue:
+  empty: "投稿がありません"
 
 mobile/views/pages/tag.vue:
   no-posts-found: "ハッシュタグ「{q}」が付けられた投稿は見つかりませんでした。"

--- a/src/client/app/mobile/views/pages/home.timeline.vue
+++ b/src/client/app/mobile/views/pages/home.timeline.vue
@@ -4,8 +4,7 @@
 
 	<mk-notes ref="timeline" :more="existMore ? more : null">
 		<div slot="empty">
-			<fa :icon="['far', 'comments']"/>
-			%i18n:@empty%
+			<fa :icon="['far', 'comments']"/>{{ $t('empty') }}
 		</div>
 	</mk-notes>
 </div>
@@ -13,10 +12,13 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import i18n from '../../../i18n';
 
 const fetchLimit = 10;
 
 export default Vue.extend({
+	i18n: i18n('mobile/views/pages/home.timeline.vue'),
+	
 	props: {
 		src: {
 			type: String,


### PR DESCRIPTION
solved, thanks @acid-chicken. ~~日本語表記のみを ymlファイルに追加しましたが、他言語ローカライゼーションの ymlファイルへの追加の方法がわかりません。Crowdin が自動的にやってくれるのか、それとも何らかのコマンドがあるのか。サポートお願いします。~~

~~I add only japanese translations on this commit. l dunno how to add l10n to all yml files. Crowdin automatically adds them? or Is there a command to add them?~~

![image](https://user-images.githubusercontent.com/27640522/52794861-ff2e1480-30b3-11e9-8045-fae761bf8e1e.png)
![image](https://user-images.githubusercontent.com/27640522/52794891-0bb26d00-30b4-11e9-96fe-77e24c1228f9.png)
