### PR TITLE
i18n: reaction-picker.vue

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -591,6 +591,7 @@ common/views/components/poll-editor.vue:
 
 common/views/components/reaction-picker.vue:
   choose-reaction: "リアクションを選択"
+  input-reaction-placeholder: "または絵文字を入力"
 
 common/views/components/emoji-picker.vue:
   custom-emoji: "カスタム絵文字"

--- a/src/client/app/common/views/components/reaction-picker.vue
+++ b/src/client/app/common/views/components/reaction-picker.vue
@@ -16,7 +16,7 @@
 			<button @click="react('pudding')" @mouseover="onMouseover" @mouseout="onMouseout" tabindex="10" :title="$t('@.reactions.pudding')" v-particle><mk-reaction-icon reaction="pudding"/></button>
 		</div>
 		<div v-if="enableEmojiReaction" class="text">
-			<input v-model="text" placeholder="または絵文字を入力" @keyup.enter="reactText" @input="tryReactText" v-autocomplete="{ model: 'text' }">
+			<input v-model="text" :placeholder="$t('input-reaction-placeholder')" @keyup.enter="reactText" @input="tryReactText" v-autocomplete="{ model: 'text' }">
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Summary

reaction-picker の任意の絵文字を入力できるinputのplaceholder「"または絵文字を入力"」が
i18nに対応できるように