### PR TITLE
Fix: selectコンポーネントに余分な下線が付く

### DIFF
--- a/src/client/app/common/views/components/ui/select.vue
+++ b/src/client/app/common/views/components/ui/select.vue
@@ -176,6 +176,9 @@ root(fill)
 			color rgba(#000, 0.54)
 			pointer-events none
 
+			&:empty
+				display none
+
 			> *
 				display block
 				min-width 16px


### PR DESCRIPTION
## Summary
select コンポーネントで prefix や suffix がない時に余分な下線がついてしまうのを修正
修正方法は input コンポーネントと同じ方法にしてます

![image](https://user-images.githubusercontent.com/30769358/65343942-49124680-dc11-11e9-886c-957bb626186c.png)
↓
![image](https://user-images.githubusercontent.com/30769358/65343964-516a8180-dc11-11e9-829a-bc81a47809b8.png)