### PR TITLE
Supports scrollbar width in Firefox

### DIFF
--- a/src/client/app/desktop/style.styl
+++ b/src/client/app/desktop/style.styl
@@ -12,7 +12,7 @@ html
 	background var(--bg)
 
 	&, div, textarea
-		scrollbar-width: thin;
+		scrollbar-width thin
 
 	&, *
 		scrollbar-color var(--scrollbarHandle) var(--scrollbarTrack)

--- a/src/client/app/desktop/style.styl
+++ b/src/client/app/desktop/style.styl
@@ -11,6 +11,9 @@ html
 	height 100%
 	background var(--bg)
 
+	&, div, textarea
+		scrollbar-width: thin;
+
 	&, *
 		scrollbar-color var(--scrollbarHandle) var(--scrollbarTrack)
 


### PR DESCRIPTION
# Summary
Firefoxでもスクロールバーの幅変更をサポート
![image](https://user-images.githubusercontent.com/30769358/52991873-e5912200-3451-11e9-807d-ba34fd44e22b.png)

`*`に適用したところ`select`あたりがイマイチだったので適用対象を絞っています

前動かなかったのですがいつの間にか動くようになってました in Firefox 65.0.1