### PR TITLE
Fix: user menu

### DIFF
--- a/src/client/app/common/views/components/user-menu.vue
+++ b/src/client/app/common/views/components/user-menu.vue
@@ -7,7 +7,6 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import copyToClipboard from '../../../common/scripts/copy-to-clipboard';
 import { faExclamationCircle, faMicrophoneSlash } from '@fortawesome/free-solid-svg-icons';
 import { faSnowflake } from '@fortawesome/free-regular-svg-icons';
 
@@ -27,19 +26,23 @@ export default Vue.extend({
 			icon: ['fas', 'list'],
 			text: this.$t('push-to-list'),
 			action: this.pushList
-		}, null, {
-			icon: this.user.isMuted ? ['fas', 'eye'] : ['far', 'eye-slash'],
-			text: this.user.isMuted ? this.$t('unmute') : this.$t('mute'),
-			action: this.toggleMute
-		}, {
-			icon: 'ban',
-			text: this.user.isBlocking ? this.$t('unblock') : this.$t('block'),
-			action: this.toggleBlock
-		}, null, {
-			icon: faExclamationCircle,
-			text: this.$t('report-abuse'),
-			action: this.reportAbuse
-		}];
+		}] as any;
+		
+		if (this.$store.getters.isSignedIn && this.$store.state.i.id != this.user.id) {
+			menu = menu.concat([null, {
+				icon: this.user.isMuted ? ['fas', 'eye'] : ['far', 'eye-slash'],
+				text: this.user.isMuted ? this.$t('unmute') : this.$t('mute'),
+				action: this.toggleMute
+			}, {
+				icon: 'ban',
+				text: this.user.isBlocking ? this.$t('unblock') : this.$t('block'),
+				action: this.toggleBlock
+			}, null, {
+				icon: faExclamationCircle,
+				text: this.$t('report-abuse'),
+				action: this.reportAbuse
+			}]);
+		}
 
 		if (this.$store.getters.isSignedIn && (this.$store.state.i.isAdmin || this.$store.state.i.isModerator)) {
 			menu = menu.concat([null, {

--- a/src/client/app/desktop/views/home/user/user.header.vue
+++ b/src/client/app/desktop/views/home/user/user.header.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="header" :class="{ shadow: $store.state.device.useShadow, round: $store.state.device.roundedCorners }">
 	<div class="banner-container" :style="style">
-		<div class="banner" ref="banner" :style="style" @click="onBannerClick"></div>
+		<div class="banner" ref="banner" :style="style"></div>
 		<div class="fade"></div>
 		<div class="title">
 			<p class="name">
@@ -105,14 +105,6 @@ export default Vue.extend({
 			if (blur <= 10) banner.style.filter = `blur(${blur}px)`;
 		},
 
-		onBannerClick() {
-			if (!this.$store.getters.isSignedIn || this.$store.state.i.id != this.user.id) return;
-
-			this.$updateBanner().then(i => {
-				this.user.bannerUrl = i.bannerUrl;
-			});
-		},
-
 		menu() {
 			this.$root.new(XUserMenu, {
 				source: this.$refs.menu,
@@ -171,9 +163,6 @@ export default Vue.extend({
 
 			> .menu
 				height 100%
-				display block
-				position absolute
-				left -42px
 				padding 0 14px
 				color #fff
 				text-shadow 0 0 8px #000


### PR DESCRIPTION
Fix #4843, Fix #4844 for v11

v10 #4845 と同じ

- Firefoxで自分のメニューが開けないのを修正
- ユーザーページのバナーの使われてないイベントonBannerClickを削除
- 自分のユーザーメニューにはミュートなどを表示しないように
- 不要なimportcopyToClipboardを削除
