### PR TITLE
Fix: リモートユーザーの修復処理が自動的に実行されない for v10

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -294,13 +294,6 @@ export async function updatePerson(uri: string, resolver?: Resolver, hint?: obje
 	}
 	//#endregion
 
-	// 繋がらないインスタンスに何回も試行するのを防ぐ, 後続の同様処理の連続試行を防ぐ ため 試行前にも更新する
-	await User.update({ _id: exist._id }, {
-		$set: {
-			lastFetchedAt: new Date(),
-		},
-	});
-
 	if (resolver == null) resolver = new Resolver();
 
 	const object = hint || await resolver.resolve(uri) as any;

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -9,7 +9,7 @@ import chalk from 'chalk';
 
 const logger = remoteLogger.createSubLogger('resolve-user');
 
-export default async (username: string, _host: string, option?: any, resync?: boolean): Promise<IUser> => {
+export default async (username: string, _host: string, option?: any, resync = false): Promise<IUser> => {
 	const usernameLower = username.toLowerCase();
 
 	if (_host == null) {

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -41,6 +41,13 @@ export default async (username: string, _host: string, option?: any, resync?: bo
 
 	// resyncオプション OR ユーザー情報が古い場合は、WebFilgerからやりなおして返す
 	if (resync || user.lastFetchedAt == null || Date.now() - user.lastFetchedAt.getTime() > 1000 * 60 * 60 * 24) {
+		// 繋がらないインスタンスに何回も試行するのを防ぐ, 後続の同様処理の連続試行を防ぐ ため 試行前にも更新する
+		await User.update({ _id: user._id }, {
+			$set: {
+				lastFetchedAt: new Date(),
+			},
+		});
+
 		logger.info(`try resync: ${acctLower}`);
 		const self = await resolveSelf(acctLower);
 

--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -28,7 +28,7 @@ export default async (username: string, _host: string, option?: any, resync?: bo
 		return await User.findOne({ usernameLower, host: null });
 	}
 
-	const user = await User.findOne({ usernameLower, host }, option);
+	const user = await User.findOne({ usernameLower, host }, option) as IRemoteUser;
 
 	const acctLower = `${usernameLower}@${hostAscii}`;
 
@@ -39,14 +39,15 @@ export default async (username: string, _host: string, option?: any, resync?: bo
 		return await createPerson(self.href);
 	}
 
-	if (resync) {
+	// resyncオプション OR ユーザー情報が古い場合は、WebFilgerからやりなおして返す
+	if (resync || user.lastFetchedAt == null || Date.now() - user.lastFetchedAt.getTime() > 1000 * 60 * 60 * 24) {
 		logger.info(`try resync: ${acctLower}`);
 		const self = await resolveSelf(acctLower);
 
-		if ((user as IRemoteUser).uri !== self.href) {
+		if (user.uri !== self.href) {
 			// if uri mismatch, Fix (user@host <=> AP's Person id(IRemoteUser.uri)) mapping.
 			logger.info(`uri missmatch: ${acctLower}`);
-			logger.info(`recovery missmatch uri for (username=${username}, host=${host}) from ${(user as IRemoteUser).uri} to ${self.href}`);
+			logger.info(`recovery missmatch uri for (username=${username}, host=${host}) from ${user.uri} to ${self.href}`);
 
 			// validate uri
 			const uri = new URL(self.href);

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -96,9 +96,6 @@ export default define(meta, async (ps, me) => {
 			throw new ApiError(meta.errors.noSuchUser);
 		}
 
-		// ユーザー情報更新
-		resolveRemoteUser(ps.username, ps.host, { }, false);
-
 		return await pack(user, me, {
 			detail: true
 		});

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy';
 import ID, { transform, transformMany } from '../../../../misc/cafy-id';
-import User, { pack, isRemoteUser } from '../../../../models/user';
+import User, { pack } from '../../../../models/user';
 import resolveRemoteUser from '../../../../remote/resolve-user';
 import define from '../../define';
 import { apiLogger } from '../../logger';
@@ -97,11 +97,7 @@ export default define(meta, async (ps, me) => {
 		}
 
 		// ユーザー情報更新
-		if (isRemoteUser(user)) {
-			if (user.lastFetchedAt == null || Date.now() - user.lastFetchedAt.getTime() > 1000 * 60 * 60 * 24) {
-				resolveRemoteUser(ps.username, ps.host, { }, true);
-			}
-		}
+		resolveRemoteUser(ps.username, ps.host, { }, false);
 
 		return await pack(user, me, {
 			detail: true


### PR DESCRIPTION
## Summary
Fix #4761 for v10
- updatePersonでlastFetchedAtの事前更新をしないように
- resolve-userで古かったら (resyncが未指定でも)
  lastFetchedAtの事前更新 / WebFinger / updatePerson をするように

結果的に、ユーザー情報閲覧 (users/show) と ローカルからメンションされた時に
ユーザー情報が古かったらWebFingerから更新されるようになっています。