### PR TITLE
Elasticsearchのインデックス名をconfigで変更できるように

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -28,6 +28,7 @@ export type Source = {
 		host: string;
 		port: number;
 		pass: string;
+		index?: string;
 	};
 
 	autoAdmin?: boolean;

--- a/src/db/elasticsearch.ts
+++ b/src/db/elasticsearch.ts
@@ -38,11 +38,11 @@ const client = config.elasticsearch ? new elasticsearch.Client({
 
 if (client) {
 	client.indices.exists({
-		index: 'misskey_note'
+		index: config.elasticsearch.index || 'misskey_note',
 	}).then(exist => {
 		if (!exist.body) {
 			client.indices.create({
-				index: 'misskey_note',
+				index: config.elasticsearch.index || 'misskey_note',
 				body: index
 			});
 		}

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -5,6 +5,7 @@ import { ApiError } from '../../error';
 import { Notes } from '../../../../models';
 import { In } from 'typeorm';
 import { ID } from '../../../../misc/cafy-id';
+import config from '../../../../config';
 
 export const meta = {
 	desc: {
@@ -87,7 +88,7 @@ export default define(meta, async (ps, me) => {
 	: [];
 
 	const result = await es.search({
-		index: 'misskey_note',
+		index: config.elasticsearch.index || 'misskey_note',
 		body: {
 			size: ps.limit!,
 			from: ps.offset,

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -434,7 +434,7 @@ function index(note: Note) {
 	if (note.text == null || config.elasticsearch == null) return;
 
 	es!.index({
-		index: 'misskey_note',
+		index: config.elasticsearch.index || 'misskey_note',
 		id: note.id.toString(),
 		body: {
 			text: note.text.toLowerCase(),


### PR DESCRIPTION
複数インスタンスの運用を行う際に、ESが一つのほうが負担が少ないので
インデックス名をconfigで変更できるようにしました。