### PR TITLE
Fix: Firefoxでトークの下が隠れてしまう for v11

### DIFF
--- a/src/client/app/common/views/components/messaging-room.vue
+++ b/src/client/app/common/views/components/messaging-room.vue
@@ -300,17 +300,13 @@ export default Vue.extend({
 
 <style lang="stylus" scoped>
 .mk-messaging-room
-	display flex
-	flex 1
-	flex-direction column
-	height 100%
 	background var(--messagingRoomBg)
 
 	> .body
 		width 100%
 		max-width 600px
 		margin 0 auto
-		flex 1
+		min-height calc(100% - 103px)
 
 		> .init,
 		> .empty


### PR DESCRIPTION
## Summary
Fix #4092 for v11

Desktop Firefox, Desktop Chrome, Android Chrome, Android Firefox で確認済み