### PR TITLE
投票するときに投稿として扱わないように

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -79,8 +79,6 @@ export type INote = {
 
 	uri: string;
 
-	voting: boolean;
-
 	/**
 	 * 人気の投稿度合いを表すスコア
 	 */

--- a/src/remote/activitypub/renderer/vote.ts
+++ b/src/remote/activitypub/renderer/vote.ts
@@ -1,0 +1,20 @@
+import config from '../../../config';
+import { INote } from '../../../models/note';
+import { IRemoteUser, ILocalUser } from '../../../models/user';
+
+export default async function renderVote(user: ILocalUser, choice: number, pollNote: INote, pollOwner: IRemoteUser): Promise<any> {
+	const attributedTo = `${config.url}/users/${user._id}`;
+
+	const to: string[] = [pollOwner.uri];
+
+	return {
+		id: `${config.url}/notes/${note._id}`,
+		type: 'Note',
+		attributedTo,
+		content: choice,
+		published: (new Date()).toISOString(),
+		to,
+		inReplyTo: pollNote.uri,
+		name: pollNote.poll.choices.find(x => x.id === choice).text
+	};
+}

--- a/src/remote/activitypub/renderer/vote.ts
+++ b/src/remote/activitypub/renderer/vote.ts
@@ -1,20 +1,15 @@
 import config from '../../../config';
 import { INote } from '../../../models/note';
 import { IRemoteUser, ILocalUser } from '../../../models/user';
+import { IPollVote } from '../../../models/poll-vote';
 
-export default async function renderVote(user: ILocalUser, choice: number, pollNote: INote, pollOwner: IRemoteUser): Promise<any> {
-	const attributedTo = `${config.url}/users/${user._id}`;
-
-	const to: string[] = [pollOwner.uri];
-
+export default async function renderVote(user: ILocalUser, vote: IPollVote, pollNote: INote, pollOwner: IRemoteUser): Promise<any> {
 	return {
-		id: `${config.url}/notes/${note._id}`,
+		id: `${config.url}/users/${user._id}#votes/${vote._id}`,
 		type: 'Note',
-		attributedTo,
-		content: choice,
-		published: (new Date()).toISOString(),
-		to,
+		attributedTo: `${config.url}/users/${user._id}`,
+		to: [pollOwner.uri],
 		inReplyTo: pollNote.uri,
-		name: pollNote.poll.choices.find(x => x.id === choice).text
+		name: pollNote.poll.choices.find(x => x.id === vote.choice).text
 	};
 }

--- a/src/server/api/endpoints/notes/polls/vote.ts
+++ b/src/server/api/endpoints/notes/polls/vote.ts
@@ -114,7 +114,7 @@ export default define(meta, async (ps, user) => {
 	}
 
 	// Create vote
-	await Vote.insert({
+	const vote = await Vote.insert({
 		createdAt,
 		noteId: note._id,
 		userId: user._id,
@@ -172,7 +172,7 @@ export default define(meta, async (ps, user) => {
 			_id: note.userId
 		});
 
-		deliver(user, renderActivity(renderCreate(await renderVote(user, ps.choice, note, pollOwner), note)), pollOwner.inbox);
+		deliver(user, renderActivity(renderCreate(await renderVote(user, vote, note, pollOwner), note)), pollOwner.inbox);
 	}
 
 	return;

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -108,7 +108,6 @@ type Option = {
 	questionUri?: string;
 	uri?: string;
 	app?: IApp;
-	voting?: boolean;
 };
 
 export default async (user: IUser, data: Option, silent = false) => new Promise<INote>(async (res, rej) => {
@@ -455,7 +454,6 @@ async function insertNote(user: IUser, data: Option, tags: string[], emojis: str
 				? data.visibleUsers.map(u => u._id)
 				: []
 			: [],
-		voting: data.voting || false,
 
 		// 以下非正規化データ
 		_reply: data.reply ? {


### PR DESCRIPTION
アンケートに投票するとき、投稿としてアクティビティを送信するのではなく(見かけ上)投票アクティビティとして送信するようにしています
ただMastodonは投票を投稿として受信するようなのでアクティビティタイプはNoteのままで、AP上は投稿アクティビティのようにしています
「タイムラインに投票が流れる」問題も修正されます

まだ動作未確認です。あとIDをどうするか(適当にランダムなものにして大丈夫なのかどうかが分かってない)