### PR TITLE
Proxy for SMTP

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -130,3 +130,11 @@ autoAdmin: true
 #syslog:
 #  host: localhost
 #  port: 514
+
+# Proxy for HTTP/HTTPS
+#proxy: http://127.0.0.1:3128
+
+# Proxy for SMTP/SMTPS
+#proxySmtp: http://127.0.0.1:3128   # use HTTP/1.1 CONNECT
+#proxySmtp: socks4://127.0.0.1:1080 # use SOCKS4
+#proxySmtp: socks5://127.0.0.1:1080 # use SOCKS5

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -34,6 +34,7 @@ export type Source = {
 	autoAdmin?: boolean;
 
 	proxy?: string;
+	proxySmtp?: string;
 
 	accesslog?: string;
 

--- a/src/services/send-email.ts
+++ b/src/services/send-email.ts
@@ -1,6 +1,7 @@
 import * as nodemailer from 'nodemailer';
 import { fetchMeta } from '../misc/fetch-meta';
 import Logger from './logger';
+import config from '../config';
 
 export const logger = new Logger('email');
 
@@ -14,6 +15,7 @@ export async function sendEmail(to: string, subject: string, text: string) {
 		port: meta.smtpPort,
 		secure: meta.smtpSecure,
 		ignoreTLS: !enableAuth,
+		proxy: config.proxySmtp,
 		auth: enableAuth ? {
 			user: meta.smtpUser,
 			pass: meta.smtpPass


### PR DESCRIPTION
## Summary
~~Resolve #2894~~
Resolve #5370

SMTPでProxyを使用できるようにしています
多くのHTTP用のProxyはSMTP用には設定されてないと思われるため、HTTP用とは設定を別にしています。

参考:
https://nodemailer.com/smtp/proxies/

「未設定時」と「HTTP/1.1 CONNECT使用時」でメールが送信できることは確認済み