### PR TITLE
Doc: Update installing command

### DIFF
--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -11,7 +11,7 @@ This guide describes how to install and setup Misskey with Docker.
 ----------------------------------------------------------------
 1. `git clone -b master git://github.com/syuilo/misskey.git` Clone Misskey repository's master branch.
 2. `cd misskey` Move to misskey directory.
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
 
 *2.* Configure Misskey
 ----------------------------------------------------------------
@@ -67,7 +67,7 @@ Just `docker-compose up -d`. GLHF!
 ### How to update your Misskey server to the latest version
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 4. `git stash pop`
 5. `docker-compose build`
 6. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/docker.fr.md
+++ b/docs/docker.fr.md
@@ -12,7 +12,7 @@ Ce guide explique comment installer et configurer Misskey avec Docker.
 ----------------------------------------------------------------
 1. `git clone -b master git://github.com/syuilo/misskey.git` Clone le dépôt de Misskey sur la branche master.
 2. `cd misskey` Naviguez dans le dossier du dépôt.
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout sur le tag de la [dernière version](https://github.com/syuilo/misskey/releases/latest).
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` Checkout sur le tag de la [dernière version](https://github.com/syuilo/misskey/releases/latest).
 
 *2.* Configuration de Misskey
 ----------------------------------------------------------------
@@ -40,7 +40,7 @@ Utilisez la commande `docker-compose up -d`. GLHF!
 ### How to update your Misskey server to the latest version
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 4. `git stash pop`
 5. `docker-compose build`
 6. Consultez le [ChangeLog](../CHANGELOG.md) pour avoir les éventuelles informations de migration

--- a/docs/docker.ja.md
+++ b/docs/docker.ja.md
@@ -11,7 +11,7 @@ Dockerを使ったMisskey構築方法
 ----------------------------------------------------------------
 1. `git clone -b master git://github.com/syuilo/misskey.git` masterブランチからMisskeyレポジトリをクローン
 2. `cd misskey` misskeyディレクトリに移動
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 
 *2.* 設定ファイルの作成と編集
 ----------------------------------------------------------------
@@ -67,7 +67,7 @@ cp docker_example.env docker.env
 ### Misskeyを最新バージョンにアップデートする方法:
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 4. `git stash pop`
 5. `docker-compose build`
 6. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -40,7 +40,7 @@ Please install and setup these softwares:
 1. `su - misskey` Connect to misskey user.
 2. `git clone -b master git://github.com/syuilo/misskey.git` Clone the misskey repo from master branch.
 3. `cd misskey` Navigate to misskey directory
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
+4. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
 5. `npm install` Install misskey dependencies.
 
 *5.* Configure Misskey
@@ -109,7 +109,7 @@ You can check if the service is running with `systemctl status misskey`.
 
 ### How to update your Misskey server to the latest version
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -40,7 +40,7 @@ Installez les paquets suivants :
 1. `su - misskey` Basculez vers l'utilisateur misskey.
 2. `git clone -b master git://github.com/syuilo/misskey.git` Clonez la branche master du dépôt misskey.
 3. `cd misskey` Accédez au dossier misskey.
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
+4. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
 5. `npm install` Installez les dépendances de misskey.
 
 *5.* Création du fichier de configuration
@@ -103,7 +103,7 @@ Vous pouvez vérifier si le service a démarré en utilisant la commande `system
 
 ### Méthode de mise à jour vers la plus récente version de Misskey
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Consultez [ChangeLog](../CHANGELOG.md) pour les information de migration.

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -47,7 +47,7 @@ adduser --disabled-password --disabled-login misskey
 1. `su - misskey` misskeyユーザーを使用
 2. `git clone -b master git://github.com/syuilo/misskey.git` masterブランチからMisskeyレポジトリをクローン
 3. `cd misskey` misskeyディレクトリに移動
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+4. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 5. `npm install` Misskeyの依存パッケージをインストール
 
 *5.* 設定ファイルを作成する
@@ -115,7 +115,7 @@ CentOSで1024以下のポートを使用してMisskeyを使用する場合は`Ex
 
 ### Misskeyを最新バージョンにアップデートする方法:
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. `git checkout $(git tag -l | grep -Ev -- '-(rc|alpha)\.[0-9]+$' | sort -V | tail -n 1)`
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する


### PR DESCRIPTION
## 概要
[今のセットアップドキュメント](https://github.com/syuilo/misskey/blob/f0a29721c9fb10f97faf386bc9d6b1b2fad97895/docs/setup.ja.md)にある「最新のリリースを確認」のコマンドを実行するとアルファ版のタグがチェックアウトされます。

```bash
$ git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1
11.0.0-alpha.4
```

アルファ版のタグを取り除けるようにコマンドの更新をお願いします。