### PR TITLE
Fix: postgres redis cache の option が適用されない

### DIFF
--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -150,11 +150,9 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 			options: {
 				host: config.redis.host,
 				port: config.redis.port,
-				options: {
-					password: config.redis.pass,
-					prefix: config.redis.prefix,
-					db: config.redis.db || 0
-				}
+				password: config.redis.pass,
+				prefix: config.redis.prefix,
+				db: config.redis.db || 0
 			}
 		} : false,
 		logging: log,


### PR DESCRIPTION
## Summary
Fix #5113

password, prefix, db の指定方法が誤っていて適用されないのを修正
https://github.com/typeorm/typeorm/blob/master/docs/caching.md
https://github.com/NodeRedis/node_redis#options-object-properties