### PR TITLE
Improve "npm run watch"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"migrateandstart": "npm run migrate && npm run start",
 		"build": "webpack && gulp build",
 		"webpack": "webpack",
+		"dev": "run-p watch gulpstart",
+		"gulpstart": "run-s gulp start",
 		"watch": "webpack --watch",
 		"gulp": "gulp build",
 		"clean": "gulp clean",
@@ -266,6 +268,7 @@
 		"xev": "2.0.1"
 	},
 	"devDependencies": {
-		"@types/fluent-ffmpeg": "2.1.10"
+		"@types/fluent-ffmpeg": "2.1.10",
+		"npm-run-all": "4.1.5"
 	}
 }

--- a/src/client/app/mios.ts
+++ b/src/client/app/mios.ts
@@ -178,14 +178,10 @@ export default class MiOS extends EventEmitter {
 
 			// Init service worker
 			// 本番でなければ Service Worker を登録しない
-			if (this.shouldRegisterSw && env !== 'production') {
+			if (this.shouldRegisterSw) {
 				this.getMeta().then(data => {
 					if (data.swPublickey) this.registerSw(data.swPublickey);
 				});
-			}
-			if (env !== 'production') {
-				// 本番でなければ既にある Service Worker にさようなら
-				navigator.serviceWorker.getRegistration().then(reg => reg.unregister());
 			}
 		};
 

--- a/src/client/app/mios.ts
+++ b/src/client/app/mios.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'eventemitter3';
 import { v4 as uuid } from 'uuid';
 
 import initStore from './store';
-import { apiUrl, version, locale } from './config';
+import { apiUrl, version, locale, env } from './config';
 import Progress from './common/scripts/loading';
 
 import Err from './common/views/components/connect-failed.vue';
@@ -177,10 +177,15 @@ export default class MiOS extends EventEmitter {
 			callback();
 
 			// Init service worker
-			if (this.shouldRegisterSw) {
+			// 本番でなければ Service Worker を登録しない
+			if (this.shouldRegisterSw && env !== 'production') {
 				this.getMeta().then(data => {
 					if (data.swPublickey) this.registerSw(data.swPublickey);
 				});
+			}
+			if (env !== 'production') {
+				// 本番でなければ既にある Service Worker にさようなら
+				navigator.serviceWorker.getRegistration().then(reg => reg.unregister());
 			}
 		};
 

--- a/src/client/app/sw.js
+++ b/src/client/app/sw.js
@@ -14,15 +14,24 @@ const apiUrl = `${location.origin}/api/`;
 self.addEventListener('install', ev => {
 	console.info('installed');
 
+	const requests = [
+		"/",
+		`/assets/desktop.${version}.js`,
+		`/assets/mobile.${version}.js`,
+		"/assets/error.jpg"
+	];
+
   ev.waitUntil(
 		caches.open(cacheName)
 			.then(cache => {
-				return cache.addAll([
-					"/",
-					`/assets/desktop.${version}.js`,
-					`/assets/mobile.${version}.js`,
-					"/assets/error.jpg"
-				]);
+				if (_ENV_ === "production") {
+					// 本番ではキャッシュ
+					console.info("Registered caches.");
+					return cache.addAll(requests);
+				} else {
+					// 開発時はキャッシュしない & 既にあるキャッシュを殺す
+					return cache.delete(requests);
+				}
 			})
 			.then(() => self.skipWaiting())
   );

--- a/src/client/app/sw.js
+++ b/src/client/app/sw.js
@@ -15,21 +15,21 @@ self.addEventListener('install', ev => {
 	console.info('installed');
 
 	const requests = [
-		"/",
+		'/',
 		`/assets/desktop.${version}.js`,
 		`/assets/mobile.${version}.js`,
-		"/assets/error.jpg"
+		'/assets/error.jpg'
 	];
 
   ev.waitUntil(
 		caches.open(cacheName)
 			.then(cache => {
-				if (_ENV_ === "production") {
+				if (_ENV_ === 'production') {
 					// 本番ではキャッシュ
-					console.info("Registered caches.");
+					console.info('Registered caches.');
 					return cache.addAll(requests);
 				} else {
-					// 開発時はキャッシュしない & 既にあるキャッシュを殺す
+					// 開発時はキャッシュしない & 既にあるキャッシュを削除
 					return cache.delete(requests);
 				}
 			})
@@ -57,7 +57,7 @@ self.addEventListener('fetch', ev => {
 				return response || fetch(ev.request);
 			})
 			.catch(() => {
-				return caches.match("/");
+				return caches.match('/');
 			})
 	);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3784,7 +3784,7 @@ error-inject@^1.0.0:
   resolved "https://registry.yarnpkg.com/error-inject/-/error-inject-1.0.0.tgz#e2b3d91b54aed672f309d950d154850fa11d4f37"
   integrity sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=
 
-es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.5.1:
+es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.4.3, es-abstract@^1.5.1:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
   integrity sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==
@@ -4602,7 +4602,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
@@ -6590,6 +6590,16 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -7117,6 +7127,11 @@ memory-fs@^0.4.0, memory-fs@^0.4.1:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
 
 meow@^3.3.0:
   version "3.7.0"
@@ -7685,6 +7700,21 @@ npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-run-all@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -8301,6 +8331,13 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -8382,6 +8419,11 @@ picomatch@^2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
   integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+
+pidtree@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
+  integrity sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==
 
 pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
@@ -9548,6 +9590,15 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -10222,6 +10273,11 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
+shell-quote@^1.6.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
+  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
 showdown-highlightjs-extension@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/showdown-highlightjs-extension/-/showdown-highlightjs-extension-0.1.2.tgz#0fc90190283c1ae03fc4cccce3f1be6a5a58e4ce"
@@ -10585,6 +10641,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
+string.prototype.padend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
+  integrity sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.4.3"
+    function-bind "^1.0.2"
+
 string.prototype.trimleft@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
@@ -10659,6 +10724,11 @@ strip-bom@^2.0.0:
   integrity sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-dirs@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
## Summary

現状だとキャッシュが効いてしまって意味を成さない `npm run watch` の改善

- production でない場合、フロントエンドのコードをキャッシュしないように
- production でない場合、ServiceWorkerを削除
- `yarn dev` で webpack のウォッチをしつつサーバーを動かすように
  - ブラウザをリロードすることで変更が反映される