### PR TITLE
Improve url-preview

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -83,9 +83,19 @@ export default (opts: Opts = {}) => ({
 			if (this.appearNote.text) {
 				const ast = parse(this.appearNote.text);
 				// TODO: 再帰的にURL要素がないか調べる
-				return unique(ast
+				const urls = unique(ast
 					.filter(t => ((t.node.type == 'url' || t.node.type == 'link') && t.node.props.url && !t.node.props.silent))
 					.map(t => t.node.props.url));
+
+				// unique without hash
+				// [ http://a/#1, http://a/#2, http://b/#3 ] => [ http://a/#1, http://b/#3 ]
+				const removeHash = x => x.replace(/#[^#]*$/, '');
+
+				return urls.reduce((array, url) => {
+					const removed = removeHash(url);
+					if (!array.map(x => removeHash(x)).includes(removed)) array.push(url);
+					return array;
+				}, []);
 			} else {
 				return null;
 			}

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -30,7 +30,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../i18n';
-import { url as local } from '../../../config';
+import { url as local, lang } from '../../../config';
 
 export default Vue.extend({
 	i18n: i18n('common/views/components/url-preview.vue'),
@@ -116,9 +116,11 @@ export default Vue.extend({
 		if (requestUrl.hostname === 'music.youtube.com')
 			requestUrl.hostname = 'youtube.com';
 
+		const requestLang = (lang || 'ja-JP').replace('ja-KS', 'ja-JP');
+
 		requestUrl.hash = '';
 
-		fetch(`/url?url=${encodeURIComponent(requestUrl.href)}`).then(res => {
+		fetch(`/url?url=${encodeURIComponent(requestUrl.href)}&lang=${requestLang}`).then(res => {
 			res.json().then(info => {
 				if (info.url == null) return;
 				this.title = info.title;

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -113,8 +113,9 @@ export default Vue.extend({
 			return;
 		}
 
-		if (requestUrl.hostname === 'music.youtube.com')
+		if (requestUrl.hostname === 'music.youtube.com') {
 			requestUrl.hostname = 'youtube.com';
+		}
 
 		const requestLang = (lang || 'ja-JP').replace('ja-KS', 'ja-JP');
 

--- a/src/client/app/common/views/components/url-preview.vue
+++ b/src/client/app/common/views/components/url-preview.vue
@@ -89,10 +89,10 @@ export default Vue.extend({
 	},
 
 	created() {
-		const url = new URL(this.url);
+		const requestUrl = new URL(this.url);
 
-		if (this.detail && url.hostname == 'twitter.com' && /^\/.+\/status(es)?\/\d+/.test(url.pathname)) {
-			this.tweetUrl = url;
+		if (this.detail && requestUrl.hostname == 'twitter.com' && /^\/.+\/status(es)?\/\d+/.test(requestUrl.pathname)) {
+			this.tweetUrl = requestUrl;
 			const twttr = (window as any).twttr || {};
 			const loadTweet = () => twttr.widgets.load(this.$refs.tweet);
 
@@ -113,10 +113,12 @@ export default Vue.extend({
 			return;
 		}
 
-		if (url.hostname === 'music.youtube.com')
-			url.hostname = 'youtube.com';
+		if (requestUrl.hostname === 'music.youtube.com')
+			requestUrl.hostname = 'youtube.com';
 
-		fetch(`/url?url=${encodeURIComponent(this.url)}`).then(res => {
+		requestUrl.hash = '';
+
+		fetch(`/url?url=${encodeURIComponent(requestUrl.href)}`).then(res => {
 			res.json().then(info => {
 				if (info.url == null) return;
 				this.title = info.title;

--- a/src/server/web/url-preview.ts
+++ b/src/server/web/url-preview.ts
@@ -12,18 +12,20 @@ module.exports = async (ctx: Koa.BaseContext) => {
 	const meta = await fetchMeta();
 
 	logger.info(meta.summalyProxy
-		? `(Proxy) Getting preview of ${ctx.query.url} ...`
-		: `Getting preview of ${ctx.query.url} ...`);
+		? `(Proxy) Getting preview of ${ctx.query.url}@${ctx.query.lang} ...`
+		: `Getting preview of ${ctx.query.url}@${ctx.query.lang} ...`);
 
 	try {
 		const summary = meta.summalyProxy ? await request.get({
 			url: meta.summalyProxy,
 			qs: {
-				url: ctx.query.url
+				url: ctx.query.url,
+				lang: ctx.query.lang || 'ja-JP'
 			},
 			json: true
 		}) : await summaly(ctx.query.url, {
-			followRedirects: false
+			followRedirects: false,
+			lang: ctx.query.lang || 'ja-JP'
 		});
 
 		logger.succ(`Got preview of ${ctx.query.url}: ${summary.title}`);


### PR DESCRIPTION
## Summary
Resolve #5067
URLプレビュー先がロケールごとにコンテンツを分けている場合に、Misskeyの表示ロケールに応じたプレビューが表示されるように。

例: 上から ja-JP / en-US / zh-TW それぞれのロケールで表示した場合

![image](https://user-images.githubusercontent.com/30769358/59899519-fe293d00-942f-11e9-84bf-678a0a297c08.png)

Resolve #5068
ハッシュ違いのURLではプレビューカードをまとめるように、サーバーにプレビューをリクエストするときにハッシュ部分は付けないように

例: 上の2つのURLは同じページを参照しているのでまとめられている
![image](https://user-images.githubusercontent.com/30769358/59899732-c1aa1100-9430-11e9-9f93-094bd08d8c35.png)

その他`music.youtube.com`の置き換えが機能していないのなどを修正