### PR TITLE
Use menu instead of prompt Fix #4540, Fix #342

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1567,7 +1567,6 @@ mobile/views/components/drive.vue:
   url-prompt: "アップロードしたいファイルのURL"
   uploading: "アップロードをリクエストしました。アップロードが完了するまで時間がかかる場合があります。"
   folder-name-cannot-empty: "フォルダ名を空白にすることはできません。"
-  cannot-same-folder: "同じフォルダーは指定できません。"
 
 mobile/views/components/drive-file-chooser.vue:
   select-file: "ファイルを選択"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1562,12 +1562,12 @@ mobile/views/components/drive.vue:
   file-count: "ファイル"
   nothing-in-drive: "ドライブには何もありません"
   folder-is-empty: "このフォルダは空です"
-  prompt: "何をしますか？(数字を入力してください): <1 → ファイルをアップロード | 2 → ファイルをURLでアップロード | 3 → フォルダ作成 | 4 → このフォルダ名を変更 | 5 → このフォルダを移動 | 6 → このフォルダを削除>"
-  deletion-alert: "ごめんなさい！フォルダの削除は未実装です...。"
   folder-name: "フォルダー名"
   here-is-root: "現在いる場所はルートで、フォルダではありません。"
   url-prompt: "アップロードしたいファイルのURL"
   uploading: "アップロードをリクエストしました。アップロードが完了するまで時間がかかる場合があります。"
+  folder-name-cannot-empty: "フォルダ名を空白にすることはできません。"
+  cannot-same-folder: "同じフォルダーは指定できません。"
 
 mobile/views/components/drive-file-chooser.vue:
   select-file: "ファイルを選択"
@@ -1656,6 +1656,15 @@ mobile/views/components/ui.nav.vue:
   game: "ゲーム"
   admin: "管理"
   about: "Misskeyについて"
+
+mobile/views/pages/drive.vue:
+  contextmenu:
+    upload: "ファイルをアップロード"
+    url-upload: "ファイルをURLでアップロード"
+    create-folder: "フォルダーを作成"
+    rename-folder: "フォルダー名を変更"
+    move-folder: "このフォルダを移動"
+    delete-folder: "このフォルダを削除"
 
 mobile/views/pages/user-lists.vue:
   title: "リスト"

--- a/src/client/app/mobile/views/components/drive.vue
+++ b/src/client/app/mobile/views/components/drive.vue
@@ -379,43 +379,30 @@ export default Vue.extend({
 			});
 		},
 
-		openContextMenu() {
-			const fn = window.prompt(this.$t('prompt'));
-			if (fn == null || fn == '') return;
-			switch (fn) {
-				case '1':
-					this.selectLocalFile();
-					break;
-				case '2':
-					this.urlUpload();
-					break;
-				case '3':
-					this.createFolder();
-					break;
-				case '4':
-					this.renameFolder();
-					break;
-				case '5':
-					this.moveFolder();
-					break;
-				case '6':
-					this.deleteFolder();
-					break;
-			}
-		},
-
 		selectLocalFile() {
 			(this.$refs.file as any).click();
 		},
 
 		createFolder() {
-			const name = window.prompt(this.$t('folder-name'));
-			if (name == null || name == '') return;
-			this.$root.api('drive/folders/create', {
-				name: name,
-				parentId: this.folder ? this.folder.id : undefined
-			}).then(folder => {
-				this.addFolder(folder, true);
+			this.$root.dialog({
+				title: this.$t('folder-name')
+				input: {
+					default: this.folder.name
+				}
+			}).then(({ result: name }) => {
+				if (!name) {
+					this.$root.dialog({
+						type: 'error',
+						text: this.$t('folder-name-cannot-empty')
+					});
+					return;
+				}
+				this.$root.api('drive/folders/create', {
+					name: name,
+					parentId: this.folder ? this.folder.id : undefined
+				}).then(folder => {
+					this.addFolder(folder, true);
+				});
 			});
 		},
 
@@ -427,13 +414,25 @@ export default Vue.extend({
 				});
 				return;
 			}
-			const name = window.prompt(this.$t('folder-name'), this.folder.name);
-			if (name == null || name == '') return;
-			this.$root.api('drive/folders/update', {
-				name: name,
-				folderId: this.folder.id
-			}).then(folder => {
-				this.cd(folder);
+			this.$root.dialog({
+				title: this.$t('folder-name')
+				input: {
+					default: this.folder.name
+				}
+			}).then(({ result: name }) => {
+				if (!name) {
+					this.$root.dialog({
+						type: 'error',
+						text: this.$t('cannot-empty')
+					});
+					return;
+				}
+				this.$root.api('drive/folders/update', {
+					name: name,
+					folderId: this.folder.id
+				}).then(folder => {
+					this.cd(folder);
+				});
 			});
 		},
 

--- a/src/client/app/mobile/views/pages/drive.vue
+++ b/src/client/app/mobile/views/pages/drive.vue
@@ -5,7 +5,7 @@
 		<template v-if="file"><mk-file-type-icon data-icon :type="file.type" style="margin-right:4px;"/>{{ file.name }}</template>
 		<template v-if="!folder && !file"><span style="margin-right:4px;"><fa icon="cloud"/></span>{{ $t('@.drive') }}</template>
 	</template>
-	<template #func><button @click="fn"><fa icon="ellipsis-h"/></button></template>
+	<template #func v-if="folder || (!folder && !file)"><button @click="openContextMenu" ref="contextSource"><fa icon="ellipsis-h"/></button></template>
 	<x-drive
 		ref="browser"
 		:init-folder="initFolder"
@@ -26,9 +26,12 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import Progress from '../../../common/scripts/loading';
+import XMenu from '../../../common/views/components/menu.vue';
+import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
+import { faCloudUploadAlt } from '@fortawesome/free-solid-svg-icons';
 
 export default Vue.extend({
-	i18n: i18n(),
+	i18n: i18n('mobile/views/pages/drive.vue'),
 	components: {
 		XDrive: () => import('../components/drive.vue').then(m => m.default),
 	},
@@ -62,9 +65,6 @@ export default Vue.extend({
 			} else {
 				(this.$refs as any).browser.goRoot(true);
 			}
-		},
-		fn() {
-			(this.$refs as any).browser.openContextMenu();
 		},
 		onMoveRoot(silent) {
 			const title = `${this.$root.instanceName} Drive`;
@@ -104,6 +104,46 @@ export default Vue.extend({
 
 			this.file = file;
 			this.folder = null;
+		},
+		openContextMenu() {
+			let items = [{
+					type: 'item',
+					text: this.$t('contextmenu.upload'),
+					icon: 'upload',
+					action: this.$refs.browser.selectLocalFile
+				}, {
+					type: 'item',
+					text: this.$t('contextmenu.url-upload'),
+					icon: faCloudUploadAlt,
+					action: this.$refs.browser.urlUpload
+				}, {
+					type: 'item',
+					text: this.$t('contextmenu.create-folder'),
+					icon: ['far', 'folder'],
+					action: this.$refs.browser.createFolder
+				}] as any
+			if (this.folder) {
+				items = items.concat([{
+					type: 'item',
+					text: this.$t('contextmenu.rename-folder'),
+					icon: 'i-cursor',
+					action: this.$refs.browser.renameFolder
+				}, {
+					type: 'item',
+					text: this.$t('contextmenu.move-folder'),
+					icon: ['far', 'folder-open'],
+					action: this.$refs.browser.moveFolder
+				}, {
+					type: 'item',
+					text: this.$t('contextmenu.delete-folder'),
+					icon: faTrashAlt,
+					action: this.$refs.browser.deleteFolder
+				}])
+			}
+			this.$root.new(XMenu, {
+				items,
+				source: this.$refs.contextSource,
+			});
 		}
 	}
 });

--- a/src/client/app/mobile/views/pages/drive.vue
+++ b/src/client/app/mobile/views/pages/drive.vue
@@ -106,9 +106,6 @@ export default Vue.extend({
 			this.folder = null;
 		},
 		openContextMenu() {
-			if (this.folder) {
-				items = items.concat()
-			}
 			this.$root.new(XMenu, {
 				items: [{
 					type: 'item',

--- a/src/client/app/mobile/views/pages/drive.vue
+++ b/src/client/app/mobile/views/pages/drive.vue
@@ -106,7 +106,11 @@ export default Vue.extend({
 			this.folder = null;
 		},
 		openContextMenu() {
-			let items = [{
+			if (this.folder) {
+				items = items.concat()
+			}
+			this.$root.new(XMenu, {
+				items: [{
 					type: 'item',
 					text: this.$t('contextmenu.upload'),
 					icon: 'upload',
@@ -121,9 +125,7 @@ export default Vue.extend({
 					text: this.$t('contextmenu.create-folder'),
 					icon: ['far', 'folder'],
 					action: this.$refs.browser.createFolder
-				}] as any
-			if (this.folder) {
-				items = items.concat([{
+				}, ...(this.folder ? [{
 					type: 'item',
 					text: this.$t('contextmenu.rename-folder'),
 					icon: 'i-cursor',
@@ -138,10 +140,7 @@ export default Vue.extend({
 					text: this.$t('contextmenu.delete-folder'),
 					icon: faTrashAlt,
 					action: this.$refs.browser.deleteFolder
-				}])
-			}
-			this.$root.new(XMenu, {
-				items,
+				}] : [])],
 				source: this.$refs.contextSource,
 			});
 		}


### PR DESCRIPTION
## Summary
Fix #4540, Fix #342

- プロンプトの代わりにメニューを出すように
  * 操作できないものはそもそも表示しないように
- ついでにwindow.promptをdialogに