### PR TITLE
リモートアンケートの期限が保存されないのを修正

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -215,8 +215,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 
 	const apEmojis = emojis.map(emoji => emoji.name);
 
-	const questionUri = note._misskey_question;
-	const poll = await extractPollFromQuestion(note._misskey_question || note, resolver).catch(() => undefined);
+	const poll = await extractPollFromQuestion(note, resolver).catch(() => undefined);
 
 	// ユーザーの情報が古かったらついでに更新しておく
 	if (actor.lastFetchedAt == null || Date.now() - actor.lastFetchedAt.getTime() > 1000 * 60 * 60 * 24) {
@@ -239,7 +238,6 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 		apMentions,
 		apHashtags,
 		apEmojis,
-		questionUri,
 		poll,
 		uri: note.id
 	}, silent);

--- a/src/remote/activitypub/models/question.ts
+++ b/src/remote/activitypub/models/question.ts
@@ -15,7 +15,7 @@ export async function extractPollFromQuestion(source: string | IObject, resolver
 	}
 
 	const multiple = !question.oneOf;
-	const expiresAt = question.endTime ? new Date(question.endTime) : null;
+	const expiresAt = question.endTime ? new Date(question.endTime) : question.closed ? new Date(question.closed) : null;
 
 	if (multiple && !question.anyOf) {
 		throw new Error('invalid question');

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -90,14 +90,11 @@ export default async function renderNote(note: Note, dive = true): Promise<any> 
 		poll = await Polls.findOne({ noteId: note.id });
 	}
 
-	let question: string | undefined;
 	if (poll) {
 		if (text == null) text = '';
 		const url = `${config.url}/notes/${note.id}`;
 		// TODO: i18n
 		text += `\n[リモートで結果を表示](${url})`;
-
-		question = `${config.url}/questions/${note.id}`;
 	}
 
 	let apText = text;
@@ -156,7 +153,6 @@ export default async function renderNote(note: Note, dive = true): Promise<any> 
 		content,
 		_misskey_content: text,
 		_misskey_quote: quote,
-		_misskey_question: question,
 		published: note.createdAt.toISOString(),
 		to,
 		cc,

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -74,17 +74,16 @@ export interface INote extends IObject {
 	type: 'Note' | 'Question' | 'Article' | 'Audio' | 'Document' | 'Image' | 'Page' | 'Video';
 	_misskey_content?: string;
 	_misskey_quote?: string;
-	_misskey_question?: string;
 }
 
 export interface IQuestion extends IObject {
 	type: 'Note' | 'Question';
 	_misskey_content?: string;
 	_misskey_quote?: string;
-	_misskey_question?: string;
 	oneOf?: IQuestionChoice[];
 	anyOf?: IQuestionChoice[];
 	endTime?: Date;
+	closed?: Date;
 }
 
 export const isQuestion = (object: IObject): object is IQuestion =>

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -109,28 +109,6 @@ router.get('/notes/:note/activity', async ctx => {
 	setResponseType(ctx);
 });
 
-// question
-router.get('/questions/:question', async (ctx, next) => {
-	const pollNote = await Notes.findOne({
-		id: ctx.params.question,
-		userHost: null,
-		visibility: In(['public', 'home']),
-		localOnly: false,
-		hasPoll: true
-	});
-
-	if (pollNote == null) {
-		ctx.status = 404;
-		return;
-	}
-
-	const user = await Users.findOne(pollNote.userId).then(ensure);
-	const poll = await Polls.findOne({ noteId: pollNote.id }).then(ensure);
-
-	ctx.body = renderActivity(await renderQuestion(user as ILocalUser, pollNote, poll));
-	setResponseType(ctx);
-});
-
 // outbox
 router.get('/users/:user/outbox', Outbox);
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -100,7 +100,6 @@ type Option = {
 	apMentions?: User[] | null;
 	apHashtags?: string[] | null;
 	apEmojis?: string[] | null;
-	questionUri?: string | null;
 	uri?: string | null;
 	app?: App | null;
 };


### PR DESCRIPTION
## Summary
Fix #5195 
リモートから取得したアンケートの期限が保存されないのを修正
(互換用の有効期限の概念がない旧`_misskey_question`を優先していた)
`_misskey_question`が必要なインスタンス (10.92.0未満) はもうほぼないので 
互換用の`_misskey_question`の採用と公開機能自体を削除

期限切れのアンケートをリモートから取得した場合に期限が保存されないのを修正
(`closed`を見ないといけない)