### PR TITLE
Fix: スクロールしてると絵文字ピッカーの位置がずれる

### DIFF
--- a/src/client/app/desktop/views/components/emoji-picker-dialog.vue
+++ b/src/client/app/desktop/views/components/emoji-picker-dialog.vue
@@ -75,7 +75,7 @@ export default Vue.extend({
 
 <style lang="stylus" scoped>
 .gcafiosrssbtbnbzqupfmglvzgiaipyv
-	position fixed
+	position absolute
 	top 0
 	left 0
 	z-index 3000


### PR DESCRIPTION
## Summary
Fix #5115 

#5104 から該当修正部分だけ