### PR TITLE
Correct syntax error

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -134,7 +134,7 @@ export default (opts: Opts = {}) => ({
 		},
 
 		reactDirectly(reaction) {
-			(this.$root.api('notes/reactions/create', {
+			this.$root.api('notes/reactions/create', {
 				noteId: this.appearNote.id,
 				reaction: reaction
 			});

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -1,4 +1,4 @@
-@charset 'utf-8'
+@charset "utf-8"
 
 /*
 	::selection


### PR DESCRIPTION
## Summary

あいにく見つかってしまったので・・・
* 削除されなかった片方の（
* charset定義時には「’」ではなく「”」を使わなければならないんだそうです