### PR TITLE
Move task of locales copying from webpack to gulp

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -17,6 +17,7 @@ import * as rename from 'gulp-rename';
 import * as mocha from 'gulp-mocha';
 import * as replace from 'gulp-replace';
 const uglifyes = require('uglify-es');
+import * as fs from 'fs';
 
 const locales = require('./locales');
 
@@ -51,7 +52,16 @@ gulp.task('build:copy:fonts', () =>
 	gulp.src('./node_modules/three/examples/fonts/**/*').pipe(gulp.dest('./built/client/assets/fonts/'))
 );
 
-gulp.task('build:copy', gulp.parallel('build:copy:views', 'build:copy:fonts', () =>
+gulp.task('build:copy:locales', cb => {
+	fs.mkdirSync('./built/client/assets/locales', { recursive: true });
+
+	for (const [lang, locale] of Object.entries(locales))
+		fs.writeFileSync(`./built/client/assets/locales/${lang}.json`, JSON.stringify(locale), 'utf-8');
+
+	cb();
+});
+
+gulp.task('build:copy', gulp.parallel('build:copy:views', 'build:copy:fonts', 'build:copy:locales', () =>
 	gulp.src([
 		'./src/const.json',
 		'./src/server/web/views/**/*',

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -130,11 +130,6 @@ module.exports = {
 		}),
 		new WebpackOnBuildPlugin((stats: any) => {
 			fs.writeFileSync('./built/client/meta.json', JSON.stringify({ version: meta.version }), 'utf-8');
-
-			fs.mkdirSync('./built/client/assets/locales', { recursive: true });
-
-			for (const [lang, locale] of Object.entries(locales))
-				fs.writeFileSync(`./built/client/assets/locales/${lang}.json`, JSON.stringify(locale), 'utf-8');
 		}),
 		new VueLoaderPlugin(),
 		new webpack.optimize.ModuleConcatenationPlugin()


### PR DESCRIPTION
## Summary
webpackした時のみlocalesがコピーされるのは不便なので

* localesを `gulp build:copy:locales` でコピーできるように
* 全体をビルドするコマンドはそのまま
