### PR TITLE
To retry AP deliver queue

### DIFF
--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -25,6 +25,26 @@ export const deliverQueue = initializeQueue('deliver');
 export const inboxQueue = initializeQueue('inbox');
 export const dbQueue = initializeQueue('db');
 
+deliverQueue
+	.on('waiting', (jobId) => {
+		queueLogger.debug(`[deliver] waiting id=${jobId}`);
+	})
+	.on('active', (job) => {
+		queueLogger.debug(`[deliver] active id=${job.id} to=${job.data.to}`);
+	})
+	.on('completed', (job, result) => {
+		queueLogger.debug(`[deliver] completed(${result}) id=${job.id} to=${job.data.to}`);
+	})
+	.on('failed', (job, err) => {
+		queueLogger.debug(`[deliver] failed(${err}) id=${job.id} to=${job.data.to}`);
+	})
+	.on('error', (error) => {
+		queueLogger.error(`[deliver] error ${error}`);
+	})
+	.on('stalled', (job) => {
+		queueLogger.warn(`[deliver] stalled id=${job.id} to=${job.data.to}`);
+	});
+
 export function deliver(user: ILocalUser, content: any, to: any) {
 	if (content == null) return null;
 
@@ -38,7 +58,7 @@ export function deliver(user: ILocalUser, content: any, to: any) {
 		attempts: 8,
 		backoff: {
 			type: 'exponential',
-			delay: 1000
+			delay: 60 * 1000
 		},
 		removeOnComplete: true,
 		removeOnFail: true


### PR DESCRIPTION
## Summary
Fix #4456

- AP deliver で 非4xxエラー (5xxなどのステータスコード, DNS error, socket error, timeout)
  の場合はリトライするように
- AP deliver のリトライタイミングを 1m, 3m, 7m, 15m, 31m, 1h, 2h, 4h 後に
  (時間は初回からの積算で表記)
- AP deliver queue の状態をログ出力するように