### PR TITLE
Fix: ObjectStrage利用時にドライブファイルアイコンが表示されない (v10)

### DIFF
--- a/src/client/app/common/views/widgets/post-form.vue
+++ b/src/client/app/common/views/widgets/post-form.vue
@@ -24,7 +24,7 @@
 			<div class="files" v-show="files.length != 0">
 				<x-draggable :list="files" :options="{ animation: 150 }">
 					<div v-for="file in files" :key="file.id">
-						<div class="img" :style="{ backgroundImage: `url(${file.thumbnailUrl})` }" :title="file.name"></div>
+						<div class="img" :style="{ backgroundImage: `url(${file.thumbnailUrl || '/assets/thumbnail-not-available.png'})` }" :title="file.name"></div>
 						<img class="remove" @click="detachMedia(file.id)" src="/assets/desktop/remove.png" :title="$t('attach-cancel')" alt=""/>
 					</div>
 				</x-draggable>
@@ -263,17 +263,14 @@ export default define({
 				border solid 4px transparent
 				cursor move
 
-				&:hover > .remove
-					display block
-
 				> .img
 					width 64px
 					height 64px
 					background-size cover
 					background-position center center
+					background-color: rgba(128, 128, 128, 0.3)
 
 				> .remove
-					display none
 					position absolute
 					top -6px
 					right -6px

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -30,7 +30,7 @@
 			<div class="files" :class="{ with: poll }" v-show="files.length != 0">
 				<x-draggable :list="files" :options="{ animation: 150 }">
 					<div v-for="file in files" :key="file.id">
-						<div class="img" :style="{ backgroundImage: `url(${file.thumbnailUrl})` }" :title="file.name"></div>
+						<div class="img" :style="{ backgroundImage: `url(${file.thumbnailUrl || '/assets/thumbnail-not-available.png'})` }" :title="file.name"></div>
 						<img class="remove" @click="detachMedia(file.id)" src="/assets/desktop/remove.png" :title="$t('attach-cancel')" alt=""/>
 					</div>
 				</x-draggable>
@@ -640,17 +640,14 @@ export default Vue.extend({
 						border solid 4px transparent
 						cursor move
 
-						&:hover > .remove
-							display block
-
 						> .img
 							width 64px
 							height 64px
 							background-size cover
 							background-position center center
+							background-color: rgba(128, 128, 128, 0.3)
 
 						> .remove
-							display none
 							position absolute
 							top -6px
 							right -6px

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -24,7 +24,7 @@
 			<div class="attaches" v-show="files.length != 0">
 				<x-draggable class="files" :list="files" :options="{ animation: 150 }">
 					<div class="file" v-for="file in files" :key="file.id">
-						<div class="img" :style="`background-image: url(${file.thumbnailUrl})`" @click="detachMedia(file)"></div>
+						<div class="img" :style="`background-image: url(${file.thumbnailUrl || '/assets/thumbnail-not-available.png'})`" @click="detachMedia(file)"></div>
 					</div>
 				</x-draggable>
 			</div>
@@ -506,6 +506,7 @@ export default Vue.extend({
 							height 64px
 							background-size cover
 							background-position center center
+							background-color: rgba(128, 128, 128, 0.3)
 
 			> .mk-uploader
 				margin 8px 0 0 0

--- a/src/misc/get-drive-file-url.ts
+++ b/src/misc/get-drive-file-url.ts
@@ -8,7 +8,7 @@ export default function(file: IDriveFile, thumbnail = false): string {
 
 	if (file.metadata.withoutChunks) {
 		if (thumbnail) {
-			return file.metadata.thumbnailUrl || file.metadata.webpublicUrl || (isImage ? file.metadata.url : '/assets/thumbnail-not-available.png');
+			return file.metadata.thumbnailUrl || file.metadata.webpublicUrl || (isImage ? file.metadata.url : null);
 		} else {
 			return file.metadata.webpublicUrl || file.metadata.url;
 		}


### PR DESCRIPTION
## Summary
#4673 など for v10
- ObjectStrage利用時にドライブで非メディアファイルのアイコンが表示されないのを修正
- 投稿フォームでサムネイルが利用できないファイルの場合に「thumbnail not available」になる仕様は、ObjectStrage利用時も未利用時もそのまま
- 投稿フォームでサムネイルが読み込めなくても、何か添付があることはわかるように修正
![image](https://user-images.githubusercontent.com/30769358/56090030-02d4f080-5ed7-11e9-9d5c-364e8a2dc686.png)
