### PR TITLE
Tune worker/job counts

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -116,8 +116,12 @@ autoAdmin: true
 # Whether disable HSTS
 #disableHsts: true
 
-# Clustering
+# Number of worker processes
 #clusterLimit: 1
+
+# Job concurrency per worker
+# deliverJobConcurrency: 128;
+# inboxJobConcurrency: 16;
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4

--- a/src/boot/master.ts
+++ b/src/boot/master.ts
@@ -159,7 +159,7 @@ async function init(): Promise<Config> {
 	return config;
 }
 
-async function spawnWorkers(limit: number = Infinity) {
+async function spawnWorkers(limit: number = 1) {
 	const workers = Math.min(limit, os.cpus().length);
 	bootLogger.info(`Starting ${workers} worker${workers === 1 ? '' : 's'}...`);
 	await Promise.all([...Array(workers)].map(spawnWorker));

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -42,6 +42,9 @@ export type Source = {
 	id: string;
 
 	outgoingAddressFamily?: 'ipv4' | 'ipv6' | 'dual';
+
+	deliverJobConcurrency?: number;
+	inboxJobConcurrency?: number;
 };
 
 /**

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -203,8 +203,8 @@ export function createCleanRemoteFilesJob() {
 
 export default function() {
 	if (!program.onlyServer) {
-		deliverQueue.process(128, processDeliver);
-		inboxQueue.process(128, processInbox);
+		deliverQueue.process(config.deliverJobConcurrency || 128, processDeliver);
+		inboxQueue.process(config.inboxJobConcurrency || 16, processInbox);
 		processDb(dbQueue);
 		procesObjectStorage(objectStorageQueue);
 	}


### PR DESCRIPTION
## Summary
Resolve #5266
Resolve #5270
Resolve #5008

ワーカープロセス数やジョブ並列度のデフォルト値を大抵の環境で妥当と思われる値に変更
APジョブ並列度を変更できるように

- 大抵の環境で多すぎるので(#5266)Workerの既定値を1に
  既に変更している環境ではその値が使われるので影響なし
- AP inboxの並列度が多すぎるので(#5270) 128 => 16に
- AP deliver/inbox job の並列度を変更できるように
  ただ、設定値はほぼ変える必要はないと思います
  (低スペックで連合が速い場合にinboxの並列度を下げておきたいとかくらい)