### PR TITLE
Cookieでログインした場合ログアウトできるように

### DIFF
--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -126,7 +126,8 @@ export default (os: MiOS) => new Vuex.Store({
 
 		logout(ctx) {
 			ctx.commit('updateI', null);
-			document.cookie = 'i=;';
+			document.cookie = 'i=; max-age=0';
+			document.cookie = 'i=; max-age=0; domain=' + document.location.hostname;
 			localStorage.removeItem('i');
 		},
 


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->

外部サービス連携でログインした場合まだCookieのiを使ってログイン処理を行っているが
ログアウトの時Cookieの削除が実際できてなく何度もログアウトしてもログインされたままになってる

https://suki.tsuki.network/ で動作確認済み
あとコンソールでmisskey.ioでも動作確認済み
~再確認中~