### PR TITLE
Hide suspended user profile

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -164,7 +164,8 @@ router.get('/users/:user', async (ctx, next) => {
 
 	const user = await Users.findOne({
 		id: userId,
-		host: null
+		host: null,
+		isSuspended: false
 	});
 
 	await userInfo(ctx, user);
@@ -175,7 +176,8 @@ router.get('/@:user', async (ctx, next) => {
 
 	const user = await Users.findOne({
 		usernameLower: ctx.params.user.toLowerCase(),
-		host: null
+		host: null,
+		isSuspended: false
 	});
 
 	await userInfo(ctx, user);

--- a/src/server/api/endpoints/admin/suspend-user.ts
+++ b/src/server/api/endpoints/admin/suspend-user.ts
@@ -2,7 +2,7 @@ import $ from 'cafy';
 import { ID } from '../../../../misc/cafy-id';
 import define from '../../define';
 import deleteFollowing from '../../../../services/following/delete';
-import { Users, Followings } from '../../../../models';
+import { Users, Followings, Notifications } from '../../../../models';
 import { User } from '../../../../models/entities/user';
 import { insertModerationLog } from '../../../../services/insert-moderation-log';
 import { doPostSuspend } from '../../../../services/suspend-user';
@@ -55,6 +55,7 @@ export default define(meta, async (ps, me) => {
 	(async () => {
 		await doPostSuspend(user).catch(e => {});
 		await unFollowAll(user).catch(e => {});
+		await readAllNotify(user).catch(e => {});
 	})();
 });
 
@@ -74,4 +75,13 @@ async function unFollowAll(follower: User) {
 
 		await deleteFollowing(follower, followee, true);
 	}
+}
+
+async function readAllNotify(notifier: User) {
+	await Notifications.update({
+		notifierId: notifier.id,
+		isRead: false,
+	}, {
+		isRead: true
+	});
 }

--- a/src/server/api/endpoints/users/show.ts
+++ b/src/server/api/endpoints/users/show.ts
@@ -66,13 +66,18 @@ export const meta = {
 export default define(meta, async (ps, me) => {
 	let user;
 
+	const isAdminOrModerator = me && (me.isAdmin || me.isModerator);
+
 	if (ps.userIds) {
 		if (ps.userIds.length === 0) {
 			return [];
 		}
 
-		const users = await Users.find({
+		const users = await Users.find(isAdminOrModerator ? {
 			id: In(ps.userIds)
+		} : {
+			id: In(ps.userIds),
+			isSuspended: false
 		});
 
 		return await Promise.all(users.map(u => Users.pack(u, me, {
@@ -93,7 +98,7 @@ export default define(meta, async (ps, me) => {
 			user = await Users.findOne(q);
 		}
 
-		if (user == null) {
+		if (user == null || (!isAdminOrModerator && user.isSuspended)) {
 			throw new ApiError(meta.errors.noSuchUser);
 		}
 

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -102,7 +102,8 @@ const getFeed = async (acct: string) => {
 	const { username, host } = parseAcct(acct);
 	const user = await Users.findOne({
 		usernameLower: username.toLowerCase(),
-		host
+		host,
+		isSuspended: false
 	});
 
 	return user && await packFeed(user);
@@ -150,7 +151,8 @@ router.get('/@:user', async (ctx, next) => {
 	const { username, host } = parseAcct(ctx.params.user);
 	const user = await Users.findOne({
 		usernameLower: username.toLowerCase(),
-		host
+		host,
+		isSuspended: false
 	});
 
 	if (user != null) {
@@ -170,6 +172,7 @@ router.get('/@:user', async (ctx, next) => {
 		ctx.set('Cache-Control', 'public, max-age=30');
 	} else {
 		// リモートユーザーなので
+		// モデレータがAPI経由で参照可能にするために404にはしない
 		await next();
 	}
 });
@@ -177,7 +180,8 @@ router.get('/@:user', async (ctx, next) => {
 router.get('/users/:user', async ctx => {
 	const user = await Users.findOne({
 		id: ctx.params.user,
-		host: null
+		host: null,
+		isSuspended: false
 	});
 
 	if (user == null) {

--- a/src/server/well-known.ts
+++ b/src/server/well-known.ts
@@ -49,7 +49,8 @@ router.get('/.well-known/nodeinfo', async ctx => {
 router.get(webFingerPath, async ctx => {
 	const fromId = (id: User['id']): Record<string, any> => ({
 		id,
-		host: null
+		host: null,
+		isSuspended: false
 	});
 
 	const generateQuery = (resource: string) =>
@@ -63,7 +64,8 @@ router.get(webFingerPath, async ctx => {
 	const fromAcct = (acct: Acct): Record<string, any> | number =>
 		!acct.host || acct.host === config.host.toLowerCase() ? {
 			usernameLower: acct.username,
-			host: null
+			host: null,
+			isSuspended: false
 		} : 422;
 
 	if (typeof ctx.query.resource !== 'string') {


### PR DESCRIPTION
## Summary
Related #5450
凍結ユーザーのプロファイルなどを表示しないように

- users/show API (ただしモデレーターは参照できる)
- Web ユーザーページ (ogは隠す、ただしモデレーターはAPI経由で参照できる)
- Feed
- AP WebFinger / User
- 通知に表示しないように
