### PR TITLE
Better migration for UserProfile1556746559567

### DIFF
--- a/migration/1556746559567-UserProfile.ts
+++ b/migration/1556746559567-UserProfile.ts
@@ -3,21 +3,14 @@ import {MigrationInterface, QueryRunner} from "typeorm";
 export class UserProfile1556746559567 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(`UPDATE "user_profile" SET github = FALSE`);
-        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "githubId"`);
-        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "githubId" VARCHAR(64)`);
-        await queryRunner.query(`UPDATE "user_profile" SET discord = FALSE`);
-        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "discordExpiresDate"`);
-        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "discordExpiresDate" VARCHAR(64)`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "githubId" TYPE VARCHAR(64) USING "githubId"::VARCHAR(64)`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "discordExpiresDate" TYPE VARCHAR(64) USING "discordExpiresDate"::VARCHAR(64)`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(`UPDATE "user_profile" SET github = FALSE`);
-        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "githubId"`);
-        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "githubId" INTEGER`);
-        await queryRunner.query(`UPDATE "user_profile" SET discord = FALSE`);
-        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "discordExpiresDate"`);
-        await queryRunner.query(`ALTER TABLE "user_profile" ADD COLUMN "discordExpiresDate" INTEGER`);
+        await queryRunner.query(`UPDATE "user_profile" SET github = FALSE, discord = FALSE`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "githubId" TYPE INTEGER USING NULL`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "discordExpiresDate" TYPE INTEGER USING NULL`);
     }
 
 }


### PR DESCRIPTION
## Summary

Migration UserProfile1556746559567 
外部サービス連携関連のUserProfileのタイプ訂正、 0e764a2b3e2aed345750b87f4a77bee345598c69 の実行時
GitHubとDiscordの認証が既にある場合認証情報が維持されるようにしてみました。
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
