### PR TITLE
Docker: Back to npm from yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,11 @@ RUN apk add --no-cache \
     pkgconfig \
     python \
     zlib-dev
-RUN npm i -g yarn
 
 COPY package.json ./
-RUN yarn install
+RUN npm i
 COPY . ./
-RUN yarn build
+RUN npm run build
 
 FROM base AS runner
 


### PR DESCRIPTION
## Summary
yarnではなくセットアップドキュメントと同様にnpmを使うようにする変更です。  
yarnとnpmの差異に依存する不具合は発生しなくなるはずです。

過去にビルドできなくなっていたのは、`npm i`する時に`src/crypto_key.cc`がビルドされていなかったためです。  
現在は`src/crypto_key.cc`は無いのでビルドエラーは再現しません。

なお、migrationブランチ用のDockerfileは後日作成予定です。  
後でdevelopブランチやmasterブランチにマージする時に必要になると思います。

なお、このプルリクエストは https://github.com/syuilo/misskey/pull/4698 と競合してます。