### PR TITLE
Fix: proxy-media後のContent-Typeが違う

### DIFF
--- a/src/server/proxy/proxy-media.ts
+++ b/src/server/proxy/proxy-media.ts
@@ -33,7 +33,7 @@ export async function proxyMedia(ctx: Koa.BaseContext) {
 			};
 		}
 
-		ctx.set('Content-Type', type);
+		ctx.set('Content-Type', image.type);
 		ctx.set('Cache-Control', 'max-age=31536000, immutable');
 		ctx.body = image.data;
 	} catch (e) {


### PR DESCRIPTION
## Summary
`/proxy/~`でフォーマット変換が発生してもContent-Typeが元のままなのを修正