### PR TITLE
Update deprecated vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,10 +2,10 @@
 	"recommendations": [
 		"ducksoupdev.vue2",
 		"editorconfig.editorconfig",
-		"eg2.tslint",
 		"eg2.vscode-npm-script",
 		"hollowtree.vue-snippets",
 		"ms-vscode.typescript-javascript-grammar",
+		"ms-vscode.vscode-typescript-tslint-plugin",
 		"octref.vetur",
 		"sysoev.language-stylus"
 	]


### PR DESCRIPTION
## Summary
https://marketplace.visualstudio.com/items?itemName=eg2.tslint

> **Note**: This extension has been deprecated in favor of the [vscode-typescript-tslint-plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin). To learn about the differences between vscode-tslint and the new extension please refer to this [document](https://github.com/Microsoft/vscode-typescript-tslint-plugin#differences-with-the-vscode-tslint-extension).

らしいので