### PR TITLE
Fix: Punycodeなインスタンスが重複登録される

### DIFF
--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -16,7 +16,8 @@ import discord from './service/discord';
 import github from './service/github';
 import twitter from './service/twitter';
 import Instance from '../../models/instance';
-import { toASCII } from 'punycode';
+import { toApHost } from '../../misc/convert-host';
+import { unique } from '../../prelude/array';
 
 // Init app
 const app = new Koa();
@@ -72,7 +73,7 @@ router.get('/v1/instance/peers', async ctx => {
 			host: 1
 		});
 
-	const punyCodes = instances.map(instance => toASCII(instance.host));
+	const punyCodes = unique(instances.map(instance => toApHost(instance.host)));
 
 	ctx.body = punyCodes;
 });

--- a/src/services/register-or-fetch-instance-doc.ts
+++ b/src/services/register-or-fetch-instance-doc.ts
@@ -1,8 +1,11 @@
 import Instance, { IInstance } from '../models/instance';
 import federationChart from '../services/chart/federation';
+import { toDbHost } from '../misc/convert-host';
 
 export async function registerOrFetchInstanceDoc(host: string): Promise<IInstance> {
 	if (host == null) return null;
+
+	host = toDbHost(host);
 
 	const index = await Instance.findOne({ host });
 


### PR DESCRIPTION
## Summary
- PunycodeなインスタンスがPunycode/Unicodeで2つ登録される
- Punycodeなインスタンスがpeers APIで2回登場する

を修正

v11はなおしたみたいですね