### PR TITLE
Fix: リモートユーザーの修復処理が自動的に実行されない など for v11

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -271,11 +271,6 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 	}
 	//#endregion
 
-	// 繋がらないインスタンスに何回も試行するのを防ぐ, 後続の同様処理の連続試行を防ぐ ため 試行前にも更新する
-	await Users.update(exist.id, {
-		lastFetchedAt: new Date(),
-	});
-
 	if (resolver == null) resolver = new Resolver();
 
 	const object = hint || await resolver.resolve(uri) as any;

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -344,13 +344,13 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 		url: person.url,
 		fields,
 		description: person.summary ? fromHtml(person.summary) : null,
-		twitterUserId: services.twitter.userId,
-		twitterScreenName: services.twitter.screenName,
-		githubId: services.github.id,
-		githubLogin: services.github.login,
-		discordId: services.discord.id,
-		discordUsername: services.discord.username,
-		discordDiscriminator: services.discord.discriminator,
+		twitterUserId: services.twitter ? services.twitter.userId : null,
+		twitterScreenName: services.twitter ? services.twitter.screenName : null,
+		githubId: services.github ? services.github.id : null,
+		githubLogin: services.github ? services.github.login : null,
+		discordId: services.discord ? services.discord.id : null,
+		discordUsername: services.discord ? services.discord.username : null,
+		discordDiscriminator: services.discord ? services.discord.discriminator : null,
 	});
 
 	// ハッシュタグ更新

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -95,13 +95,6 @@ export default define(meta, async (ps, me) => {
 			throw new ApiError(meta.errors.noSuchUser);
 		}
 
-		// ユーザー情報更新
-		if (Users.isRemoteUser(user)) {
-			if (user.lastFetchedAt == null || Date.now() - user.lastFetchedAt.getTime() > 1000 * 60 * 60 * 24) {
-				resolveUser(user.username, user.host, { }, true);
-			}
-		}
-
 		return await Users.pack(user, me, {
 			detail: true
 		});


### PR DESCRIPTION
## Summary
Fix #4761 for v11 と 他のバグ1件修正

for v10 #4763 にある以下の修正の他に
> - updatePersonでlastFetchedAtの事前更新をしないように
> - resolve-userで古かったら (resyncが未指定でも)
> - lastFetchedAtの事前更新 / WebFinger / updatePerson をするように
>
> 結果的に、ユーザー情報閲覧 (users/show) と ローカルからメンションされた時に
> ユーザー情報が古かったらWebFingerから更新されるようになっています。

v11のみにある
updatePersonでUserProfiles, ハッシュタグ, ピン留め投稿 などが更新されないバグを修正しています。