### PR TITLE
Implement Update Question

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -35,6 +35,7 @@ export type INote = {
 	_id: mongo.ObjectID;
 	createdAt: Date;
 	deletedAt: Date;
+	updatedAt?: Date;
 	fileIds: mongo.ObjectID[];
 	replyId: mongo.ObjectID;
 	renoteId: mongo.ObjectID;

--- a/src/queue/processors/http/process-inbox.ts
+++ b/src/queue/processors/http/process-inbox.ts
@@ -82,7 +82,7 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 		}) as IRemoteUser;
 	}
 
-	// Update activityの場合は、ここで署名検証/更新処理まで実施して終了
+	// Update Person activityの場合は、ここで署名検証/更新処理まで実施して終了
 	if (activity.type === 'Update') {
 		if (activity.object && activity.object.type === 'Person') {
 			if (user == null) {
@@ -92,9 +92,9 @@ export default async (job: bq.Job, done: any): Promise<void> => {
 			} else {
 				updatePerson(activity.actor, null, activity.object);
 			}
+			done();
+			return;
 		}
-		done();
-		return;
 	}
 
 	// アクティビティを送信してきたユーザーがまだMisskeyサーバーに登録されていなかったら登録する

--- a/src/remote/activitypub/kernel/index.ts
+++ b/src/remote/activitypub/kernel/index.ts
@@ -2,6 +2,7 @@ import { Object } from '../type';
 import { IRemoteUser } from '../../../models/user';
 import create from './create';
 import performDeleteActivity from './delete';
+import performUpdateActivity from './update';
 import follow from './follow';
 import undo from './undo';
 import like from './like';
@@ -21,6 +22,10 @@ const self = async (actor: IRemoteUser, activity: Object): Promise<void> => {
 
 	case 'Delete':
 		await performDeleteActivity(actor, activity);
+		break;
+
+	case 'Update':
+		await performUpdateActivity(actor, activity);
 		break;
 
 	case 'Follow':

--- a/src/remote/activitypub/kernel/update/index.ts
+++ b/src/remote/activitypub/kernel/update/index.ts
@@ -1,0 +1,28 @@
+import { IRemoteUser } from '../../../../models/user';
+import { IUpdate, IObject } from '../../type';
+import { apLogger } from '../../logger';
+import { updateQuestion } from '../../models/question';
+
+/**
+ * Updateアクティビティを捌きます
+ */
+export default async (actor: IRemoteUser, activity: IUpdate): Promise<void> => {
+	if ('actor' in activity && actor.uri !== activity.actor) {
+		throw new Error('invalid actor');
+	}
+
+	apLogger.debug('Update');
+
+	const object = activity.object as IObject;
+
+	switch (object.type) {
+		case 'Question':
+			apLogger.debug('Question');
+			await updateQuestion(object).catch(e => console.log(e));
+			break;
+
+		default:
+			apLogger.warn(`Unknown type: ${object.type}`);
+			break;
+	}
+};

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -18,6 +18,7 @@ import { extractPollFromQuestion } from './question';
 import vote from '../../../services/note/polls/vote';
 import { apLogger } from '../logger';
 import { IDriveFile } from '../../../models/drive-file';
+import { deliverQuestionUpdate } from '../../../services/note/polls/update';
 
 const logger = apLogger;
 
@@ -136,6 +137,12 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 			} else if (index >= 0) {
 				logger.info(`vote from AP: actor=${actor.username}@${actor.host}, note=${note.id}, choice=${name}`);
 				await vote(actor, reply, index);
+
+				const newNote = await Note.findOne({
+					_id: reply._id
+				});
+
+				deliverQuestionUpdate(newNote);
 			}
 			return null;
 		};

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -138,11 +138,8 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 				logger.info(`vote from AP: actor=${actor.username}@${actor.host}, note=${note.id}, choice=${name}`);
 				await vote(actor, reply, index);
 
-				const newNote = await Note.findOne({
-					_id: reply._id
-				});
-
-				deliverQuestionUpdate(newNote);
+				// リモートフォロワーにUpdate配信
+				deliverQuestionUpdate(reply._id);
 			}
 			return null;
 		};

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -32,8 +32,8 @@ export async function extractPollFromQuestion(source: string | IQuestion): Promi
  * @param uri URI of AP Question object
  * @returns true if updated
  */
-export async function updateQuestion(uri: string) {
-	if (typeof uri !== 'string') throw 'uri is not string';
+export async function updateQuestion(value: any) {
+	const uri = value == 'string' ? value : value.id;
 
 	// URIがこのサーバーを指しているならスキップ
 	if (uri.startsWith(config.url + '/')) throw 'uri points local';
@@ -44,9 +44,9 @@ export async function updateQuestion(uri: string) {
 	if (note == null) throw 'Question is not registed';
 	//#endregion
 
-	// fetch new Question object
+	// resolve new Question object
 	const resolver = new Resolver();
-	const question = await resolver.resolve(uri) as IQuestion;
+	const question = await resolver.resolve(value) as IQuestion;
 	apLogger.debug(`fetched question: ${JSON.stringify(question, null, 2)}`);
 
 	if (question.type !== 'Question') throw 'object is not a Question';

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -1,18 +1,8 @@
-import { IChoice, IPoll } from '../../../models/note';
+import config from '../../../config';
+import Note, { IChoice, IPoll } from '../../../models/note';
 import Resolver from '../resolver';
-import { ICollection } from '../type';
-
-interface IQuestionChoice {
-	name?: string;
-	replies?: ICollection;
-	_misskey_votes?: number;
-}
-
-interface IQuestion {
-	oneOf?: IQuestionChoice[];
-	anyOf?: IQuestionChoice[];
-	endTime?: Date;
-}
+import { IQuestion } from '../type';
+import { apLogger } from '../logger';
 
 export async function extractPollFromQuestion(source: string | IQuestion): Promise<IPoll> {
 	const question = typeof source === 'string' ? await new Resolver().resolve(source) as IQuestion : source;
@@ -35,4 +25,56 @@ export async function extractPollFromQuestion(source: string | IQuestion): Promi
 		multiple,
 		expiresAt
 	};
+}
+
+/**
+ * Update votes of Question
+ * @param uri URI of AP Question object
+ * @returns true if updated
+ */
+export async function updateQuestion(uri: string) {
+	if (typeof uri !== 'string') throw 'uri is not string';
+
+	// URIがこのサーバーを指しているならスキップ
+	if (uri.startsWith(config.url + '/')) throw 'uri points local';
+
+	//#region このサーバーに既に登録されているか
+	const note = await Note.findOne({ uri });
+
+	if (note == null) throw 'Question is not registed';
+	//#endregion
+
+	// fetch new Question object
+	const resolver = new Resolver();
+	const question = await resolver.resolve(uri) as IQuestion;
+	apLogger.debug(`fetched question: ${JSON.stringify(question, null, 2)}`);
+
+	if (question.type !== 'Question') throw 'object is not a Question';
+
+	const apChoices = question.oneOf || question.anyOf;
+	const dbChoices = note.poll.choices;
+
+	let changed = false;
+
+	for (const db of dbChoices) {
+		const oldCount = db.votes;
+		const newCount = apChoices.filter(ap => ap.name === db.text)[0].replies.totalItems;
+
+		if (oldCount != newCount) {
+			changed = true;
+			db.votes = newCount;
+		}
+	}
+
+	if (changed) {
+		await Note.update({
+			_id: note._id
+		}, {
+			$set: {
+				'poll.choices': dbChoices
+			}
+		});
+	}
+
+	return changed;
 }

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -33,7 +33,7 @@ export async function extractPollFromQuestion(source: string | IQuestion): Promi
  * @returns true if updated
  */
 export async function updateQuestion(value: any) {
-	const uri = value == 'string' ? value : value.id;
+	const uri = typeof value == 'string' ? value : value.id;
 
 	// URIがこのサーバーを指しているならスキップ
 	if (uri.startsWith(config.url + '/')) throw 'uri points local';

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -66,15 +66,14 @@ export async function updateQuestion(uri: string) {
 		}
 	}
 
-	if (changed) {
-		await Note.update({
-			_id: note._id
-		}, {
-			$set: {
-				'poll.choices': dbChoices
-			}
-		});
-	}
+	await Note.update({
+		_id: note._id
+	}, {
+		$set: {
+			'poll.choices': dbChoices,
+			updatedAt: new Date(),
+		}
+	});
 
 	return changed;
 }

--- a/src/remote/activitypub/renderer/question.ts
+++ b/src/remote/activitypub/renderer/question.ts
@@ -5,7 +5,7 @@ import { INote } from '../../../models/note';
 export default async function renderQuestion(user: ILocalUser, note: INote) {
 	const question = {
 		type: 'Question',
-		id: `${config.url}/questions/${note._id}`,
+		id: `${config.url}/notes/${note._id}`,
 		actor: `${config.url}/users/${user._id}`,
 		content:  note.text || '',
 		[note.poll.multiple ? 'anyOf' : 'oneOf']: note.poll.choices.map(c => ({

--- a/src/remote/activitypub/renderer/question.ts
+++ b/src/remote/activitypub/renderer/question.ts
@@ -5,7 +5,7 @@ import { INote } from '../../../models/note';
 export default async function renderQuestion(user: ILocalUser, note: INote) {
 	const question = {
 		type: 'Question',
-		id: `${config.url}/notes/${note._id}`,
+		id: `${config.url}/questions/${note._id}`,
 		actor: `${config.url}/users/${user._id}`,
 		content:  note.text || '',
 		[note.poll.multiple ? 'anyOf' : 'oneOf']: note.poll.choices.map(c => ({

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -43,10 +43,26 @@ export interface IOrderedCollection extends IObject {
 }
 
 export interface INote extends IObject {
-	type: 'Note';
+	type: 'Note' | 'Question';
 	_misskey_content: string;
 	_misskey_quote: string;
 	_misskey_question: string;
+}
+
+export interface IQuestion extends IObject {
+	type: 'Note' | 'Question';
+	_misskey_content: string;
+	_misskey_quote: string;
+	_misskey_question: string;
+	oneOf?: IQuestionChoice[];
+	anyOf?: IQuestionChoice[];
+	endTime?: Date;
+}
+
+interface IQuestionChoice {
+	name?: string;
+	replies?: ICollection;
+	_misskey_votes?: number;
 }
 
 export interface IPerson extends IObject {

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -97,6 +97,10 @@ export interface IDelete extends IActivity {
 	type: 'Delete';
 }
 
+export interface IUpdate extends IActivity {
+	type: 'Update';
+}
+
 export interface IUndo extends IActivity {
 	type: 'Undo';
 }
@@ -139,6 +143,7 @@ export type Object =
 	IOrderedCollection |
 	ICreate |
 	IDelete |
+	IUpdate |
 	IUndo |
 	IFollow |
 	IAccept |

--- a/src/server/api/endpoints/notes/polls/vote.ts
+++ b/src/server/api/endpoints/notes/polls/vote.ts
@@ -174,11 +174,7 @@ export default define(meta, async (ps, user) => {
 	}
 
 	// リモートフォロワーにUpdate配信
-	const newNote = await Note.findOne({
-		_id: note._id
-	});
-
-	deliverQuestionUpdate(newNote);
+	deliverQuestionUpdate(note._id);
 
 	return;
 });

--- a/src/server/api/endpoints/notes/polls/vote.ts
+++ b/src/server/api/endpoints/notes/polls/vote.ts
@@ -13,6 +13,7 @@ import { getNote } from '../../../common/getters';
 import { deliver } from '../../../../../queue';
 import { renderActivity } from '../../../../../remote/activitypub/renderer';
 import renderVote from '../../../../../remote/activitypub/renderer/vote';
+import { deliverQuestionUpdate } from '../../../../../services/note/polls/update';
 
 export const meta = {
 	desc: {
@@ -171,6 +172,13 @@ export default define(meta, async (ps, user) => {
 
 		deliver(user, renderActivity(await renderVote(user, vote, note, pollOwner)), pollOwner.inbox);
 	}
+
+	// リモートフォロワーにUpdate配信
+	const newNote = await Note.findOne({
+		_id: note._id
+	});
+
+	deliverQuestionUpdate(newNote);
 
 	return;
 });

--- a/src/services/note/polls/update.ts
+++ b/src/services/note/polls/update.ts
@@ -4,10 +4,10 @@ import ms = require('ms');
 import Logger from '../../logger';
 import User, { isLocalUser, isRemoteUser } from '../../../models/user';
 import Following from '../../../models/following';
-import renderQuestion from '../../../remote/activitypub/renderer/question';
 import renderUpdate from '../../../remote/activitypub/renderer/update';
 import { renderActivity } from '../../../remote/activitypub/renderer';
 import { deliver } from '../../../queue';
+import renderNote from '../../../remote/activitypub/renderer/note';
 
 const logger = new Logger('pollsUpdate');
 
@@ -47,7 +47,7 @@ export async function deliverQuestionUpdate(note: INote) {
 		}
 
 		if (queue.length > 0) {
-			const content = renderActivity(renderUpdate(await renderQuestion(user, note), user));
+			const content = renderActivity(renderUpdate(await renderNote(note, false), user));
 			for (const inbox of queue) {
 				deliver(user, content, inbox);
 			}

--- a/src/services/note/polls/update.ts
+++ b/src/services/note/polls/update.ts
@@ -1,4 +1,5 @@
-import { INote } from '../../../models/note';
+import * as mongo from 'mongodb';
+import Note, { INote } from '../../../models/note';
 import { updateQuestion } from '../../../remote/activitypub/models/question';
 import ms = require('ms');
 import Logger from '../../logger';
@@ -24,7 +25,11 @@ export async function triggerUpdate(note: INote) {
 	}
 }
 
-export async function deliverQuestionUpdate(note: INote) {
+export async function deliverQuestionUpdate(noteId: mongo.ObjectID) {
+	const note = await Note.findOne({
+		_id: noteId,
+	});
+
 	const user = await User.findOne({
 		_id: note.userId
 	});

--- a/src/services/note/polls/update.ts
+++ b/src/services/note/polls/update.ts
@@ -1,0 +1,56 @@
+import { INote } from '../../../models/note';
+import { updateQuestion } from '../../../remote/activitypub/models/question';
+import ms = require('ms');
+import Logger from '../../logger';
+import User, { isLocalUser, isRemoteUser } from '../../../models/user';
+import Following from '../../../models/following';
+import renderQuestion from '../../../remote/activitypub/renderer/question';
+import renderUpdate from '../../../remote/activitypub/renderer/update';
+import { renderActivity } from '../../../remote/activitypub/renderer';
+import { deliver } from '../../../queue';
+
+const logger = new Logger('pollsUpdate');
+
+export async function triggerUpdate(note: INote) {
+	if (!note.updatedAt || Date.now() - new Date(note.updatedAt).getTime() > ms('1min')) {
+		logger.info(`Updating ${note._id}`);
+
+		try {
+			const updated = await updateQuestion(note.uri);
+			logger.info(`Updated ${note._id} ${updated ? 'changed' : 'nochange'}`);
+		} catch (e) {
+			logger.error(e);
+		}
+	}
+}
+
+export async function deliverQuestionUpdate(note: INote) {
+	const user = await User.findOne({
+		_id: note.userId
+	});
+
+	const followers = await Following.find({
+		followeeId: user._id
+	});
+
+	const queue: string[] = [];
+
+	// フォロワーがリモートユーザーかつ投稿者がローカルユーザーならUpdateを配信
+	if (isLocalUser(user)) {
+		for (const following of followers) {
+			const follower = following._follower;
+
+			if (isRemoteUser(follower)) {
+				const inbox = follower.sharedInbox || follower.inbox;
+				if (!queue.includes(inbox)) queue.push(inbox);
+			}
+		}
+
+		if (queue.length > 0) {
+			const content = renderActivity(renderUpdate(await renderQuestion(user, note), user));
+			for (const inbox of queue) {
+				deliver(user, content, inbox);
+			}
+		}
+	}
+}

--- a/src/tools/refresh-question.ts
+++ b/src/tools/refresh-question.ts
@@ -1,0 +1,14 @@
+import { updateQuestion } from '../remote/activitypub/models/question';
+
+async function main(uri: string): Promise<any> {
+	return await updateQuestion(uri);
+}
+
+const args = process.argv.slice(2);
+const uri = args[0];
+
+main(uri).then(result => {
+	console.log(`Done: ${result}`);
+}).catch(e => {
+	console.warn(e);
+});


### PR DESCRIPTION
# Summary
投票された時にリモートにUpdateを送信して投票数が更新されるようにしてます
Misskey間で動作を確認しています
- 投票されたときにAPでUpdate Questionアクティビティを送信する
- Update Questionアクティビティを受け取ったら投票数を更新する

その他
- refresh-question: 手動更新コマンド
- triggerUpdate: 一定時間経ってたら更新を試みる関数