### PR TITLE
Fix: Keycap Number Sign が表示できない

### DIFF
--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -145,6 +145,7 @@ export const mfmLanguage = P.createLanguage({
 		if (!match) return P.makeFailure(i, 'not a hashtag');
 		let hashtag = match[1];
 		hashtag = removeOrphanedBrackets(hashtag);
+		if (hashtag.match(/^\ufe0f/)) return P.makeFailure(i, 'not a hashtag');
 		if (hashtag.match(/^[0-9]+$/)) return P.makeFailure(i, 'not a hashtag');
 		if (input[i - 1] != null && input[i - 1].match(/[a-z0-9]/i)) return P.makeFailure(i, 'not a hashtag');
 		if (hashtag.length > 50) return P.makeFailure(i, 'not a hashtag');

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -145,7 +145,7 @@ export const mfmLanguage = P.createLanguage({
 		if (!match) return P.makeFailure(i, 'not a hashtag');
 		let hashtag = match[1];
 		hashtag = removeOrphanedBrackets(hashtag);
-		if (hashtag.match(/^\ufe0f/)) return P.makeFailure(i, 'not a hashtag');
+		if (hashtag.match(/^(\u20e3|\ufe0f)/)) return P.makeFailure(i, 'not a hashtag');
 		if (hashtag.match(/^[0-9]+$/)) return P.makeFailure(i, 'not a hashtag');
 		if (input[i - 1] != null && input[i - 1].match(/[a-z0-9]/i)) return P.makeFailure(i, 'not a hashtag');
 		if (hashtag.length > 50) return P.makeFailure(i, 'not a hashtag');

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -640,7 +640,14 @@ describe('MFM', () => {
 				]);
 			});
 
-			it('ignore single Keycap Number Sign (U+0023 + U+FE0F + U+20E3)', () => {
+			it('ignore Keycap Number Sign (U+0023 + U+20E3)', () => {
+				const tokens = parse('#⃣');
+				assert.deepStrictEqual(tokens, [
+					leaf('emoji', { emoji: '#⃣' })
+				]);
+			});
+
+			it('ignore Keycap Number Sign (U+0023 + U+FE0F + U+20E3)', () => {
 				const tokens = parse('#️⃣');
 				assert.deepStrictEqual(tokens, [
 					leaf('emoji', { emoji: '#️⃣' })

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -639,6 +639,13 @@ describe('MFM', () => {
 					text('/bar'),
 				]);
 			});
+
+			it('ignore single Keycap Number Sign (U+0023 + U+FE0F + U+20E3)', () => {
+				const tokens = parse('#️⃣');
+				assert.deepStrictEqual(tokens, [
+					leaf('emoji', { emoji: '#️⃣' })
+				]);
+			});
 		});
 
 		describe('quote', () => {


### PR DESCRIPTION
## Summary
Fix #5427 
ハッシュタグのテキストが
- U+FE0F (絵文字スタイルセレクタ)
- U+20E3(囲み文字)

で始まるのはありえないので除外するように