### PR TITLE
updateHashtagを並列で行わないように

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -12,7 +12,7 @@ import { ITag, extractHashtags } from './tag';
 import { IIdentifier } from './identifier';
 import { apLogger } from '../logger';
 import { Note } from '../../../models/entities/note';
-import { updateHashtag } from '../../../services/update-hashtag';
+import { updateUsertags } from '../../../services/update-hashtag';
 import { Users, UserNotePinings, Instances, DriveFiles, Followings, UserProfiles, UserPublickeys } from '../../../models';
 import { User, IRemoteUser } from '../../../models/entities/user';
 import { Emoji } from '../../../models/entities/emoji';
@@ -194,8 +194,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 	usersChart.update(user!, true);
 
 	// ハッシュタグ更新
-	for (const tag of tags) updateHashtag(user!, tag, true, true);
-	for (const tag of (user!.tags || []).filter(x => !tags.includes(x))) updateHashtag(user!, tag, true, false);
+	updateUsertags(user!, tags);
 
 	//#region アイコンとヘッダー画像をフェッチ
 	const [avatar, banner] = (await Promise.all<DriveFile | null>([
@@ -355,8 +354,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 	});
 
 	// ハッシュタグ更新
-	for (const tag of tags) updateHashtag(exist, tag, true, true);
-	for (const tag of (exist.tags || []).filter(x => !tags.includes(x))) updateHashtag(exist, tag, true, false);
+	updateUsertags(exist, tags);
 
 	// 該当ユーザーが既にフォロワーになっていた場合はFollowingもアップデートする
 	await Followings.update({

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -8,7 +8,7 @@ import { parse, parsePlain } from '../../../../mfm/parse';
 import extractEmojis from '../../../../misc/extract-emojis';
 import extractHashtags from '../../../../misc/extract-hashtags';
 import * as langmap from 'langmap';
-import { updateHashtag } from '../../../../services/update-hashtag';
+import { updateUsertags } from '../../../../services/update-hashtag';
 import { ApiError } from '../../error';
 import { Users, DriveFiles, UserProfiles, Pages } from '../../../../models';
 import { User } from '../../../../models/entities/user';
@@ -264,8 +264,7 @@ export default define(meta, async (ps, user, app) => {
 	updates.tags = tags;
 
 	// ハッシュタグ更新
-	for (const tag of tags) updateHashtag(user, tag, true, true);
-	for (const tag of user.tags.filter(x => !tags.includes(x))) updateHashtag(user, tag, true, false);
+	updateUsertags(user, tags);
 	//#endregion
 
 	if (Object.keys(updates).length > 0) await Users.update(user.id, updates);

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -9,7 +9,7 @@ import watch from './watch';
 import { parse } from '../../mfm/parse';
 import { resolveUser } from '../../remote/resolve-user';
 import config from '../../config';
-import { updateHashtag } from '../update-hashtag';
+import { updateHashtags } from '../update-hashtag';
 import { concat } from '../../prelude/array';
 import insertNoteUnread from './unread';
 import { registerOrFetchInstanceDoc } from '../register-or-fetch-instance-doc';
@@ -202,7 +202,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 	}
 
 	// ハッシュタグ更新
-	for (const tag of tags) updateHashtag(user, tag);
+	updateHashtags(user, tags);
 
 	// Increment notes count (user)
 	incNotesCountOfUser(user);

--- a/src/services/update-hashtag.ts
+++ b/src/services/update-hashtag.ts
@@ -4,6 +4,22 @@ import { hashtagChart } from './chart';
 import { genId } from '../misc/gen-id';
 import { Hashtag } from '../models/entities/hashtag';
 
+export async function updateHashtags(user: User, tags: string[]) {
+	for (const tag of tags) {
+		await updateHashtag(user, tag);
+	}
+}
+
+export async function updateUsertags(user: User, tags: string[]) {
+	for (const tag of tags) {
+		await updateHashtag(user, tag, true, true);
+	}
+
+	for (const tag of (user.tags || []).filter(x => !tags.includes(x))) {
+		await updateHashtag(user, tag, true, false);
+	}
+}
+
 export async function updateHashtag(user: User, tag: string, isUserAttached = false, inc = true) {
 	tag = tag.toLowerCase();
 


### PR DESCRIPTION
## Summary
https://github.com/syuilo/misskey/pull/5263#issuecomment-522201674
ハッシュタグの更新がタグの数だけ並列で行われてDBを重くしてしまうことがあるのを修正