### PR TITLE
外部サービス連携後のPackedUserがその情報を持つように

### DIFF
--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -128,6 +128,19 @@ export class UserRepository extends Repository<User> {
 					detail: true
 				}),
 				twoFactorEnabled: profile!.twoFactorEnabled,
+				twitter: profile!.twitter ? {
+					id: profile!.twitterUserId,
+					screenName: profile!.twitterScreenName
+				} : null,
+				github: profile!.github ? {
+					id: profile!.githubId,
+					login: profile!.githubLogin
+				} : null,
+				discord: profile!.discord ? {
+					id: profile!.discordId,
+					username: profile!.discordUsername,
+					discriminator: profile!.discordDiscriminator
+				} : null,
 			} : {}),
 
 			...(opts.detail && meId === user.id ? {


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
User.packのロジックに外部サービス連携のデータを注入する機能が抜けていて
連携されているアカウントでも設定画面はいつも連携されていないように表示されていました。

この修正後はちゃんと表示されるようになります。
![image](https://user-images.githubusercontent.com/17376330/57155153-b0239000-6e15-11e9-84e2-2ddbcf0da744.png)
