### PR TITLE
投稿フォームが画面外にはみ出さないように

### DIFF
--- a/src/client/app/desktop/views/components/post-form-window.vue
+++ b/src/client/app/desktop/views/components/post-form-window.vue
@@ -10,7 +10,7 @@
 		</span>
 	</template>
 
-	<div class="mk-post-form-window--body">
+	<div class="mk-post-form-window--body" :style="{ maxHeight: `${maxHeight}px` }">
 		<mk-note-preview v-if="reply" class="notePreview" :note="reply"/>
 		<x-post-form ref="form"
 			:reply="reply"
@@ -59,6 +59,12 @@ export default Vue.extend({
 			files: [],
 			geo: null
 		};
+	},
+
+	computed: {
+		maxHeight() {
+			return window.innerHeight - 50;
+		},
 	},
 
 	mounted() {

--- a/src/client/app/desktop/views/components/window.vue
+++ b/src/client/app/desktop/views/components/window.vue
@@ -260,14 +260,14 @@ export default Vue.extend({
 				let moveLeft = me.clientX - moveBaseX;
 				let moveTop = me.clientY - moveBaseY;
 
-				// 上はみ出し
-				if (moveTop < 0) moveTop = 0;
+				// 下はみ出し
+				if (moveTop + windowHeight > browserHeight) moveTop = browserHeight - windowHeight;
 
 				// 左はみ出し
 				if (moveLeft < 0) moveLeft = 0;
 
-				// 下はみ出し
-				if (moveTop + windowHeight > browserHeight) moveTop = browserHeight - windowHeight;
+				// 上はみ出し
+				if (moveTop < 0) moveTop = 0;
 
 				// 右はみ出し
 				if (moveLeft + windowWidth > browserWidth) moveLeft = browserWidth - windowWidth;
@@ -442,10 +442,10 @@ export default Vue.extend({
 			const browserHeight = window.innerHeight;
 			const windowWidth = main.offsetWidth;
 			const windowHeight = main.offsetHeight;
-			if (position.left < 0) main.style.left = 0;
-			if (position.top < 0) main.style.top = 0;
-			if (position.left + windowWidth > browserWidth) main.style.left = browserWidth - windowWidth + 'px';
-			if (position.top + windowHeight > browserHeight) main.style.top = browserHeight - windowHeight + 'px';
+			if (position.left < 0) main.style.left = 0;     // 左はみ出し
+			if (position.top + windowHeight > browserHeight) main.style.top = browserHeight - windowHeight + 'px';  // 下はみ出し
+			if (position.left + windowWidth > browserWidth) main.style.left = browserWidth - windowWidth + 'px';    // 右はみ出し
+			if (position.top < 0) main.style.top = 0;       // 上はみ出し
 		}
 	}
 });


### PR DESCRIPTION
## Summary
Fix #5201 

画面の高さより長い投稿フォームを出さないように (リバーシ等と同じようにスクロールするように)
![image](https://user-images.githubusercontent.com/30769358/61575561-f8467a80-ab07-11e9-9e13-3853c4c5d789.png)

画面の高さより長いなんらかのウィンドウが出てきた場合でも上がはみ出さないように。
(ドラッグ等で画面内フィットが発生したときに、下を基準ではなく上を基準にして収めるように。)
