### PR TITLE
image以外はproxyしないように

### DIFF
--- a/src/server/proxy/proxy-media.ts
+++ b/src/server/proxy/proxy-media.ts
@@ -17,6 +17,8 @@ export async function proxyMedia(ctx: Koa.BaseContext) {
 
 		const [type, ext] = await detectMine(path);
 
+		if (!type.startsWith('image/')) throw 403;
+
 		let image: IImage;
 
 		if ('static' in ctx.query && ['image/png', 'image/gif'].includes(type)) {


### PR DESCRIPTION
## Summary
特に不要なのと利用されるのもよくはないので、/proxy/でimage以外は403を出すようにしています。