### PR TITLE
リアクションピッカーに絵文字ピッカーなど

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -624,7 +624,7 @@ common/views/components/poll-editor.vue:
 
 common/views/components/reaction-picker.vue:
   choose-reaction: "リアクションを選択"
-  input-reaction-placeholder: "または絵文字を入力"
+  input-reaction-placeholder: "絵文字を入力"
 
 common/views/components/emoji-picker.vue:
   custom-emoji: "カスタム絵文字"

--- a/src/client/app/common/views/components/reaction-picker.vue
+++ b/src/client/app/common/views/components/reaction-picker.vue
@@ -17,6 +17,10 @@
 		</div>
 		<div v-if="enableEmojiReaction" class="text">
 			<input v-model="text" :placeholder="$t('input-reaction-placeholder')" @keyup.enter="reactText" @input="tryReactText" v-autocomplete="{ model: 'text' }">
+			<button title="OK" @click="reactText"><fa icon="check"/></button>
+			<button title="Pick" class="emoji" @click="emoji" ref="emoji" v-if="!$root.isMobile">
+				<fa :icon="['far', 'laugh']"/>
+			</button>
 		</div>
 	</div>
 </div>
@@ -162,6 +166,19 @@ export default Vue.extend({
 			if (!this.text) return;
 			if (!this.text.match(emojiRegex)) return;
 			this.reactText();
+		},
+
+		async emoji() {
+			const Picker = await import('../../../desktop/views/components/emoji-picker-dialog.vue').then(m => m.default);
+			const button = this.$refs.emoji;
+			const rect = button.getBoundingClientRect();
+			const vm = this.$root.new(Picker, {
+				x: button.offsetWidth + rect.left + window.pageXOffset,
+				y: rect.top + window.pageYOffset
+			});
+			vm.$once('chosen', emoji => {
+				this.react(emoji);
+			});
 		},
 
 		onMouseover(e) {
@@ -315,14 +332,15 @@ export default Vue.extend({
 					box-shadow inset 0 0.15em 0.3em rgba(27, 31, 35, 0.15)
 
 		> .text
+			display flex
+			justify-content center
+			align-items center
 			width 216px
-			padding 0 8px 8px 8px
 
 			> input
 				width 100%
 				padding 10px
 				margin 0
-				text-align center
 				font-size 16px
 				color var(--desktopPostFormTextareaFg)
 				background var(--desktopPostFormTextareaBg)
@@ -338,5 +356,16 @@ export default Vue.extend({
 				&:focus
 					border-color var(--primaryAlpha05)
 					transition border-color 0s ease
+
+			> button
+				cursor pointer
+				padding 0 8px
+				margin 0
+				font-size 1em
+				color var(--desktopPostFormTransparentButtonFg)
+				background transparent
+				outline none
+				border solid 1px transparent
+				border-radius 4px
 
 </style>

--- a/src/client/app/desktop/views/components/emoji-picker-dialog.vue
+++ b/src/client/app/desktop/views/components/emoji-picker-dialog.vue
@@ -75,7 +75,7 @@ export default Vue.extend({
 
 <style lang="stylus" scoped>
 .gcafiosrssbtbnbzqupfmglvzgiaipyv
-	position fixed
+	position absolute
 	top 0
 	left 0
 	z-index 13000

--- a/src/client/app/desktop/views/components/emoji-picker-dialog.vue
+++ b/src/client/app/desktop/views/components/emoji-picker-dialog.vue
@@ -78,7 +78,7 @@ export default Vue.extend({
 	position fixed
 	top 0
 	left 0
-	z-index 3000
+	z-index 13000
 	box-shadow 0 2px 12px 0 rgba(0, 0, 0, 0.3)
 
 </style>


### PR DESCRIPTION
## Summary
Resolve #4794 リアクションピッカーから絵文字ピッカーを呼べるようにしています (Desktopのみ)
Resolve #4567 マウスやタップで確定できるようにチェックボタンを追加しています
Fix #5115

![image](https://user-images.githubusercontent.com/30769358/60687388-498c2280-9ee9-11e9-83a8-15f93ba1ea78.png)
