### PR TITLE
「削除して編集」機能を追加

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -570,7 +570,7 @@ common/views/components/note-menu.vue:
   delete: "削除"
   delete-confirm: "この投稿を削除しますか？"
   delete-and-edit: "削除して編集"
-  delete-and-edit-confirm: "この投稿を削除してもう一度編集しますか？この投稿へのリアクション、リノート、返信は全て削除されます。"
+  delete-and-edit-confirm: "この投稿を削除してもう一度編集しますか？この投稿へのリアクション、リノート、返信も全て削除されます。"
   remote: "投稿元で見る"
   pin-limit-exceeded: "これ以上ピン留めできません。"
 

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -569,6 +569,8 @@ common/views/components/note-menu.vue:
   unpin: "ピン留め解除"
   delete: "削除"
   delete-confirm: "この投稿を削除しますか？"
+  delete-and-edit: "削除して編集"
+  delete-and-edit-confirm: "この投稿を削除してもう一度編集しますか？この投稿へのリアクション、リノート、返信は全て削除されます。"
   remote: "投稿元で見る"
   pin-limit-exceeded: "これ以上ピン留めできません。"
 

--- a/src/client/app/common/scripts/post-form.ts
+++ b/src/client/app/common/scripts/post-form.ts
@@ -35,6 +35,10 @@ export default (opts) => ({
 			type: String,
 			required: false
 		},
+		initialNote: {
+			type: Object,
+			required: false
+		},
 		instant: {
 			type: Boolean,
 			required: false,
@@ -194,6 +198,28 @@ export default (opts) => ({
 					}
 					this.$emit('change-attached-files', this.files);
 				}
+			}
+			if (this.initialNote) {
+				// 削除して編集
+				const init = this.initialNote;
+				this.text = init.text ? init.text : '';
+				this.files = init.files;
+				this.cw = init.cw;
+				this.useCw = init.cw != null;
+				if (init.poll) {
+					this.poll = true;
+					this.$nextTick(() => {
+						(this.$refs.poll as any).set({
+							choices: init.poll.choices.map(c => c.text),
+							multiple: init.poll.multiple
+						});
+					});
+				}
+				// hack 位置情報投稿が動くようになったら適用する
+				this.geo = null;
+				this.visibility = init.visibility;
+				this.localOnly = init.localOnly;
+				this.quoteId = init.renote ? init.renote.id : null;
 			}
 
 			this.$nextTick(() => this.watch());

--- a/src/client/app/common/views/components/note-menu.vue
+++ b/src/client/app/common/views/components/note-menu.vue
@@ -173,8 +173,8 @@ export default Vue.extend({
 					this.destroyDom();
 				});
 				this.$post({
-					initialText: this.note.text,
-					instant: true
+					initialNote: this.note,
+					reply: this.note.reply,
 				});
 			});
 		},

--- a/src/client/app/common/views/components/note-menu.vue
+++ b/src/client/app/common/views/components/note-menu.vue
@@ -73,13 +73,14 @@ export default Vue.extend({
 				text: this.$t('pin'),
 				action: () => this.togglePin(true)
 			} : undefined,
-			this.note.userId == this.$store.state.i.id ? {
-				icon: 'undo-alt',
-				text: this.$t('delete-and-edit'),
-				action: this.deleteAndEdit
-			} : undefined,
 			...(this.note.userId == this.$store.state.i.id || this.$store.state.i.isAdmin || this.$store.state.i.isModerator ? [
-				null, {
+				null,
+				this.note.userId == this.$store.state.i.id ? {
+					icon: 'undo-alt',
+					text: this.$t('delete-and-edit'),
+					action: this.deleteAndEdit
+				} : undefined,
+				{
 					icon: ['far', 'trash-alt'],
 					text: this.$t('delete'),
 					action: this.del

--- a/src/client/app/common/views/components/note-menu.vue
+++ b/src/client/app/common/views/components/note-menu.vue
@@ -73,6 +73,11 @@ export default Vue.extend({
 				text: this.$t('pin'),
 				action: () => this.togglePin(true)
 			} : undefined,
+			this.note.userId == this.$store.state.i.id ? {
+				icon: 'undo-alt',
+				text: this.$t('delete-and-edit'),
+				action: this.deleteAndEdit
+			} : undefined,
 			...(this.note.userId == this.$store.state.i.id || this.$store.state.i.isAdmin || this.$store.state.i.isModerator ? [
 				null, {
 					icon: ['far', 'trash-alt'],
@@ -150,6 +155,25 @@ export default Vue.extend({
 					noteId: this.note.id
 				}).then(() => {
 					this.destroyDom();
+				});
+			});
+		},
+
+		deleteAndEdit() {
+			this.$root.dialog({
+				type: 'warning',
+				text: this.$t('delete-and-edit-confirm'),
+				showCancelButton: true
+			}).then(({ canceled }) => {
+				if (canceled) return;
+				this.$root.api('notes/delete', {
+					noteId: this.note.id
+				}).then(() => {
+					this.destroyDom();
+				});
+				this.$post({
+					initialText: this.note.text,
+					instant: true
 				});
 			});
 		},

--- a/src/client/app/desktop/script.ts
+++ b/src/client/app/desktop/script.ts
@@ -63,7 +63,9 @@ init(async (launch, os) => {
 					this.$root.newAsync(() => import('./views/components/post-form-window.vue').then(m => m.default), {
 						reply: o.reply,
 						mention: o.mention,
-						animation: o.animation == null ? true : o.animation
+						animation: o.animation == null ? true : o.animation,
+						initialText: o.initialText,
+						instant: o.instant
 					}).then(vm => {
 						if (o.cb) vm.$once('closed', o.cb);
 					});

--- a/src/client/app/desktop/script.ts
+++ b/src/client/app/desktop/script.ts
@@ -65,7 +65,8 @@ init(async (launch, os) => {
 						mention: o.mention,
 						animation: o.animation == null ? true : o.animation,
 						initialText: o.initialText,
-						instant: o.instant
+						instant: o.instant,
+						initialNote: o.initialNote,
 					}).then(vm => {
 						if (o.cb) vm.$once('closed', o.cb);
 					});

--- a/src/client/app/desktop/views/components/post-form-window.vue
+++ b/src/client/app/desktop/views/components/post-form-window.vue
@@ -15,6 +15,9 @@
 		<x-post-form ref="form"
 			:reply="reply"
 			:mention="mention"
+			:initial-text="initialText"
+			:instant="instant"
+
 			@posted="onPosted"
 			@change-uploadings="onChangeUploadings"
 			@change-attached-files="onChangeFiles"
@@ -50,7 +53,18 @@ export default Vue.extend({
 			type: Boolean,
 			required: false,
 			default: true
-		}
+		},
+
+		initialText: {
+			type: String,
+			required: false
+		},
+
+		instant: {
+			type: Boolean,
+			required: false,
+			default: false
+		},
 	},
 
 	data() {

--- a/src/client/app/desktop/views/components/post-form-window.vue
+++ b/src/client/app/desktop/views/components/post-form-window.vue
@@ -16,6 +16,7 @@
 			:reply="reply"
 			:mention="mention"
 			:initial-text="initialText"
+			:initial-note="initialNote"
 			:instant="instant"
 
 			@posted="onPosted"
@@ -57,6 +58,11 @@ export default Vue.extend({
 
 		initialText: {
 			type: String,
+			required: false
+		},
+
+		initialNote: {
+			type: Object,
 			required: false
 		},
 

--- a/src/client/app/init.ts
+++ b/src/client/app/init.ts
@@ -125,7 +125,8 @@ import {
 	faMapMarker,
 	faRobot,
 	faHourglassHalf,
-	faGavel
+	faGavel,
+	faUndoAlt,
 } from '@fortawesome/free-solid-svg-icons';
 
 import {
@@ -258,6 +259,7 @@ library.add(
 	faRobot,
 	faHourglassHalf,
 	faGavel,
+	faUndoAlt,
 
 	farBell,
 	farEnvelope,

--- a/src/client/app/mobile/script.ts
+++ b/src/client/app/mobile/script.ts
@@ -56,7 +56,8 @@ init((launch, os) => {
 					mention: o.mention,
 					renote: o.renote,
 					initialText: o.initialText,
-					instant: o.instant
+					instant: o.instant,
+					initialNote: o.initialNote,
 				});
 				vm.$once('cancel', recover);
 				vm.$once('posted', recover);

--- a/src/client/app/mobile/script.ts
+++ b/src/client/app/mobile/script.ts
@@ -54,7 +54,9 @@ init((launch, os) => {
 				const vm = this.$root.new(PostFormDialog, {
 					reply: o.reply,
 					mention: o.mention,
-					renote: o.renote
+					renote: o.renote,
+					initialText: o.initialText,
+					instant: o.instant
 				});
 				vm.$once('cancel', recover);
 				vm.$once('posted', recover);

--- a/src/client/app/mobile/views/components/post-form-dialog.vue
+++ b/src/client/app/mobile/views/components/post-form-dialog.vue
@@ -7,6 +7,7 @@
 			:renote="renote"
 			:mention="mention"
 			:initial-text="initialText"
+			:initial-note="initialNote"
 			:instant="instant"
 			@posted="onPosted"
 			@cancel="onCanceled"/>
@@ -39,6 +40,10 @@ export default Vue.extend({
 		},
 		initialText: {
 			type: String,
+			required: false
+		},
+		initialNote: {
+			type: Object,
 			required: false
 		},
 		instant: {


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->

Mastodonの「削除して下書きに戻す」機能に近いのを実装しました。

1. 自分の投稿のメニューに `削除して編集` を追加。

<img src="https://user-images.githubusercontent.com/7106976/61406586-1a2cdb00-a917-11e9-838d-a98c55540758.png" height="400"/>

2. クリックすると確認ダイアログが表示される

<img src="https://user-images.githubusercontent.com/7106976/61406603-231dac80-a917-11e9-8bc3-7225ba9cde72.png" height="256"/>

3. 該当の投稿が削除され、投稿画面が表示される
<img src="https://user-images.githubusercontent.com/7106976/61406965-f5853300-a917-11e9-9f66-ec664220f7d8.png" height="256"/>
