### PR TITLE
ダウンロードURLにdownloadを付けないなど

### DIFF
--- a/src/client/app/desktop/views/components/drive.file.vue
+++ b/src/client/app/desktop/views/components/drive.file.vue
@@ -37,7 +37,6 @@ import i18n from '../../../i18n';
 import copyToClipboard from '../../../common/scripts/copy-to-clipboard';
 import updateAvatar from '../../api/update-avatar';
 import updateBanner from '../../api/update-banner';
-import { appendQuery } from '../../../../../prelude/url';
 import XFileThumbnail from '../../../common/views/components/drive-file-thumbnail.vue';
 
 export default Vue.extend({
@@ -87,7 +86,8 @@ export default Vue.extend({
 				action: this.copyUrl
 			}, {
 				type: 'link',
-				href: appendQuery(this.file.url, 'download'),
+				href: this.file.url,
+				target: '_blank',
 				text: this.$t('contextmenu.download'),
 				icon: 'download',
 				download: this.file.name

--- a/src/client/app/mobile/views/components/drive.file-detail.vue
+++ b/src/client/app/mobile/views/components/drive.file-detail.vue
@@ -57,7 +57,6 @@
 import Vue from 'vue';
 import i18n from '../../../i18n';
 import { gcd } from '../../../../../prelude/math';
-import { appendQuery } from '../../../../../prelude/url';
 import XFileThumbnail from '../../../common/views/components/drive-file-thumbnail.vue';
 
 export default Vue.extend({
@@ -91,7 +90,7 @@ export default Vue.extend({
 		},
 
 		dlUrl(): string {
-			return appendQuery(this.file.url, 'download');
+			return this.file.url;
 		}
 	},
 

--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -46,9 +46,7 @@ export default async function(ctx: Koa.BaseContext) {
 		ctx.set('Content-Disposition', contentDisposition('inline', `${rename(file.name, { suffix: '-web' })}`));
 		ctx.body = InternalStorage.read(key);
 	} else {
-		if ('download' in ctx.query) {
-			ctx.set('Content-Disposition', contentDisposition('attachment', `${file.name}`));
-		}
+		ctx.set('Content-Disposition', contentDisposition('inline', `${file.name}`));
 
 		const readable = InternalStorage.read(file.accessKey!);
 		readable.on('error', commonReadableHandlerGenerator(ctx));


### PR DESCRIPTION
## Summary
Resolve #5487
ダウンロードURLに`?download`を付けないように
FirefoxとChrome かつ 非オブジェクトストレージでダウンロードが機能することを確認済み

#5446 でダウンロードしようとしたら表示になってしまった場合に 開いてた内容が失われてしまって悲しいので、とりあえずデスクトップでダウンロード時はtargetを_blankにするように