### PR TITLE
ページURLが他と重複してたらエラーを投げるように

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1817,6 +1817,7 @@ pages:
   read-page: "Viewing the source"
   page-created: "Created the page!"
   page-updated: "Updated the page"
+  name-already-exists: "Specified page url already exists"
   are-you-sure-delete: "Do you want to delete this page?"
   page-deleted: "The page has been deleted"
   edit-this-page: "Edit this page"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2015,6 +2015,7 @@ pages:
   read-page: "ソースを表示中"
   page-created: "ページを作成しました"
   page-updated: "ページを更新しました"
+  name-already-exists: "指定されたページURLは既に存在しています"
   are-you-sure-delete: "このページを削除しますか？"
   page-deleted: "ページを削除しました"
   edit-this-page: "このページを編集"

--- a/src/client/app/common/views/pages/page-editor/page-editor.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.vue
@@ -242,7 +242,7 @@ export default Vue.extend({
 						text: this.$t('page-updated')
 					});
 				}).catch(err => {
-					if(err.id == '4650348e-301c-499a-83c9-6aa988c66bc1'){
+					if(err.id == '2298a392-d4a1-44c5-9ebb-ac1aeaa5a9ab'){
 						this.$root.dialog({
 							type: 'error',
 							text: this.$t('name-already-exists')

--- a/src/client/app/common/views/pages/page-editor/page-editor.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.vue
@@ -245,7 +245,7 @@ export default Vue.extend({
 						text: this.$t('page-updated')
 					});
 				}).catch(err => {
-					if(err.id == 'uuid-for-name-already-exists'){
+					if(err.id == '4650348e-301c-499a-83c9-6aa988c66bc1'){
 						this.$root.dialog({
 							type: 'error',
 							text: this.$t('name-already-exists')
@@ -263,7 +263,7 @@ export default Vue.extend({
 					});
 					this.$router.push(`/i/pages/edit/${this.pageId}`);
 				}).catch(err => {
-					if(err.id == 'uuid-for-name-already-exists'){
+					if(err.id == '4650348e-301c-499a-83c9-6aa988c66bc1'){
 						this.$root.dialog({
 							type: 'error',
 							text: this.$t('name-already-exists')

--- a/src/client/app/common/views/pages/page-editor/page-editor.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.vue
@@ -234,9 +234,6 @@ export default Vue.extend({
 
 			if (this.pageId) {
 				options.pageId = this.pageId;
-			}
-
-			if (this.pageId) {
 				this.$root.api('pages/update', options)
 				.then(page => {
 					this.currentName = this.name.trim();

--- a/src/client/app/common/views/pages/page-editor/page-editor.vue
+++ b/src/client/app/common/views/pages/page-editor/page-editor.vue
@@ -220,37 +220,41 @@ export default Vue.extend({
 
 	methods: {
 		save() {
+			const options = {
+				title: this.title.trim(),
+				name: this.name.trim(),
+				summary: this.summary,
+				font: this.font,
+				hideTitleWhenPinned: this.hideTitleWhenPinned,
+				alignCenter: this.alignCenter,
+				content: this.content,
+				variables: this.variables,
+				eyeCatchingImageId: this.eyeCatchingImageId,
+			};
+
 			if (this.pageId) {
-				this.$root.api('pages/update', {
-					pageId: this.pageId,
-					title: this.title.trim(),
-					name: this.name.trim(),
-					summary: this.summary,
-					font: this.font,
-					hideTitleWhenPinned: this.hideTitleWhenPinned,
-					alignCenter: this.alignCenter,
-					content: this.content,
-					variables: this.variables,
-					eyeCatchingImageId: this.eyeCatchingImageId,
-				}).then(page => {
+				options.pageId = this.pageId;
+			}
+
+			if (this.pageId) {
+				this.$root.api('pages/update', options)
+				.then(page => {
 					this.currentName = this.name.trim();
 					this.$root.dialog({
 						type: 'success',
 						text: this.$t('page-updated')
 					});
+				}).catch(err => {
+					if(err.id == 'uuid-for-name-already-exists'){
+						this.$root.dialog({
+							type: 'error',
+							text: this.$t('name-already-exists')
+						});
+					}
 				});
 			} else {
-				this.$root.api('pages/create', {
-					title: this.title.trim(),
-					name: this.name.trim(),
-					summary: this.summary,
-					font: this.font,
-					hideTitleWhenPinned: this.hideTitleWhenPinned,
-					alignCenter: this.alignCenter,
-					content: this.content,
-					variables: this.variables,
-					eyeCatchingImageId: this.eyeCatchingImageId,
-				}).then(page => {
+				this.$root.api('pages/create', options)
+				.then(page => {
 					this.pageId = page.id;
 					this.currentName = this.name.trim();
 					this.$root.dialog({
@@ -258,6 +262,13 @@ export default Vue.extend({
 						text: this.$t('page-created')
 					});
 					this.$router.push(`/i/pages/edit/${this.pageId}`);
+				}).catch(err => {
+					if(err.id == 'uuid-for-name-already-exists'){
+						this.$root.dialog({
+							type: 'error',
+							text: this.$t('name-already-exists')
+						});
+					}
 				});
 			}
 		},

--- a/src/server/api/endpoints/pages/create.ts
+++ b/src/server/api/endpoints/pages/create.ts
@@ -76,6 +76,11 @@ export const meta = {
 			code: 'NO_SUCH_FILE',
 			id: 'b7b97489-0f66-4b12-a5ff-b21bd63f6e1c'
 		},
+		nameAlreadyExists: {
+			message: 'Specified name already exists.',
+			code: 'NAME_ALREADY_EXISTS',
+			id: '4650348e-301c-499a-83c9-6aa988c66bc1'
+		}
 	}
 };
 
@@ -91,6 +96,15 @@ export default define(meta, async (ps, user) => {
 			throw new ApiError(meta.errors.noSuchFile);
 		}
 	}
+
+	await Pages.find({
+		userId: user.id,
+		name: ps.name
+	}).then(result => {
+		if (result.length > 0) {
+			throw new ApiError(meta.errors.nameAlreadyExists);
+		}
+	});
 
 	const page = await Pages.save(new Page({
 		id: genId(),

--- a/src/server/api/endpoints/pages/update.ts
+++ b/src/server/api/endpoints/pages/update.ts
@@ -4,6 +4,7 @@ import define from '../../define';
 import { ApiError } from '../../error';
 import { Pages, DriveFiles } from '../../../../models';
 import { ID } from '../../../../misc/cafy-id';
+import { Not } from 'typeorm';
 
 export const meta = {
 	desc: {
@@ -85,6 +86,11 @@ export const meta = {
 			code: 'NO_SUCH_FILE',
 			id: 'cfc23c7c-3887-490e-af30-0ed576703c82'
 		},
+		nameAlreadyExists: {
+			message: 'Specified name already exists.',
+			code: 'NAME_ALREADY_EXISTS',
+			id: '4650348e-301c-499a-83c9-6aa988c66bc1'
+		}
 	}
 };
 
@@ -108,6 +114,16 @@ export default define(meta, async (ps, user) => {
 			throw new ApiError(meta.errors.noSuchFile);
 		}
 	}
+
+	await Pages.find({
+		id: Not(ps.pageId),
+		userId: user.id,
+		name: ps.name
+	}).then(result => {
+		if (result.length > 0) {
+			throw new ApiError(meta.errors.nameAlreadyExists);
+		}
+	});
 
 	await Pages.update(page.id, {
 		updatedAt: new Date(),

--- a/src/server/api/endpoints/pages/update.ts
+++ b/src/server/api/endpoints/pages/update.ts
@@ -89,7 +89,7 @@ export const meta = {
 		nameAlreadyExists: {
 			message: 'Specified name already exists.',
 			code: 'NAME_ALREADY_EXISTS',
-			id: '4650348e-301c-499a-83c9-6aa988c66bc1'
+			id: '2298a392-d4a1-44c5-9ebb-ac1aeaa5a9ab'
 		}
 	}
 };


### PR DESCRIPTION
## Summary
resolve #5019 

+ ページを作成するときと更新するときに指定されたnameがすでに存在するか確認
+ 存在した場合はエラーを投げてクライアントにメッセージを送る

あとオプションが冗長だったのでまとめちゃいましたが問題があったら戻します。