### PR TITLE
フォローインポートで自分をスキップするように

### DIFF
--- a/src/queue/processors/db/import-following.ts
+++ b/src/queue/processors/db/import-following.ts
@@ -45,6 +45,9 @@ export async function importFollowing(job: Bull.Job, done: any): Promise<void> {
 			target = await resolveUser(username, host);
 		}
 
+		// skip myself
+		if (target._id.equals(job.data.user._id)) continue;
+
 		logger.info(`Follow ${target._id} ...`);
 
 		follow(user, target);

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -568,7 +568,8 @@ async function publishToFollowers(note: INote, user: IUser, noteActivity: any) {
 	});
 
 	const followers = await Following.find({
-		followeeId: note.userId
+		followeeId: note.userId,
+		followerId: { $ne: note.userId }	// バグでフォロワーに自分がいることがあるため
 	});
 
 	const queue: string[] = [];


### PR DESCRIPTION
## Summary
Fix #4613 
Related #4598

フォローインポートで自分自身はスキップするように
フォロワーにpublishするときに自分自身がいてもスキップするように