### PR TITLE
AP Emojiのupdatedは採用しないように

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -299,9 +299,8 @@ export async function extractEmojis(tags: ITag[], host: string): Promise<Emoji[]
 		});
 
 		if (exists) {
-			if ((tag.updated != null && exists.updatedAt == null)
-				|| (tag.id != null && exists.uri == null)
-				|| (tag.updated != null && exists.updatedAt != null && new Date(tag.updated) > exists.updatedAt)
+			if ((tag.id != null && exists.uri == null)
+				|| (tag.icon!.url !== exists.url)
 			) {
 				await Emojis.update({
 					host,
@@ -309,7 +308,7 @@ export async function extractEmojis(tags: ITag[], host: string): Promise<Emoji[]
 				}, {
 					uri: tag.id,
 					url: tag.icon!.url,
-					updatedAt: new Date(tag.updated!),
+					updatedAt: new Date(),
 				});
 
 				return await Emojis.findOne({
@@ -329,7 +328,7 @@ export async function extractEmojis(tags: ITag[], host: string): Promise<Emoji[]
 			name,
 			uri: tag.id,
 			url: tag.icon!.url,
-			updatedAt: tag.updated ? new Date(tag.updated) : undefined,
+			updatedAt: new Date(),
 			aliases: []
 		} as Partial<Emoji>);
 	}));

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -299,7 +299,9 @@ export async function extractEmojis(tags: ITag[], host: string): Promise<Emoji[]
 		});
 
 		if (exists) {
-			if ((tag.id != null && exists.uri == null)
+			if ((tag.updated != null && exists.updatedAt == null)
+				|| (tag.id != null && exists.uri == null)
+				|| (tag.updated != null && exists.updatedAt != null && new Date(tag.updated) > exists.updatedAt)
 				|| (tag.icon!.url !== exists.url)
 			) {
 				await Emojis.update({


### PR DESCRIPTION
## Summary
Resolve #5218 

リモートカスタム絵文字情報の`updated `はあまりあてにならないので採用しないように
どうせ変更される項目`url`しかないし、既にDBから取得済みなのでそのまま`url`を比較するように