### PR TITLE
Send Delete activity on suspend

### DIFF
--- a/src/server/api/endpoints/admin/suspend-user.ts
+++ b/src/server/api/endpoints/admin/suspend-user.ts
@@ -5,6 +5,7 @@ import deleteFollowing from '../../../../services/following/delete';
 import { Users, Followings } from '../../../../models';
 import { User } from '../../../../models/entities/user';
 import { insertModerationLog } from '../../../../services/insert-moderation-log';
+import { doPostSuspend } from '../../../../services/suspend-user';
 
 export const meta = {
 	desc: {
@@ -52,6 +53,8 @@ export default define(meta, async (ps, me) => {
 	});
 
 	unFollowAll(user);
+
+	doPostSuspend(user);
 });
 
 async function unFollowAll(follower: User) {

--- a/src/server/api/endpoints/admin/suspend-user.ts
+++ b/src/server/api/endpoints/admin/suspend-user.ts
@@ -52,9 +52,10 @@ export default define(meta, async (ps, me) => {
 		targetId: user.id,
 	});
 
-	unFollowAll(user);
-
-	doPostSuspend(user);
+	(async () => {
+		await doPostSuspend(user).catch(e => {});
+		await unFollowAll(user).catch(e => {});
+	})();
 });
 
 async function unFollowAll(follower: User) {

--- a/src/server/api/endpoints/admin/unsuspend-user.ts
+++ b/src/server/api/endpoints/admin/unsuspend-user.ts
@@ -3,6 +3,7 @@ import { ID } from '../../../../misc/cafy-id';
 import define from '../../define';
 import { Users } from '../../../../models';
 import { insertModerationLog } from '../../../../services/insert-moderation-log';
+import { doPostUnsuspend } from '../../../../services/unsuspend-user';
 
 export const meta = {
 	desc: {
@@ -40,4 +41,6 @@ export default define(meta, async (ps, me) => {
 	insertModerationLog(me, 'unsuspend', {
 		targetId: user.id,
 	});
+
+	doPostUnsuspend(user);
 });

--- a/src/server/api/endpoints/i/delete-account.ts
+++ b/src/server/api/endpoints/i/delete-account.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcryptjs';
 import define from '../../define';
 import { Users, UserProfiles } from '../../../../models';
 import { ensure } from '../../../../prelude/ensure';
+import { doPostSuspend } from '../../../../services/suspend-user';
 
 export const meta = {
 	requireCredential: true,
@@ -25,6 +26,9 @@ export default define(meta, async (ps, user) => {
 	if (!same) {
 		throw new Error('incorrect password');
 	}
+
+	// 物理削除する前にDelete activityを送信する
+	await doPostSuspend(user).catch(e => {});
 
 	await Users.delete(user.id);
 });

--- a/src/services/suspend-user.ts
+++ b/src/services/suspend-user.ts
@@ -1,0 +1,34 @@
+import renderDelete from '../remote/activitypub/renderer/delete';
+import { renderActivity } from '../remote/activitypub/renderer';
+import { deliver } from '../queue';
+import config from '../config';
+import { User } from '../models/entities/user';
+import { Users, Followings } from '../models';
+import { Not, IsNull } from 'typeorm';
+
+export async function doPostSuspend(user: User) {
+	if (Users.isLocalUser(user)) {
+		// 知り得る全SharedInboxにDelete配信
+		const content = renderActivity(renderDelete(`${config.url}/users/${user.id}`, user));
+
+		const queue: string[] = [];
+
+		const followings = await Followings.find({
+			where: [
+				{ followerSharedInbox: Not(IsNull()) },
+				{ followeeSharedInbox: Not(IsNull()) }
+			],
+			select: ['followerSharedInbox', 'followeeSharedInbox']
+		});
+
+		const inboxes = followings.map(x => x.followerSharedInbox || x.followeeSharedInbox);
+
+		for (const inbox of inboxes) {
+			if (inbox != null && !queue.includes(inbox)) queue.push(inbox);
+		}
+
+		for (const inbox of queue) {
+			deliver(user as any, content, inbox);
+		}
+	}
+}

--- a/src/services/unsuspend-user.ts
+++ b/src/services/unsuspend-user.ts
@@ -1,0 +1,35 @@
+import renderDelete from '../remote/activitypub/renderer/delete';
+import renderUndo from '../remote/activitypub/renderer/undo';
+import { renderActivity } from '../remote/activitypub/renderer';
+import { deliver } from '../queue';
+import config from '../config';
+import { User } from '../models/entities/user';
+import { Users, Followings } from '../models';
+import { Not, IsNull } from 'typeorm';
+
+export async function doPostUnsuspend(user: User) {
+	if (Users.isLocalUser(user)) {
+		// 知り得る全SharedInboxにUndo Delete配信
+		const content = renderActivity(renderUndo(renderDelete(`${config.url}/users/${user.id}`, user), user));
+
+		const queue: string[] = [];
+
+		const followings = await Followings.find({
+			where: [
+				{ followerSharedInbox: Not(IsNull()) },
+				{ followeeSharedInbox: Not(IsNull()) }
+			],
+			select: ['followerSharedInbox', 'followeeSharedInbox']
+		});
+
+		const inboxes = followings.map(x => x.followerSharedInbox || x.followeeSharedInbox);
+
+		for (const inbox of inboxes) {
+			if (inbox != null && !queue.includes(inbox)) queue.push(inbox);
+		}
+
+		for (const inbox of queue) {
+			deliver(user as any, content, inbox);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Suspend 時に Delete Activity を送信するように
Unsuspend 時に Undo Delete Activity を送信するように

Mastodon宛てに Delete を送って該当ユーザーが消えるのを確認済み