### PR TITLE
Fix: AP actor Service のサポートが不完全 (v10)

### DIFF
--- a/src/queue/processors/inbox.ts
+++ b/src/queue/processors/inbox.ts
@@ -11,6 +11,7 @@ import Logger from '../../services/logger';
 import { registerOrFetchInstanceDoc } from '../../services/register-or-fetch-instance-doc';
 import Instance from '../../models/instance';
 import instanceChart from '../../services/chart/instance';
+import { validActor } from '../../remote/activitypub/type';
 
 const logger = new Logger('inbox');
 
@@ -79,7 +80,7 @@ export default async (job: Bull.Job): Promise<void> => {
 
 	// Update Person activityの場合は、ここで署名検証/更新処理まで実施して終了
 	if (activity.type === 'Update') {
-		if (activity.object && activity.object.type === 'Person') {
+		if (activity.object && validActor.includes(activity.object.type)) {
 			if (user == null) {
 				logger.warn('Update activity received, but user not registed.');
 			} else if (!httpSignature.verifySignature(signature, user.publicKey.publicKeyPem)) {

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -6,7 +6,7 @@ import config from '../../../config';
 import User, { validateUsername, isValidName, IUser, IRemoteUser, isRemoteUser } from '../../../models/user';
 import Resolver from '../resolver';
 import { resolveImage } from './image';
-import { isCollectionOrOrderedCollection, isCollection, IPerson } from '../type';
+import { isCollectionOrOrderedCollection, isCollection, IPerson, validActor } from '../type';
 import { IDriveFile } from '../../../models/drive-file';
 import Meta from '../../../models/meta';
 import { fromHtml } from '../../../mfm/fromHtml';
@@ -38,7 +38,7 @@ function validatePerson(x: any, uri: string) {
 		return new Error('invalid person: object is null');
 	}
 
-	if (x.type != 'Person' && x.type != 'Service') {
+	if (!validActor.includes(x.type)) {
 		return new Error(`invalid person: object is not a person or service '${x.type}'`);
 	}
 

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -65,6 +65,8 @@ interface IQuestionChoice {
 	_misskey_votes?: number;
 }
 
+export const validActor = ['Person', 'Service'];
+
 export interface IPerson extends IObject {
 	type: 'Person';
 	name: string;

--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -10,6 +10,7 @@ import Resolver from '../../../../remote/activitypub/resolver';
 import { ApiError } from '../../error';
 import Instance from '../../../../models/instance';
 import { extractDbHost } from '../../../../misc/convert-host';
+import { validActor } from '../../../../remote/activitypub/type';
 
 export const meta = {
 	tags: ['federation'],
@@ -95,7 +96,7 @@ async function fetchAny(uri: string) {
 	}
 
 	// それでもみつからなければ新規であるため登録
-	if (object.type === 'Person') {
+	if (validActor.includes(object.type)) {
 		const user = await createPerson(object.id);
 		return {
 			type: 'User',


### PR DESCRIPTION
## Summary
v10のみ F i x #4660 
inbox に Update[Service] が来たとき, ap/show で Service が来たとき
にServiceも許容するように変更

https://github.com/syuilo/misskey/compare/v10...346design:actor のうちの Service に関係する場所のみ
