### PR TITLE
デッキ使用中に別タブでユーザーページ等を開いたときにはデッキにしないように

### DIFF
--- a/src/client/app/desktop/script.ts
+++ b/src/client/app/desktop/script.ts
@@ -128,7 +128,7 @@ init(async (launch, os) => {
 	const router = new VueRouter({
 		mode: 'history',
 		routes: [
-			os.store.getters.isSignedIn && os.store.state.device.deckMode
+			os.store.getters.isSignedIn && os.store.state.device.deckMode && document.location.pathname === '/'
 				? { path: '/', name: 'index', component: MkDeck, children: [
 					{ path: '/@:user', name: 'user', component: () => import('./views/deck/deck.user-column.vue').then(m => m.default), children: [
 						{ path: '', name: 'user', component: () => import('./views/deck/deck.user-column.home.vue').then(m => m.default) },


### PR DESCRIPTION
# Summary
Resolve #4270

デッキ使用中でも、ユーザー等のリンクを別タブ (つまり直接URL指定で) 開いたときには
「デッキのカラム群＋ユーザーペイン」でなく「ホームのページ」を開くようにしています
