### PR TITLE
Fix external service authentication

### DIFF
--- a/migration/1556746559567-UserProfile.ts
+++ b/migration/1556746559567-UserProfile.ts
@@ -1,0 +1,23 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UserProfile1556746559567 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`UPDATE "user_profile" SET github = FALSE`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "githubId"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "githubId" VARCHAR(64)`);
+        await queryRunner.query(`UPDATE "user_profile" SET discord = FALSE`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "discordExpiresDate"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "discordExpiresDate" VARCHAR(64)`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`UPDATE "user_profile" SET github = FALSE`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "githubId"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "githubId" INTEGER`);
+        await queryRunner.query(`UPDATE "user_profile" SET discord = FALSE`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "discordExpiresDate"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "discordExpiresDate" INTEGER`);
+    }
+
+}

--- a/src/models/entities/user-profile.ts
+++ b/src/models/entities/user-profile.ts
@@ -144,10 +144,10 @@ export class UserProfile {
 	})
 	public githubAccessToken: string | null;
 
-	@Column('integer', {
-		nullable: true, default: null,
+	@Column('varchar', {
+		length: 64, nullable: true, default: null,
 	})
-	public githubId: number | null;
+	public githubId: string | null;
 
 	@Column('varchar', {
 		length: 64, nullable: true, default: null,
@@ -169,10 +169,10 @@ export class UserProfile {
 	})
 	public discordRefreshToken: string | null;
 
-	@Column('integer', {
-		nullable: true, default: null,
+	@Column('varchar', {
+		length: 64, nullable: true, default: null,
 	})
-	public discordExpiresDate: number | null;
+	public discordExpiresDate: string | null;
 
 	@Column('varchar', {
 		length: 64, nullable: true, default: null,

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -203,12 +203,8 @@ router.get('/dc/cb', async ctx => {
 		}
 
 		const profile = await UserProfiles.createQueryBuilder()
-			.where('discord @> :discord', {
-				discord: {
-					id: id,
-				},
-			})
-			.andWhere('userHost IS NULL')
+			.where('"discordId" = :id', { id: id })
+			.andWhere('"userHost" IS NULL')
 			.getOne();
 
 		if (profile == null) {

--- a/src/server/api/service/github.ts
+++ b/src/server/api/service/github.ts
@@ -193,12 +193,8 @@ router.get('/gh/cb', async ctx => {
 		}
 
 		const link = await UserProfiles.createQueryBuilder()
-			.where('github @> :github', {
-				github: {
-					id: id,
-				},
-			})
-			.andWhere('userHost IS NULL')
+			.where('"githubId" = :id', { id: id })
+			.andWhere('"userHost" IS NULL')
 			.getOne();
 
 		if (link == null) {

--- a/src/server/api/service/twitter.ts
+++ b/src/server/api/service/twitter.ts
@@ -141,12 +141,8 @@ router.get('/tw/cb', async ctx => {
 		const result = await twAuth!.done(JSON.parse(twCtx), ctx.query.oauth_verifier);
 
 		const link = await UserProfiles.createQueryBuilder()
-			.where('twitter @> :twitter', {
-				twitter: {
-					userId: result.userId,
-				},
-			})
-			.andWhere('userHost IS NULL')
+			.where('"twitterUserId" = :id', { id: result.userId })
+			.andWhere('"userHost" IS NULL')
 			.getOne();
 
 		if (link == null) {


### PR DESCRIPTION
## Summary

#4831 から、PRのbranch選択ミスで変なのが混じっちゃって再リクエストします。

`UserProfile`の`discordExpiresDate`のTypeがIntegerだったのでDiscordのOAuth応答の`ExpiresDate`（多分unix timestamp）をアップデートするときこういうエラーが出ています。
```
May 02 05:59:38 tsuki.network misskey[12233]:   QueryFailedError: value "1557349178698" is out of range for type integer
May 02 05:59:38 tsuki.network misskey[12233]:       at new QueryFailedError (/home/misskey/live/node_modules/typeorm/error/QueryFailedError.js:11:28)
May 02 05:59:38 tsuki.network misskey[12233]:       at Query.callback (/home/misskey/live/node_modules/typeorm/driver/postgres/PostgresQueryRunner.js:174:38)
May 02 05:59:38 tsuki.network misskey[12233]:       at Query.handleError (/home/misskey/live/node_modules/pg/lib/query.js:142:17)
May 02 05:59:38 tsuki.network misskey[12233]:       at Connection.connectedErrorMessageHandler (/home/misskey/live/node_modules/pg/lib/client.js:183:17)
May 02 05:59:38 tsuki.network misskey[12233]:       at Connection.emit (events.js:188:13)
May 02 05:59:38 tsuki.network misskey[12233]:       at Socket.<anonymous> (/home/misskey/live/node_modules/pg/lib/connection.js:125:12)
May 02 05:59:38 tsuki.network misskey[12233]:       at Socket.emit (events.js:188:13)
May 02 05:59:38 tsuki.network misskey[12233]:       at addChunk (_stream_readable.js:288:12)
May 02 05:59:38 tsuki.network misskey[12233]:       at readableAddChunk (_stream_readable.js:269:11)
May 02 05:59:38 tsuki.network misskey[12233]:       at Socket.Readable.push (_stream_readable.js:224:10)
May 02 05:59:38 tsuki.network misskey[12233]:       at Pipe.onStreamRead [as onread] (internal/stream_base_commons.js:145:17)
```
このFixと、今も特に問題なく多分今後数年は問題なさそうけど念の為GitHubのUserIDのTypeも変更しました。
Migration スクリプトに関しては アップグレードは suki.tsuki.network で動作確認済みですが
ダウングレードは未検証です。

とりあえずDiscordとGitHub連携は動作確認しました。