### PR TITLE
Resolve #5117

### DIFF
--- a/src/server/api/private/signup.ts
+++ b/src/server/api/private/signup.ts
@@ -1,6 +1,5 @@
 import * as Koa from 'koa';
 import * as bcrypt from 'bcryptjs';
-import { publishMainStream } from '../../../services/stream';
 import { generateKeyPair } from 'crypto';
 import generateUserToken from '../common/generate-native-user-token';
 import config from '../../../config';
@@ -139,7 +138,7 @@ export default async (ctx: Koa.BaseContext) => {
 	usersChart.update(account, true);
 
 	// Append signin history
-	const record = await Signins.save({
+	await Signins.save({
 		id: genId(),
 		createdAt: new Date(),
 		userId: account.id,
@@ -147,9 +146,6 @@ export default async (ctx: Koa.BaseContext) => {
 		headers: ctx.headers,
 		success: true
 	});
-
-	// Publish signin event
-	publishMainStream(account.id, 'signin', await Signins.pack(record));
 
 	const res = await Users.pack(account, account, {
 		detail: true,


### PR DESCRIPTION
## Summary

Resolve #5117
![image](https://user-images.githubusercontent.com/17376330/61324141-acb47800-a84c-11e9-90ed-76c4ce4e1883.png)


## History
v11でPostgreSQLに移行したときにユーザーが手動でsigninテーブルの内容を消す機能が廃止されたのでsigninテーブルに保存しておいても良さそうってことで