### PR TITLE
url-previewでembedプレイヤー展開をオプトインにする

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -257,6 +257,9 @@ common/views/pages/explore.vue:
   explore: "{host}を探索"
   users-info: "現在{users}ユーザーが登録されています"
 
+common/views/components/url-preview.vue:
+  enable-player: "プレイヤーを開く"
+
 common/views/components/user-list.vue:
   no-users: "ユーザーがいません"
 

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -214,7 +214,7 @@ export default Vue.extend({
 				& + article
 					left 0
 					width 100%
-			
+
 		@media (max-width 550px)
 			font-size 12px
 

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -1,6 +1,6 @@
 <template>
-<div v-if="player.url" class="player" :style="`padding: ${(player.height || 0) / (player.width || 1) * 100}% 0 0`">
-	<iframe :src="player.url" :width="player.width || '100%'" :heigth="player.height || 250" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen />
+<div v-if="playerEnabled" class="player" :style="`padding: ${(player.height || 0) / (player.width || 1) * 100}% 0 0`">
+	<iframe :src="player.url + (player.url.match(/\?/) ? '&autoplay=1&auto_play=1' : '?autoplay=1&auto_play=1')" :width="player.width || '100%'" :heigth="player.height || 250" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen />
 </div>
 <div v-else-if="tweetUrl && detail" class="twitter">
 	<blockquote ref="tweet" class="twitter-tweet" :data-theme="$store.state.device.darkmode ? 'dark' : null">
@@ -9,7 +9,9 @@
 </div>
 <div v-else class="mk-url-preview">
 	<a :class="{ mini: narrow, compact }" :href="url" target="_blank" :title="url" v-if="!fetching">
-		<div class="thumbnail" v-if="thumbnail" :style="`background-image: url('${thumbnail}')`"></div>
+		<div class="thumbnail" v-if="thumbnail" :style="`background-image: url('${thumbnail}')`">
+			<button v-if="!playerEnabled && player.url" @click.prevent="playerEnabled = true" :title="$t('enable-player')"><fa :icon="['far', 'play-circle']"/></button>
+		</div>
 		<article>
 			<header>
 				<h1 :title="title">{{ title }}</h1>
@@ -26,88 +28,11 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import i18n from '../../../i18n';
 import { url as misskeyUrl } from '../../../config';
 
-// THIS IS THE WHITELIST FOR THE EMBED PLAYER
-const whiteList = [
-	'afreecatv.com',
-	'aparat.com',
-	'applemusic.com',
-	'amazon.com',
-	'awa.fm',
-	'bandcamp.com',
-	'bbc.co.uk',
-	'beatport.com',
-	'bilibili.com',
-	'boomstream.com',
-	'breakers.tv',
-	'cam4.com',
-	'cavelis.net',
-	'chaturbate.com',
-	'cnn.com',
-	'cybergame.tv',
-	'dailymotion.com',
-	'deezer.com',
-	'djlive.pl',
-	'e-onkyo.com',
-	'eventials.com',
-	'facebook.com',
-	'fc2.com',
-	'gameplank.tv',
-	'goodgame.ru',
-	'google.com',
-	'hardtunes.com',
-	'instagram.com',
-	'johnnylooch.com',
-	'kexp.org',
-	'lahzenegar.com',
-	'liveedu.tv',
-	'livetube.cc',
-	'livestream.com',
-	'meridix.com',
-	'mixcloud.com',
-	'mixer.com',
-	'mobcrush.com',
-	'mylive.in.th',
-	'myspace.com',
-	'netflix.com',
-	'newretrowave.com',
-	'nhk.or.jp',
-	'nicovideo.jp',
-	'nico.ms',
-	'noisetrade.com',
-	'nood.tv',
-	'npr.org',
-	'openrec.tv',
-	'pandora.com',
-	'pandora.tv',
-	'picarto.tv',
-	'pscp.tv',
-	'restream.io',
-	'reverbnation.com',
-	'sermonaudio.com',
-	'smashcast.tv',
-	'songkick.com',
-	'soundcloud.com',
-	'spinninrecords.com',
-	'spotify.com',
-	'stitcher.com',
-	'stream.me',
-	'switchboard.live',
-	'tunein.com',
-	'twitcasting.tv',
-	'twitch.tv',
-	'twitter.com',
-	'vaughnlive.tv',
-	'veoh.com',
-	'vimeo.com',
-	'watchpeoplecode.com',
-	'web.tv',
-	'youtube.com',
-	'youtu.be'
-];
-
 export default Vue.extend({
+	i18n: i18n('common/views/components/url-preview.vue'),
 	props: {
 		url: {
 			type: String,
@@ -147,7 +72,8 @@ export default Vue.extend({
 				height: null
 			},
 			tweetUrl: null,
-			misskeyUrl
+			playerEnabled: false,
+			misskeyUrl,
 		};
 	},
 
@@ -188,9 +114,7 @@ export default Vue.extend({
 				this.icon = info.icon;
 				this.sitename = info.sitename;
 				this.fetching = false;
-				if (whiteList.some(x => x == url.hostname || url.hostname.endsWith(`.${x}`))) {
-					this.player = info.player;
-				}
+				this.player = info.player;
 			})
 		});
 	}
@@ -230,6 +154,17 @@ export default Vue.extend({
 			height 100%
 			background-position center
 			background-size cover
+			display flex
+			justify-content center
+			align-items center
+
+			> button
+				font-size 3.5em
+				opacity: 0.7
+
+				&:hover
+					font-size 4em
+					opacity 0.9
 
 			& + article
 				left 100px
@@ -279,7 +214,7 @@ export default Vue.extend({
 				& + article
 					left 0
 					width 100%
-
+			
 		@media (max-width 550px)
 			font-size 12px
 


### PR DESCRIPTION
# Summary

Resolve #3300
Resolve #3768

URLプレビューに於いてembedプレイヤーをクリックするまで開かないようにしています
(音楽系のプレイリストのembedは縦長なことが多くTLを埋めてしまう、
TL上でそのまま再生しても流れると再生が途切れてしまう などのため)

- 最初は通常のプレビューカードを表示して、サムネイル欄に再生ボタンを表示
- 再生ボタンを押すとembedプレイヤーを表示する
  - 可能ならば自動再生を試みる (Misskeyとembed内で2回再生ボタンを押させるのを防ぐ)
- embedプレイヤーをオプトインにしたので、ハードコードのembed許可リストを廃止

YouTubeとかSOUNDCLOUDでいい動きします