### PR TITLE
Follow requests page improvements

### DIFF
--- a/src/client/app/common/views/pages/follow-requests.vue
+++ b/src/client/app/common/views/pages/follow-requests.vue
@@ -70,5 +70,6 @@ export default Vue.extend({
 
 	> span
 		margin 0 0 0 auto
+		color var(--text)
 
 </style>

--- a/src/client/app/common/views/pages/follow-requests.vue
+++ b/src/client/app/common/views/pages/follow-requests.vue
@@ -9,7 +9,7 @@
 						<mk-user-name :user="req.follower"/>
 					</router-link>
 					<span>
-						<a @click="accept(req.follower)">{{ $t('accept') }}</a>|<a @click="reject(req.follower)">{{ $t('reject') }}</a>
+						<a @click="accept(req.follower)">{{ $t('accept') }}</a> | <a @click="reject(req.follower)">{{ $t('reject') }}</a>
 					</span>
 				</div>
 			</sequential-entrance>


### PR DESCRIPTION
## Summary
1. The `Accept` and `Reject` links are too close.
2. The `|` separator is hardly visible in the default dark theme.

![Misskey follow request actions](https://user-images.githubusercontent.com/14329097/64908531-085b8e80-d734-11e9-8893-fc5896f2e5f7.png)
