### PR TITLE
Fix: オフライン時に大室櫻子が出てこない

### DIFF
--- a/src/client/app/common/views/components/connect-failed.vue
+++ b/src/client/app/common/views/components/connect-failed.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="mk-connect-failed">
-	<img src="/assets/error.jpg" alt=""/>
+	<img src="/assets/error.jpg" onerror="this.src='https://raw.githubusercontent.com/syuilo/misskey/develop/src/client/assets/error.jpg';" alt=""/>
 	<h1>{{ $t('title') }}</h1>
 	<p class="text">
 		<span>{{ this.$t('description').substr(0, this.$t('description').indexOf('{')) }}</span>

--- a/src/client/app/common/views/components/connect-failed.vue
+++ b/src/client/app/common/views/components/connect-failed.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="mk-connect-failed">
-	<img src="https://raw.githubusercontent.com/syuilo/misskey/develop/src/client/assets/error.jpg" alt=""/>
+	<img src="/assets/error.jpg" alt=""/>
 	<h1>{{ $t('title') }}</h1>
 	<p class="text">
 		<span>{{ this.$t('description').substr(0, this.$t('description').indexOf('{')) }}</span>


### PR DESCRIPTION
## Summary
PWA等でオフライン時のエラー画像が
ローカルassetsにあってServiceWorkerキャッシュにも入れてるにもかかわらず
リンク先がリモートなので表示されないのを修正

https://github.com/syuilo/misskey/blob/96b88ee369bc6d6d5510b0df96b96fb08088268f/src/client/app/sw.js#L20-L25

![image](https://user-images.githubusercontent.com/30769358/66109852-82c75200-e600-11e9-81b1-781884f938f3.png)

でもこれをやると、非PWAで該当サーバーだけがオフラインでSWのキャッシュに画像がない場合は
表示されなくなりそうだからどうしよう。

Data-URIが良さそうだけど過去にやっててやめた跡があるし