### PR TITLE
Fix: HashtagがUpdateできない

### DIFF
--- a/src/services/update-hashtag.ts
+++ b/src/services/update-hashtag.ts
@@ -13,7 +13,7 @@ export async function updateHashtag(user: User, tag: string, isUserAttached = fa
 
 	if (index != null) {
 		const q = Hashtags.createQueryBuilder('tag').update()
-			.where('tag.name = :name', { name: tag });
+			.where('name = :name', { name: tag });
 
 		const set = {} as any;
 
@@ -21,45 +21,45 @@ export async function updateHashtag(user: User, tag: string, isUserAttached = fa
 			if (inc) {
 				// 自分が初めてこのタグを使ったなら
 				if (!index.attachedUserIds.some(id => id === user.id)) {
-					set.attachedUserIds = () => `array_append(tag.attachedUserIds, '${user.id}')`;
-					set.attachedUsersCount = () => `tag.attachedUsersCount + 1`;
+					set.attachedUserIds = () => `array_append("attachedUserIds", '${user.id}')`;
+					set.attachedUsersCount = () => `"attachedUsersCount" + 1`;
 				}
 				// 自分が(ローカル内で)初めてこのタグを使ったなら
 				if (Users.isLocalUser(user) && !index.attachedLocalUserIds.some(id => id === user.id)) {
-					set.attachedLocalUserIds = () => `array_append(tag.attachedLocalUserIds, '${user.id}')`;
-					set.attachedLocalUsersCount = () => `tag.attachedLocalUsersCount + 1`;
+					set.attachedLocalUserIds = () => `array_append("attachedLocalUserIds", '${user.id}')`;
+					set.attachedLocalUsersCount = () => `"attachedLocalUsersCount" + 1`;
 				}
 				// 自分が(リモートで)初めてこのタグを使ったなら
 				if (Users.isRemoteUser(user) && !index.attachedRemoteUserIds.some(id => id === user.id)) {
-					set.attachedRemoteUserIds = () => `array_append(tag.attachedRemoteUserIds, '${user.id}')`;
-					set.attachedRemoteUsersCount = () => `tag.attachedRemoteUsersCount + 1`;
+					set.attachedRemoteUserIds = () => `array_append("attachedRemoteUserIds", '${user.id}')`;
+					set.attachedRemoteUsersCount = () => `"attachedRemoteUsersCount" + 1`;
 				}
 			} else {
-				set.attachedUserIds = () => `array_remove(tag.attachedUserIds, '${user.id}')`;
-				set.attachedUsersCount = () => `tag.attachedUsersCount - 1`;
+				set.attachedUserIds = () => `array_remove("attachedUserIds", '${user.id}')`;
+				set.attachedUsersCount = () => `"attachedUsersCount" - 1`;
 				if (Users.isLocalUser(user)) {
-					set.attachedLocalUserIds = () => `array_remove(tag.attachedLocalUserIds, '${user.id}')`;
-					set.attachedLocalUsersCount = () => `tag.attachedLocalUsersCount - 1`;
+					set.attachedLocalUserIds = () => `array_remove("attachedLocalUserIds", '${user.id}')`;
+					set.attachedLocalUsersCount = () => `"attachedLocalUsersCount" - 1`;
 				} else {
-					set.attachedRemoteUserIds = () => `array_remove(tag.attachedRemoteUserIds, '${user.id}')`;
-					set.attachedRemoteUsersCount = () => `tag.attachedRemoteUsersCount - 1`;
+					set.attachedRemoteUserIds = () => `array_remove("attachedRemoteUserIds", '${user.id}')`;
+					set.attachedRemoteUsersCount = () => `"attachedRemoteUsersCount" - 1`;
 				}
 			}
 		} else {
 			// 自分が初めてこのタグを使ったなら
 			if (!index.mentionedUserIds.some(id => id === user.id)) {
-				set.mentionedUserIds = () => `array_append(tag.mentionedUserIds, '${user.id}')`;
-				set.mentionedUsersCount = () => `tag.mentionedUsersCount + 1`;
+				set.mentionedUserIds = () => `array_append("mentionedUserIds", '${user.id}')`;
+				set.mentionedUsersCount = () => `"mentionedUsersCount" + 1`;
 			}
 			// 自分が(ローカル内で)初めてこのタグを使ったなら
 			if (Users.isLocalUser(user) && !index.mentionedLocalUserIds.some(id => id === user.id)) {
-				set.mentionedLocalUserIds = () => `array_append(tag.mentionedLocalUserIds, '${user.id}')`;
-				set.mentionedLocalUsersCount = () => `tag.mentionedLocalUsersCount + 1`;
+				set.mentionedLocalUserIds = () => `array_append("mentionedLocalUserIds", '${user.id}')`;
+				set.mentionedLocalUsersCount = () => `"mentionedLocalUsersCount" + 1`;
 			}
 			// 自分が(リモートで)初めてこのタグを使ったなら
 			if (Users.isRemoteUser(user) && !index.mentionedRemoteUserIds.some(id => id === user.id)) {
-				set.mentionedRemoteUserIds = () => `array_append(tag.mentionedRemoteUserIds, '${user.id}')`;
-				set.mentionedRemoteUsersCount = () => `tag.mentionedRemoteUsersCount + 1`;
+				set.mentionedRemoteUserIds = () => `array_append("mentionedRemoteUserIds", '${user.id}')`;
+				set.mentionedRemoteUsersCount = () => `"mentionedRemoteUsersCount" + 1`;
 			}
 		}
 


### PR DESCRIPTION
## Summary
以下のエラーが出て既存のHashtagのUpdateに失敗するのを修正
```
message: 'missing FROM-clause entry for table "tag"',
query: `UPDATE "hashtag" SET "attachedUserIds" = array_remove(tag.attachedUserIds, '816b772ddd70b5fe8b764fbf'), "attachedUsersCount" = tag.attachedUsersCount - 1, "attachedLocalUserIds" = array_remove(tag.attachedLocalUserIds, '816b772ddd70b5fe8b764fbf'), "attachedLocalUsersCount" = tag.attachedLocalUsersCount - 1 WHERE tag.name = $1`,
parameters: [ 'x21' ]
```
https://github.com/syuilo/misskey/pull/5263#issuecomment-522214284
https://github.com/syuilo/misskey/pull/5263#issuecomment-522214508

昔はうまくいってたのかはよくわからないけど

現状は
- `tag.`ってどこを見てる？
- カラム名に大文字を含むときはダブルクオーテーションでくくる必要があるみたい

みたいな感じなので、修正してUpdate出来ることを確認済です。