### PR TITLE
ユーザー名の突き抜けの修正

### DIFF
--- a/src/client/app/common/views/components/user-name.vue
+++ b/src/client/app/common/views/components/user-name.vue
@@ -1,5 +1,5 @@
 <template>
-<mfm :text="user.name || user.username" :plain="true" :nowrap="true" :custom-emojis="user.emojis"/>
+<mfm :text="user.name || user.username" :plain="true" :nowrap="nowrap" :custom-emojis="user.emojis"/>
 </template>
 
 <script lang="ts">
@@ -10,7 +10,11 @@ export default Vue.extend({
 		user: {
 			type: Object,
 			required: true
-		}
+		},
+		nowrap: {
+			type: Boolean,
+			default: true
+		},
 	}
 });
 </script>

--- a/src/client/app/common/views/deck/deck.column.vue
+++ b/src/client/app/common/views/deck/deck.column.vue
@@ -14,7 +14,7 @@
 			<template v-if="active"><fa icon="angle-up"/></template>
 			<template v-else><fa icon="angle-down"/></template>
 		</button>
-		<span><slot name="header"></slot></span>
+		<span class="header"><slot name="header"></slot></span>
 		<span class="count" v-if="count > 0">({{ count }})</span>
 		<button v-if="!isTemporaryColumn" class="menu" ref="menu" @click.stop="showMenu"><fa icon="caret-down"/></button>
 		<button v-else class="close" @click.stop="close"><fa icon="times"/></button>
@@ -395,7 +395,12 @@ export default Vue.extend({
 		&.indicate
 			box-shadow 0 3px 0 0 var(--primary)
 
-		> span
+		> .header
+			display flex
+			align-items center
+			width 100%
+			overflow hidden
+
 			[data-icon]
 				margin-right 8px
 

--- a/src/client/app/common/views/deck/deck.column.vue
+++ b/src/client/app/common/views/deck/deck.column.vue
@@ -396,9 +396,11 @@ export default Vue.extend({
 			box-shadow 0 3px 0 0 var(--primary)
 
 		> .header
-			display flex
+			display inline-block
 			align-items center
 			overflow hidden
+			text-overflow ellipsis
+			white-space nowrap
 
 			[data-icon]
 				margin-right 8px

--- a/src/client/app/common/views/deck/deck.column.vue
+++ b/src/client/app/common/views/deck/deck.column.vue
@@ -398,7 +398,6 @@ export default Vue.extend({
 		> .header
 			display flex
 			align-items center
-			width 100%
 			overflow hidden
 
 			[data-icon]
@@ -407,6 +406,9 @@ export default Vue.extend({
 		> .count
 			margin-left 4px
 			opacity 0.5
+		
+		> span:only-of-type
+			width 100%
 
 		> .toggleActive
 		> .menu

--- a/src/client/app/common/views/deck/deck.notification.vue
+++ b/src/client/app/common/views/deck/deck.notification.vue
@@ -54,8 +54,8 @@
 		<div>
 			<header>
 				<fa icon="user-clock" class="icon"/>
-				<router-link :to="notification.user | userPage">
-					<mk-user-name :user="notification.user" class="name"/>
+				<router-link :to="notification.user | userPage" class="name">
+					<mk-user-name :user="notification.user"/>
 				</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>
@@ -67,8 +67,8 @@
 		<div>
 			<header>
 				<fa icon="chart-pie" class="icon"/>
-				<router-link :to="notification.user | userPage">
-					<mk-user-name :user="notification.user" class="name"/>
+				<router-link :to="notification.user | userPage" class="name">
+					<mk-user-name :user="notification.user"/>
 				</router-link>
 				<mk-time :time="notification.createdAt"/>
 			</header>

--- a/src/client/app/common/views/deck/deck.notification.vue
+++ b/src/client/app/common/views/deck/deck.notification.vue
@@ -167,6 +167,10 @@ export default Vue.extend({
 					display inline-block
 					margin-right 3px
 
+		&.reaction
+			> div > header
+				align-items normal
+
 		&.renote
 			> div > header [data-icon]
 				color #77B255

--- a/src/client/app/common/views/deck/deck.user-column.vue
+++ b/src/client/app/common/views/deck/deck.user-column.vue
@@ -17,7 +17,7 @@
 				<mk-follow-button v-if="$store.getters.isSignedIn && user.id != $store.state.i.id" :user="user" class="follow" mini/>
 				<mk-avatar class="avatar" :user="user" :disable-preview="true" :key="user.id"/>
 				<router-link class="name" :to="user | userPage()">
-					<mk-user-name :user="user" :key="user.id"/>
+					<mk-user-name :user="user" :key="user.id" :nowrap="false"/>
 				</router-link>
 				<span class="acct">@{{ user | acct }} <fa v-if="user.isLocked == true" class="locked" icon="lock" fixed-width/></span>
 				<span class="followed" v-if="user.isFollowed">{{ $t('follows-you') }}</span>

--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -313,6 +313,10 @@ export default Vue.extend({
 						display inline-block
 						margin-right 3px
 
+				&.reaction
+					.text header
+						align-items normal
+
 				&.renote, &.quote
 					.text header [data-icon]
 						color #77B255

--- a/src/client/app/desktop/views/components/notifications.vue
+++ b/src/client/app/desktop/views/components/notifications.vue
@@ -11,17 +11,16 @@
 		<component :is="!$store.state.device.reduceMotion ? 'transition-group' : 'div'" name="mk-notifications" class="transition" tag="div">
 			<template v-for="(notification, i) in _notifications">
 				<div class="notification" :class="notification.type" :key="notification.id">
-					<mk-time :time="notification.createdAt"/>
-
 					<template v-if="notification.type == 'reaction'">
 						<mk-avatar class="avatar" :user="notification.user"/>
 						<div class="text">
-							<p>
-								<mk-reaction-icon :reaction="notification.reaction"/>
-								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id">
+							<header>
+								<mk-reaction-icon :reaction="notification.reaction" class="icon"/>
+								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id" class="name">
 									<mk-user-name :user="notification.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<fa icon="quote-left"/>
 									<mfm :text="getNoteSummary(notification.note)" :plain="true" :nowrap="true" :custom-emojis="notification.note.emojis"/>
@@ -33,11 +32,13 @@
 					<template v-if="notification.type == 'renote'">
 						<mk-avatar class="avatar" :user="notification.note.user"/>
 						<div class="text">
-							<p><fa icon="retweet"/>
-								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">
+							<header>
+								<fa icon="retweet" class="icon"/>
+								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId" class="name">
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note.renote)">
 								<fa icon="quote-left"/>
 									<mfm :text="getNoteSummary(notification.note.renote)" :plain="true" :nowrap="true" :custom-emojis="notification.note.renote.emojis"/>
@@ -49,11 +50,13 @@
 					<template v-if="notification.type == 'quote'">
 						<mk-avatar class="avatar" :user="notification.note.user"/>
 						<div class="text">
-							<p><fa icon="quote-left"/>
-								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">
+							<header>
+								<fa icon="quote-left" class="icon"/>
+								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId" class="name">
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<mfm :text="getNoteSummary(notification.note)" :plain="true" :custom-emojis="notification.note.emojis"/>
 							</router-link>
@@ -63,33 +66,39 @@
 					<template v-if="notification.type == 'follow'">
 						<mk-avatar class="avatar" :user="notification.user"/>
 						<div class="text">
-							<p><fa icon="user-plus"/>
-								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id">
+							<header>
+								<fa icon="user-plus" class="icon"/>
+								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id" class="name">
 									<mk-user-name :user="notification.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 						</div>
 					</template>
 
 					<template v-if="notification.type == 'receiveFollowRequest'">
 						<mk-avatar class="avatar" :user="notification.user"/>
 						<div class="text">
-							<p><fa icon="user-clock"/>
-								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id">
+							<header>
+								<fa icon="user-clock" class="icon"/>
+								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id" class="name">
 									<mk-user-name :user="notification.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 						</div>
 					</template>
 
 					<template v-if="notification.type == 'reply'">
 						<mk-avatar class="avatar" :user="notification.note.user"/>
 						<div class="text">
-							<p><fa icon="reply"/>
-								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">
+							<header>
+								<fa icon="reply" class="icon"/>
+								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId" class="name">
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<mfm :text="getNoteSummary(notification.note)" :plain="true" :custom-emojis="notification.note.emojis"/>
 							</router-link>
@@ -99,11 +108,13 @@
 					<template v-if="notification.type == 'mention'">
 						<mk-avatar class="avatar" :user="notification.note.user"/>
 						<div class="text">
-							<p><fa icon="at"/>
-								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId">
+							<header>
+								<fa icon="at" class="icon"/>
+								<router-link :to="notification.note.user | userPage" v-user-preview="notification.note.userId" class="name">
 									<mk-user-name :user="notification.note.user"/>
 								</router-link>
-							</p>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-preview" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<mfm :text="getNoteSummary(notification.note)" :plain="true" :custom-emojis="notification.note.emojis"/>
 							</router-link>
@@ -113,9 +124,13 @@
 					<template v-if="notification.type == 'pollVote'">
 						<mk-avatar class="avatar" :user="notification.user"/>
 						<div class="text">
-							<p><fa icon="chart-pie"/><router-link :to="notification.user | userPage" v-user-preview="notification.user.id">
-								<mk-user-name :user="notification.user"/>
-							</router-link></p>
+							<header>
+								<fa icon="chart-pie" class="icon"/>
+								<router-link :to="notification.user | userPage" v-user-preview="notification.user.id" class="name">
+									<mk-user-name :user="notification.user"/>
+								</router-link>
+								<mk-time :time="notification.createdAt"/>
+							</header>
 							<router-link class="note-ref" :to="notification.note | notePage" :title="getNoteSummary(notification.note)">
 								<fa icon="quote-left"/>
 									<mfm :text="getNoteSummary(notification.note)" :plain="true" :nowrap="true" :custom-emojis="notification.note.emojis"/>
@@ -241,15 +256,6 @@ export default Vue.extend({
 				&:last-child
 					border-bottom none
 
-				> .mk-time
-					display inline
-					position absolute
-					top 16px
-					right 12px
-					vertical-align top
-					color var(--noteHeaderInfo)
-					font-size small
-
 				&:after
 					content ""
 					display block
@@ -270,11 +276,22 @@ export default Vue.extend({
 					width calc(100% - 36px)
 					padding-left 8px
 
-					p
-						margin 0
+					> header
+						display flex
+						align-items baseline
+						white-space nowrap
 
-						[data-icon], .mk-reaction-icon
+						> .icon
 							margin-right 4px
+
+						> .name
+							overflow hidden
+							text-overflow ellipsis
+
+						> .mk-time
+							margin-left auto
+							color var(--noteHeaderInfo)
+							font-size 0.9em
 
 				.note-preview
 					color var(--noteText)
@@ -297,19 +314,19 @@ export default Vue.extend({
 						margin-right 3px
 
 				&.renote, &.quote
-					.text p [data-icon]
+					.text header [data-icon]
 						color #77B255
 
 				&.follow
-					.text p [data-icon]
+					.text header [data-icon]
 						color #53c7ce
 
 				&.receiveFollowRequest
-					.text p [data-icon]
+					.text header [data-icon]
 						color #888
 
 				&.reply, &.mention
-					.text p [data-icon]
+					.text header [data-icon]
 						color #555
 
 			> .date

--- a/src/client/app/desktop/views/components/user-preview.vue
+++ b/src/client/app/desktop/views/components/user-preview.vue
@@ -4,7 +4,7 @@
 		<div class="banner" :style="u.bannerUrl ? `background-image: url(${u.bannerUrl})` : ''"></div>
 		<mk-avatar class="avatar" :user="u" :disable-preview="true"/>
 		<div class="title">
-			<router-link class="name" :to="u | userPage"><mk-user-name :user="u"/></router-link>
+			<router-link class="name" :to="u | userPage"><mk-user-name :user="u" :nowrap="false"/></router-link>
 			<p class="username"><mk-acct :user="u"/></p>
 		</div>
 		<div class="description">

--- a/src/client/app/desktop/views/home/user/user.header.vue
+++ b/src/client/app/desktop/views/home/user/user.header.vue
@@ -5,7 +5,7 @@
 		<div class="fade"></div>
 		<div class="title">
 			<p class="name">
-				<mk-user-name :user="user"/>
+				<mk-user-name :user="user" :nowrap="false"/>
 			</p>
 			<div>
 				<span class="username"><mk-acct :user="user" :detail="true" /></span>

--- a/src/client/app/mobile/views/components/notification.vue
+++ b/src/client/app/mobile/views/components/notification.vue
@@ -180,6 +180,10 @@ export default Vue.extend({
 					display inline-block
 					margin-right 3px
 
+		&.reaction
+			> div > header
+				align-items normal
+
 		&.renote
 			> div > header [data-icon]
 				color #77B255

--- a/src/client/app/mobile/views/pages/user/index.vue
+++ b/src/client/app/mobile/views/pages/user/index.vue
@@ -17,7 +17,7 @@
 					<mk-follow-button v-if="$store.getters.isSignedIn && $store.state.i.id != user.id" :user="user"/>
 				</div>
 				<div class="title">
-					<h1><mk-user-name :user="user" :key="user.id"/></h1>
+					<h1><mk-user-name :user="user" :key="user.id" :nowrap="false"/></h1>
 					<span class="username"><mk-acct :user="user" :detail="true" :key="user.id"/></span>
 					<span class="followed" v-if="user.isFollowed">{{ $t('follows-you') }}</span>
 				</div>


### PR DESCRIPTION
## Summary
Fix #5150
いくつかのユーザー名の突き抜けを修正

**通知のユーザー名の突き抜けを修正**
desktop - 通知
deck - 通知 - フォローリクエスト / 投票

![image](https://user-images.githubusercontent.com/30769358/62830053-e063a180-bc42-11e9-8c6f-095777e7337b.png)

**ユーザーページでのユーザー名の突き抜けを修正**
desktop / deck / mobile / ポップアップ

![image](https://user-images.githubusercontent.com/30769358/62830069-2ae51e00-bc43-11e9-9bb4-6e3e096b8b6b.png)
↓
![image](https://user-images.githubusercontent.com/30769358/62830074-47815600-bc43-11e9-97a8-909c703781a9.png)

**通知のリアクションでリアクションアイコンとユーザー名のアイコンの縦がずれてるのを修正**
![image](https://user-images.githubusercontent.com/30769358/62830087-8fa07880-bc43-11e9-9f75-8203b4e146d7.png)
↓
![image](https://user-images.githubusercontent.com/30769358/62830088-9202d280-bc43-11e9-9b95-dc55ab1d4223.png)

**デッキのユーザーカラムでユーザー名が長いと閉じれなくなるのを修正**
![image](https://user-images.githubusercontent.com/30769358/62830104-d8583180-bc43-11e9-973f-d2f0f0db46ac.png)
↓
![image](https://user-images.githubusercontent.com/30769358/62830105-de4e1280-bc43-11e9-97df-3d2ca1108f2f.png)
