### PR TITLE
Use Snowflake ID in v10

### DIFF
--- a/src/misc/gen-id.ts
+++ b/src/misc/gen-id.ts
@@ -1,0 +1,12 @@
+import { genMeid7 } from './id/meid7';
+
+const method = 'meid7';
+
+export function genId(date?: Date): string {
+	if (!date || (date > new Date())) date = new Date();
+
+	switch (method) {
+		case 'meid7': return genMeid7(date);
+		default: throw new Error('unknown id generation method');
+	}
+}

--- a/src/misc/id/meid7.ts
+++ b/src/misc/id/meid7.ts
@@ -1,0 +1,28 @@
+const CHARS = '0123456789abcdef';
+
+//  4bit Fixed hex value '7'
+// 44bit UNIX Time ms in Hex
+// 48bit Random value in Hex
+
+function getTime(time: number) {
+	if (time < 0) time = 0;
+	if (time === 0) {
+		return CHARS[0];
+	}
+
+	return time.toString(16).padStart(11, CHARS[0]);
+}
+
+function getRandom() {
+	let str = '';
+
+	for (let i = 0; i < 12; i++) {
+		str += CHARS[Math.floor(Math.random() * CHARS.length)];
+	}
+
+	return str;
+}
+
+export function genMeid7(date: Date): string {
+	return '7' + getTime(date.getTime()) + getRandom();
+}

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -34,6 +34,7 @@ import Instance from '../../models/instance';
 import extractMentions from '../../misc/extract-mentions';
 import extractEmojis from '../../misc/extract-emojis';
 import extractHashtags from '../../misc/extract-hashtags';
+import { genId } from '../../misc/gen-id';
 
 type NotificationType = 'reply' | 'renote' | 'quote' | 'mention';
 
@@ -434,6 +435,7 @@ async function publish(user: IUser, note: INote, noteObj: any, reply: INote, ren
 
 async function insertNote(user: IUser, data: Option, tags: string[], emojis: string[], mentionedUsers: IUser[]) {
 	const insert: any = {
+		_id: genId(data.createdAt),
 		createdAt: data.createdAt,
 		fileIds: data.files ? data.files.map(file => file._id) : [],
 		replyId: data.reply ? data.reply._id : null,


### PR DESCRIPTION
## Summary
Related #2497 

投稿IDの生成方法を生成日時基準のIDに変更しています

ObjectID
```
32bit UNIX time sec in Hex (到着日時基準)
64bit noise
```

New Note ID
```
 4bit Fixed hex value '7'
44bit UNIX Time ms in Hex (生成日時基準)
48bit noise
```

投稿IDをミリ秒精度で生成するように 
→1秒未満の投稿の順番がくずれなくなる

投稿IDを到着日時ではなく生成日時で生成するように 
→遅延到着, Renote等で到着した投稿が順番通り表示されるようになる

IDは`7xxxxxxxxxxxxxxxxxxxxxxx`のように現状と同じ24文字Hex文字列で
未採番部分の時刻を表すIDを使うようにしているため現行IDと重複なくつながります。