### PR TITLE
Fix: admin/driveのアイコンがずれてる

### DIFF
--- a/src/client/app/admin/views/drive.vue
+++ b/src/client/app/admin/views/drive.vue
@@ -242,7 +242,7 @@ export default Vue.extend({
 
 		> div:nth-child(1)
 			> .thumbnail
-				display block
+				display flex
 				width 64px
 				height 64px
 				background-size cover


### PR DESCRIPTION
## Summary
#4674 で管理画面でアイコンが寄っているのを修正
v10は #4708 で修正済み

Before
![image](https://user-images.githubusercontent.com/30769358/56153211-94845100-5ff0-11e9-9630-338ee9fa7629.png)
After
![image](https://user-images.githubusercontent.com/30769358/56153218-95b57e00-5ff0-11e9-896d-d4dc8469f81b.png)
