### PR TITLE
uuid() と lint

### DIFF
--- a/src/@types/lookup-dns-cache.d.ts
+++ b/src/@types/lookup-dns-cache.d.ts
@@ -1,5 +1,5 @@
 declare module 'lookup-dns-cache' {
-	import { LookupOneOptions, LookupAllOptions, LookupOptions, LookupAddress } from 'dns'
+	import { LookupOneOptions, LookupAllOptions, LookupOptions, LookupAddress } from 'dns';
 
 	function lookup(hostname: string, family: number, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void): void;
 	function lookup(hostname: string, options: LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void): void;

--- a/src/client/app/common/views/components/settings/tags.vue
+++ b/src/client/app/common/views/components/settings/tags.vue
@@ -16,7 +16,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import i18n from '../../../../i18n';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	i18n: i18n('desktop/views/components/settings.tags.vue'),

--- a/src/client/app/common/views/components/settings/theme.vue
+++ b/src/client/app/common/views/components/settings/theme.vue
@@ -125,7 +125,7 @@ import Vue from 'vue';
 import i18n from '../../../../i18n';
 import { lightTheme, darkTheme, builtinThemes, applyTheme, Theme } from '../../../../theme';
 import { Chrome } from 'vue-color';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import * as tinycolor from 'tinycolor2';
 import * as JSON5 from 'json5';
 import { faMoon, faSun } from '@fortawesome/free-regular-svg-icons';

--- a/src/client/app/common/views/components/trends.chart.vue
+++ b/src/client/app/common/views/components/trends.chart.vue
@@ -31,7 +31,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	props: {

--- a/src/client/app/common/views/deck/deck.vue
+++ b/src/client/app/common/views/deck/deck.vue
@@ -21,7 +21,7 @@ import i18n from '../../../i18n';
 import XColumnCore from './deck.column-core.vue';
 import Menu from '../../../common/views/components/menu.vue';
 
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	i18n: i18n('deck'),

--- a/src/client/app/common/views/deck/deck.widgets-column.vue
+++ b/src/client/app/common/views/deck/deck.widgets-column.vue
@@ -54,7 +54,7 @@ import Vue from 'vue';
 import i18n from '../../../i18n';
 import XColumn from './deck.column.vue';
 import * as XDraggable from 'vuedraggable';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	i18n: i18n(),

--- a/src/client/app/common/views/pages/page-editor/els/page-editor.el.if.vue
+++ b/src/client/app/common/views/pages/page-editor/els/page-editor.el.if.vue
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { faPlus, faQuestion } from '@fortawesome/free-solid-svg-icons';
 import i18n from '../../../../../i18n';
 import XContainer from '../page-editor.container.vue';
@@ -76,7 +76,7 @@ export default Vue.extend({
 			});
 			if (canceled) return;
 
-			const id = uuid.v4();
+			const id = uuid();
 			this.value.children.push({ id, type });
 		},
 	}

--- a/src/client/app/common/views/pages/page-editor/els/page-editor.el.section.vue
+++ b/src/client/app/common/views/pages/page-editor/els/page-editor.el.section.vue
@@ -18,7 +18,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { faPlus, faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 import { faStickyNote } from '@fortawesome/free-regular-svg-icons';
 import i18n from '../../../../../i18n';
@@ -88,7 +88,7 @@ export default Vue.extend({
 			});
 			if (canceled) return;
 
-			const id = uuid.v4();
+			const id = uuid();
 			this.value.children.push({ id, type });
 		},
 	}

--- a/src/client/app/common/views/pages/page-editor/page-editor.script-block.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.script-block.vue
@@ -58,7 +58,7 @@ import i18n from '../../../../i18n';
 import XContainer from './page-editor.container.vue';
 import { faPencilAlt, faPlug } from '@fortawesome/free-solid-svg-icons';
 import { isLiteralBlock, funcDefs, blockDefs } from '../../../../../../misc/aiscript/index';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	i18n: i18n('pages'),
@@ -143,7 +143,7 @@ export default Vue.extend({
 			this.warn = null;
 
 			if (this.value.type === 'fn') {
-				const id = uuid.v4();
+				const id = uuid();
 				this.value.value = {};
 				Vue.set(this.value.value, 'slots', []);
 				Vue.set(this.value.value, 'expression', { id, type: null });
@@ -156,7 +156,7 @@ export default Vue.extend({
 
 				const empties = [];
 				for (let i = 0; i < fn.value.slots.length; i++) {
-					const id = uuid.v4();
+					const id = uuid();
 					empties.push({ id, type: null });
 				}
 				Vue.set(this.value, 'args', empties);
@@ -167,7 +167,7 @@ export default Vue.extend({
 
 			const empties = [];
 			for (let i = 0; i < funcDefs[this.value.type].in.length; i++) {
-				const id = uuid.v4();
+				const id = uuid();
 				empties.push({ id, type: null });
 			}
 			Vue.set(this.value, 'args', empties);

--- a/src/client/app/common/views/pages/page-editor/page-editor.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.vue
@@ -99,7 +99,7 @@ import { faSave, faStickyNote, faTrashAlt } from '@fortawesome/free-regular-svg-
 import i18n from '../../../../i18n';
 import XVariable from './page-editor.script-block.vue';
 import XBlocks from './page-editor.blocks.vue';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import { blockDefs } from '../../../../../../misc/aiscript/index';
 import { ASTypeChecker } from '../../../../../../misc/aiscript/type-checker';
 import { url } from '../../../../config';
@@ -201,7 +201,7 @@ export default Vue.extend({
 			this.variables = this.page.variables;
 			this.eyeCatchingImageId = this.page.eyeCatchingImageId;
 		} else {
-			const id = uuid.v4();
+			const id = uuid();
 			this.content = [{
 				id,
 				type: 'text',
@@ -292,7 +292,7 @@ export default Vue.extend({
 			});
 			if (canceled) return;
 
-			const id = uuid.v4();
+			const id = uuid();
 			this.content.push({ id, type });
 		},
 
@@ -316,7 +316,7 @@ export default Vue.extend({
 				return;
 			}
 
-			const id = uuid.v4();
+			const id = uuid();
 			this.variables.push({ id, name, type: null });
 		},
 

--- a/src/client/app/common/views/widgets/posts-monitor.vue
+++ b/src/client/app/common/views/widgets/posts-monitor.vue
@@ -71,7 +71,7 @@
 <script lang="ts">
 import define from '../../../common/define-widget';
 import i18n from '../../../i18n';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default define({
 	name: 'posts-monitor',

--- a/src/client/app/common/views/widgets/server.cpu-memory.vue
+++ b/src/client/app/common/views/widgets/server.cpu-memory.vue
@@ -63,7 +63,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	props: ['connection'],

--- a/src/client/app/desktop/views/home/home.vue
+++ b/src/client/app/desktop/views/home/home.vue
@@ -79,7 +79,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import * as XDraggable from 'vuedraggable';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import XWelcome from '../pages/welcome.vue';
 
 export default Vue.extend({

--- a/src/client/app/mios.ts
+++ b/src/client/app/mios.ts
@@ -1,7 +1,7 @@
 import autobind from 'autobind-decorator';
 import Vue from 'vue';
 import { EventEmitter } from 'eventemitter3';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 import initStore from './store';
 import { apiUrl, version, locale } from './config';

--- a/src/client/app/mobile/views/pages/widgets.vue
+++ b/src/client/app/mobile/views/pages/widgets.vue
@@ -54,7 +54,7 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import * as XDraggable from 'vuedraggable';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export default Vue.extend({
 	i18n: i18n('mobile/views/pages/widgets.vue'),

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -1,11 +1,11 @@
 import config from '../../../config';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 
 export const renderActivity = (x: any) => {
 	if (x == null) return null;
 
 	if (x !== null && typeof x === 'object' && x.id == null) {
-		x.id = `${config.url}/${uuid.v4()}`;
+		x.id = `${config.url}/${uuid()}`;
 	}
 
 	return Object.assign({

--- a/src/server/api/endpoints/auth/session/generate.ts
+++ b/src/server/api/endpoints/auth/session/generate.ts
@@ -1,4 +1,4 @@
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import $ from 'cafy';
 import config from '../../../../../config';
 import define from '../../../define';
@@ -64,7 +64,7 @@ export default define(meta, async (ps) => {
 	}
 
 	// Generate token
-	const token = uuid.v4();
+	const token = uuid();
 
 	// Create session token document
 	const doc = await AuthSessions.save({

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -5,7 +5,7 @@ import { OAuth2 } from 'oauth';
 import config from '../../../config';
 import { publishMainStream } from '../../../services/stream';
 import redis from '../../../db/redis';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import signin from '../common/signin';
 import { fetchMeta } from '../../../misc/fetch-meta';
 import { Users, UserProfiles } from '../../../models';

--- a/src/server/api/service/github.ts
+++ b/src/server/api/service/github.ts
@@ -5,7 +5,7 @@ import { OAuth2 } from 'oauth';
 import config from '../../../config';
 import { publishMainStream } from '../../../services/stream';
 import redis from '../../../db/redis';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import signin from '../common/signin';
 import { fetchMeta } from '../../../misc/fetch-meta';
 import { Users, UserProfiles } from '../../../models';

--- a/src/server/api/service/twitter.ts
+++ b/src/server/api/service/twitter.ts
@@ -1,6 +1,6 @@
 import * as Koa from 'koa';
 import * as Router from 'koa-router';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import autwh from 'autwh';
 import redis from '../../../db/redis';
 import { publishMainStream } from '../../../services/stream';

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import * as fs from 'fs';
 
 import * as crypto from 'crypto';
-import * as uuid from 'uuid';
+import { v4 as uuid } from 'uuid';
 import * as sharp from 'sharp';
 
 import { publishMainStream, publishDriveStream } from '../stream';
@@ -55,7 +55,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 			|| `${ meta.objectStorageUseSSL ? 'https' : 'http' }://${ meta.objectStorageEndpoint }${ meta.objectStoragePort ? `:${meta.objectStoragePort}` : '' }/${ meta.objectStorageBucket }`;
 
 		// for original
-		const key = `${meta.objectStoragePrefix}/${uuid.v4()}${ext}`;
+		const key = `${meta.objectStoragePrefix}/${uuid()}${ext}`;
 		const url = `${ baseUrl }/${ key }`;
 
 		// for alts
@@ -72,7 +72,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 		];
 
 		if (alts.webpublic) {
-			webpublicKey = `${meta.objectStoragePrefix}/webpublic-${uuid.v4()}.${alts.webpublic.ext}`;
+			webpublicKey = `${meta.objectStoragePrefix}/webpublic-${uuid()}.${alts.webpublic.ext}`;
 			webpublicUrl = `${ baseUrl }/${ webpublicKey }`;
 
 			logger.info(`uploading webpublic: ${webpublicKey}`);
@@ -80,7 +80,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 		}
 
 		if (alts.thumbnail) {
-			thumbnailKey = `${meta.objectStoragePrefix}/thumbnail-${uuid.v4()}.${alts.thumbnail.ext}`;
+			thumbnailKey = `${meta.objectStoragePrefix}/thumbnail-${uuid()}.${alts.thumbnail.ext}`;
 			thumbnailUrl = `${ baseUrl }/${ thumbnailKey }`;
 
 			logger.info(`uploading thumbnail: ${thumbnailKey}`);
@@ -104,9 +104,9 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 
 		return await DriveFiles.save(file);
 	} else { // use internal storage
-		const accessKey = uuid.v4();
-		const thumbnailAccessKey = 'thumbnail-' + uuid.v4();
-		const webpublicAccessKey = 'webpublic-' + uuid.v4();
+		const accessKey = uuid();
+		const thumbnailAccessKey = 'thumbnail-' + uuid();
+		const webpublicAccessKey = 'webpublic-' + uuid();
 
 		const url = InternalStorage.saveFromPath(accessKey, path);
 


### PR DESCRIPTION
## uuid() の使い方の整理

https://www.npmjs.com/package/uuid
```
Deprecation warning:
The use of require('uuid') is deprecated and will not be supported after version 3.x of this module.
Instead, use require('uuid/[v1|v3|v4|v5]') as shown in the examples below.
```

のようで`import * as uuid from 'uuid';`で`uuid()`を呼ぶのは良くない気がして
全部`import { v4 as uuid } from 'uuid';`に替えました

## lint
```
ERROR: (semicolon) C:/Workspace/misskey/src/@types/lookup-dns-cache.d.ts[2, 88]: Missing semicolon
```