### PR TITLE
Change home button to timeline

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1088,7 +1088,6 @@ desktop/views/components/ui.header.account.vue:
   dark: "闇に飲まれる"
 
 desktop/views/components/ui.header.nav.vue:
-  home: "ホーム"
   game: "ゲーム"
 
 desktop/views/components/ui.header.notifications.vue:

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -61,6 +61,7 @@ common:
   drive: "ドライブ"
   messaging: "トーク"
   deck: "デッキ"
+  timeline: "タイムライン"
   explore: "みつける"
   following: "フォロー中"
   followers: "フォロワー"

--- a/src/client/app/desktop/views/components/ui.header.nav.vue
+++ b/src/client/app/desktop/views/components/ui.header.nav.vue
@@ -1,8 +1,8 @@
 <template>
 <div class="nav">
 	<ul>
-		<li class="home active" @click="goToTop">
-			<router-link to="/"><fa icon="home"/><p>{{ $t('home') }}</p></router-link>
+		<li v-if="!$store.state.device.deckMode" class="timeline" @click="goToTop">
+			<router-link to="/"><fa icon="list"/><p>{{ $t('@.timeline') }}</p></router-link>
 		</li>
 		<li class="featured">
 			<router-link to="/featured"><fa :icon="faNewspaper"/><p>{{ $t('@.featured-notes') }}</p></router-link>


### PR DESCRIPTION
# Summary
10.86.0でナビゲーションのUIを変更
- 「ホーム」ボタンの名前を「タイムライン」に変更
- デッキモードでは「ホーム」ボタンを削除
- 「ホーム」ボタンをハイライトしないように

「ホーム」というボタンが存在すると
デッキでホームに切り替わることを期待して「ホーム」を押しても何も起きない
ホームで「デッキ」がないので、デッキに切り替えるボタンがないように見える
デッキでも、常に「ホーム」にフォーカスがあって混乱する
ということが起きるため