### PR TITLE
Bye on-build-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
 		"nodemailer": "5.1.1",
 		"nprogress": "0.2.0",
 		"object-assign-deep": "0.4.0",
-		"on-build-webpack": "0.1.0",
 		"os-utils": "0.0.14",
 		"parse5": "5.1.0",
 		"parsimmon": "1.12.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -6,10 +6,18 @@ import * as fs from 'fs';
 import * as webpack from 'webpack';
 import chalk from 'chalk';
 const { VueLoaderPlugin } = require('vue-loader');
-const WebpackOnBuildPlugin = require('on-build-webpack');
 //const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+
+class WebpackOnBuildPlugin {
+	constructor(readonly callback: (stats: any) => void) {
+	}
+
+	public apply(compiler: any) {
+		compiler.hooks.done.tap('WebpackOnBuildPlugin', this.callback);
+	}
+}
 
 const isProduction = process.env.NODE_ENV == 'production';
 


### PR DESCRIPTION
# Summary

> DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

がうるさいのでむしゃくしゃしてやった。
