### PR TITLE
2段階認証コードの入力フォームタイプの訂正

### DIFF
--- a/src/client/app/common/views/components/signin.vue
+++ b/src/client/app/common/views/components/signin.vue
@@ -10,7 +10,7 @@
 		<span>{{ $t('password') }}</span>
 		<template #prefix><fa icon="lock"/></template>
 	</ui-input>
-	<ui-input v-if="user && user.twoFactorEnabled" v-model="token" type="number" required>
+	<ui-input v-if="user && user.twoFactorEnabled" v-model="token" type="text" pattern="^[0-9]{6}$" autocomplete="off" spellcheck="false" required>
 		<span>{{ $t('@.2fa') }}</span>
 		<template #prefix><fa icon="gavel"/></template>
 	</ui-input>


### PR DESCRIPTION
## Summary

またやっちゃいました

Fix #4849, Resolve #4848
https://suki.tsuki.network/ で検証済み

![image](https://user-images.githubusercontent.com/17376330/57249767-c7b28100-7080-11e9-9031-29a6c52ded35.png)
ちゃんとstring形式で送ってますし、先頭の０が拔けちゃう問題もなくなってます。
Google Authenticator だと２FAコードは６文字に限定されてるので
`/[0-9]+/`の代わりに`/[0-9]{6}/`を使って入力を検証しています。