### PR TITLE
Use proxy instead of weserv for url-preview images

### DIFF
--- a/src/server/proxy/proxy-media.ts
+++ b/src/server/proxy/proxy-media.ts
@@ -6,7 +6,7 @@ import * as request from 'request';
 import fileType from 'file-type';
 import { serverLogger } from '..';
 import config from '../../config';
-import { IImage, ConvertToPng } from '../../services/drive/image-processor';
+import { IImage, ConvertToPng, ConvertToJpeg } from '../../services/drive/image-processor';
 import checkSvg from '../../misc/check-svg';
 
 export async function proxyMedia(ctx: Koa.BaseContext) {
@@ -29,6 +29,8 @@ export async function proxyMedia(ctx: Koa.BaseContext) {
 
 		if ('static' in ctx.query && ['image/png', 'image/gif'].includes(type)) {
 			image = await ConvertToPng(path, 498, 280);
+		} else if ('preview' in ctx.query && ['image/jpeg', 'image/png', 'image/gif'].includes(type)) {
+			image = await ConvertToJpeg(path, 200, 200);
 		} else {
 			image = {
 				data: fs.readFileSync(path),

--- a/src/server/web/url-preview.ts
+++ b/src/server/web/url-preview.ts
@@ -3,6 +3,8 @@ import * as request from 'request-promise-native';
 import summaly from 'summaly';
 import fetchMeta from '../../misc/fetch-meta';
 import Logger from '../../services/logger';
+import config from '../../config';
+import { query } from '../../prelude/url';
 
 const logger = new Logger('url-preview');
 
@@ -44,7 +46,10 @@ module.exports = async (ctx: Koa.BaseContext) => {
 function wrap(url: string): string {
 	return url != null
 		? url.match(/^https?:\/\//)
-			? `https://images.weserv.nl/?url=${encodeURIComponent(url.replace(/^http:\/\//, '').replace(/^https:\/\//, 'ssl:'))}&w=200&h=200`
+			? `${config.url}/proxy/preview.jpg?${query({
+				url,
+				preview: '1'
+			})}`
 			: url
 		: null;
 }


### PR DESCRIPTION
## Summary
Fix #4464 

URLプレビューのサムネイルの表示に
外部サービス (images.weserv.nl) を使用するのではなく自力でProxyするように変更

キャッシュについては、すでにCDNやWebサーバーでキャッシュ設定をしていれば
同じようにキャッシュされるはずです。

なおインスタンスのサーバー自体が取得先のホストにブロックされている場合は
これでも表示はされませんので proxy 等を設定する必要があります。