### PR TITLE
Tune font

### DIFF
--- a/src/client/app/common/views/components/google.vue
+++ b/src/client/app/common/views/components/google.vue
@@ -41,7 +41,6 @@ export default Vue.extend({
 		padding 10px
 		width 100%
 		height 40px
-		font-family sans-serif
 		font-size 16px
 		color var(--googleSearchFg)
 		background var(--googleSearchBg)

--- a/src/client/app/common/views/components/page/page.vue
+++ b/src/client/app/common/views/components/page/page.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="iroscrza" :class="{ shadow: $store.state.device.useShadow, round: $store.state.device.roundedCorners, center: page.alignCenter }" :style="{ fontFamily: page.font }">
+<div class="iroscrza" :class="{ shadow: $store.state.device.useShadow, round: $store.state.device.roundedCorners, center: page.alignCenter, serif: page.font === 'serif' }">
 	<header v-if="showTitle">
 		<div class="title">{{ page.title }}</div>
 	</header>
@@ -150,6 +150,10 @@ export default Vue.extend({
 .iroscrza
 	overflow hidden
 	background var(--face)
+	
+	&.serif
+		> div
+			font-family serif
 
 	&.center
 		text-align center

--- a/src/client/app/desktop/views/components/drive.vue
+++ b/src/client/app/desktop/views/components/drive.vue
@@ -10,10 +10,6 @@
 			<span class="separator" v-if="folder != null"><fa icon="angle-right"/></span>
 			<span class="folder current" v-if="folder != null">{{ folder.name }}</span>
 		</div>
-		<!--
-			TODO: #343
-			<input class="search" type="search" placeholder="&#xf002; %i18n:@search%"/>
-		-->
 	</nav>
 	<div class="main" :class="{ uploading: uploadings.length > 0, fetching }"
 		ref="main"
@@ -646,33 +642,6 @@ export default Vue.extend({
 
 					> [data-icon]
 						margin 0
-
-		> .search
-			display inline-block
-			vertical-align bottom
-			user-select text
-			cursor auto
-			margin 0
-			padding 0 18px
-			width 200px
-			font-size 1em
-			line-height 38px
-			background transparent
-			outline none
-			//border solid 1px #ddd
-			border none
-			border-radius 0
-			box-shadow none
-			transition color 0.5s ease, border 0.5s ease
-			font-family FontAwesome, sans-serif
-
-			&[data-active='true']
-				background #fff
-
-			&::-webkit-input-placeholder,
-			&:-ms-input-placeholder,
-			&:-moz-placeholder
-				color $ui-control-foreground-color
 
 	> .main
 		padding 8px

--- a/src/client/app/desktop/views/components/ui.header.account.vue
+++ b/src/client/app/desktop/views/components/ui.header.account.vue
@@ -197,7 +197,6 @@ export default Vue.extend({
 			max-width 16em
 			line-height 48px
 			font-weight bold
-			font-family Meiryo, sans-serif
 			text-decoration none
 
 			@media (max-width 1100px)

--- a/src/client/app/init.css
+++ b/src/client/app/init.css
@@ -5,7 +5,7 @@
  */
 
 html {
-	font-family: sans-serif;
+	font-family: Roboto, HelveticaNeue, Arial, sans-serif;
 }
 
 body > noscript {

--- a/src/client/app/reset.styl
+++ b/src/client/app/reset.styl
@@ -15,7 +15,7 @@ progress
 	box-shadow none
 
 textarea
-	font-family sans-serif
+	font-family Roboto, HelveticaNeue, Arial, sans-serif
 
 button
 	margin 0

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -18,7 +18,7 @@ html, body
 	padding 0
 	scroll-behavior smooth
 	text-size-adjust 100%
-	font-family sans-serif
+	font-family Roboto, HelveticaNeue, Arial, sans-serif
 
 html.changing-theme
 	&, *

--- a/src/server/web/views/info.pug
+++ b/src/server/web/views/info.pug
@@ -8,7 +8,7 @@ html
 		title Misskey
 		style.
 			html {
-				font-family: sans-serif;
+				font-family: Roboto, HelveticaNeue, Arial, sans-serif;
 			}
 
 			main {


### PR DESCRIPTION
## Summary
Resolve #5124 
一部のAndroid端末でも欧文フォントがまともになるように修正。
(font-familyはGoogleのモバイルの検索結果ページのやつです)
Window Desktopなどでもフォントが変わることになりますが
TwitterやGoogleと同じようなフォントで表示されるようになるだけなので
さほど変というわけでもないと思います。

不要そうなフォント指定等を削除

ページでセリフ体を指定したときにページ外のフッター領域等まで反映されるのが変な気がしたので
セリフ体の指定は本文以外には反映されないように変更しています。
![image](https://user-images.githubusercontent.com/30769358/60855121-80da3680-a23d-11e9-80d3-ca8e0ddc9bba.png)