### PR TITLE
Fix activity calendar for desktop widget

### DIFF
--- a/src/client/app/desktop/views/components/activity.calendar.vue
+++ b/src/client/app/desktop/views/components/activity.calendar.vue
@@ -1,5 +1,5 @@
 <template>
-<svg :viewBox="`0 0 21 7`">
+<svg viewBox="0 0 21 7">
 	<rect v-for="record in data" class="day"
 		width="1" height="1"
 		:x="record.x" :y="record.date.weekday"

--- a/src/client/app/desktop/views/components/activity.calendar.vue
+++ b/src/client/app/desktop/views/components/activity.calendar.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
 		const day = now.getDate();
 
 		let x = 20;
-		this.data.slice().forEach((d, i) => {
+		this.data = this.data.map((d, i) => {
 			d.x = x;
 
 			const date = new Date(year, month, day - i);
@@ -59,6 +59,8 @@ export default Vue.extend({
 			d.color = `hsl(${ch}, ${cs}%, ${cl}%)`;
 
 			if (d.date.weekday == 0) x--;
+
+			return d;
 		});
 	}
 });

--- a/src/client/app/desktop/views/components/activity.calendar.vue
+++ b/src/client/app/desktop/views/components/activity.calendar.vue
@@ -1,5 +1,5 @@
 <template>
-<svg :viewBox="`0 0 ${weeks} 7`">
+<svg :viewBox="`0 0 21 7`">
 	<rect v-for="record in data" class="day"
 		width="1" height="1"
 		:x="record.x" :y="record.date.weekday"
@@ -28,11 +28,6 @@ import Vue from 'vue';
 
 export default Vue.extend({
 	props: ['data'],
-	data() {
-		return {
-			weeks: 21
-		};
-	},
 	created() {
 		for (const d of this.data) {
 			d.total = d.notes + d.replies + d.renotes;
@@ -43,9 +38,8 @@ export default Vue.extend({
 		const year = now.getFullYear();
 		const month = now.getMonth();
 		const day = now.getDate();
-		if (now.getDay() == 6) this.weeks = 20;
 
-		let x = this.weeks - 1;
+		let x = 20;
 		this.data.slice().forEach((d, i) => {
 			d.x = x;
 

--- a/src/client/app/desktop/views/components/activity.calendar.vue
+++ b/src/client/app/desktop/views/components/activity.calendar.vue
@@ -40,7 +40,7 @@ export default Vue.extend({
 		const day = now.getDate();
 
 		let x = 20;
-		this.data = this.data.map((d, i) => {
+		this.data.slice().forEach((d, i) => {
 			d.x = x;
 
 			const date = new Date(year, month, day - i);
@@ -59,8 +59,6 @@ export default Vue.extend({
 			d.color = `hsl(${ch}, ${cs}%, ${cl}%)`;
 
 			if (d.date.weekday == 0) x--;
-
-			return d;
 		});
 	}
 });

--- a/src/client/app/desktop/views/components/activity.calendar.vue
+++ b/src/client/app/desktop/views/components/activity.calendar.vue
@@ -1,11 +1,11 @@
 <template>
-<svg viewBox="0 0 21 7">
+<svg :viewBox="`0 0 ${weeks} 7`">
 	<rect v-for="record in data" class="day"
 		width="1" height="1"
 		:x="record.x" :y="record.date.weekday"
 		rx="1" ry="1"
 		fill="transparent">
-		<title>{{ record.date.year }}/{{ record.date.month }}/{{ record.date.day }}</title>
+		<title>{{ record.date.year }}/{{ record.date.month + 1 }}/{{ record.date.day }}</title>
 	</rect>
 	<rect v-for="record in data" class="day"
 		:width="record.v" :height="record.v"
@@ -28,6 +28,11 @@ import Vue from 'vue';
 
 export default Vue.extend({
 	props: ['data'],
+	data() {
+		return {
+			weeks: 21
+		};
+	},
 	created() {
 		for (const d of this.data) {
 			d.total = d.notes + d.replies + d.renotes;
@@ -38,18 +43,19 @@ export default Vue.extend({
 		const year = now.getFullYear();
 		const month = now.getMonth();
 		const day = now.getDate();
+		if (now.getDay() == 6) this.weeks = 20;
 
-		let x = 0;
-		this.data.slice().reverse().forEach((d, i) => {
+		let x = this.weeks - 1;
+		this.data.slice().forEach((d, i) => {
 			d.x = x;
 
 			const date = new Date(year, month, day - i);
 			d.date = {
 				year: date.getFullYear(),
 				month: date.getMonth(),
-				day: date.getDate()
+				day: date.getDate(),
+				weekday: date.getDay()
 			};
-			d.date.weekday = (new Date(d.date.year, d.date.month - 1, d.date.day)).getDay();
 
 			d.v = peak == 0 ? 0 : d.total / (peak / 2);
 			if (d.v > 1) d.v = 1;
@@ -58,7 +64,7 @@ export default Vue.extend({
 			const cl = 15 + ((1 - d.v) * 80);
 			d.color = `hsl(${ch}, ${cs}%, ${cl}%)`;
 
-			if (d.date.weekday == 6) x++;
+			if (d.date.weekday == 0) x--;
 		});
 	}
 });

--- a/src/client/app/desktop/views/components/activity.chart.vue
+++ b/src/client/app/desktop/views/components/activity.chart.vue
@@ -46,7 +46,7 @@ export default Vue.extend({
 	props: ['data'],
 	data() {
 		return {
-			viewBoxX: 140,
+			viewBoxX: 147,
 			viewBoxY: 60,
 			zoom: 1,
 			pos: 0,

--- a/src/client/app/desktop/views/components/activity.vue
+++ b/src/client/app/desktop/views/components/activity.vue
@@ -48,7 +48,7 @@ export default Vue.extend({
 		this.$root.api('charts/user/notes', {
 			userId: this.user.id,
 			span: 'day',
-			limit: 7 * 20
+			limit: 7 * 21
 		}).then(activity => {
 			this.activity = activity.diffs.normal.map((_, i) => ({
 				total: activity.diffs.normal[i] + activity.diffs.reply[i] + activity.diffs.renote[i],


### PR DESCRIPTION
## Summary

デスクトップ版のアクティビティウィジェットの日付とデータの表示が変だったのを修正

### 修正前
日付と曜日の表示がおかしい
![image](https://user-images.githubusercontent.com/17376330/61566826-5ba8bc00-aab8-11e9-9f65-bcd1b4cbf9e4.png)

### 修正後
テスト用のデータでは `d.v = date.getDate() / 31`を使用しました
![image](https://user-images.githubusercontent.com/17376330/61568150-15099080-aabd-11e9-8a1f-25299aa3ae86.png)