### PR TITLE
Change Twemoji CDN

### DIFF
--- a/src/client/app/common/views/components/autocomplete.vue
+++ b/src/client/app/common/views/components/autocomplete.vue
@@ -30,6 +30,7 @@
 import Vue from 'vue';
 import * as emojilib from 'emojilib';
 import contains from '../../../common/scripts/contains';
+import { twemojiBase } from '../../../../../misc/twemoji-base';
 
 type EmojiDef = {
 	emoji: string;
@@ -54,7 +55,7 @@ const emjdb: EmojiDef[] = lib.map((x: any) => ({
 	emoji: x[1].char,
 	name: x[0],
 	aliasOf: null,
-	url: `https://twemoji.maxcdn.com/2/svg/${char2file(x[1].char)}.svg`
+	url: `${twemojiBase}/2/svg/${char2file(x[1].char)}.svg`
 }));
 
 for (const x of lib as any) {
@@ -64,7 +65,7 @@ for (const x of lib as any) {
 				emoji: x[1].char,
 				name: k,
 				aliasOf: x[0],
-				url: `https://twemoji.maxcdn.com/2/svg/${char2file(x[1].char)}.svg`
+				url: `${twemojiBase}/2/svg/${char2file(x[1].char)}.svg`
 			});
 		}
 	}

--- a/src/client/app/common/views/components/emoji.vue
+++ b/src/client/app/common/views/components/emoji.vue
@@ -10,6 +10,7 @@ import Vue from 'vue';
 // スクリプトサイズがデカい
 //import { lib } from 'emojilib';
 import { getStaticImageUrl } from '../../../common/scripts/get-static-image-url';
+import { twemojiBase } from '../../../../../misc/twemoji-base';
 
 export default Vue.extend({
 	props: {
@@ -77,7 +78,7 @@ export default Vue.extend({
 			if (!codes.includes('200d')) codes = codes.filter(x => x != 'fe0f');
 			codes = codes.filter(x => x && x.length);
 
-			this.url = `https://twemoji.maxcdn.com/2/svg/${codes.join('-')}.svg`;
+			this.url = `${twemojiBase}/2/svg/${codes.join('-')}.svg`;
 		}
 	}
 });

--- a/src/misc/twemoji-base.ts
+++ b/src/misc/twemoji-base.ts
@@ -1,0 +1,4 @@
+export const twemojiBase = 'https://cdn.jsdelivr.net/npm/twemoji@11.3.0';
+// https://cdn.jsdelivr.net/npm/twemoji@11.3.0
+// https://cdnjs.cloudflare.com/ajax/libs/twemoji/11.3.0
+// https://twemoji.maxcdn.com


### PR DESCRIPTION
## Summary
Resolve #4526

Twemojiの読み込み元CDNをIPv6が使えてアジア圏からでも速そうなのに変更

`cdnjs.cloudflare.com`か`cdn.jsdelivr.net`で悩んだのですが
jsDelivrが「Cloudflareも含めたマルチCDNで中国大陸でも使える」
とのことなのでそちらにしました。