### PR TITLE
Hot fix: ポストフォームでファイルを投稿した際、nullが返ってきたときに追加しないように

### DIFF
--- a/src/client/app/common/views/widgets/post-form.vue
+++ b/src/client/app/common/views/widgets/post-form.vue
@@ -97,6 +97,7 @@ export default define({
 		},
 
 		attachMedia(driveFile) {
+			if (!driveFile) return;
 			this.files.push(driveFile);
 			this.$emit('change-attached-files', this.files);
 		},

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -275,6 +275,7 @@ export default Vue.extend({
 		},
 
 		attachMedia(driveFile) {
+			if (!driveFile) return;
 			this.files.push(driveFile);
 			this.$emit('change-attached-files', this.files);
 		},

--- a/src/client/app/desktop/views/components/post-form.vue
+++ b/src/client/app/desktop/views/components/post-form.vue
@@ -228,7 +228,7 @@ export default Vue.extend({
 				const draft = JSON.parse(localStorage.getItem('drafts') || '{}')[this.draftId];
 				if (draft) {
 					this.text = draft.data.text;
-					this.files = draft.data.files;
+					this.files = (draft.data.files || []).filter(e => e);
 					if (draft.data.poll) {
 						this.poll = true;
 						this.$nextTick(() => {

--- a/src/client/app/mobile/views/components/post-form.vue
+++ b/src/client/app/mobile/views/components/post-form.vue
@@ -254,6 +254,7 @@ export default Vue.extend({
 		},
 
 		attachMedia(driveFile) {
+			if (!driveFile) return;
 			this.files.push(driveFile);
 			this.$emit('change-attached-files', this.files);
 		},


### PR DESCRIPTION
## Summary
ポストフォームで、ドライブのファイル作成結果がnullと返ってくると（←原因は不明だが）`files: [null]`となり、UI上で削除できなくて詰むのを修正  
デスクトップでは書きかけの投稿を復元するときに== trueのものだけを復元するように