### PR TITLE
Resolve audioTag undefined error

### DIFF
--- a/src/client/app/common/views/components/media-banner.vue
+++ b/src/client/app/common/views/components/media-banner.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
 	},
 	mounted() {
 		const audioTag = this.$refs.audio as HTMLAudioElement;
-		audioTag.volume = this.$store.state.device.mediaVolume;
+		if (audioTag) audioTag.volume = this.$store.state.device.mediaVolume;
 	},
 	methods: {
 		volumechange() {


### PR DESCRIPTION
# Summary
メディア以外のファイルが添付されてると
`this.$refs.audio`や`audioTag`が`undefined`といったエラーが出るのを修正