### PR TITLE
Ignore 4xx references in AP

### DIFF
--- a/src/remote/activitypub/kernel/announce/note.ts
+++ b/src/remote/activitypub/kernel/announce/note.ts
@@ -29,7 +29,19 @@ export default async function(resolver: Resolver, actor: IRemoteUser, activity: 
 		return;
 	}
 
-	const renote = await resolveNote(note);
+	// Announce対象をresolve
+	let renote;
+	try {
+		renote = await resolveNote(note);
+	} catch (e) {
+		// 対象が4xxならスキップ
+		if (e.statusCode >= 400 && e.statusCode < 500) {	// 4xx
+			logger.warn(`Ignored announce target ${note.inReplyTo} - ${e.statusCode}`);
+			return;
+		}
+		logger.warn(`Error in announce target ${note.inReplyTo} - ${e.statusCode || e}`);
+		throw e;
+	}
 
 	logger.info(`Creating the (Re)Note: ${uri}`);
 

--- a/src/remote/activitypub/kernel/announce/note.ts
+++ b/src/remote/activitypub/kernel/announce/note.ts
@@ -35,7 +35,7 @@ export default async function(resolver: Resolver, actor: IRemoteUser, activity: 
 		renote = await resolveNote(note);
 	} catch (e) {
 		// 対象が4xxならスキップ
-		if (e.statusCode >= 400 && e.statusCode < 500) {	// 4xx
+		if (e.statusCode >= 400 && e.statusCode < 500) {
 			logger.warn(`Ignored announce target ${note.inReplyTo} - ${e.statusCode}`);
 			return;
 		}

--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -27,7 +27,17 @@ export async function createImage(actor: IRemoteUser, value: any): Promise<IDriv
 	const instance = await fetchMeta();
 	const cache = instance.cacheRemoteFiles;
 
-	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache);
+	let file;
+	try {
+		file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache);
+	} catch (e) {
+		// 4xxの場合は添付されてなかったことにする
+		if (e >= 400 && e < 500) {
+			logger.warn(`Ignored image: ${image.url} - ${e}`);
+			return null;
+		}
+		throw e;
+	}
 
 	if (file.metadata.isRemote) {
 		// URLが異なっている場合、同じ画像が以前に異なるURLで登録されていたということなので、

--- a/src/remote/activitypub/resolver.ts
+++ b/src/remote/activitypub/resolver.ts
@@ -1,9 +1,6 @@
 import * as request from 'request-promise-native';
 import { IObject } from './type';
 import config from '../../config';
-import { apLogger } from './logger';
-
-export const logger = apLogger.createSubLogger('resolver');
 
 export default class Resolver {
 	private history: Set<string>;
@@ -34,7 +31,6 @@ export default class Resolver {
 			}
 
 			default: {
-				logger.error(`unknown collection type: ${collection.type}`);
 				throw new Error(`unknown collection type: ${collection.type}`);
 			}
 		}
@@ -44,7 +40,6 @@ export default class Resolver {
 
 	public async resolve(value: any): Promise<IObject> {
 		if (value == null) {
-			logger.error('resolvee is null (or undefined)');
 			throw new Error('resolvee is null (or undefined)');
 		}
 
@@ -53,7 +48,6 @@ export default class Resolver {
 		}
 
 		if (this.history.has(value)) {
-			logger.error(`cannot resolve already resolved one: ${value}`);
 			throw new Error('cannot resolve already resolved one');
 		}
 
@@ -68,12 +62,6 @@ export default class Resolver {
 				Accept: 'application/activity+json, application/ld+json'
 			},
 			json: true
-		}).catch(e => {
-			logger.error(`request error: ${value}: ${e.message}`, {
-				url: value,
-				e: e
-			});
-			throw new Error(`request error: ${e.message}`);
 		});
 
 		if (object === null || (
@@ -81,10 +69,6 @@ export default class Resolver {
 				!object['@context'].includes('https://www.w3.org/ns/activitystreams') :
 				object['@context'] !== 'https://www.w3.org/ns/activitystreams'
 		)) {
-			logger.error(`invalid response: ${value}`, {
-				url: value,
-				object: object
-			});
 			throw new Error('invalid response');
 		}
 

--- a/src/services/drive/upload-from-url.ts
+++ b/src/services/drive/upload-from-url.ts
@@ -42,7 +42,7 @@ export default async (
 		const writable = fs.createWriteStream(path);
 
 		writable.on('finish', () => {
-			logger.succ(`Download succeeded: ${chalk.cyan(url)}`);
+			logger.succ(`Download finished: ${chalk.cyan(url)}`);
 			res();
 		});
 


### PR DESCRIPTION
## Summary
APから受信した投稿の参照先で4xxが発生したときの動作を修正

- APからのNoteについて
  - リプライ対象が4xxの場合:
    Before: リトライを行い、最終的にNote自体なかったことになる
    After: リトライを行わず、リプライしてないNoteとして扱う
  - 添付ファイルが4xxの場合:
    Before: リトライを行い、最終的にNote自体なかったことになる
    After: リトライを行わず、該当添付ファイルはなかったことにする
- APからのAnnounceについて
  - Announce (Renote / Boost) 対象が4xxの場合:
    Before: リトライを行い、最終的にAnnounce自体なかったことになる
    After: リトライを行わず、最終的にAnnounce自体なかったことにする

4xx以外の場合 (5xx, 接続できない など) はこれまで通りリトライを行います

resolver内でログを出力する場所でどうも #4420 が発生してエラーが上がってこないので
resolver内でログは出力しないようにしています