### PR TITLE
設定でPostgreSQLのクエリー結果のキャッシュを無効できるように

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -62,6 +62,9 @@ db:
   user: example-misskey-user
   pass: example-misskey-pass
 
+  # Whether disable Caching queries
+  #disableCache: true
+
   # Extra Connection options
   #extra:
   #  ssl: true

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -14,6 +14,7 @@ export type Source = {
 		db: string;
 		user: string;
 		pass: string;
+		disableCache?: boolean;
 		extra?: { [x: string]: string };
 	};
 	redis: {

--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -96,7 +96,7 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 		extra: config.db.extra,
 		synchronize: process.env.NODE_ENV === 'test' || sync,
 		dropSchema: process.env.NODE_ENV === 'test' && !justBorrow,
-		cache: {
+		cache: !config.db.disableCache ? {
 			type: 'redis',
 			options: {
 				host: config.redis.host,
@@ -107,7 +107,7 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 					db: config.redis.db || 0
 				}
 			}
-		},
+		} : false,
 		logging: log,
 		logger: log ? new MyCustomLogger() : undefined,
 		entities: [


### PR DESCRIPTION
## Summary

思ったよりRedisのコネクションが多く生じていてHerokuの低ティアとかでは
```
ReplyError: Ready check failed: ERR max number of clients reached
```
とかになるガチらしい