### PR TITLE
Fix #5172

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -782,6 +782,9 @@ common/views/components/profile-editor.vue:
   saved: "プロフィールを保存しました"
   uploading: "アップロード中"
   upload-failed: "アップロードに失敗しました"
+  unable-to-process: "操作を完了できません"
+  avatar-not-an-image: "アイコンとして指定したファイルは画像ではありません"
+  banner-not-an-image: "バナーとして指定したファイルは画像ではありません"
   email: "メール設定"
   email-address: "メールアドレス"
   email-verified: "メールアドレスが確認されました"
@@ -927,6 +930,7 @@ desktop:
   uploading-avatar: "新しいアバターをアップロードしています"
   avatar-updated: "アバターを更新しました"
   choose-avatar: "アバターにする画像を選択"
+  unable-to-process: "操作を完了できません"
   invalid-filetype: "この形式のファイルはサポートされていません"
 
 desktop/views/components/activity.chart.vue:

--- a/src/client/app/common/views/components/settings/profile.vue
+++ b/src/client/app/common/views/components/settings/profile.vue
@@ -265,6 +265,29 @@ export default Vue.extend({
 						text: this.$t('saved')
 					});
 				}
+			}).catch(err => {
+				this.saving = false;
+				switch(err.id) {
+					case 'f419f9f8-2f4d-46b1-9fb4-49d3a2fd7191':
+						this.$root.dialog({
+							type: 'error',
+							title: this.$t('unable-to-process'),
+							text: this.$t('avatar-not-an-image')
+						});
+						break;
+					case '75aedb19-2afd-4e6d-87fc-67941256fa60':
+						this.$root.dialog({
+							type: 'error',
+							title: this.$t('unable-to-process'),
+							text: this.$t('banner-not-an-image')
+						});
+						break;
+					default:
+						this.$root.dialog({
+							type: 'error',
+							text: this.$t('unable-to-process')
+						});
+				}
 			});
 		},
 

--- a/src/client/app/desktop/api/update-avatar.ts
+++ b/src/client/app/desktop/api/update-avatar.ts
@@ -83,6 +83,21 @@ export default ($root: any) => {
 			});
 
 			return i;
+		}).catch(err => {
+			switch(err.id) {
+				case 'f419f9f8-2f4d-46b1-9fb4-49d3a2fd7191':
+					$root.dialog({
+						type: 'error',
+						title: locale['desktop']['unable-to-process'],
+						text: locale['desktop']['invalid-filetype']
+					});
+					break;
+				default:
+					$root.dialog({
+						type: 'error',
+						text: locale['desktop']['unable-to-process']
+					});
+			}
 		});
 	};
 

--- a/src/client/app/desktop/api/update-banner.ts
+++ b/src/client/app/desktop/api/update-banner.ts
@@ -83,6 +83,21 @@ export default ($root: any) => {
 			});
 
 			return i;
+		}).catch(err => {
+			switch(err.id) {
+				case '75aedb19-2afd-4e6d-87fc-67941256fa60':
+					$root.dialog({
+						type: 'error',
+						title: locale['desktop']['unable-to-process'],
+						text: locale['desktop']['invalid-filetype']
+					});
+					break;
+				default:
+					$root.dialog({
+						type: 'error',
+						text: locale['desktop']['unable-to-process']
+					});
+			}
 		});
 	};
 


### PR DESCRIPTION
## Summary

Including Fix #5172

* プロフィールエディターでアイコンとバナーに画像ではないファイルを指定した場合保存したときエラーメッセージが出るように
![image](https://user-images.githubusercontent.com/17376330/61346993-17d66c80-a896-11e9-9f7d-32423bec1c62.png)
![image](https://user-images.githubusercontent.com/17376330/61347003-258bf200-a896-11e9-87f1-c7b7cbed7515.png)

* Driveのコンテキストメニューからアイコンとバナーを設定するとき画像ではないファイルならエラーメッセージが出るように
![image](https://user-images.githubusercontent.com/17376330/61347082-8a474c80-a896-11e9-8cfe-7082cdaaadda.png)
