### PR TITLE
Docker: Uncomment redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,13 @@ services:
       - internal_network
       - external_network
 
-#  redis:
-#    restart: always
-#    image: redis:4.0-alpine
-#    networks:
-#      - internal_network
-#    volumes:
-#      - ./redis:/data
+  redis:
+    restart: always
+    image: redis:4.0-alpine
+    networks:
+      - internal_network
+    volumes:
+      - ./redis:/data
 
   db:
     restart: always


### PR DESCRIPTION
## 概要
Misskey 11.0.0からRedisが必須になったので、それをdocker-compose.ymlに反映しました。