### PR TITLE
Fix: リアクションのカスタム絵文字の情報がNoteに添付されない

### DIFF
--- a/src/models/note.ts
+++ b/src/models/note.ts
@@ -259,7 +259,7 @@ export const pack = async (
 				fields: { _id: false }
 			});
 		} else {
-			_note.emojis = unique(concat([_note.emojis, Object.keys(_note.reactionCounts)]));
+			_note.emojis = unique(concat([_note.emojis, Object.keys(_note.reactionCounts).map(x => x.replace(/:/g, ''))]));
 
 			_note.emojis = Emoji.find({
 				name: { $in: _note.emojis },


### PR DESCRIPTION
## Summary
リアクションでカスタマイズ絵文字が使用されていた場合Noteに添付していたつもりだったが、
マッチしてなくて添付されていなかったのを修正。

https://mastodon.juggler.jp/users/tateisu/statuses/101781087893985337