### PR TITLE
Docker: Remove quotes in docker_example.env

### DIFF
--- a/.config/docker_example.env
+++ b/.config/docker_example.env
@@ -1,5 +1,4 @@
 # db settings
-POSTGRES_PASSWORD="example-misskey-pass"
-POSTGRES_USER="example-misskey-user"
-POSTGRES_DB="misskey"
-
+POSTGRES_PASSWORD=example-misskey-pass
+POSTGRES_USER=example-misskey-user
+POSTGRES_DB=misskey


### PR DESCRIPTION
## Summary

Dockerはenv_fileのクォーテーションマークを解析しないようです。  
もしdocker.envが以下のようになっていたとします。

```
POSTGRES_PASSWORD="example-misskey-pass"
POSTGRES_USER="example-misskey-user"
POSTGRES_DB="misskey"
```

その場合、実際に設定されるPostgresqlのパスワードは`"example-misskey-pass"`となります。  
クォーテーションマーク込みになるので予期しない動作に見えるかもしれません。

そこで、`docker_example.env`からクォーテーションマークを消すことにしました。