### PR TITLE
Fix: some post form errors

### DIFF
--- a/src/client/app/common/views/components/post-form-attaches.vue
+++ b/src/client/app/common/views/components/post-form-attaches.vue
@@ -36,7 +36,7 @@ export default Vue.extend({
 			required: true
 		},
 		detachMediaFn: {
-			type: Object,
+			type: Function,
 			required: false
 		}
 	},

--- a/src/client/app/desktop/views/components/post-form-window.vue
+++ b/src/client/app/desktop/views/components/post-form-window.vue
@@ -5,8 +5,8 @@
 			<span class="icon" v-if="geo"><fa icon="map-marker-alt"/></span>
 			<span v-if="!reply">{{ $t('note') }}</span>
 			<span v-if="reply">{{ $t('reply') }}</span>
-			<span class="count" v-if="files.length != 0">{{ this.$t('attaches').replace('{}', files.length) }}</span>
-			<span class="count" v-if="uploadings.length != 0">{{ this.$t('uploading-media').replace('{}', uploadings.length) }}<mk-ellipsis/></span>
+			<span class="count" v-if="files.length != 0">{{ $t('attaches').replace('{}', files.length) }}</span>
+			<span class="count" v-if="uploadings.length != 0">{{ $t('uploading-media').replace('{}', uploadings.length) }}<mk-ellipsis/></span>
 		</span>
 	</template>
 


### PR DESCRIPTION
## Summary
投稿フォームで出てくるいくつかのエラーを修正

(developで？) ホームか投稿フォームを開いたときに以下のエラーが出るのを修正
`Invalid prop: type check failed for prop "detachMediaFn". Expected Object, got Function`

投稿フォームで添付ファイルを付けた際に以下のエラーが出るのを修正
`Error in render: "TypeError: this is null"` 
これをなおすと投稿フォームのヘッダに添付ファイル数がちゃんと表示されるようになるみたい
![image](https://user-images.githubusercontent.com/30769358/61662325-2ba42780-ad09-11e9-82ff-c6942b311f2f.png)