### PR TITLE
Escでメディアビューワが閉じれるように

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -43,7 +43,7 @@ export default (opts: Opts = {}) => ({
 				'ctrl+q': this.renoteDirectly,
 				'up|k|shift+tab': this.focusBefore,
 				'down|j|tab': this.focusAfter,
-				'esc': this.blur,
+				//'esc': this.blur,
 				'm|o': () => this.menu(true),
 				's': this.toggleShowContent,
 				'1': () => this.reactDirectly('like'),

--- a/src/client/app/common/views/components/image-viewer.vue
+++ b/src/client/app/common/views/components/image-viewer.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="dkjvrdxtkvqrwmhfickhndpmnncsgacq">
+<div class="dkjvrdxtkvqrwmhfickhndpmnncsgacq" v-hotkey.global="keymap">
 	<div class="bg" @click="close"></div>
 	<img :src="image.url" :alt="image.name" :title="image.name" @click="close"/>
 </div>
@@ -18,6 +18,14 @@ export default Vue.extend({
 			duration: 100,
 			easing: 'linear'
 		});
+	},
+	computed: {
+		keymap(): any {
+			return {
+				'esc': this.close,
+				'backspace': this.close,
+			};
+		}
 	},
 	methods: {
 		close() {

--- a/src/client/app/common/views/components/image-viewer.vue
+++ b/src/client/app/common/views/components/image-viewer.vue
@@ -23,7 +23,6 @@ export default Vue.extend({
 		keymap(): any {
 			return {
 				'esc': this.close,
-				'backspace': this.close,
 			};
 		}
 	},

--- a/src/client/app/desktop/views/components/media-video-dialog.vue
+++ b/src/client/app/desktop/views/components/media-video-dialog.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="mk-media-video-dialog">
+<div class="mk-media-video-dialog" v-hotkey.global="keymap">
 	<div class="bg" @click="close"></div>
 	<video :src="video.url" :title="video.name" controls autoplay ref="video" @volumechange="volumechange"/>
 </div>
@@ -21,6 +21,14 @@ export default Vue.extend({
 		const videoTag = this.$refs.video as HTMLVideoElement;
 		if (this.start) videoTag.currentTime = this.start
 		videoTag.volume = this.$store.state.device.mediaVolume;
+	},
+	computed: {
+		keymap(): any {
+			return {
+				'esc': this.close,
+				'backspace': this.close,
+			};
+		}
 	},
 	methods: {
 		close() {

--- a/src/client/app/desktop/views/components/media-video-dialog.vue
+++ b/src/client/app/desktop/views/components/media-video-dialog.vue
@@ -26,7 +26,6 @@ export default Vue.extend({
 		keymap(): any {
 			return {
 				'esc': this.close,
-				'backspace': this.close,
 			};
 		}
 	},


### PR DESCRIPTION
## Summary
画像ビューワやビデオビューワを表示時に、Escや~~Backspace~~でビューワが閉じれるように
~~あくまでもBackspaceキーで反応なのでブラウザバックは対象外~~

Noteの`'esc': this.blur,`とどうしても被ってしまうのでNoteのEscの方は無効化
(Noteのフォーカスが外せなくなるけど外せなくても困らなそうな気がしたので)
