### PR TITLE
実行時にpackage.jsonを参照しないように

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -96,7 +96,7 @@ gulp.task('cleanall', gulp.parallel('clean', cb =>
 ));
 
 gulp.task('build:client:script', () => {
-	const client = require('./built/client/meta.json');
+	const client = require('./built/meta.json');
 	return gulp.src(['./src/client/app/boot.js', './src/client/app/safe.js'])
 		.pipe(replace('VERSION', JSON.stringify(client.version)))
 		.pipe(replace('ENV', JSON.stringify(env)))

--- a/src/argv.ts
+++ b/src/argv.ts
@@ -1,8 +1,8 @@
 import * as program from 'commander';
-import * as pkg from '../package.json';
+import config from './config';
 
 program
-	.version(pkg.version)
+	.version(config.version)
 	.option('--no-daemons', 'Disable daemon processes (for debbuging)')
 	.option('--disable-clustering', 'Disable clustering')
 	.option('--only-server', 'Run server only (without job queue processing)')

--- a/src/boot/master.ts
+++ b/src/boot/master.ts
@@ -8,7 +8,6 @@ import Logger from '../services/logger';
 import loadConfig from '../config/load';
 import { Config } from '../config/types';
 import { lessThan } from '../prelude/array';
-import * as pkg from '../../package.json';
 import { program } from '../argv';
 import { showMachineInfo } from '../misc/show-machine-info';
 import { initDb } from '../db/postgre';
@@ -16,10 +15,10 @@ import { initDb } from '../db/postgre';
 const logger = new Logger('core', 'cyan');
 const bootLogger = logger.createSubLogger('boot', 'magenta', false);
 
-function greet() {
+function greet(config: Config) {
 	if (!program.quiet) {
 		//#region Misskey logo
-		const v = `v${pkg.version}`;
+		const v = `v${config.version}`;
 		console.log('  _____ _         _           ');
 		console.log(' |     |_|___ ___| |_ ___ _ _ ');
 		console.log(' | | | | |_ -|_ -| \'_| -_| | |');
@@ -35,20 +34,20 @@ function greet() {
 	}
 
 	bootLogger.info('Welcome to Misskey!');
-	bootLogger.info(`Misskey v${pkg.version}`, null, true);
+	bootLogger.info(`Misskey v${config.version}`, null, true);
 }
 
 /**
  * Init master process
  */
 export async function masterMain() {
-	greet();
-
 	let config!: Config;
 
 	try {
 		// initialize app
 		config = await init();
+
+		greet(config);
 
 		if (config.port == null || Number.isNaN(config.port)) {
 			bootLogger.error('The port is not configured. Please configure port.', null, true);

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { Source, Mixin } from './types';
-import * as pkg from '../../package.json';
+import * as meta from '../client/meta.json';
 
 /**
  * Path of configuration directory
@@ -30,6 +30,7 @@ export default function load() {
 
 	config.port = config.port || parseInt(process.env.PORT || '', 10);
 
+	mixin.version = meta.version;
 	mixin.host = url.host;
 	mixin.hostname = url.hostname;
 	mixin.scheme = url.protocol.replace(/:$/, '');
@@ -38,7 +39,7 @@ export default function load() {
 	mixin.apiUrl = `${mixin.scheme}://${mixin.host}/api`;
 	mixin.authUrl = `${mixin.scheme}://${mixin.host}/auth`;
 	mixin.driveUrl = `${mixin.scheme}://${mixin.host}/files`;
-	mixin.userAgent = `Misskey/${pkg.version} (${config.url})`;
+	mixin.userAgent = `Misskey/${meta.version} (${config.url})`;
 
 	if (config.autoAdmin == null) config.autoAdmin = false;
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -5,7 +5,7 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { Source, Mixin } from './types';
-import * as meta from '../client/meta.json';
+import * as meta from '../meta.json';
 
 /**
  * Path of configuration directory

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -57,6 +57,7 @@ export type Source = {
  * Misskeyが自動的に(ユーザーが設定した情報から推論して)設定する情報
  */
 export type Mixin = {
+	version: string;
 	host: string;
 	hostname: string;
 	scheme: string;

--- a/src/meta.json
+++ b/src/meta.json
@@ -1,0 +1,3 @@
+{
+	"version": "unknown"
+}

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -3,7 +3,6 @@ import * as os from 'os';
 import config from '../../../config';
 import define from '../define';
 import { fetchMeta } from '../../../misc/fetch-meta';
-import * as pkg from '../../../../package.json';
 import { Emojis } from '../../../models';
 import { getConnection } from 'typeorm';
 import redis from '../../../db/redis';
@@ -35,7 +34,7 @@ export const meta = {
 				type: 'string' as const,
 				optional: false as const, nullable: false as const,
 				description: 'The version of Misskey of this instance.',
-				example: pkg.version
+				example: config.version
 			},
 			name: {
 				type: 'string' as const,
@@ -101,7 +100,7 @@ export default define(meta, async (ps, me) => {
 		maintainerName: instance.maintainerName,
 		maintainerEmail: instance.maintainerEmail,
 
-		version: pkg.version,
+		version: config.version,
 
 		name: instance.name,
 		uri: config.url,

--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -18,37 +18,15 @@ export const links = [/* (awaiting release) {
 }];
 
 const nodeinfo2 = async () => {
-	const meta = await fetchMeta(true);
-
 	const [
-		{
-			name,
-			description,
-			maintainerName,
-			maintainerEmail,
-			langs,
-			ToSUrl,
-			repositoryUrl,
-			feedbackUrl,
-			announcements,
-			disableRegistration,
-			disableLocalTimeline,
-			disableGlobalTimeline,
-			enableRecaptcha,
-			maxNoteTextLength,
-			enableTwitterIntegration,
-			enableGithubIntegration,
-			enableDiscordIntegration,
-			enableEmail,
-			enableServiceWorker
-		},
+		meta,
 		// total,
 		// activeHalfyear,
 		// activeMonth,
 		// localPosts,
 		// localComments
 	] = await Promise.all([
-		meta
+		fetchMeta(true),
 		// User.count({ host: null }),
 		// User.count({ host: null, updatedAt: { $gt: new Date(Date.now() - 15552000000) } }),
 		// User.count({ host: null, updatedAt: { $gt: new Date(Date.now() - 2592000000) } }),
@@ -67,34 +45,34 @@ const nodeinfo2 = async () => {
 			inbound: [] as string[],
 			outbound: ['atom1.0', 'rss2.0']
 		},
-		openRegistrations: !disableRegistration,
+		openRegistrations: !meta.disableRegistration,
 		usage: {
 			users: {} // { total, activeHalfyear, activeMonth },
 			// localPosts,
 			// localComments
 		},
 		metadata: {
-			name,
-			description,
+			name: meta.name,
+			description: meta.description,
 			maintainer: {
-				name: maintainerName,
-				email: maintainerEmail
+				name: meta.maintainerName,
+				email: meta.maintainerEmail
 			},
-			langs,
-			ToSUrl,
-			repositoryUrl,
-			feedbackUrl,
-			announcements,
-			disableRegistration,
-			disableLocalTimeline,
-			disableGlobalTimeline,
-			enableRecaptcha,
-			maxNoteTextLength,
-			enableTwitterIntegration,
-			enableGithubIntegration,
-			enableDiscordIntegration,
-			enableEmail,
-			enableServiceWorker
+			langs: meta.langs,
+			ToSUrl: meta.ToSUrl,
+			repositoryUrl: meta.repositoryUrl,
+			feedbackUrl: meta.feedbackUrl,
+			announcements: meta.announcements,
+			disableRegistration: meta.disableRegistration,
+			disableLocalTimeline: meta.disableLocalTimeline,
+			disableGlobalTimeline: meta.disableGlobalTimeline,
+			enableRecaptcha: meta.enableRecaptcha,
+			maxNoteTextLength: meta.maxNoteTextLength,
+			enableTwitterIntegration: meta.enableTwitterIntegration,
+			enableGithubIntegration: meta.enableGithubIntegration,
+			enableDiscordIntegration: meta.enableDiscordIntegration,
+			enableEmail: meta.enableEmail,
+			enableServiceWorker: meta.enableServiceWorker
 		}
 	};
 };

--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -2,7 +2,6 @@ import * as Router from 'koa-router';
 import config from '../config';
 import { fetchMeta } from '../misc/fetch-meta';
 // import User from '../models/user';
-import { name as softwareName, version, repository } from '../../package.json';
 // import Note from '../models/note';
 
 const router = new Router();
@@ -19,6 +18,8 @@ export const links = [/* (awaiting release) {
 }];
 
 const nodeinfo2 = async () => {
+	const meta = await fetchMeta(true);
+
 	const [
 		{
 			name,
@@ -47,7 +48,7 @@ const nodeinfo2 = async () => {
 		// localPosts,
 		// localComments
 	] = await Promise.all([
-		fetchMeta(true),
+		meta
 		// User.count({ host: null }),
 		// User.count({ host: null, updatedAt: { $gt: new Date(Date.now() - 15552000000) } }),
 		// User.count({ host: null, updatedAt: { $gt: new Date(Date.now() - 2592000000) } }),
@@ -57,9 +58,9 @@ const nodeinfo2 = async () => {
 
 	return {
 		software: {
-			name: softwareName,
-			version,
-			repository: repository.url
+			name: 'Misskey',
+			version: config.version,
+			repository: meta.repositoryUrl,
 		},
 		protocols: ['activitypub'],
 		services: {

--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -36,7 +36,7 @@ const nodeinfo2 = async () => {
 
 	return {
 		software: {
-			name: 'Misskey',
+			name: 'misskey',
 			version: config.version,
 			repository: meta.repositoryUrl,
 		},

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -13,7 +13,6 @@ import * as views from 'koa-views';
 import docs from './docs';
 import packFeed from './feed';
 import { fetchMeta } from '../../misc/fetch-meta';
-import * as pkg from '../../../package.json';
 import { genOpenapiSpec } from '../api/openapi/gen-spec';
 import config from '../../config';
 import { Users, Notes, Emojis, UserProfiles, Pages } from '../../models';
@@ -256,7 +255,7 @@ router.get('/info', async ctx => {
 		where: { host: null }
 	});
 	await ctx.render('info', {
-		version: pkg.version,
+		version: config.version,
 		machine: os.hostname(),
 		os: os.platform(),
 		node: process.version,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -129,7 +129,7 @@ module.exports = {
 			'process.env.NODE_ENV': JSON.stringify(isProduction ? 'production' : 'development')
 		}),
 		new WebpackOnBuildPlugin((stats: any) => {
-			fs.writeFileSync('./built/client/meta.json', JSON.stringify({ version: meta.version }), 'utf-8');
+			fs.writeFileSync('./built/meta.json', JSON.stringify({ version: meta.version }), 'utf-8');
 
 			fs.mkdirSync('./built/client/assets/locales', { recursive: true });
 


### PR DESCRIPTION
## Summary
Resolve #5416

実行時に`package.json`を直接参照せずにビルド時に生成される`meta.json`を参照するように
`package.json`をリネームして`node ./index.js`とかで起動できるようになってるのとか確認済み