### PR TITLE
assetsのjs要求時にsaltを付けないように

### DIFF
--- a/src/client/app/boot.js
+++ b/src/client/app/boot.js
@@ -108,11 +108,6 @@
 		app = isMobile ? 'mobile' : 'desktop';
 	}
 
-	// Get salt query
-	const salt = localStorage.getItem('salt')
-		? `?salt=${localStorage.getItem('salt')}`
-		: '';
-
 	// Load an app script
 	// Note: 'async' make it possible to load the script asyncly.
 	//       'defer' make it possible to run the script when the dom loaded.
@@ -154,9 +149,6 @@
 		localStorage.setItem('shouldFlush', 'false');
 
 		localStorage.removeItem('locale');
-
-		// Random
-		localStorage.setItem('salt', Math.random().toString().substr(2, 8));
 
 		// Clear cache (service worker)
 		try {

--- a/src/client/app/boot.js
+++ b/src/client/app/boot.js
@@ -117,7 +117,7 @@
 	// Note: 'async' make it possible to load the script asyncly.
 	//       'defer' make it possible to run the script when the dom loaded.
 	const script = document.createElement('script');
-	script.setAttribute('src', `/assets/${app}.${ver}.js${salt}`);
+	script.setAttribute('src', `/assets/${app}.${ver}.js`);
 	script.setAttribute('async', 'true');
 	script.setAttribute('defer', 'true');
 	head.appendChild(script);

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -55,7 +55,6 @@ router.get('/assets/*', async ctx => {
 	await send(ctx as any, ctx.path, {
 		root: client,
 		maxage: ms('7 days'),
-		immutable: true
 	});
 });
 


### PR DESCRIPTION
# Summary
assetsのjs要求時に付加している`salt=`を付けないようにしています
- クライアントごとに違うURLになるので、Node => Web, CDN でキャッシュが利用できずに効率が悪くなる
- 結局Code Splittingしてる箇所が効かないので中途半端 #4338

なため

生成するコードはいちおう残しています

その代替としてassetsのimmutableを外しています。
(そもそも、CloudFlare使ってるところはimmutableがクライアントまで伝わってないように見えるので、パフォーマンス的な違いもないのではと思います)