### PR TITLE
AP Undo Announce

### DIFF
--- a/src/remote/activitypub/kernel/undo/announce.ts
+++ b/src/remote/activitypub/kernel/undo/announce.ts
@@ -1,34 +1,14 @@
-import config from '../../../../config';
 import { Notes } from '../../../../models';
-import { Note } from '../../../../models/entities/note';
 import { IRemoteUser } from '../../../../models/entities/user';
 import { IAnnounce, getApId } from '../../type';
 import deleteNote from '../../../../services/note/delete';
 
 export const undoAnnounce = async (actor: IRemoteUser, activity: IAnnounce): Promise<void> => {
-	const targetUri = getApId(activity.object);
+	const uri = getApId(activity);
 
-	let note: Note | undefined;
-
-	if (targetUri.startsWith(config.url + '/')) {
-		// Announce target is local
-		const targetNoteId = targetUri.split('/').pop();
-
-		note = await Notes.findOne({
-			renoteId: targetNoteId
-		});
-	} else {
-		// Announce target is remote
-		const targetNote = await Notes.findOne({
-			uri: targetUri
-		});
-
-		if (!targetNote) return;
-
-		note = await Notes.findOne({
-			renoteId: targetNote.id
-		});
-	}
+	const note = await Notes.findOne({
+		uri
+	});
 
 	if (!note) return;
 

--- a/src/remote/activitypub/kernel/undo/announce.ts
+++ b/src/remote/activitypub/kernel/undo/announce.ts
@@ -1,0 +1,36 @@
+import config from '../../../../config';
+import { Notes } from '../../../../models';
+import { Note } from '../../../../models/entities/note';
+import { IRemoteUser } from '../../../../models/entities/user';
+import { IAnnounce, getApId } from '../../type';
+import deleteNote from '../../../../services/note/delete';
+
+export const undoAnnounce = async (actor: IRemoteUser, activity: IAnnounce): Promise<void> => {
+	const targetUri = getApId(activity.object);
+
+	let note: Note | undefined;
+
+	if (targetUri.startsWith(config.url + '/')) {
+		// Announce target is local
+		const targetNoteId = targetUri.split('/').pop();
+
+		note = await Notes.findOne({
+			renoteId: targetNoteId
+		});
+	} else {
+		// Announce target is remote
+		const targetNote = await Notes.findOne({
+			uri: targetUri
+		});
+
+		if (!targetNote) return;
+
+		note = await Notes.findOne({
+			renoteId: targetNote.id
+		});
+	}
+
+	if (!note) return;
+
+	await deleteNote(actor, note);
+};

--- a/src/remote/activitypub/kernel/undo/index.ts
+++ b/src/remote/activitypub/kernel/undo/index.ts
@@ -1,8 +1,9 @@
 import { IRemoteUser } from '../../../../models/entities/user';
-import { IUndo, IFollow, IBlock, ILike } from '../../type';
+import { IUndo, IFollow, IBlock, ILike, IAnnounce } from '../../type';
 import unfollow from './follow';
 import unblock from './block';
 import undoLike from './like';
+import { undoAnnounce } from './announce';
 import Resolver from '../../resolver';
 import { apLogger } from '../../logger';
 
@@ -37,6 +38,9 @@ export default async (actor: IRemoteUser, activity: IUndo): Promise<void> => {
 			break;
 		case 'Like':
 			undoLike(actor, object as ILike);
+			break;
+		case 'Announce':
+			undoAnnounce(actor, object as IAnnounce);
 			break;
 	}
 };


### PR DESCRIPTION
## Summary
Resolve #5384
APでRenote/Boost取り消しをやりとりするように
- Renote取り消し時に、Delete NoteではなくUndo Announceを送るように
- Undo Announceを受け取ったら、そのRenoteを消すように

