### PR TITLE
デッキからホームに行くメニューをホームと表記する

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -60,6 +60,7 @@ common:
   trash: "ゴミ箱"
   drive: "ドライブ"
   messaging: "トーク"
+  home: "ホーム"
   deck: "デッキ"
   timeline: "タイムライン"
   explore: "みつける"

--- a/src/client/app/desktop/views/components/ui.header.account.vue
+++ b/src/client/app/desktop/views/components/ui.header.account.vue
@@ -62,9 +62,8 @@
 			<ul>
 				<li @click="toggleDeckMode">
 					<p>
-						<span>{{ $t('@.deck') }}</span>
-						<template v-if="$store.state.device.inDeckMode"><i><fa :icon="faHome"/></i></template>
-						<template v-else><i><fa :icon="faColumns"/></i></template>
+						<template v-if="$store.state.device.inDeckMode"><span>{{ $t('@.home') }}</span><i><fa :icon="faHome"/></i></template>
+						<template v-else><span>{{ $t('@.deck') }}</span><i><fa :icon="faColumns"/></i></template>
 					</p>
 				</li>
 				<li @click="dark">


### PR DESCRIPTION
# Summary
Fix #4288 

デッキからホームに行くメニューを「デッキ」ではなく「ホーム」と表記するようにしています。
![image](https://user-images.githubusercontent.com/30769358/53285066-709a5100-379f-11e9-890d-0b2687ed9a08.png)
↓
![image](https://user-images.githubusercontent.com/30769358/53285068-755f0500-379f-11e9-9860-b355858a352c.png)
