### PR TITLE
Refactor removal of trailing comma/period

### DIFF
--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -167,8 +167,7 @@ export const mfmLanguage = P.createLanguage({
 			}
 			url = removeOrphanedBrackets(url);
 			while (url.endsWith('.') || url.endsWith(',')) {
-				if (url.endsWith('.')) url = url.substr(0, url.lastIndexOf('.'));
-				if (url.endsWith(',')) url = url.substr(0, url.lastIndexOf(','));
+				url = url.substr(0, url.length - 1);
 			}
 			return P.makeSuccess(i + url.length, url);
 		}).map(x => createLeaf('url', { url: x }));

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -166,9 +166,7 @@ export const mfmLanguage = P.createLanguage({
 				url = match[0];
 			}
 			url = removeOrphanedBrackets(url);
-			while (url.endsWith('.') || url.endsWith(',')) {
-				url = url.substr(0, url.length - 1);
-			}
+			url = url.replace(/[.,]*$/, '');
 			return P.makeSuccess(i + url.length, url);
 		}).map(x => createLeaf('url', { url: x }));
 	},


### PR DESCRIPTION
## Summary
~コンマとピリオドに対して、末尾の文字を消すという処理は共通なので、内側のif文で分岐する必要がなさそう。~

正規表現で置換した方がシンプル