### PR TITLE
Fix #4581

### DIFF
--- a/src/client/app/common/views/components/forkit.vue
+++ b/src/client/app/common/views/components/forkit.vue
@@ -15,12 +15,6 @@ export default Vue.extend({
 		return {
 			repositoryUrl: 'https://github.com/syuilo/misskey'
 		};
-	},
-	created() {
-		this.$root.getMeta().then(meta => {
-			if (meta.maintainer)
-				this.repositoryUrl = meta.maintainer.repository_url;
-		});
 	}
 });
 </script>

--- a/src/client/app/common/views/components/nav.vue
+++ b/src/client/app/common/views/components/nav.vue
@@ -23,12 +23,6 @@ export default Vue.extend({
 			repositoryUrl: 'https://github.com/syuilo/misskey',
 			feedbackUrl: 'https://github.com/syuilo/misskey/issues/new'
 		}
-	},
-	created() {
-		this.$root.getMeta().then(meta => {
-			if (meta.maintainer.repository_url) this.repositoryUrl = meta.maintainer.repository_url;
-			if (meta.maintainer.feedback_url) this.feedbackUrl = meta.maintainer.feedback_url;
-		});
 	}
 });
 </script>


### PR DESCRIPTION
## Summary
Fix #4581 ?
とりあえず、おそらくもう廃止されていて？変更もできない
DB上の`repositoryUrl`などがUIのリンクを書き換えてしまうのを修正。

レポジトリURL自体の書き換えは、forkした人は適宜ソースを書き換えてるみたいなので
特にこのままでいいかなと思います。