### PR TITLE
Accepts Article object

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -41,6 +41,7 @@ export type INote = {
 	replyId: mongo.ObjectID;
 	renoteId: mongo.ObjectID;
 	poll: IPoll;
+	name?: string;
 	text: string;
 	tags: string[];
 	tagsLower: string[];
@@ -390,6 +391,10 @@ export const pack = async (
 		}
 	}
 	//#endregion
+
+	if (_note.name) {
+		_note.text = `【${_note.name}】\n${_note.text}`;
+	}
 
 	if (_note.user.isCat && _note.text) {
 		_note.text = (_note.text

--- a/src/remote/activitypub/kernel/announce/index.ts
+++ b/src/remote/activitypub/kernel/announce/index.ts
@@ -24,10 +24,8 @@ export default async (actor: IRemoteUser, activity: IAnnounce): Promise<void> =>
 
 	switch (object.type) {
 	case 'Note':
-		announceNote(resolver, actor, activity, object as INote);
-		break;
-
 	case 'Question':
+	case 'Article':
 		announceNote(resolver, actor, activity, object as INote);
 		break;
 

--- a/src/remote/activitypub/kernel/create/index.ts
+++ b/src/remote/activitypub/kernel/create/index.ts
@@ -29,10 +29,8 @@ export default async (actor: IRemoteUser, activity: ICreate): Promise<void> => {
 		break;
 
 	case 'Note':
-		createNote(resolver, actor, object);
-		break;
-
 	case 'Question':
+	case 'Article':
 		createNote(resolver, actor, object);
 		break;
 

--- a/src/remote/activitypub/kernel/delete/index.ts
+++ b/src/remote/activitypub/kernel/delete/index.ts
@@ -21,10 +21,8 @@ export default async (actor: IRemoteUser, activity: IDelete): Promise<void> => {
 
 	switch (object.type) {
 	case 'Note':
-		deleteNote(actor, uri);
-		break;
-
 	case 'Question':
+	case 'Article':
 		deleteNote(actor, uri);
 		break;
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -57,7 +57,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 
 	const object: any = await resolver.resolve(value);
 
-	if (!object || !['Note', 'Question'].includes(object.type)) {
+	if (!object || !['Note', 'Question', 'Article'].includes(object.type)) {
 		logger.error(`invalid note: ${value}`, {
 			resolver: {
 				history: resolver.getHistory()
@@ -199,6 +199,7 @@ export async function createNote(value: any, resolver?: Resolver, silent = false
 		files,
 		reply,
 		renote: quote,
+		name: note.name,
 		cw,
 		text,
 		viaMobile: false,

--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -103,7 +103,7 @@ async function fetchAny(uri: string) {
 		};
 	}
 
-	if (['Note', 'Question'].includes(object.type)) {
+	if (['Note', 'Question', 'Article'].includes(object.type)) {
 		const note = await createNote(object.id);
 		return {
 			type: 'Note',

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -91,6 +91,7 @@ class NotificationManager {
 
 type Option = {
 	createdAt?: Date;
+	name?: string;
 	text?: string;
 	reply?: INote;
 	renote?: INote;
@@ -437,6 +438,7 @@ async function insertNote(user: IUser, data: Option, tags: string[], emojis: str
 		fileIds: data.files ? data.files.map(file => file._id) : [],
 		replyId: data.reply ? data.reply._id : null,
 		renoteId: data.renote ? data.renote._id : null,
+		name: data.name,
 		text: data.text,
 		poll: data.poll,
 		cw: data.cw == null ? null : data.cw,


### PR DESCRIPTION
## Summary
Resolve #4498
- Accepts AP object `Article`. (like a `Note)
- Save property `name` of AP.
- Send `name` as title to client.

WriteFreelyから送られてくる`Article`を保存するようにしています
`Article=multi-paragraph`, `Note=single-paragraph` みたいな定義らしいですが、
どちらもほぼ同じと思われるため`Note`扱いで受け取ってます。

また`name`としてblogのタイトルを送ってくるようなので
とりあえず`name`として保存して、pack時にMFMタイトルとして送るようにしています。

細かい書式はともかく、とりあえずpullで取得できることは確認しています。
![image](https://user-images.githubusercontent.com/30769358/54368541-b61faf00-46b7-11e9-83fe-d54a2220b6e3.png)
