### PR TITLE
Modify ssl directive to 'ssl' for listen directive

### DIFF
--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -25,10 +25,9 @@ server {
 }
 
 server {
-    listen 443 http2;
-    listen [::]:443 http2;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name example.tld;
-    ssl on;
     ssl_session_cache shared:ssl_session_cache:10m;
 
     # To use Let's Encrypt certificate


### PR DESCRIPTION
the "ssl" directive is deprecated. 
http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl
