### PR TITLE
Fix: リンクバリデーションリンクが一瞬表示されてしまう

### DIFF
--- a/src/server/web/views/user.pug
+++ b/src/server/web/views/user.pug
@@ -37,7 +37,5 @@ block meta
 	if profile.url
 		link(rel='alternate' href=profile.url type='text/html')
 
-block content
-	div#me(style={ display: 'none' })
-		each m in me
-			a(rel='me' href=`${m}`) #{m}
+	each m in me
+		link(rel='me' href=`${m}`)

--- a/src/server/web/views/user.pug
+++ b/src/server/web/views/user.pug
@@ -38,6 +38,6 @@ block meta
 		link(rel='alternate' href=profile.url type='text/html')
 
 block content
-	div#me
+	div#me(style={ display: 'none' })
 		each m in me
 			a(rel='me' href=`${m}`) #{m}


### PR DESCRIPTION
## Summary
#5161 で追加したユーザーページのリンクバリデーション用リンクが
ロード時に一瞬表示されてしまうのを修正
