### PR TITLE
IDが誤採番されたインスタンス修復用のIDロジック

### DIFF
--- a/src/misc/gen-id.ts
+++ b/src/misc/gen-id.ts
@@ -1,6 +1,7 @@
 import { ulid } from 'ulid';
 import { genAid } from './id/aid';
 import { genMeid } from './id/meid';
+import { genMeidg } from './id/meidg';
 import { genObjectId } from './id/object-id';
 import config from '../config';
 
@@ -12,6 +13,7 @@ export function genId(date?: Date): string {
 	switch (metohd) {
 		case 'aid': return genAid(date);
 		case 'meid': return genMeid(date);
+		case 'meidg': return genMeidg(date);
 		case 'ulid': return ulid(date.getTime());
 		case 'objectid': return genObjectId(date);
 		default: throw new Error('unknown id generation method');

--- a/src/misc/id/meidg.ts
+++ b/src/misc/id/meidg.ts
@@ -1,0 +1,28 @@
+const CHARS = '0123456789abcdef';
+
+//  4bit Fixed hex value 'g'
+// 44bit UNIX Time ms in Hex
+// 48bit Random value in Hex
+
+function getTime(time: number) {
+	if (time < 0) time = 0;
+	if (time === 0) {
+		return CHARS[0];
+	}
+
+	return time.toString(16).padStart(11, CHARS[0]);
+}
+
+function getRandom() {
+	let str = '';
+
+	for (let i = 0; i < 12; i++) {
+		str += CHARS[Math.floor(Math.random() * CHARS.length)];
+	}
+
+	return str;
+}
+
+export function genMeidg(date: Date): string {
+	return 'g' + getTime(date.getTime()) + getRandom();
+}


### PR DESCRIPTION
## Summary
Resolve #4815

の修復用のために`meidg`というIDロジックを入れる (隠しなのでexample.ymlには明記しない)
```
5xxxxxxxxxxxxxxxxxxxxxxx ←マイグレ前の採番
:
f8xxxxxxxxxxxxxxxxxxxxxxx ←マイグレ後の誤採番
:
gxxxxxxxxxxxxxxxxxxxxxxx ←meidgの採番
```
