### PR TITLE
Fix: v11で未認知ユーザーからActivityが飛んできた場合に処理できない

### DIFF
--- a/src/queue/processors/inbox.ts
+++ b/src/queue/processors/inbox.ts
@@ -14,6 +14,7 @@ import { UserPublickey } from '../../models/entities/user-publickey';
 import fetchMeta from '../../misc/fetch-meta';
 import { toPuny, toPunyNullable } from '../../misc/convert-host';
 import { validActor } from '../../remote/activitypub/type';
+import { ensure } from '../../prelude/ensure';
 
 const logger = new Logger('inbox');
 
@@ -30,41 +31,12 @@ export default async (job: Bull.Job): Promise<void> => {
 	//#endregion
 
 	const keyIdLower = signature.keyId.toLowerCase();
-	let user: IRemoteUser | undefined;
-	let key: UserPublickey | undefined;
+	let user: IRemoteUser;
+	let key: UserPublickey;
 
 	if (keyIdLower.startsWith('acct:')) {
-		const acct = parseAcct(keyIdLower.slice('acct:'.length));
-		const host = toPunyNullable(acct.host);
-		const username = toPuny(acct.username);
-
-		if (host === null) {
-			logger.warn(`request was made by local user: @${username}`);
-			return;
-		}
-
-		// アクティビティ内のホストの検証
-		try {
-			ValidateActivity(activity, host);
-		} catch (e) {
-			logger.warn(e.message);
-			return;
-		}
-
-		// ブロックしてたら中断
-		// TODO: いちいちデータベースにアクセスするのはコスト高そうなのでどっかにキャッシュしておく
-		const meta = await fetchMeta();
-		if (meta.blockedHosts.includes(host)) {
-			logger.info(`Blocked request: ${host}`);
-			return;
-		}
-
-		user = await Users.findOne({
-			usernameLower: username.toLowerCase(),
-			host: host
-		}) as IRemoteUser;
-
-		key = await UserPublickeys.findOne(user.id);
+		logger.warn(`Old keyId is no longer supported. ${keyIdLower}`);
+		return;
 	} else {
 		// アクティビティ内のホストの検証
 		const host = toPuny(new URL(signature.keyId).hostname);
@@ -83,34 +55,35 @@ export default async (job: Bull.Job): Promise<void> => {
 			return;
 		}
 
-		key = await UserPublickeys.findOne({
+		const _key = await UserPublickeys.findOne({
 			keyId: signature.keyId
 		});
 
-		if (key) user = await Users.findOne(key.userId) as IRemoteUser;
+		if (_key) {
+			// 登録済みユーザー
+			user = await Users.findOne(_key.userId) as IRemoteUser;
+			key = _key;
+		} else {
+			// 未登録ユーザーの場合はリモート解決
+			user = await resolvePerson(activity.actor) as IRemoteUser;
+			if (user == null) {
+				throw new Error('failed to resolve user');
+			}
+
+			key = await UserPublickeys.findOne(user.id).then(ensure);
+		}
 	}
 
 	// Update Person activityの場合は、ここで署名検証/更新処理まで実施して終了
 	if (activity.type === 'Update') {
 		if (activity.object && validActor.includes(activity.object.type)) {
-			if (user == null || key == null) {
-				logger.warn('Update activity received, but user not registed.');
-			} else if (!httpSignature.verifySignature(signature, key.keyPem)) {
+			if (!httpSignature.verifySignature(signature, key.keyPem)) {
 				logger.warn('Update activity received, but signature verification failed.');
 			} else {
 				updatePerson(activity.actor, null, activity.object);
 			}
 			return;
 		}
-	}
-
-	// アクティビティを送信してきたユーザーがまだMisskeyサーバーに登録されていなかったら登録する
-	if (user == null) {
-		user = await resolvePerson(activity.actor) as IRemoteUser;
-	}
-
-	if (user == null || key == null) {
-		throw new Error('failed to resolve user');
 	}
 
 	if (!httpSignature.verifySignature(signature, key.keyPem)) {


### PR DESCRIPTION
## Summary
Related #4729 

- v11で未認知ユーザーからActivityが飛んできた場合 (いきなりフォローされたなど) にエラーになるのを修正
- `acct:`で始まる古いkeyID (#1828) のサポートを廃止
  (まず来ない上に、これ用のコード書いて~~検証するのがめんどい~~ 検証する方法がないので、Pleromaですらサポートしてないのでまず大丈夫だと思います)
