### PR TITLE
MIDIは汎用表示にする

### DIFF
--- a/src/client/app/common/views/components/media-banner.vue
+++ b/src/client/app/common/views/components/media-banner.vue
@@ -5,7 +5,7 @@
 		<b>{{ $t('sensitive') }}</b>
 		<span>{{ $t('click-to-show') }}</span>
 	</div>
-	<div class="audio" v-else-if="media.type.startsWith('audio')">
+	<div class="audio" v-else-if="media.type.startsWith('audio') && media.type !== 'audio/midi'">
 		<audio class="audio"
 			:src="media.url"
 			:title="media.name"


### PR DESCRIPTION
# Summary

> MIDIがオーディオファイルとして認識されてプレイヤー表示になってしまうの

です。
