### PR TITLE
Fix signin

### DIFF
--- a/src/server/api/common/signin.ts
+++ b/src/server/api/common/signin.ts
@@ -2,9 +2,6 @@ import * as Koa from 'koa';
 
 import config from '../../../config';
 import { ILocalUser } from '../../../models/entities/user';
-import { Signins } from '../../../models';
-import { genId } from '../../../misc/gen-id';
-import { publishMainStream } from '../../../services/stream';
 
 export default function(ctx: Koa.BaseContext, user: ILocalUser, redirect = false) {
 	if (redirect) {
@@ -27,19 +24,4 @@ export default function(ctx: Koa.BaseContext, user: ILocalUser, redirect = false
 		ctx.body = { i: user.token };
 		ctx.status = 200;
 	}
-
-	(async () => {
-		// Append signin history
-		const record = await Signins.save({
-			id: genId(),
-			createdAt: new Date(),
-			userId: user.id,
-			ip: ctx.ip,
-			headers: ctx.headers,
-			success: true
-		});
-
-		// Publish signin event
-		publishMainStream(user.id, 'signin', await Signins.pack(record));
-	})();
 }

--- a/src/server/api/private/signin.ts
+++ b/src/server/api/private/signin.ts
@@ -61,7 +61,7 @@ export default async (ctx: Koa.BaseContext) => {
 			userId: user.id,
 			ip: ctx.ip,
 			headers: ctx.headers,
-			success: false
+			success: !!(status || failure)
 		});
 
 		// Publish signin event

--- a/src/server/api/private/signin.ts
+++ b/src/server/api/private/signin.ts
@@ -215,7 +215,6 @@ export default async (ctx: Koa.BaseContext) => {
 			}))
 		};
 		ctx.status = 200;
-		signin(ctx, user);
 		return;
 	}
 	// never get here


### PR DESCRIPTION
## Summary
Fix #5179

- ~~failメソッドが statusがあってfailureがないときに変な挙動 (falseをログるけどctxはエラーにしない) をするので、successパラメータを明示的に与えるように修正~~
- ~~failというメソッドが実態と違う名前なので修正~~
- 成否にかかわらずpublishMainStreamが発生するのを修正
- 一番下に流れ落ちるの類がわかりづらいので、成否が確定したらそのブロックでreturnするように
- `no keys found`の後におそらく`return`が抜けて後続処理を行っているのを修正
- failはfail専用に
- failを正常処理として呼び出してしまうコードが残っているのを修正
