### PR TITLE
11.24.0の注意書きを追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ unreleased
 
 11.24.0 (2019/07/05)
 --------------------
-注意: このアップデート後に、`node built/tools/accept-migration Init 1000000000000`してください。
+### 注意
+- このアップデート後に、`node built/tools/accept-migration Init 1000000000000`してください。
+- プロセスを起動(もしくは再起動)する前に[マイグレーション](#migration)の手順を実行してください
+
 
 ### ✨Improvements
 * WebAuthnサポート


### PR DESCRIPTION
11.24.0以降適用後に一部APIでエラーが出ていて、

```npm run migrate```を実行したら直ったのでそれに関する内容を追記