### PR TITLE
Apply DB limit to the maximum note text length

### DIFF
--- a/src/misc/hard-limits.ts
+++ b/src/misc/hard-limits.ts
@@ -1,0 +1,8 @@
+
+// If you change DB_* values, you must also change the DB schema.
+
+/**
+ * Maximum note text length that can be stored in DB.
+ * Surrogate pairs count as one
+ */
+export const DB_MAX_NOTE_TEXT_LENGTH = 8192;

--- a/src/server/api/endpoints/admin/update-meta.ts
+++ b/src/server/api/endpoints/admin/update-meta.ts
@@ -3,6 +3,7 @@ import define from '../../define';
 import { getConnection } from 'typeorm';
 import { Meta } from '../../../../models/entities/meta';
 import { insertModerationLog } from '../../../../services/insert-moderation-log';
+import { DB_MAX_NOTE_TEXT_LENGTH } from '../../../../misc/hard-limits';
 
 export const meta = {
 	desc: {
@@ -121,7 +122,7 @@ export const meta = {
 		},
 
 		maxNoteTextLength: {
-			validator: $.optional.num.min(0),
+			validator: $.optional.num.min(0).max(DB_MAX_NOTE_TEXT_LENGTH),
 			desc: {
 				'ja-JP': '投稿の最大文字数'
 			}

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -7,6 +7,7 @@ import * as pkg from '../../../../package.json';
 import { Emojis } from '../../../models';
 import { getConnection } from 'typeorm';
 import redis from '../../../db/redis';
+import { DB_MAX_NOTE_TEXT_LENGTH } from '../../../misc/hard-limits';
 
 export const meta = {
 	stability: 'stable',
@@ -138,7 +139,7 @@ export default define(meta, async (ps, me) => {
 		bannerUrl: instance.bannerUrl,
 		errorImageUrl: instance.errorImageUrl,
 		iconUrl: instance.iconUrl,
-		maxNoteTextLength: instance.maxNoteTextLength,
+		maxNoteTextLength: Math.min(instance.maxNoteTextLength, DB_MAX_NOTE_TEXT_LENGTH),
 		emojis: emojis.map(e => ({
 			id: e.id,
 			aliases: e.aliases,

--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -10,6 +10,7 @@ import { User } from '../../../../models/entities/user';
 import { Users, DriveFiles, Notes } from '../../../../models';
 import { DriveFile } from '../../../../models/entities/drive-file';
 import { Note } from '../../../../models/entities/note';
+import { DB_MAX_NOTE_TEXT_LENGTH } from '../../../../misc/hard-limits';
 
 let maxNoteTextLength = 1000;
 
@@ -55,7 +56,9 @@ export const meta = {
 
 		text: {
 			validator: $.optional.nullable.str.pipe(text =>
-				length(text.trim()) <= maxNoteTextLength && text.trim() != ''
+				text.trim() != ''
+					&& length(text.trim()) <= maxNoteTextLength
+					&& Array.from(text.trim()).length <= DB_MAX_NOTE_TEXT_LENGTH	// DB limit
 			),
 			default: null as any,
 			desc: {


### PR DESCRIPTION
## Summary
Resolve #5444
合字を考慮して8192以下でも、合字を考慮なしで8192を超えていたらバリデートでエラーにするように
文字数カウンタで通過しても実際は投稿できないことがあるという問題は起きてしまうが
文字数が長すぎるというエラー自体はクライアントに戻ってるのでこれでいいかなと

Resolve #5016
meta.maxNoteTextLength値を8193以上に設定できないようにするように
updateだけ制限するとすでに8193以上に設定されているインスタンスで
そのままだとインスタンス情報が更新できなくなるのでmetaとしてfetchされる値も制限しています