### PR TITLE
Fix users/search

### DIFF
--- a/src/server/api/endpoints/users/search.ts
+++ b/src/server/api/endpoints/users/search.ts
@@ -71,7 +71,7 @@ export default define(meta, async (ps, me) => {
 			.find({
 				host: null,
 				usernameLower: new RegExp('^' + escapeRegexp(ps.query.replace('@', '').toLowerCase())),
-				isSuspended: false
+				isSuspended: { $ne: true }
 			}, {
 				limit: ps.limit,
 				skip: ps.offset
@@ -82,7 +82,7 @@ export default define(meta, async (ps, me) => {
 				.find({
 					host: { $ne: null },
 					usernameLower: new RegExp('^' + escapeRegexp(ps.query.replace('@', '').toLowerCase())),
-					isSuspended: false
+					isSuspended: { $ne: true }
 				}, {
 					limit: ps.limit - users.length
 				});


### PR DESCRIPTION
## Summary
ユーザーサジェストで、ユーザーが (過去にサスペンド履歴のある今サスペンドされてないユーザーしか) かからなくなってるのを修正