### PR TITLE
Fix: ユーザー名等のMFMが折り返されてしまう

### DIFF
--- a/src/client/app/common/views/components/misskey-flavored-markdown.vue
+++ b/src/client/app/common/views/components/misskey-flavored-markdown.vue
@@ -1,5 +1,5 @@
 <template>
-<mfm-core v-bind="$attrs" class="havbbuyv" v-once/>
+<mfm-core v-bind="$attrs" class="havbbuyv" :class="{ plain: $attrs['plain-text'] }" v-once/>
 </template>
 
 <script lang="ts">
@@ -16,6 +16,9 @@ export default Vue.extend({
 <style lang="stylus" scoped>
 .havbbuyv
 	white-space pre-wrap
+
+	&.plain
+		white-space pre
 
 	>>> .title
 		display block


### PR DESCRIPTION
## Summary
96e23b0e5b20c382f2a0ad9d52761f41c1c0840e の後
ユーザー名等の一行表示したい箇所が折り返されてしまうのを修正。

11.23.1 (連続したスペースが消える)
![image](https://user-images.githubusercontent.com/30769358/60722715-b4327200-9f6c-11e9-8216-5b5dec431c2e.png)

11.24.0 (一行表示が折り返されてしまう)
![image](https://user-images.githubusercontent.com/30769358/60722396-b6480100-9f6b-11e9-9036-fe25fb72e885.png)

修正後
![image](https://user-images.githubusercontent.com/30769358/60722400-b942f180-9f6b-11e9-831f-ac4b03bc0464.png)
