### PR TITLE
「メッセージ」「トーク」「ダイレクト投稿」( Fix #2748 )

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -621,7 +621,7 @@ common/views/components/notification-settings.vue:
   title: "通知"
   mark-as-read-all-notifications: "すべての通知を既読にする"
   mark-as-read-all-unread-notes: "すべての投稿を既読にする"
-  mark-as-read-all-talk-messages: "すべてのトークを既読にする"
+  mark-as-read-all-talk-messages: "すべてのトークのメッセージを既読にする"
   auto-watch: "投稿の自動ウォッチ"
   auto-watch-desc: "リアクションしたり返信したりした投稿に関する通知を自動的に受け取るようにします。"
 
@@ -1477,6 +1477,9 @@ desktop/views/pages/welcome.vue:
 
 desktop/views/pages/drive.vue:
   title: "Misskey Drive"
+
+desktop/views/pages/messaging-room.vue:
+  title: "{0}とのトーク"
 
 desktop/views/pages/note.vue:
   prev: "前の投稿"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -925,12 +925,6 @@ desktop/views/input-dialog.vue:
   cancel: "キャンセル"
   ok: "決定"
 
-desktop/views/components/messaging-room-window.vue:
-  title: "トーク:"
-
-desktop/views/components/messaging-window.vue:
-  title: "トーク"
-
 desktop/views/components/note-detail.vue:
   private: "この投稿は非公開です"
   deleted: "この投稿は削除されました"
@@ -1478,9 +1472,6 @@ desktop/views/pages/welcome.vue:
 desktop/views/pages/drive.vue:
   title: "Misskey Drive"
 
-desktop/views/pages/messaging-room.vue:
-  title: "{0}とのトーク"
-
 desktop/views/pages/note.vue:
   prev: "前の投稿"
   next: "次の投稿"
@@ -1535,9 +1526,6 @@ desktop/views/pages/user/user.timeline.vue:
   with-replies: "投稿と返信"
   with-media: "メディア"
   my-posts: "私の投稿"
-
-desktop/views/widgets/messaging.vue:
-  title: "トーク"
 
 desktop/views/widgets/notifications.vue:
   title: "通知"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -926,10 +926,10 @@ desktop/views/input-dialog.vue:
   ok: "決定"
 
 desktop/views/components/messaging-room-window.vue:
-  title: "メッセージ:"
+  title: "トーク:"
 
 desktop/views/components/messaging-window.vue:
-  title: "メッセージ"
+  title: "トーク"
 
 desktop/views/components/note-detail.vue:
   private: "この投稿は非公開です"
@@ -1100,7 +1100,7 @@ desktop/views/components/timeline.vue:
   hybrid: "ソーシャル"
   global: "グローバル"
   mentions: "あなた宛て"
-  messages: "メッセージ"
+  messages: "ダイレクト投稿"
   list: "リスト"
   hashtag: "ハッシュタグ"
   add-tag-timeline: "ハッシュタグを追加"
@@ -1534,7 +1534,7 @@ desktop/views/pages/user/user.timeline.vue:
   my-posts: "私の投稿"
 
 desktop/views/widgets/messaging.vue:
-  title: "メッセージ"
+  title: "トーク"
 
 desktop/views/widgets/notifications.vue:
   title: "通知"
@@ -1683,7 +1683,7 @@ mobile/views/pages/home.vue:
   hybrid: "ソーシャル"
   global: "グローバル"
   mentions: "あなた宛て"
-  messages: "メッセージ"
+  messages: "ダイレクト投稿"
 
 mobile/views/pages/tag.vue:
   no-posts-found: "ハッシュタグ「{q}」が付けられた投稿は見つかりませんでした。"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -621,7 +621,7 @@ common/views/components/notification-settings.vue:
   title: "通知"
   mark-as-read-all-notifications: "すべての通知を既読にする"
   mark-as-read-all-unread-notes: "すべての投稿を既読にする"
-  mark-as-read-all-talk-messages: "すべてのトークのメッセージを既読にする"
+  mark-as-read-all-talk-messages: "すべてのトークを既読にする"
   auto-watch: "投稿の自動ウォッチ"
   auto-watch-desc: "リアクションしたり返信したりした投稿に関する通知を自動的に受け取るようにします。"
 

--- a/src/client/app/desktop/views/components/messaging-room-window.vue
+++ b/src/client/app/desktop/views/components/messaging-room-window.vue
@@ -1,6 +1,6 @@
 <template>
 <mk-window ref="window" width="500px" height="560px" :popout-url="popout" @closed="destroyDom">
-	<template #header><fa icon="comments"/> {{ $t('title') }} <mk-user-name :user="user"/></template>
+	<template #header><fa icon="comments"/> {{ $t('@.messaging') }}: <mk-user-name :user="user"/></template>
 	<x-messaging-room :user="user" :class="$style.content"/>
 </mk-window>
 </template>
@@ -12,7 +12,7 @@ import { url } from '../../../config';
 import getAcct from '../../../../../misc/acct/render';
 
 export default Vue.extend({
-	i18n: i18n('desktop/views/components/messaging-room-window.vue'),
+	i18n: i18n(),
 	components: {
 		XMessagingRoom: () => import('../../../common/views/components/messaging-room.vue').then(m => m.default)
 	},

--- a/src/client/app/desktop/views/components/messaging-window.vue
+++ b/src/client/app/desktop/views/components/messaging-window.vue
@@ -1,6 +1,6 @@
 <template>
 <mk-window ref="window" width="500px" height="560px" @closed="destroyDom">
-	<template #header :class="$style.header"><fa icon="comments"/>{{ $t('title') }}</template>
+	<template #header :class="$style.header"><fa icon="comments"/>{{ $t('@.messaging') }}</template>
 	<x-messaging :class="$style.content" @navigate="navigate"/>
 </mk-window>
 </template>
@@ -11,7 +11,7 @@ import i18n from '../../../i18n';
 import MkMessagingRoomWindow from './messaging-room-window.vue';
 
 export default Vue.extend({
-	i18n: i18n('desktop/views/components/messaging-window.vue'),
+	i18n: i18n(),
 	components: {
 		XMessaging: () => import('../../../common/views/components/messaging.vue').then(m => m.default)
 	},

--- a/src/client/app/desktop/views/pages/messaging-room.vue
+++ b/src/client/app/desktop/views/pages/messaging-room.vue
@@ -51,7 +51,7 @@ export default Vue.extend({
 				this.user = user;
 				this.fetching = false;
 
-				document.title = `メッセージ: ${getUserName(this.user)}`;
+				document.title = this.$t('title', getUserName(this.user));
 
 				Progress.done();
 			});

--- a/src/client/app/desktop/views/pages/messaging-room.vue
+++ b/src/client/app/desktop/views/pages/messaging-room.vue
@@ -12,7 +12,7 @@ import parseAcct from '../../../../../misc/acct/parse';
 import getUserName from '../../../../../misc/get-user-name';
 
 export default Vue.extend({
-	i18n: i18n('.vue'),
+	i18n: i18n(),
 	components: {
 		XMessagingRoom: () => import('../../../common/views/components/messaging-room.vue').then(m => m.default)
 	},
@@ -51,7 +51,7 @@ export default Vue.extend({
 				this.user = user;
 				this.fetching = false;
 
-				document.title = this.$t('title', getUserName(this.user));
+				document.title = this.$t('@.messaging') + ': ' + getUserName(this.user);
 
 				Progress.done();
 			});

--- a/src/client/app/desktop/views/widgets/messaging.vue
+++ b/src/client/app/desktop/views/widgets/messaging.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="mkw-messaging">
 	<ui-container :show-header="props.design == 0">
-		<template #header><fa icon="comments"/>{{ $t('title') }}</template>
+		<template #header><fa icon="comments"/>{{ $t('@.messaging') }}</template>
 		<template #func><button @click="add"><fa icon="plus"/></button></template>
 
 		<x-messaging ref="index" compact @navigate="navigate"/>
@@ -21,7 +21,7 @@ export default define({
 		design: 0
 	})
 }).extend({
-	i18n: i18n('desktop/views/widgets/messaging.vue'),
+	i18n: i18n(''),
 	components: {
 		XMessaging: () => import('../../../common/views/components/messaging.vue').then(m => m.default)
 	},


### PR DESCRIPTION
Fix #2748

トーク: 一対一のチャット機能・画面
メッセージ: トークでやり取りする発言
ダイレクト投稿: 自分向けのダイレクト投稿が一覧されるTL

## Summary
表記ゆれが激しかったため、（案として）上記のように統一しました
