### PR TITLE
タイトルやアイコンがきちんと設定されないことがあるのを修正

### DIFF
--- a/src/client/app/common/views/pages/explore.vue
+++ b/src/client/app/common/views/pages/explore.vue
@@ -143,7 +143,11 @@ export default Vue.extend({
 		this.$root.getMeta().then(meta => {
 			this.meta = meta;
 		});
-	}
+	},
+
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 });
 </script>
 

--- a/src/client/app/common/views/pages/favorites.vue
+++ b/src/client/app/common/views/pages/favorites.vue
@@ -40,5 +40,9 @@ export default Vue.extend({
 			icon: faStar
 		});
 	},
+
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 });
 </script>

--- a/src/client/app/common/views/pages/featured.vue
+++ b/src/client/app/common/views/pages/featured.vue
@@ -40,5 +40,9 @@ export default Vue.extend({
 			icon: faNewspaper
 		});
 	},
+
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 });
 </script>

--- a/src/client/app/common/views/pages/pages.vue
+++ b/src/client/app/common/views/pages/pages.vue
@@ -52,6 +52,9 @@ export default Vue.extend({
 			icon: faStickyNote
 		});
 	},
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 	methods: {
 		create() {
 			this.$router.push(`/i/pages/new`);

--- a/src/client/app/common/views/pages/user-groups.vue
+++ b/src/client/app/common/views/pages/user-groups.vue
@@ -62,6 +62,8 @@ export default Vue.extend({
 		};
 	},
 	mounted() {
+		document.title = this.$root.instanceName;
+
 		this.$root.api('users/groups/owned').then(groups => {
 			this.ownedGroups = groups;
 		});

--- a/src/client/app/common/views/pages/user-lists.vue
+++ b/src/client/app/common/views/pages/user-lists.vue
@@ -33,6 +33,8 @@ export default Vue.extend({
 		};
 	},
 	mounted() {
+		document.title = this.$root.instanceName;
+		
 		this.$root.api('users/lists/list').then(lists => {
 			this.fetching = false;
 			this.lists = lists;

--- a/src/client/app/desktop/views/home/timeline.vue
+++ b/src/client/app/desktop/views/home/timeline.vue
@@ -94,6 +94,8 @@ export default Vue.extend({
 	},
 
 	mounted() {
+		document.title = this.$root.instanceName;
+
 		(this.$refs.tl as any).$once('loaded', () => {
 			this.$emit('loaded');
 		});

--- a/src/client/app/desktop/views/pages/settings.vue
+++ b/src/client/app/desktop/views/pages/settings.vue
@@ -13,6 +13,9 @@ export default Vue.extend({
 	components: {
 		XSettings: () => import('../components/settings.vue').then(m => m.default)
 	},
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 });
 </script>
 

--- a/src/client/app/mios.ts
+++ b/src/client/app/mios.ts
@@ -28,7 +28,12 @@ export default class MiOS extends EventEmitter {
 	};
 
 	public get instanceName() {
-		return this.meta ? (this.meta.data.name || 'Misskey') : 'Misskey';
+		const siteName = document.querySelector('meta[property="og:site_name"]') as HTMLMetaElement;
+		if (siteName && siteName.content) {
+			return siteName.content;
+		}
+
+		return 'Misskey';
 	}
 
 	private isMetaFetching = false;

--- a/src/client/app/mobile/views/pages/notifications.vue
+++ b/src/client/app/mobile/views/pages/notifications.vue
@@ -25,6 +25,9 @@ export default Vue.extend({
 			faBell,
 		};
 	},
+	mounted() {
+		document.title = this.$root.instanceName;
+	},
 	methods: {
 		beforeInit() {
 			Progress.start();

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -164,7 +164,8 @@ router.get('/@:user', async (ctx, next) => {
 
 		await ctx.render('user', {
 			user, profile, me,
-			instanceName: meta.name || 'Misskey'
+			instanceName: meta.name || 'Misskey',
+			icon: meta.iconUrl
 		});
 		ctx.set('Cache-Control', 'public, max-age=30');
 	} else {
@@ -197,7 +198,8 @@ router.get('/notes/:note', async ctx => {
 		await ctx.render('note', {
 			note: _note,
 			summary: getNoteSummary(_note),
-			instanceName: meta.name || 'Misskey'
+			instanceName: meta.name || 'Misskey',
+			icon: meta.iconUrl
 		});
 
 		if (['public', 'home'].includes(note.visibility)) {

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -283,6 +283,7 @@ router.get('*', async ctx => {
 	await ctx.render('base', {
 		img: meta.bannerUrl,
 		title: meta.name || 'Misskey',
+		instanceName: meta.name || 'Misskey',
 		desc: meta.description,
 		icon: meta.iconUrl
 	});


### PR DESCRIPTION
## Summary
Fix #5264, Fix #5269 など

インスタンス名を変更しているときにちゃんとタイトルに反映されないことがあるのを修正
タイトルが変更されるユーザー/ノート ページに直アクセス後に、他のページに遷移してもタイトルが戻らないのを修正
faviconを変更しているときに反映されないページがあるのを修正

- `og:site_name`がユーザーページとか以外では正しく反映されないのを修正
- `instanceName`プロパティがAPI metaがfetch済みかを考慮してないため不正確な値を返してしまうのを修正
→metaをちゃんと待機するようにすると結構めんどくさくなるため`og:site_name`を見て採用するように変更
- deckにインスタンス名変更が反映されないのを修正
- mobileにインスタンス名変更が反映されないのを修正
- タイトルが変更されるユーザー/ノート ページに直アクセス後に、他のページに遷移してもタイトルが戻らないのを修正 (これはインスタンス名変更は関係なくおきる)
- ユーザーページとノートページでfaviconが反映されてなかったのを修正