### PR TITLE
docs to run in production mode

### DIFF
--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -73,7 +73,7 @@ If you're still encountering errors about some modules, use node-gyp:
 Well done! Now, you have an environment that run to Misskey.
 
 ### Launch normally
-Just `npm start`. GLHF!
+Just `NODE_ENV=production npm start`. GLHF!
 
 ### Launch with systemd
 

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -55,14 +55,9 @@ As root:
 *6.* Build Misskey
 ----------------------------------------------------------------
 
-Before build, you need to set `NODE_ENV` to `production`. like this:
-* Linux: `export NODE_ENV=production`
-* Windows (PowerShell): `$env:NODE_ENV="production"`
-* Windows (CMD): `set NODE_ENV=production`
-
 Build misskey with the following:
 
-`npm run build`
+`NODE_ENV=production npm run build`
 
 If you're on Debian, you will need to install the `build-essential`, `python` package.
 
@@ -71,7 +66,7 @@ If you're still encountering errors about some modules, use node-gyp:
 1. `npm install -g node-gyp`
 2. `node-gyp configure`
 3. `node-gyp build`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 
 *7.* That is it.
 ----------------------------------------------------------------
@@ -114,7 +109,7 @@ You can check if the service is running with `systemctl status misskey`.
 1. `git fetch`
 2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
 3. `npm install`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 5. Check [ChangeLog](../CHANGELOG.md) for migration information
 6. Restart your Misskey process to apply changes
 7. Enjoy

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -94,6 +94,7 @@ Type=simple
 User=misskey
 ExecStart=/usr/bin/npm start
 WorkingDirectory=/home/misskey/misskey
+Environment="NODE_ENV=production"
 TimeoutSec=60
 StandardOutput=syslog
 StandardError=syslog

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -57,7 +57,7 @@ En root :
 
 Construisez Misskey comme ceci :
 
-`npm run build`
+`NODE_ENV=production npm run build`
 
 Si vous êtes sous Debian, vous serez amené à installer les paquets `build-essential` et `python`.
 
@@ -66,7 +66,7 @@ Si vous rencontrez des erreurs concernant certains modules, utilisez node-gyp:
 1. `npm install -g node-gyp`
 2. `node-gyp configure`
 3. `node-gyp build`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 
 *7.* C'est tout.
 ----------------------------------------------------------------
@@ -109,7 +109,7 @@ Vous pouvez vérifier si le service a démarré en utilisant la commande `system
 1. `git fetch`
 2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
 3. `npm install`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 5. Consultez [ChangeLog](../CHANGELOG.md) pour les information de migration.
 
 ----------------------------------------------------------------

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -73,7 +73,7 @@ Si vous rencontrez des erreurs concernant certains modules, utilisez node-gyp:
 Excellent ! Maintenant, vous avez un environnement prêt pour lancer Misskey
 
 ### Lancement conventionnel
-Lancez tout simplement `npm start`. Bonne chance et amusez-vous bien !
+Lancez tout simplement `NODE_ENV=production npm start`. Bonne chance et amusez-vous bien !
 
 ### Démarrage avec systemd
 

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -89,6 +89,7 @@ Type=simple
 User=misskey
 ExecStart=/usr/bin/npm start
 WorkingDirectory=/home/misskey/misskey
+Environment="NODE_ENV=production"
 TimeoutSec=60
 StandardOutput=syslog
 StandardError=syslog

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -79,7 +79,7 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 お疲れ様でした。これでMisskeyを動かす準備は整いました。
 
 ### 通常起動
-`npm start`するだけです。GLHF!
+`NODE_ENV=production npm start`するだけです。GLHF!
 
 ### systemdを用いた起動
 1. systemdサービスのファイルを作成: `/etc/systemd/system/misskey.service`

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -99,6 +99,7 @@ Type=simple
 User=misskey
 ExecStart=/usr/bin/npm start
 WorkingDirectory=/home/misskey/misskey
+Environment="NODE_ENV=production"
 TimeoutSec=60
 StandardOutput=syslog
 StandardError=syslog

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -62,14 +62,9 @@ adduser --disabled-password --disabled-login misskey
 *6.* Misskeyのビルド
 ----------------------------------------------------------------
 
-ビルドする前に、`NODE_ENV`を`production`にする必要があります。例:
-* Linux: `export NODE_ENV=production`
-* Windows (PowerShell): `$env:NODE_ENV="production"`
-* Windows (CMD): `set NODE_ENV=production`
-
 次のコマンドでMisskeyをビルドしてください:
 
-`npm run build`
+`NODE_ENV=production npm run build`
 
 Debianをお使いであれば、`build-essential`パッケージをインストールする必要があります。
 
@@ -77,7 +72,7 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 1. `npm install -g node-gyp`
 2. `node-gyp configure`
 3. `node-gyp build`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 
 *7.* 以上です！
 ----------------------------------------------------------------
@@ -120,7 +115,7 @@ CentOSで1024以下のポートを使用してMisskeyを使用する場合は`Ex
 1. `git fetch`
 2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
 3. `npm install`
-4. `npm run build`
+4. `NODE_ENV=production npm run build`
 5. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する
 
 なにか問題が発生した場合は、`npm run clean`すると直る場合があります。


### PR DESCRIPTION
# Summary
documentの通りだとsystemdから起動した場合にproductionにならないので修正

buildについては、
ビルド前に`export NODE_ENV=production`するのではなくて
コマンド自体を`npm run build` => `NODE_ENV=production npm run build` にしたいのですが
Windowsもという前提が含まれているので困っています。

Windows かつ production て使う人ことあるのか？とか
Windowsのビルドは Git Bash使えばいいのでは？とか