### PR TITLE
オブジェクトストレージにCORS設定が必要なのをなくす

### DIFF
--- a/src/client/app/desktop/views/components/crop-window.vue
+++ b/src/client/app/desktop/views/components/crop-window.vue
@@ -3,7 +3,7 @@
 		<template #header><fa icon="crop"/>{{ title }}</template>
 		<div class="body">
 			<vue-cropper ref="cropper"
-				:src="image.url"
+				:src="imageUrl"
 				:view-mode="1"
 				:aspect-ratio="aspectRatio"
 				:container-style="{ width: '100%', 'max-height': '400px' }"
@@ -21,6 +21,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import VueCropper from 'vue-cropperjs';
+import * as url from '../../../../../prelude/url';
 
 export default Vue.extend({
 	i18n: i18n('desktop/views/components/crop-window.vue'),
@@ -40,6 +41,13 @@ export default Vue.extend({
 			type: Number,
 			required: true
 		}
+	},
+	computed: {
+		imageUrl() {
+			return `/proxy/?${url.query({
+				url: this.image.url
+			})}`;
+		},
 	},
 	methods: {
 		ok() {


### PR DESCRIPTION
## Summary
アイコンなどのcropperのために
オブジェクトストレージ使用時にCORS設定が必要なのをなくしてます