### PR TITLE
Fix: ピン留め投稿の表示順がおかしい

### DIFF
--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -72,7 +72,10 @@ export class UserRepository extends Repository<User> {
 		const meId = me ? typeof me === 'string' ? me : me.id : null;
 
 		const relation = meId && (meId !== user.id) && opts.detail ? await this.getRelation(meId, user.id) : null;
-		const pins = opts.detail ? await UserNotePinings.find({ userId: user.id }) : [];
+		const pins = opts.detail ? await UserNotePinings.find({
+			where: { userId: user.id },
+			order: { id: 'DESC' }
+		}) : [];
 		const profile = opts.detail ? await UserProfiles.findOne(user.id).then(ensure) : null;
 
 		const falsy = opts.detail ? false : undefined;

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -474,9 +474,15 @@ export async function updateFeatured(userId: User['id']) {
 		.slice(0, 5)
 		.map(item => limit(() => resolveNote(item, resolver))));
 
+	// delete
+	await UserNotePinings.delete({ userId: user.id });
+
+	// とりあえずidを別の時間をで生成して順番を維持
+	let td = 0;
 	for (const note of featuredNotes.filter(note => note != null)) {
+		td -= 1000;
 		UserNotePinings.save({
-			id: genId(),
+			id: genId(new Date(Date.now() + td)),
 			createdAt: new Date(),
 			userId: user.id,
 			noteId: note!.id

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -477,7 +477,7 @@ export async function updateFeatured(userId: User['id']) {
 	// delete
 	await UserNotePinings.delete({ userId: user.id });
 
-	// とりあえずidを別の時間をで生成して順番を維持
+	// とりあえずidを別の時間で生成して順番を維持
 	let td = 0;
 	for (const note of featuredNotes.filter(note => note != null)) {
 		td -= 1000;

--- a/src/server/activitypub/featured.ts
+++ b/src/server/activitypub/featured.ts
@@ -21,7 +21,10 @@ export default async (ctx: Router.IRouterContext) => {
 		return;
 	}
 
-	const pinings = await UserNotePinings.find({ userId: user.id });
+	const pinings = await UserNotePinings.find({
+		where: { userId: user.id },
+		order: { id: 'DESC' }
+	});
 
 	const pinnedNotes = await Promise.all(pinings.map(pining =>
 		Notes.findOne(pining.noteId).then(ensure)));


### PR DESCRIPTION
## Summary
Fix: syuilo#4904

厳密にはリモートからの全件更新時は
ソート順列を追加して、トランザクションかけてdelete=>insertするべきと思われますが
スキーマ変えるのもめんどくさいのでid生成時刻ずらしてお茶を濁しています。