### PR TITLE
Fix animation not being performed on new reaction

### DIFF
--- a/src/client/app/common/views/components/reactions-viewer.reaction.vue
+++ b/src/client/app/common/views/components/reactions-viewer.reaction.vue
@@ -26,6 +26,10 @@ export default Vue.extend({
 			type: Number,
 			required: true,
 		},
+		isInitial: {
+			type: Boolean,
+			required: true,
+		},
 		note: {
 			type: Object,
 			required: true,
@@ -40,6 +44,9 @@ export default Vue.extend({
 		isMe(): boolean {
 			return this.$store.getters.isSignedIn && this.$store.state.i.id === this.note.userId;
 		},
+	},
+	mounted() {
+		if (!this.isInitial) this.anime();
 	},
 	watch: {
 		count() {

--- a/src/client/app/common/views/components/reactions-viewer.vue
+++ b/src/client/app/common/views/components/reactions-viewer.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="mk-reactions-viewer" :class="{ isMe }">
-	<x-reaction v-for="(count, reaction) in reactions" :reaction="reaction" :count="count" :note="note" :key="reaction"/>
+	<x-reaction v-for="(count, reaction) in reactions" :reaction="reaction" :count="count" :is-initial="initialReactions.has(reaction)" :note="note" :key="reaction"/>
 </div>
 </template>
 
@@ -12,11 +12,19 @@ export default Vue.extend({
 	components: {
 		XReaction
 	},
+	data() {
+		return {
+			initialReactions: null as unknown as Set<string>
+		};
+	},
 	props: {
 		note: {
 			type: Object,
 			required: true
 		},
+	},
+	created() {
+		this.initialReactions = new Set(Object.keys(this.reactions));
 	},
 	computed: {
 		reactions(): any {

--- a/src/client/app/common/views/components/reactions-viewer.vue
+++ b/src/client/app/common/views/components/reactions-viewer.vue
@@ -14,7 +14,7 @@ export default Vue.extend({
 	},
 	data() {
 		return {
-			initialReactions: null as unknown as Set<string>
+			initialReactions: new Set(Object.keys(this.note.reactions))
 		};
 	},
 	props: {
@@ -22,9 +22,6 @@ export default Vue.extend({
 			type: Object,
 			required: true
 		},
-	},
-	created() {
-		this.initialReactions = new Set(Object.keys(this.reactions));
 	},
 	computed: {
 		reactions(): any {


### PR DESCRIPTION
## Summary
Fix #4186

reactions-viewer.reaction自身では新規リアクションかどうかを判断する方法がなさそうだったのでreactions-viewerから情報を伝搬するように
