### PR TITLE
Fix #5468

### DIFF
--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -40,18 +40,21 @@ function inbox(ctx: Router.RouterContext) {
 	ctx.status = 202;
 }
 
+const ACTIVITY_JSON = 'application/activity+json; charset=utf-8';
+const LD_JSON = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
+
 function isActivityPubReq(ctx: Router.RouterContext) {
 	ctx.response.vary('Accept');
-	const accepted = ctx.accepts('html', 'application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+	const accepted = ctx.accepts('html', ACTIVITY_JSON, LD_JSON);
 	return typeof accepted === 'string' && !accepted.match(/html/);
 }
 
 export function setResponseType(ctx: Router.RouterContext) {
-	const accept = ctx.accepts('application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
-	if (accept === 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"') {
-		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
+	const accept = ctx.accepts(ACTIVITY_JSON, LD_JSON);
+	if (accept === LD_JSON) {
+		ctx.response.type = LD_JSON;
 	} else {
-		ctx.response.type = 'application/activity+json; charset=utf-8';
+		ctx.response.type = ACTIVITY_JSON;
 	}
 }
 

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -48,7 +48,7 @@ function isActivityPubReq(ctx: Router.RouterContext) {
 
 export function setResponseType(ctx: Router.RouterContext) {
 	const accept = ctx.accepts('application/activity+json', 'application/ld+json');
-	if ((accept || '').split(';')[0] === 'application/ld+json') {
+	if ((accept || '').trim().split(';')[0] === 'application/ld+json') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -48,7 +48,7 @@ function isActivityPubReq(ctx: Router.RouterContext) {
 
 export function setResponseType(ctx: Router.RouterContext) {
 	const accept = ctx.accepts('application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
-	if (accept  === 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"') {
+	if (accept === 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -42,13 +42,13 @@ function inbox(ctx: Router.RouterContext) {
 
 function isActivityPubReq(ctx: Router.RouterContext) {
 	ctx.response.vary('Accept');
-	const accepted = (ctx.accepts('html', 'application/activity+json', 'application/ld+json') || '' as string).split(';')[0].trim();
-	return ['application/activity+json', 'application/ld+json'].includes(accepted);
+	const accepted = ctx.accepts('html', 'application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+	return typeof accepted === 'string' && !accepted.match(/html/);
 }
 
 export function setResponseType(ctx: Router.RouterContext) {
-	const accept = ctx.accepts('application/activity+json', 'application/ld+json');
-	if ((accept as string || '').split(';')[0].trim() === 'application/ld+json') {
+	const accept = ctx.accepts('application/activity+json', 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"');
+	if (accept  === 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -42,8 +42,8 @@ function inbox(ctx: Router.RouterContext) {
 
 function isActivityPubReq(ctx: Router.RouterContext) {
 	ctx.response.vary('Accept');
-	const accepted = ctx.accepts('html', 'application/activity+json', 'application/ld+json');
-	return ['application/activity+json', 'application/ld+json'].includes(accepted as string);
+	const accepted = (ctx.accepts('html', 'application/activity+json', 'application/ld+json') || '' as string).split(';')[0].trim();
+	return ['application/activity+json', 'application/ld+json'].includes(accepted);
 }
 
 export function setResponseType(ctx: Router.RouterContext) {

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -48,7 +48,7 @@ function isActivityPubReq(ctx: Router.RouterContext) {
 
 export function setResponseType(ctx: Router.RouterContext) {
 	const accpet = ctx.accepts('application/activity+json', 'application/ld+json');
-	if (accpet === 'application/ld+json') {
+	if ((accpet || '').split(';')[0] === 'application/ld+json') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -48,7 +48,7 @@ function isActivityPubReq(ctx: Router.RouterContext) {
 
 export function setResponseType(ctx: Router.RouterContext) {
 	const accept = ctx.accepts('application/activity+json', 'application/ld+json');
-	if ((accept || '').split(';')[0].trim() === 'application/ld+json') {
+	if ((accept as string || '').split(';')[0].trim() === 'application/ld+json') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -48,7 +48,7 @@ function isActivityPubReq(ctx: Router.RouterContext) {
 
 export function setResponseType(ctx: Router.RouterContext) {
 	const accept = ctx.accepts('application/activity+json', 'application/ld+json');
-	if ((accept || '').trim().split(';')[0] === 'application/ld+json') {
+	if ((accept || '').split(';')[0].trim() === 'application/ld+json') {
 		ctx.response.type = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
 	} else {
 		ctx.response.type = 'application/activity+json; charset=utf-8';


### PR DESCRIPTION
## Summary

Fix #5468

**追記:**
APのContent-Typeが
`application/activity+json; charset=utf-8`
`application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8`
にもかかわらず

`Accept: application/activity+json`
`Accept: application/ld+json`
の場合にしかAPで返さないのはおかしいので

`Accept: application/activity+json; charset=utf-8`
`Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8`
`Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
`Accept: application/ld+json; charset=utf-8`
のようなパターンでもAPとして返すようにしています
