### PR TITLE
updatePersonを試行した時点でもlastFetchedAtを更新する

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -294,6 +294,13 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 	}
 	//#endregion
 
+	// 繋がらないインスタンスに何回も試行するのを防ぐ, 後続の同様処理の連続試行を防ぐ ため 試行前にも更新する
+	await User.update({ _id: exist._id }, {
+		$set: {
+			lastFetchedAt: new Date(),
+		},
+	});
+
 	if (resolver == null) resolver = new Resolver();
 
 	const object = hint || await resolver.resolve(uri) as any;


### PR DESCRIPTION
## Summary
リモートユーザー情報を自動更新するかどうかの閾値に使用している`lastFetchedAt`を
試行前にも更新するようにしています。

- つながらなくて常に失敗するインスタンスに度々思考するのを防ぐ
- 後続で同様の処理が来て同時試行されるのを防ぐ

ため