### PR TITLE
Support PostgreSQL Extra Connection options

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -62,6 +62,10 @@ db:
   user: example-misskey-user
   pass: example-misskey-pass
 
+  # Extra Connection options
+  #extra:
+  #  ssl: true
+
 #   ┌─────────────────────┐
 #───┘ Redis configuration └─────────────────────────────────────
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -14,6 +14,7 @@ export type Source = {
 		db: string;
 		user: string;
 		pass: string;
+		extra?: { [x: string]: string };
 	};
 	redis: {
 		host: string;

--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -93,6 +93,7 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 		username: config.db.user,
 		password: config.db.pass,
 		database: config.db.db,
+		extra: config.db.extra,
 		synchronize: process.env.NODE_ENV === 'test' || sync,
 		dropSchema: process.env.NODE_ENV === 'test' && !justBorrow,
 		logging: log,

--- a/src/ormconfig.ts
+++ b/src/ormconfig.ts
@@ -8,6 +8,7 @@ const json = {
 	username: config.db.user,
 	password: config.db.pass,
 	database: config.db.db,
+	extra: config.db.extra,
 	entities: ['src/models/entities/*.ts'],
 	migrations: ['migration/*.ts'],
 	cli: {


### PR DESCRIPTION
## Summary

HerokuなどのサービスではSSL接続が必須だというので
DB設定でextra（SSLとか）オプションを設定できるように

参考：https://github.com/typeorm/typeorm/issues/278
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
