### PR TITLE
Use db instead of mongodb

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -7,6 +7,7 @@ import { URL } from 'url';
 import * as yaml from 'js-yaml';
 import { Source, Mixin } from './types';
 import * as pkg from '../../package.json';
+import Logger from '../services/logger';
 
 /**
  * Path of configuration directory
@@ -20,10 +21,20 @@ const path = process.env.NODE_ENV == 'test'
 	? `${dir}/test.yml`
 	: `${dir}/default.yml`;
 
-export default function load() {
+export default function load(logger?: Logger) {
 	const config = yaml.safeLoad(fs.readFileSync(path, 'utf-8')) as Source;
 
 	const mixin = {} as Mixin;
+
+	if (!config.db) {
+		if (logger)
+			logger.warn('`config.mongodb` is deprecated. Use `config.db` instead of this property.');
+
+		mixin.db = {
+			type: 'mongodb',
+			...config.mongodb
+		};
+	}
 
 	const url = validateUrl(config.url);
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -8,6 +8,15 @@ export type Source = {
 	port: number;
 	https?: { [x: string]: string };
 	disableHsts?: boolean;
+	db: {
+		type: 'mongodb';
+		host: string;
+		port: number;
+		db: string;
+		user: string;
+		pass: string;
+	};
+	/** @deprecated Use `db` instead of this property. */
 	mongodb: {
 		host: string;
 		port: number;
@@ -48,6 +57,14 @@ export type Source = {
  * Misskeyが自動的に(ユーザーが設定した情報から推論して)設定する情報
  */
 export type Mixin = {
+	db: {
+		type: 'mongodb';
+		host: string;
+		port: number;
+		db: string;
+		user: string;
+		pass: string;
+	};
 	host: string;
 	hostname: string;
 	scheme: string;

--- a/src/db/mongodb.ts
+++ b/src/db/mongodb.ts
@@ -1,9 +1,9 @@
 import config from '../config';
 
-const u = config.mongodb.user ? encodeURIComponent(config.mongodb.user) : null;
-const p = config.mongodb.pass ? encodeURIComponent(config.mongodb.pass) : null;
+const u = config.db.user ? encodeURIComponent(config.db.user) : null;
+const p = config.db.pass ? encodeURIComponent(config.db.pass) : null;
 
-const uri = `mongodb://${u && p ? `${u}:${p}@` : ''}${config.mongodb.host}:${config.mongodb.port}/${config.mongodb.db}`;
+const uri = `mongodb://${u && p ? `${u}:${p}@` : ''}${config.db.host}:${config.db.port}/${config.db.db}`;
 
 /**
  * monk
@@ -27,7 +27,7 @@ const nativeDbConn = async (): Promise<mongodb.Db> => {
 	const db = await ((): Promise<mongodb.Db> => new Promise((resolve, reject) => {
 		mongodb.MongoClient.connect(uri, { useNewUrlParser: true }, (e: Error, client: any) => {
 			if (e) return reject(e);
-			resolve(client.db(config.mongodb.db));
+			resolve(client.db(config.db.db));
 		});
 	}))();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ async function init(): Promise<Config> {
 	let config;
 
 	try {
-		config = loadConfig();
+		config = loadConfig(logger.createSubLogger('config'));
 	} catch (exception) {
 		if (typeof exception === 'string') {
 			configLogger.error(exception);

--- a/src/misc/check-mongodb.ts
+++ b/src/misc/check-mongodb.ts
@@ -8,9 +8,11 @@ const requiredMongoDBVersion = [3, 6];
 export function checkMongoDB(config: Config, logger: Logger) {
 	return new Promise((res, rej) => {
 		const mongoDBLogger = logger.createSubLogger('db');
-		const u = config.mongodb.user ? encodeURIComponent(config.mongodb.user) : null;
-		const p = config.mongodb.pass ? encodeURIComponent(config.mongodb.pass) : null;
-		const uri = `mongodb://${u && p ? `${u}:****@` : ''}${config.mongodb.host}:${config.mongodb.port}/${config.mongodb.db}`;
+		if (config.db.type !== 'mongodb')
+			rej(`DB type '${config.db.type}' is not supported in this version.`);
+		const u = config.db.user ? encodeURIComponent(config.db.user) : null;
+		const p = config.db.pass ? encodeURIComponent(config.db.pass) : null;
+		const uri = `mongodb://${u && p ? `${u}:****@` : ''}${config.db.host}:${config.db.port}/${config.db.db}`;
 		mongoDBLogger.info(`Connecting to ${uri} ...`);
 
 		nativeDbConn().then(db => {


### PR DESCRIPTION
## Summary

> v11以降では
> 
> ```yaml
> db:
>   type: postgresql
> ```
> 
> みたいな感じにして、v10は
> 
> ```yaml
> db:
>   type: mongodb
> ```
> 
> に変更する（互換性は維持）とかにした方が綺麗そう。

_Originally posted by @acid-chicken in https://github.com/syuilo/misskey/pull/4572/files#r268749481_
