### PR TITLE
Fix: Mastodon v2.8.0 のフォローリストがインポートできない

### DIFF
--- a/src/queue/processors/db/import-following.ts
+++ b/src/queue/processors/db/import-following.ts
@@ -34,7 +34,8 @@ export async function importFollowing(job: Bull.Job, done: any): Promise<void> {
 		linenum++;
 
 		try {
-			const { username, host } = parseAcct(line.trim());
+			const acct = line.split(',')[0].trim();
+			const { username, host } = parseAcct(acct);
 
 			let target = isSelfHost(host) ? await User.findOne({
 				host: null,


### PR DESCRIPTION
## Summary
Fix #4816 for v10

ヘッダ行がエラーになるけど、確実にヘッダ行を特定する方法がないので無視。