### PR TITLE
Enable s3ForcePathStyle

### DIFF
--- a/src/services/drive/s3.ts
+++ b/src/services/drive/s3.ts
@@ -17,6 +17,7 @@ export function getS3(meta: Meta) {
 		secretAccessKey: meta.objectStorageSecretKey,
 		region: meta.objectStorageRegion,
 		sslEnabled: meta.objectStorageUseSSL,
+		s3ForcePathStyle: true,
 		httpOptions: {
 		}
 	} as S3.ClientConfiguration;


### PR DESCRIPTION
## Summary
Fix #5232 

実際のminio環境はなかったので確認できなかったのですが
`endpoint: host.example.tld` みたいなのを指定したときに
`bucket.host.example.tld` へのアクセスになってしまうのが
`host.example.tld` になってくれるのは確認済み

S3とwasabiで壊れないのを確認済み