### PR TITLE
Fix #4300

### DIFF
--- a/src/client/app/desktop/script.ts
+++ b/src/client/app/desktop/script.ts
@@ -126,7 +126,8 @@ init(async (launch, os) => {
 
 	os.store.commit('device/set', {
 		key: 'inDeckMode',
-		value: os.store.getters.isSignedIn && os.store.state.device.deckMode && document.location.pathname === '/'
+		value: os.store.getters.isSignedIn && os.store.state.device.deckMode
+			&& (document.location.pathname === '/' || window.performance.navigation.type === 1)
 	});
 
 	// Init router

--- a/src/client/app/desktop/views/components/ui.header.account.vue
+++ b/src/client/app/desktop/views/components/ui.header.account.vue
@@ -166,7 +166,7 @@ export default Vue.extend({
 		},
 		toggleDeckMode() {
 			this.$store.commit('device/set', { key: 'deckMode', value: !this.$store.state.device.inDeckMode });
-			location.reload();
+			location.replace('/');
 		},
 	}
 });

--- a/src/client/app/desktop/views/components/ui.sidebar.vue
+++ b/src/client/app/desktop/views/components/ui.sidebar.vue
@@ -122,7 +122,7 @@ export default Vue.extend({
 	methods: {
 		toggleDeckMode(deck) {
 			this.$store.commit('device/set', { key: 'deckMode', value: deck });
-			location.reload();
+			location.replace('/');
 		},
 
 		onReversiInvited() {


### PR DESCRIPTION
# Summary
Fix #4300
- デッキでユーザーカラムを開いた状態でリロード→同じ状態になること
- デッキ切り替え→相互にできること
- デッキでユーザー等をタブ開く→ホームで開くこと
  - その開いたタブでデッキに切り替え→デッキに切り替わること

をFirefoxとChromeで確認

「デッキを切り替えた時に同じものが開かれた状態になること」は
出来なくはないのですが、ややこしいのと さほど使わなそうなのでなしになってます。
