### PR TITLE
ユーザーリストの description を single line 扱いで表示するように

### DIFF
--- a/src/client/app/common/views/components/user-list.vue
+++ b/src/client/app/common/views/components/user-list.vue
@@ -16,7 +16,7 @@
 					<p class="username">@{{ user | acct }}</p>
 				</div>
 				<div class="description" v-if="user.description" :title="user.description">
-					<mfm :text="user.description" :is-note="false" :author="user" :i="$store.state.i" :custom-emojis="user.emojis" :should-break="false"/>
+					<mfm :text="user.description" :is-note="false" :author="user" :i="$store.state.i" :custom-emojis="user.emojis" :should-break="false" :plain-text="true"/>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
Fix #4596

ユーザーリストのdescriptionを、絵文字以外のMFM展開をせずにsingle line扱いで表示するようにしています。

これによりユーザーリストのdescriptionのタグなどがリンクでなくなってはしまうものの
- あまりdescriptionをタグで書き始める人はいない
- DesktopならユーザーのツールチップでMFMされたdescriptionが参照できる
- Mobileならそもそもユーザーリストにdescriptionの列がない

のでさほど問題ないと思います。