### PR TITLE
Content-Disposition in ObjectStrage

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 		"chai-http": "4.2.1",
 		"chalk": "2.4.2",
 		"commander": "2.19.0",
+		"content-disposition": "0.5.3",
 		"crc-32": "1.2.0",
 		"css-loader": "2.1.1",
 		"cssnano": "4.1.10",

--- a/src/misc/content-disposition.ts
+++ b/src/misc/content-disposition.ts
@@ -1,0 +1,6 @@
+const cd = require('content-disposition');
+
+export function contentDisposition(type: 'inline' | 'attachment', filename: string): string {
+	const fallback = filename.replace(/[^\w.-]/g, '_');
+	return cd(filename, { type, fallback });
+}

--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -6,6 +6,7 @@ import DriveFile, { getDriveFileBucket } from '../../models/drive-file';
 import DriveFileThumbnail, { getDriveFileThumbnailBucket } from '../../models/drive-file-thumbnail';
 import DriveFileWebpublic, { getDriveFileWebpublicBucket } from '../../models/drive-file-webpublic';
 import { serverLogger } from '..';
+import { contentDisposition } from '../../misc/content-disposition';
 
 const assets = `${__dirname}/../../server/file/assets/`;
 
@@ -63,12 +64,12 @@ export default async function(ctx: Koa.BaseContext) {
 
 		if (thumb != null) {
 			ctx.set('Content-Type', 'image/jpeg');
-			ctx.set('Content-Disposition', `filename="${rename(file.filename, { suffix: '-thumb', extname: '.jpeg' })}"`);
+			ctx.set('Content-Disposition', contentDisposition('inline', `${rename(file.filename, { suffix: '-thumb', extname: '.jpeg' })}"`));
 			const bucket = await getDriveFileThumbnailBucket();
 			ctx.body = bucket.openDownloadStream(thumb._id);
 		} else {
 			if (file.contentType.startsWith('image/')) {
-				ctx.set('Content-Disposition', `filename="${file.filename}"`);
+				ctx.set('Content-Disposition', contentDisposition('inline', `${file.filename}"`));
 				await sendRaw();
 			} else {
 				ctx.status = 404;
@@ -82,17 +83,17 @@ export default async function(ctx: Koa.BaseContext) {
 
 		if (web != null) {
 			ctx.set('Content-Type', file.contentType);
-			ctx.set('Content-Disposition', `filename="${rename(file.filename, { suffix: '-web' })}"`);
+			ctx.set('Content-Disposition', contentDisposition('inline', `${rename(file.filename, { suffix: '-web' })}"`));
 
 			const bucket = await getDriveFileWebpublicBucket();
 			ctx.body = bucket.openDownloadStream(web._id);
 		} else {
-			ctx.set('Content-Disposition', `filename="${file.filename}"`);
+			ctx.set('Content-Disposition', contentDisposition('inline', `${file.filename}"`));
 			await sendRaw();
 		}
 	} else {
 		if ('download' in ctx.query) {
-			ctx.set('Content-Disposition', `attachment; filename="${file.filename}`);
+			ctx.set('Content-Disposition', contentDisposition('attachment', `${file.filename}`));
 		}
 
 		await sendRaw();

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -26,6 +26,7 @@ import { driveLogger } from './logger';
 import { IImage, ConvertToJpeg, ConvertToWebp, ConvertToPng } from './image-processor';
 import Instance from '../../models/instance';
 import checkSvg from '../../misc/check-svg';
+import { contentDisposition } from '../../misc/content-disposition';
 
 const logger = driveLogger.createSubLogger('register', 'yellow');
 
@@ -206,7 +207,7 @@ async function upload(key: string, stream: fs.ReadStream | Buffer, type: string,
 		'Cache-Control': 'max-age=31536000, immutable'
 	} as Minio.ItemBucketMetadata;
 
-	if (filename) metadata['Content-Disposition'] = `filename="${filename}"`;
+	if (filename) metadata['Content-Disposition'] = contentDisposition('inline', filename);
 
 	await minio.putObject(config.drive.bucket, key, stream, null, metadata);
 }


### PR DESCRIPTION
## Summary
Resolve #4349
#4523 の修正

- オブジェクトストレージに対応していないのを修正
- ファイル名がエンコードされてないのを修正
- `Content-Disposition`において`inline`とか`attachment`は省略不可と思われるため
(未指定なら`inline`扱い) `inline`を付けるように

例えば`o5あいうえお.png`というファイル名の場合は以下のようなヘッダになります
`Content-Disposition: inline; filename="o5____.png"; filename*=UTF-8''o5%E3%81%82%E3%81%86%E3%81%88%E3%81%8A.png`

オブジェクトストレージの`-web`サフィックスは、
オブジェクトストレージの場合付いたりつかなかったりしてややこしいので付加してません