### PR TITLE
Enable query result cache for meta / stats / hashtags trend

### DIFF
--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -96,6 +96,18 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 		extra: config.db.extra,
 		synchronize: process.env.NODE_ENV === 'test' || sync,
 		dropSchema: process.env.NODE_ENV === 'test' && !justBorrow,
+		cache: {
+			type: 'redis',
+			options: {
+				host: config.redis.host,
+				port: config.redis.port,
+				options:{
+					auth_pass: config.redis.pass,
+					prefix: config.redis.prefix,
+					db: config.redis.db || 0
+				}
+			}
+		},
 		logging: log,
 		logger: log ? new MyCustomLogger() : undefined,
 		entities: [

--- a/src/server/api/endpoints/hashtags/trend.ts
+++ b/src/server/api/endpoints/hashtags/trend.ts
@@ -59,6 +59,7 @@ export default define(meta, async () => {
 		.where(`note.createdAt > :date`, { date: new Date(Date.now() - rangeA) })
 		.andWhere(`note.tags != '{}'`)
 		.select(['note.tags', 'note.userId'])
+		.cache(60000) // 1 min
 		.getMany();
 
 	if (tagNotes.length === 0) {
@@ -108,6 +109,7 @@ export default define(meta, async () => {
 			.where(':tag = ANY(note.tags)', { tag: tag })
 			.andWhere('note.createdAt < :lt', { lt: new Date(Date.now() - (interval * i)) })
 			.andWhere('note.createdAt > :gt', { gt: new Date(Date.now() - (interval * (i + 1))) })
+			.cache(60000) // 1 min
 			.getRawOne()
 			.then(x => parseInt(x.count, 10))
 		)));
@@ -119,6 +121,7 @@ export default define(meta, async () => {
 		.select('count(distinct note.userId)')
 		.where(':tag = ANY(note.tags)', { tag: tag })
 		.andWhere('note.createdAt > :gt', { gt: new Date(Date.now() - (interval * range)) })
+		.cache(60000) // 1 min
 		.getRawOne()
 		.then(x => parseInt(x.count, 10))
 	));

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -94,7 +94,7 @@ export const meta = {
 export default define(meta, async (ps, me) => {
 	const instance = await fetchMeta(true);
 
-	const emojis = await Emojis.find({ host: null });
+	const emojis = await Emojis.find({ where: { host: null }, cache: 3600000 }); // 1 hour
 
 	const response: any = {
 		maintainerName: instance.maintainerName,

--- a/src/server/api/endpoints/stats.ts
+++ b/src/server/api/endpoints/stats.ts
@@ -57,10 +57,10 @@ export default define(meta, async () => {
 		driveUsageLocal,
 		driveUsageRemote
 	] = await Promise.all([
-		Notes.count(),
-		Notes.count({ userHost: null }),
-		Users.count(),
-		Users.count({ host: null }),
+		Notes.count({ cache: 3600000 }), // 1 hour
+		Notes.count({ where: { userHost: null }, cache: 3600000 }),
+		Users.count({ cache: 3600000 }),
+		Users.count({ where: { host: null }, cache: 3600000 }),
 		federationChart.getChart('hour', 1).then(chart => chart.instance.total[0]),
 		driveChart.getChart('hour', 1).then(chart => chart.local.totalSize[0]),
 		driveChart.getChart('hour', 1).then(chart => chart.remote.totalSize[0]),


### PR DESCRIPTION
## Summary

結構早くなった気がします。
参考資料：https://github.com/typeorm/typeorm/blob/master/docs/caching.md

## 参考
https://suki.tsuki.network で撮った結果で、
適用前後に何回かWelcomeページを再読込みして撮った結果です。
正しい計測方法で撮ったとは言い難いので長く運営した時の安定性とかは検証が必要だと思います。
### `meta.emojis`の数
361個
### statsの中身
```json
{
	"notesCount": 26211,
	"originalNotesCount": 244,
	"usersCount": 1077,
	"originalUsersCount": 21,
	"instances": "155",
	"driveUsageLocal": "24584733",
	"driveUsageRemote": "1999895480"
}
```
## 適用前
![image](https://user-images.githubusercontent.com/17376330/58359130-e3a98580-7ebc-11e9-8b05-1eb128a6dba6.png)
![image](https://user-images.githubusercontent.com/17376330/58359139-e906d000-7ebc-11e9-8471-959657df140b.png)
## 適用後
![image](https://user-images.githubusercontent.com/17376330/58359150-f3c16500-7ebc-11e9-87a8-b4af74d754e0.png)
![image](https://user-images.githubusercontent.com/17376330/58359152-f623bf00-7ebc-11e9-8b41-9ff9bb867369.png)
