### PR TITLE
Set Object Storage ACL to public-read as default

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -218,6 +218,7 @@ async function upload(key: string, stream: fs.ReadStream | Buffer, type: string,
 		Body: stream,
 		ContentType: type,
 		CacheControl: 'max-age=31536000, immutable',
+		ACL: 'public-read'
 	} as S3.PutObjectRequest;
 
 	if (filename) params.ContentDisposition = contentDisposition('inline', filename);


### PR DESCRIPTION
## Summary

ObjectStorageのアップロード時のACLをpublic-readにするように

Resolve #5024