### PR TITLE
人気のタグをクリック後も同じ位置に表示するように

### DIFF
--- a/src/client/app/common/views/pages/explore.vue
+++ b/src/client/app/common/views/pages/explore.vue
@@ -9,13 +9,6 @@
 		</div>
 	</ui-container>
 
-	<mk-user-list v-if="tag != null" :make-promise="tagUsers" :key="`${tag}-local`">
-		<fa :icon="faHashtag" fixed-width/>{{ tag }}
-	</mk-user-list>
-	<mk-user-list v-if="tag != null" :make-promise="tagRemoteUsers" :key="`${tag}-remote`">
-		<fa :icon="faHashtag" fixed-width/>{{ tag }} ({{ $t('federated') }})
-	</mk-user-list>
-
 	<ui-container :body-togglable="true">
 		<template #header><fa :icon="faHashtag" fixed-width/>{{ $t('popular-tags') }}</template>
 
@@ -24,6 +17,13 @@
 			<router-link v-for="tag in tagsRemote" :to="`/explore/tags/${tag.tag}`" :key="tag.tag">{{ tag.tag }}</router-link>
 		</div>
 	</ui-container>
+
+	<mk-user-list v-if="tag != null" :make-promise="tagUsers" :key="`${tag}-local`">
+		<fa :icon="faHashtag" fixed-width/>{{ tag }}
+	</mk-user-list>
+	<mk-user-list v-if="tag != null" :make-promise="tagRemoteUsers" :key="`${tag}-remote`">
+		<fa :icon="faHashtag" fixed-width/>{{ tag }} ({{ $t('federated') }})
+	</mk-user-list>
 
 	<template v-if="tag == null">
 		<mk-user-list :make-promise="verifiedUsers">


### PR DESCRIPTION
# Summary
人気のタグをクリック後も同じ位置 (上のまま) に表示するように

人気のタグをクリックすると、人気のタグコンテナが対象ユーザーの下の方に移動してしまいますが
これだと次のタグをクリックする時に探す必要があったり
対象ユーザーが多いと大分スクロールしないと次のタグがクリックできなかったりするので
表示位置を上のままにしておいた方が、使いやすいのではないかと思います。