### PR TITLE
ログアウトの処理と外部サービス連携Viewがセッションクッキーを作らないように

### DIFF
--- a/src/client/app/common/views/components/settings/integration.vue
+++ b/src/client/app/common/views/components/settings/integration.vue
@@ -54,7 +54,11 @@ export default Vue.extend({
 	},
 
 	mounted() {
-		document.cookie = `i=${this.$store.state.i.token}`;
+		if (!document.cookie.match(/i=(\w+)/)) {
+			document.cookie = `i=${this.$store.state.i.token}; path=/;` +
+			` domain=${document.location.hostname}; max-age=31536000;` +
+			(document.location.protocol.startsWith('https') ? ' secure' : '');
+		}
 		this.$watch('$store.state.i', () => {
 			if (this.$store.state.i.twitter) {
 				if (this.twitterForm) this.twitterForm.close();

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -126,7 +126,7 @@ export default (os: MiOS) => new Vuex.Store({
 
 		logout(ctx) {
 			ctx.commit('updateI', null);
-			document.cookie = 'i=;';
+			document.cookie = `i=; max-age=0; domain=${document.location.hostname}`;
 			localStorage.removeItem('i');
 		},
 


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->

Cookie でログイン処理をしている外部サービス連携時のログアウトの処理の修正と
設定画面を見るたびにSession Cookieを作ってたことを普通のCookieにしました。