### PR TITLE
Metaのアクセスでトランザクションを張るように

### DIFF
--- a/src/client/app/admin/views/instance.vue
+++ b/src/client/app/admin/views/instance.vue
@@ -195,7 +195,7 @@ export default Vue.extend({
 	},
 
 	created() {
-		this.$root.getMeta().then(meta => {
+		this.$root.getMeta(true).then(meta => {
 			this.maintainerName = meta.maintainerName;
 			this.maintainerEmail = meta.maintainerEmail;
 			this.disableRegistration = meta.disableRegistration;

--- a/src/server/api/endpoints/admin/update-meta.ts
+++ b/src/server/api/endpoints/admin/update-meta.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy';
 import define from '../../define';
-import { Metas } from '../../../../models';
+import { getConnection } from 'typeorm';
 import { Meta } from '../../../../models/entities/meta';
 
 export const meta = {
@@ -505,11 +505,17 @@ export default define(meta, async (ps) => {
 		set.swPrivateKey = ps.swPrivateKey;
 	}
 
-	const meta = await Metas.findOne();
+	await getConnection().transaction(async transactionalEntityManager => {
+		const meta = await transactionalEntityManager.findOne(Meta, {
+			order: {
+				id: 'DESC'
+			}
+		});
 
-	if (meta) {
-		await Metas.update(meta.id, set);
-	} else {
-		await Metas.save(set);
-	}
+		if (meta) {
+			await transactionalEntityManager.update(Meta, meta.id, set);
+		} else {
+			await transactionalEntityManager.save(Meta, set);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
Fix #4719
- 管理画面のインスタンスページではMetaをキャッシュしないように
- Metaのアクセスでトランザクションを張るように

常に同じIDで保存してユニーク制約でこけさせることも考えたけど
既におかしい環境が修正できないので。