### PR TITLE
Fix: IPv4 onlyホストからDualstackホストにAP deliverできない

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -149,3 +149,6 @@ autoAdmin: true
 
 # Clustering
 #clusterLimit: 1
+
+# IP address family used for outgoing request (ipv4, ipv6 or dual)
+#outgoingAddressFamily: ipv4

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -44,6 +44,8 @@ export type Source = {
 	clusterLimit?: number;
 
 	id: string;
+
+	outgoingAddressFamily?: 'ipv4' | 'ipv6' | 'dual';
 };
 
 /**

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -101,11 +101,18 @@ export default async (user: ILocalUser, url: string, object: any) => {
  * Resolve host (with cached, asynchrony)
  */
 async function resolveAddr(domain: string) {
+	const af = config.outgoingAddressFamily || 'ipv4';
+	const useV4 = af == 'ipv4' || af == 'dual';
+	const useV6 = af == 'ipv6' || af == 'dual';
+
+	const promises = [];
+
+	if (!useV4 && !useV6) throw 'No usable address family available';
+	if (useV4) promises.push(resolveAddrInner(domain, { family: 4 }));
+	if (useV6) promises.push(resolveAddrInner(domain, { family: 6 }));
+
 	// v4/v6で先に取得できた方を採用する
-	return await promiseAny([
-		resolveAddrInner(domain, { family: 4 }),
-		resolveAddrInner(domain, { family: 6 })
-	]);
+	return await promiseAny(promises);
 }
 
 function resolveAddrInner(domain: string, options: IRunOptions = {}): Promise<string> {


### PR DESCRIPTION
## Summary
Fix #4871 
IPv4/IPv6両方試行したり接続性をチェックしたりすると、遅かったりややこしかったりするので
AP deliver はデフォルトでIPv4だけ使用するようにして、設定で切り替えられるようにしています。