### PR TITLE
Indicate if input value is invalid

### DIFF
--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -9,6 +9,7 @@
 		<span class="title" ref="title">
 			<slot name="title"></slot>
 			<fa class="warning" v-if="invalid" :icon="['fa', 'exclamation-circle']"/>
+			<span v-if="invalid">{{ $refs.input.validationMessage }}</span>
 		</span>
 		<div class="prefix" ref="prefix"><slot name="prefix"></slot></div>
 		<template v-if="type != 'file'">
@@ -374,6 +375,7 @@ root(fill)
 
 			> .warning
 				margin-left 0.5em
+				margin-right 0.1em
 				color #fa0
 
 		> input

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -372,11 +372,15 @@ root(fill)
 			//will-change transform
 			transform-origin top left
 			transform scale(.75)
+			white-space nowrap
+			width 133%
+			overflow hidden
+			text-overflow ellipsis
 
 			> .warning
 				margin-left 0.5em
 				margin-right 0.1em
-				color #fa0
+				color var(--infoWarnFg)
 
 		> input
 			display block

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -8,8 +8,7 @@
 		<span class="label" ref="label"><slot></slot></span>
 		<span class="title" ref="title">
 			<slot name="title"></slot>
-			<fa class="warning" v-if="invalid" :icon="['fa', 'exclamation-circle']"/>
-			<span v-if="invalid">{{ $refs.input.validationMessage }}</span>
+			<span class="warning" v-if="invalid"><fa :icon="['fa', 'exclamation-circle']"/>{{ $refs.input.validationMessage }}</span>
 		</span>
 		<div class="prefix" ref="prefix"><slot name="prefix"></slot></div>
 		<template v-if="type != 'file'">
@@ -379,8 +378,10 @@ root(fill)
 
 			> .warning
 				margin-left 0.5em
-				margin-right 0.1em
 				color var(--infoWarnFg)
+
+				> svg
+					margin-right 0.1em
 
 		> input
 			display block

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -6,9 +6,11 @@
 			<div class="value" ref="passwordMetar"></div>
 		</div>
 		<span class="label" ref="label"><slot></slot></span>
-		<span class="title" ref="title"><slot name="title"></slot></span>
-		<div class="prefix" ref="prefix" v-if="!invalid"><slot name="prefix"></slot></div>
-		<div class="prefix" ref="prefix" v-else><fa :icon="['fa', 'exclamation-circle']"/></div>
+		<span class="title" ref="title">
+			<slot name="title"></slot>
+			<fa class="warning" v-if="invalid" :icon="['fa', 'exclamation-circle']"/>
+		</span>
+		<div class="prefix" ref="prefix"><slot name="prefix"></slot></div>
 		<template v-if="type != 'file'">
 			<input v-if="debounce" ref="input"
 				v-debounce="500"
@@ -369,6 +371,10 @@ root(fill)
 			//will-change transform
 			transform-origin top left
 			transform scale(.75)
+
+			> .warning
+				margin-left 0.5em
+				color #fa0
 
 		> input
 			display block

--- a/src/client/app/common/views/components/ui/input.vue
+++ b/src/client/app/common/views/components/ui/input.vue
@@ -7,7 +7,8 @@
 		</div>
 		<span class="label" ref="label"><slot></slot></span>
 		<span class="title" ref="title"><slot name="title"></slot></span>
-		<div class="prefix" ref="prefix"><slot name="prefix"></slot></div>
+		<div class="prefix" ref="prefix" v-if="!invalid"><slot name="prefix"></slot></div>
+		<div class="prefix" ref="prefix" v-else><fa :icon="['fa', 'exclamation-circle']"/></div>
 		<template v-if="type != 'file'">
 			<input v-if="debounce" ref="input"
 				v-debounce="500"
@@ -158,6 +159,7 @@ export default Vue.extend({
 		return {
 			v: this.value,
 			focused: false,
+			invalid: false,
 			passwordStrength: '',
 			id: Math.random().toString()
 		};
@@ -200,6 +202,8 @@ export default Vue.extend({
 				this.passwordStrength = strength > 0.7 ? 'high' : strength > 0.3 ? 'medium' : 'low';
 				(this.$refs.passwordMetar as any).style.width = `${strength * 100}%`;
 			}
+
+			this.invalid = this.$refs.input.validity.badInput;
 		}
 	},
 	mounted() {


### PR DESCRIPTION
## Summary

Related #5375 (resolve?)

* 今の`ui-input`は値のValidation状態を分かりづらい（Mouseホバーで出るtooltipでやっとわかる）
* `ui-input`の値のValidationがfalseになっても`v`自体がエラーになるわけでもないので普通に`null`扱いされる（これは仕様？）

→ ユーザーにValidationがfailだということを知らせる必要がありそう

![recording](https://user-images.githubusercontent.com/17376330/64740836-9ae01000-d531-11e9-9e9f-9e6afd23654d.gif)

（実は`this.$refs.input.validationMessage` を常に見えるtooltipとかで見せたかったがどうすればいいのかよくわかんなかったのでこれ）

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
