### PR TITLE
 Doc: Update setup documents for 10.x

### DIFF
--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -9,9 +9,21 @@ This guide describes how to install and setup Misskey with Docker.
 
 *1.* Download Misskey
 ----------------------------------------------------------------
-1. `git clone -b master git://github.com/syuilo/misskey.git` Clone Misskey repository's master branch.
-2. `cd misskey` Move to misskey directory.
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
+1. Clone Misskey repository's master branch.
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+2. Move to misskey directory.
+
+	`cd misskey`
+
+3. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 
 *2.* Configure Misskey
 ----------------------------------------------------------------
@@ -39,7 +51,13 @@ Just `docker-compose up -d`. GLHF!
 ### How to update your Misskey server to the latest version
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. 
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 4. `git stash pop`
 5. `docker-compose build`
 6. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -20,9 +20,11 @@ This guide describes how to install and setup Misskey with Docker.
 3. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 
 *2.* Configure Misskey
@@ -54,9 +56,11 @@ Just `docker-compose up -d`. GLHF!
 3. 
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 4. `git stash pop`
 5. `docker-compose build`

--- a/docs/docker.en.md
+++ b/docs/docker.en.md
@@ -19,13 +19,13 @@ This guide describes how to install and setup Misskey with Docker.
 
 3. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest) tag.
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 
 *2.* Configure Misskey
 ----------------------------------------------------------------
@@ -55,13 +55,13 @@ Just `docker-compose up -d`. GLHF!
 2. `git stash`
 3. 
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 4. `git stash pop`
 5. `docker-compose build`
 6. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/docker.fr.md
+++ b/docs/docker.fr.md
@@ -20,11 +20,13 @@ Ce guide explique comment installer et configurer Misskey avec Docker.
 
 3. Checkout sur le tag de la [dernière version](https://github.com/syuilo/misskey/releases/latest).
 
-   ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 
 *2.* Configuration de Misskey
 ----------------------------------------------------------------
@@ -54,13 +56,13 @@ Utilisez la commande `docker-compose up -d`. GLHF!
 2. `git stash`
 3. 
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 4. `git stash pop`
 5. `docker-compose build`
 6. Consultez le [ChangeLog](../CHANGELOG.md) pour avoir les éventuelles informations de migration

--- a/docs/docker.fr.md
+++ b/docs/docker.fr.md
@@ -10,9 +10,21 @@ Ce guide explique comment installer et configurer Misskey avec Docker.
 
 *1.* Télécharger Misskey
 ----------------------------------------------------------------
-1. `git clone -b master git://github.com/syuilo/misskey.git` Clone le dépôt de Misskey sur la branche master.
-2. `cd misskey` Naviguez dans le dossier du dépôt.
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout sur le tag de la [dernière version](https://github.com/syuilo/misskey/releases/latest).
+1. Clone le dépôt de Misskey sur la branche master.
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+2. Naviguez dans le dossier du dépôt.
+
+	`cd misskey`
+
+3. Checkout sur le tag de la [dernière version](https://github.com/syuilo/misskey/releases/latest).
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 
 *2.* Configuration de Misskey
 ----------------------------------------------------------------
@@ -40,7 +52,13 @@ Utilisez la commande `docker-compose up -d`. GLHF!
 ### How to update your Misskey server to the latest version
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. 
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 4. `git stash pop`
 5. `docker-compose build`
 6. Consultez le [ChangeLog](../CHANGELOG.md) pour avoir les éventuelles informations de migration
@@ -52,14 +70,28 @@ Utilisez la commande `docker-compose up -d`. GLHF!
 ### Configuration d'ElasticSearch (pour la fonction de recherche)
 *1.* Préparation de l'environnement
 ----------------------------------------------------------------
-1. `mkdir elasticsearch && chown 1000:1000 elasticsearch` Permet de créer le dossier d'accueil de la base ElasticSearch aves les bons droits
-2. `sysctl -w vm.max_map_count=262144` Augmente la valeur max du paramètre map_count du système (valeur minimum pour pouvoir lancer ES)
+1. Permet de créer le dossier d'accueil de la base ElasticSearch aves les bons droits
+
+	`mkdir elasticsearch && chown 1000:1000 elasticsearch`
+
+2. Augmente la valeur max du paramètre map_count du système (valeur minimum pour pouvoir lancer ES)
+
+	`sysctl -w vm.max_map_count=262144`
 
 *2.* Après lancement du docker-compose, initialisation de la base ElasticSearch
 ----------------------------------------------------------------
-1. `docker-compose -it web /bin/sh` Connexion dans le conteneur web
-2. `apk add curl` Ajout du paquet curl
-3. `curl -X PUT "es:9200/misskey" -H 'Content-Type: application/json' -d'{ "settings" : { "index" : { } }}'` Création de la base ES
+1. Connexion dans le conteneur web
+
+	`docker-compose -it web /bin/sh`
+
+2. Ajout du paquet curl
+
+	`apk add curl`
+
+3. Création de la base ES
+
+	`curl -X PUT "es:9200/misskey" -H 'Content-Type: application/json' -d'{ "settings" : { "index" : { } }}'`
+
 4. `exit`
 
 ----------------------------------------------------------------

--- a/docs/docker.fr.md
+++ b/docs/docker.fr.md
@@ -55,9 +55,11 @@ Utilisez la commande `docker-compose up -d`. GLHF!
 3. 
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 4. `git stash pop`
 5. `docker-compose build`

--- a/docs/docker.ja.md
+++ b/docs/docker.ja.md
@@ -20,9 +20,11 @@ Dockerを使ったMisskey構築方法
 3. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 
 *2.* 設定ファイルを作成する
@@ -54,9 +56,11 @@ Dockerを使ったMisskey構築方法
 3. 
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 4. `git stash pop`
 5. `docker-compose build`

--- a/docs/docker.ja.md
+++ b/docs/docker.ja.md
@@ -19,13 +19,13 @@ Dockerを使ったMisskey構築方法
 
 3. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 
 *2.* 設定ファイルを作成する
 ----------------------------------------------------------------
@@ -55,13 +55,13 @@ Dockerを使ったMisskey構築方法
 2. `git stash`
 3. 
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 4. `git stash pop`
 5. `docker-compose build`
 6. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する

--- a/docs/docker.ja.md
+++ b/docs/docker.ja.md
@@ -9,9 +9,21 @@ Dockerを使ったMisskey構築方法
 
 *1.* Misskeyのダウンロード
 ----------------------------------------------------------------
-1. `git clone -b master git://github.com/syuilo/misskey.git` masterブランチからMisskeyレポジトリをクローン
-2. `cd misskey` misskeyディレクトリに移動
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+1. masterブランチからMisskeyレポジトリをクローン
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+2. misskeyディレクトリに移動
+
+	`cd misskey`
+
+3. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 
 *2.* 設定ファイルを作成する
 ----------------------------------------------------------------
@@ -39,7 +51,13 @@ Dockerを使ったMisskey構築方法
 ### Misskeyを最新バージョンにアップデートする方法:
 1. `git fetch`
 2. `git stash`
-3. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+3. 
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 4. `git stash pop`
 5. `docker-compose build`
 6. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -55,13 +55,13 @@ As root:
 
 4. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 
 5. Install misskey dependencies.
 
@@ -140,13 +140,13 @@ You can check if the service is running with `systemctl status misskey`.
 1. `git fetch`
 2. 　
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -52,9 +52,11 @@ Please install and setup these softwares:
 4. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 
 5. Install misskey dependencies.
@@ -141,9 +143,11 @@ You can check if the service is running with `systemctl status misskey`.
 2. 　
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 3. `npm install`
 4. `NODE_ENV=production npm run build`

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Please install and setup these softwares:
 
 #### Dependencies :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
-* **[PostgreSQL](https://www.postgresql.org/)** >= 10
+* **[Node.js](https://nodejs.org/en/)** >= 10.0.0
+* **[MongoDB](https://www.mongodb.com/)** >= 3.6
 
 ##### Optional
 * [Redis](https://redis.io/)
@@ -31,9 +31,13 @@ Please install and setup these softwares:
 * [Elasticsearch](https://www.elastic.co/) - required to enable the search feature
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* Setup PostgreSQL
+*3.* Setup MongoDB
 ----------------------------------------------------------------
-:)
+As root:
+1. `mongo` Go to the mongo shell
+2. `use misskey` Use the misskey database
+3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` Create the misskey user.
+4. `exit` You're done!
 
 *4.* Install Misskey
 ----------------------------------------------------------------
@@ -87,13 +91,7 @@ If you're still encountering errors about some modules, use node-gyp:
 3. `node-gyp build`
 4. `NODE_ENV=production npm run build`
 
-*7.* Init DB
-----------------------------------------------------------------
-``` shell
-npm run init
-```
-
-*8.* That is it.
+*7.* That is it.
 ----------------------------------------------------------------
 Well done! Now, you have an environment that run to Misskey.
 

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Please install and setup these softwares:
 
 #### Dependencies :package:
-* **[Node.js](https://nodejs.org/en/)** >= 10.0.0
-* **[MongoDB](https://www.mongodb.com/)** >= 3.6
+* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
+* **[PostgreSQL](https://www.postgresql.org/)** >= 10
 
 ##### Optional
 * [Redis](https://redis.io/)
@@ -31,25 +31,42 @@ Please install and setup these softwares:
 * [Elasticsearch](https://www.elastic.co/) - required to enable the search feature
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* Setup MongoDB
+*3.* Setup PostgreSQL
 ----------------------------------------------------------------
-As root:
-1. `mongo` Go to the mongo shell
-2. `use misskey` Use the misskey database
-3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` Create the misskey user.
-4. `exit` You're done!
+:)
 
 *4.* Install Misskey
 ----------------------------------------------------------------
-1. `su - misskey` Connect to misskey user.
-2. `git clone -b master git://github.com/syuilo/misskey.git` Clone the misskey repo from master branch.
-3. `cd misskey` Navigate to misskey directory
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
-5. `npm install` Install misskey dependencies.
+1. Connect to misskey user.
+
+	`su - misskey`
+
+2. Clone the misskey repo from master branch.
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+3. Navigate to misskey directory
+
+	`cd misskey`
+
+4. Checkout to the [latest release](https://github.com/syuilo/misskey/releases/latest)
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
+
+5. Install misskey dependencies.
+
+	`npm install`
 
 *5.* Configure Misskey
 ----------------------------------------------------------------
-1. `cp .config/example.yml .config/default.yml` Copy the `.config/example.yml` and rename it to `default.yml`.
+1. Copy the `.config/example.yml` and rename it to `default.yml`.
+
+	`cp .config/example.yml .config/default.yml`
+
 2. Edit `default.yml`
 
 *6.* Build Misskey
@@ -68,7 +85,13 @@ If you're still encountering errors about some modules, use node-gyp:
 3. `node-gyp build`
 4. `NODE_ENV=production npm run build`
 
-*7.* That is it.
+*7.* Init DB
+----------------------------------------------------------------
+``` shell
+npm run init
+```
+
+*8.* That is it.
 ----------------------------------------------------------------
 Well done! Now, you have an environment that run to Misskey.
 
@@ -77,37 +100,51 @@ Just `NODE_ENV=production npm start`. GLHF!
 
 ### Launch with systemd
 
-1. Create a systemd service here: `/etc/systemd/system/misskey.service`
+1. Create a systemd service here
+
+	`/etc/systemd/system/misskey.service`
+
 2. Edit it, and paste this and save:
 
-```
-[Unit]
-Description=Misskey daemon
+	```
+	[Unit]
+	Description=Misskey daemon
 
-[Service]
-Type=simple
-User=misskey
-ExecStart=/usr/bin/npm start
-WorkingDirectory=/home/misskey/misskey
-Environment="NODE_ENV=production"
-TimeoutSec=60
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=misskey
-Restart=always
+	[Service]
+	Type=simple
+	User=misskey
+	ExecStart=/usr/bin/npm start
+	WorkingDirectory=/home/misskey/misskey
+	Environment="NODE_ENV=production"
+	TimeoutSec=60
+	StandardOutput=syslog
+	StandardError=syslog
+	SyslogIdentifier=misskey
+	Restart=always
 
-[Install]
-WantedBy=multi-user.target
-```
+	[Install]
+	WantedBy=multi-user.target
+	```
 
-3. `systemctl daemon-reload ; systemctl enable misskey` Reload systemd and enable the misskey service.
-4. `systemctl start misskey` Start the misskey service.
+3. Reload systemd and enable the misskey service.
+
+	`systemctl daemon-reload ; systemctl enable misskey`
+
+4. Start the misskey service.
+
+	`systemctl start misskey`
 
 You can check if the service is running with `systemctl status misskey`.
 
 ### How to update your Misskey server to the latest version
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. 　
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Check [ChangeLog](../CHANGELOG.md) for migration information

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Installez les paquets suivants :
 
 #### Dépendences :package:
-* **[Node.js](https://nodejs.org/en/)** >= 10.0.0
-* **[MongoDB](https://www.mongodb.com/)** >= 3.6
+* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
+* **[PostgreSQL](https://www.postgresql.org/)** >= 10
 
 ##### Optionnels
 * [Redis](https://redis.io/)
@@ -31,25 +31,42 @@ Installez les paquets suivants :
 * [Elasticsearch](https://www.elastic.co/) - requis pour pouvoir activer la fonctionnalité de recherche
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* Paramètrage de MongoDB
+*3.* Paramètrage de PostgreSQL
 ----------------------------------------------------------------
-En root :
-1. `mongo` Ouvrez le shell mongo
-2. `use misskey` Utilisez la base de données misskey
-3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` Créez l'utilisateur misskey.
-4. `exit` Vous avez terminé !
+:)
 
 *4.* Installation de Misskey
 ----------------------------------------------------------------
-1. `su - misskey` Basculez vers l'utilisateur misskey.
-2. `git clone -b master git://github.com/syuilo/misskey.git` Clonez la branche master du dépôt misskey.
-3. `cd misskey` Accédez au dossier misskey.
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
-5. `npm install` Installez les dépendances de misskey.
+1. Basculez vers l'utilisateur misskey.
+
+	`su - misskey`
+
+2. Clonez la branche master du dépôt misskey.
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+3. Accédez au dossier misskey.
+
+	`cd misskey`
+
+4. Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
+ 
+5. Installez les dépendances de misskey.
+
+	`npm install`
 
 *5.* Création du fichier de configuration
 ----------------------------------------------------------------
-1. `cp .config/example.yml .config/default.yml` Copiez le fichier `.config/example.yml` et renommez-le`default.yml`.
+1. Copiez le fichier `.config/example.yml` et renommez-le`default.yml`.
+
+	`cp .config/example.yml .config/default.yml`
+
 2. Editez le fichier `default.yml`
 
 *6.* Construction de Misskey
@@ -77,37 +94,51 @@ Lancez tout simplement `NODE_ENV=production npm start`. Bonne chance et amusez-v
 
 ### Démarrage avec systemd
 
-1. Créez un service systemd sur : `/etc/systemd/system/misskey.service`
+1. Créez un service systemd sur
+
+	`/etc/systemd/system/misskey.service`
+
 2. Editez-le puis copiez et coller ceci dans le fichier :
 
-```
-[Unit]
-Description=Misskey daemon
+	```
+	[Unit]
+	Description=Misskey daemon
 
-[Service]
-Type=simple
-User=misskey
-ExecStart=/usr/bin/npm start
-WorkingDirectory=/home/misskey/misskey
-Environment="NODE_ENV=production"
-TimeoutSec=60
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=misskey
-Restart=always
+	[Service]
+	Type=simple
+	User=misskey
+	ExecStart=/usr/bin/npm start
+	WorkingDirectory=/home/misskey/misskey
+	Environment="NODE_ENV=production"
+	TimeoutSec=60
+	StandardOutput=syslog
+	StandardError=syslog
+	SyslogIdentifier=misskey
+	Restart=always
 
-[Install]
-WantedBy=multi-user.target
-```
+	[Install]
+	WantedBy=multi-user.target
+	```
 
-3. `systemctl daemon-reload ; systemctl enable misskey` Redémarre systemd et active le service misskey.
-4. `systemctl start misskey` Démarre le service misskey.
+3. Redémarre systemd et active le service misskey.
+
+	`systemctl daemon-reload ; systemctl enable misskey`
+
+4. Démarre le service misskey.
+
+	`systemctl start misskey`
 
 Vous pouvez vérifier si le service a démarré en utilisant la commande `systemctl status misskey`.
 
 ### Méthode de mise à jour vers la plus récente version de Misskey
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. 　
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Consultez [ChangeLog](../CHANGELOG.md) pour les information de migration.

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Installez les paquets suivants :
 
 #### Dépendences :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
-* **[PostgreSQL](https://www.postgresql.org/)** >= 10
+* **[Node.js](https://nodejs.org/en/)** >= 10.0.0
+* **[MongoDB](https://www.mongodb.com/)** >= 3.6
 
 ##### Optionnels
 * [Redis](https://redis.io/)
@@ -31,9 +31,13 @@ Installez les paquets suivants :
 * [Elasticsearch](https://www.elastic.co/) - requis pour pouvoir activer la fonctionnalité de recherche
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* Paramètrage de PostgreSQL
+*3.* Paramètrage de MongoDB
 ----------------------------------------------------------------
-:)
+En root :
+1. `mongo` Ouvrez le shell mongo
+2. `use misskey` Utilisez la base de données misskey
+3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` Créez l'utilisateur misskey.
+4. `exit` Vous avez terminé !
 
 *4.* Installation de Misskey
 ----------------------------------------------------------------

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -55,13 +55,13 @@ En root :
 
 4. Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
  
 5. Installez les dépendances de misskey.
 
@@ -140,13 +140,13 @@ Vous pouvez vérifier si le service a démarré en utilisant la commande `system
 1. `git fetch`
 2. 　
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. Consultez [ChangeLog](../CHANGELOG.md) pour les information de migration.

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -52,9 +52,11 @@ Installez les paquets suivants :
 4. Checkout sur le tag de la [version la plus récente](https://github.com/syuilo/misskey/releases/latest)
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
  
 5. Installez les dépendances de misskey.
@@ -135,9 +137,11 @@ Vous pouvez vérifier si le service a démarré en utilisant la commande `system
 2. 　
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 3. `npm install`
 4. `NODE_ENV=production npm run build`

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 これらのソフトウェアをインストール・設定してください:
 
 #### 依存関係 :package:
-* **[Node.js](https://nodejs.org/en/)** (11.7.0以上)
-* **[PostgreSQL](https://www.postgresql.org/)** (10以上)
+* **[Node.js](https://nodejs.org/en/)** (10.0.0以上)
+* **[MongoDB](https://www.mongodb.com/)** (3.6以上)
 
 ##### オプション
 * [Redis](https://redis.io/)
@@ -38,9 +38,13 @@ adduser --disabled-password --disabled-login misskey
 	* 検索機能を有効にするためにはインストールが必要です。
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* PostgreSQLの設定
+*3.* MongoDBの設定
 ----------------------------------------------------------------
-:)
+ルートで:
+1. `mongo` mongoシェルを起動
+2. `use misskey` misskeyデータベースを使用
+3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` misskeyユーザーを作成
+4. `exit` mongoシェルを終了
 
 *4.* Misskeyのインストール
 ----------------------------------------------------------------
@@ -92,13 +96,7 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 3. `node-gyp build`
 4. `NODE_ENV=production npm run build`
 
-*7.* データベースを初期化
-----------------------------------------------------------------
-``` shell
-npm run init
-```
-
-*8.* 以上です！
+*7.* 以上です！
 ----------------------------------------------------------------
 お疲れ様でした。これでMisskeyを動かす準備は整いました。
 

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -62,13 +62,14 @@ adduser --disabled-password --disabled-login misskey
 
 4. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
+
 5. Misskeyの依存パッケージをインストール
 
 	`npm install`
@@ -146,13 +147,13 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 1. `git fetch`
 2. 　
 
-   ```bash
-   git tag | grep '^10\.' | sort -V --reverse | \
-   while read tag_name; do \
-   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
-   | grep -qE '"(draft|prerelease)": true'; \
-   then git checkout $tag_name; break; fi ; done
-   ```
+	```bash
+	git tag | grep '^10\.' | sort -V --reverse | \
+	while read tag_name; do \
+	if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+	| grep -qE '"(draft|prerelease)": true'; \
+	then git checkout $tag_name; break; fi ; done
+	```
 
 3. `npm install`
 4. `NODE_ENV=production npm run build`

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 これらのソフトウェアをインストール・設定してください:
 
 #### 依存関係 :package:
-* **[Node.js](https://nodejs.org/en/)** (10.0.0以上)
-* **[MongoDB](https://www.mongodb.com/)** (3.6以上)
+* **[Node.js](https://nodejs.org/en/)** (11.7.0以上)
+* **[PostgreSQL](https://www.postgresql.org/)** (10以上)
 
 ##### オプション
 * [Redis](https://redis.io/)
@@ -38,25 +38,41 @@ adduser --disabled-password --disabled-login misskey
 	* 検索機能を有効にするためにはインストールが必要です。
 * [FFmpeg](https://www.ffmpeg.org/)
 
-*3.* MongoDBの設定
+*3.* PostgreSQLの設定
 ----------------------------------------------------------------
-ルートで:
-1. `mongo` mongoシェルを起動
-2. `use misskey` misskeyデータベースを使用
-3. `db.createUser( { user: "misskey", pwd: "<password>", roles: [ { role: "readWrite", db: "misskey" } ] } )` misskeyユーザーを作成
-4. `exit` mongoシェルを終了
+:)
 
 *4.* Misskeyのインストール
 ----------------------------------------------------------------
-1. `su - misskey` misskeyユーザーを使用
-2. `git clone -b master git://github.com/syuilo/misskey.git` masterブランチからMisskeyレポジトリをクローン
-3. `cd misskey` misskeyディレクトリに移動
-4. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)` [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
-5. `npm install` Misskeyの依存パッケージをインストール
+1. misskeyユーザーを使用
+
+	`su - misskey`
+
+2. masterブランチからMisskeyレポジトリをクローン
+
+	`git clone -b master git://github.com/syuilo/misskey.git`
+
+3. misskeyディレクトリに移動
+
+	`cd misskey`
+
+4. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
+5. Misskeyの依存パッケージをインストール
+
+	`npm install`
 
 *5.* 設定ファイルを作成する
 ----------------------------------------------------------------
-1. `cp .config/example.yml .config/default.yml` `.config/example.yml`をコピーし名前を`default.yml`にする。
+1. `.config/example.yml`をコピーし名前を`default.yml`にする。
+
+	`cp .config/example.yml .config/default.yml`
+
 2. `default.yml` を編集する。
 
 *6.* Misskeyのビルド
@@ -74,7 +90,13 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 3. `node-gyp build`
 4. `NODE_ENV=production npm run build`
 
-*7.* 以上です！
+*7.* データベースを初期化
+----------------------------------------------------------------
+``` shell
+npm run init
+```
+
+*8.* 以上です！
 ----------------------------------------------------------------
 お疲れ様でした。これでMisskeyを動かす準備は整いました。
 
@@ -82,38 +104,54 @@ Debianをお使いであれば、`build-essential`パッケージをインスト
 `NODE_ENV=production npm start`するだけです。GLHF!
 
 ### systemdを用いた起動
-1. systemdサービスのファイルを作成: `/etc/systemd/system/misskey.service`
+1. systemdサービスのファイルを作成
+
+	`/etc/systemd/system/misskey.service`
+
 2. エディタで開き、以下のコードを貼り付けて保存:
 
-```
-[Unit]
-Description=Misskey daemon
+	```
+	[Unit]
+	Description=Misskey daemon
 
-[Service]
-Type=simple
-User=misskey
-ExecStart=/usr/bin/npm start
-WorkingDirectory=/home/misskey/misskey
-Environment="NODE_ENV=production"
-TimeoutSec=60
-StandardOutput=syslog
-StandardError=syslog
-SyslogIdentifier=misskey
-Restart=always
+	[Service]
+	Type=simple
+	User=misskey
+	ExecStart=/usr/bin/npm start
+	WorkingDirectory=/home/misskey/misskey
+	Environment="NODE_ENV=production"
+	TimeoutSec=60
+	StandardOutput=syslog
+	StandardError=syslog
+	SyslogIdentifier=misskey
+	Restart=always
 
-[Install]
-WantedBy=multi-user.target
-```
-CentOSで1024以下のポートを使用してMisskeyを使用する場合は`ExecStart=/usr/bin/sudo /usr/bin/npm start`に変更する必要があります。
+	[Install]
+	WantedBy=multi-user.target
+	```
 
-3. `systemctl daemon-reload ; systemctl enable misskey` systemdを再読み込みしmisskeyサービスを有効化
-4. `systemctl start misskey` misskeyサービスの起動
+	CentOSで1024以下のポートを使用してMisskeyを使用する場合は`ExecStart=/usr/bin/sudo /usr/bin/npm start`に変更する必要があります。
+
+3. systemdを再読み込みしmisskeyサービスを有効化
+
+	`systemctl daemon-reload ; systemctl enable misskey`
+
+4. misskeyサービスの起動
+
+	`systemctl start misskey`
 
 `systemctl status misskey`と入力すると、サービスの状態を調べることができます。
 
 ### Misskeyを最新バージョンにアップデートする方法:
 1. `git fetch`
-2. `git checkout $(git tag -l | grep -v 'rc[0-9]*$' | sort -V | tail -n 1)`
+2. 　
+
+   ```bash
+   git checkout \
+   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
+   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   ```
+
 3. `npm install`
 4. `NODE_ENV=production npm run build`
 5. [ChangeLog](../CHANGELOG.md)でマイグレーション情報を確認する

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -59,9 +59,11 @@ adduser --disabled-password --disabled-login misskey
 4. [最新のリリース](https://github.com/syuilo/misskey/releases/latest)を確認
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 5. Misskeyの依存パッケージをインストール
 
@@ -147,9 +149,11 @@ npm run init
 2. 　
 
    ```bash
-   git checkout \
-   $(curl -s 'https://api.github.com/repos/syuilo/misskey/releases/latest' \
-   | sed -En 's/.*"tag_name": "([^"]+)".*/\1/gp')
+   git tag | grep '^10\.' | sort -V --reverse | \
+   while read tag_name; do \
+   if ! curl -s "https://api.github.com/repos/syuilo/misskey/releases/tags/$tag_name" \
+   | grep -qE '"(draft|prerelease)": true'; \
+   then git checkout $tag_name; break; fi ; done
    ```
 
 3. `npm install`


### PR DESCRIPTION
## 概要
安定版としてv10ブランチで10.xは残っているわけですが、最新リリースをチェックアウトするともれなく11.xがインストールされてしまうのでコマンドを修正しました。  
また、コマンドが長すぎて1行に収まらないので番号付きリストのフォーマットを変更しました。

いままで:
```
1. `echo "Hello, Misskey."` コマンドの説明
```

これから:
```
1. コマンドの説明

   `echo "Hello, Misskey"`
```

## 仕組み

1. `git tag`でタグ一覧を取得（これまでと同じ）
2. `grep`で10.xのタグだけにする
3. `sort -V --reverse`で降順に並び替える
4. 各タグのリリースの情報をGitHub apiで取得
5. prereleaseでもdraftでもないリリースだったらそのタグをチェックアウト