### PR TITLE
Fix typo in misskey.nginx

### DIFF
--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -1,7 +1,7 @@
 # Sample nginx configuration for Misskey
 #
 # 1. Replace example.tld to your domain
-# 2. Copy to /etc/nginx/sites-available/ and then symlink from /etc/nginx/sites-ebabled/
+# 2. Copy to /etc/nginx/sites-available/ and then symlink from /etc/nginx/sites-enabled/
 #    or copy to /etc/nginx/conf.d/
 
 # For WebSocket


### PR DESCRIPTION
sites-ebabled => sites-enabled

ホンマに小さな指摘で恐れ入りますが、スペルミスしている模様なのでPR出しておきます( ˇωˇ )
