### PR TITLE
閉じずに残ってしまうメニューなどの修正

### DIFF
--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -143,12 +143,15 @@ export default (opts: Opts = {}) => ({
 		react(viaKeyboard = false) {
 			pleaseLogin(this.$root);
 			this.blur();
-			this.$root.new(MkReactionPicker, {
+			const w = this.$root.new(MkReactionPicker, {
 				source: this.$refs.reactButton,
 				note: this.appearNote,
 				showFocus: viaKeyboard,
 				animation: !viaKeyboard
 			}).$once('closed', this.focus);
+			this.$once('hook:beforeDestroy', () => {
+				w.close();
+			});
 		},
 
 		reactDirectly(reaction) {
@@ -195,13 +198,16 @@ export default (opts: Opts = {}) => ({
 		menu(viaKeyboard = false) {
 			if (this.openingMenu) return;
 			this.openingMenu = true;
-			this.$root.new(MkNoteMenu, {
+			const w = this.$root.new(MkNoteMenu, {
 				source: this.$refs.menuButton,
 				note: this.appearNote,
 				animation: !viaKeyboard
 			}).$once('closed', () => {
 				this.openingMenu = false;
 				this.focus();
+			});
+			this.$once('hook:beforeDestroy', () => {
+				w.destroyDom();
 			});
 		},
 

--- a/src/client/app/common/scripts/post-form.ts
+++ b/src/client/app/common/scripts/post-form.ts
@@ -328,6 +328,9 @@ export default (opts) => ({
 			w.$once('chosen', v => {
 				this.applyVisibility(v);
 			});
+			this.$once('hook:beforeDestroy', () => {
+				w.close();
+			});
 		},
 
 		applyVisibility(v: string) {
@@ -456,6 +459,9 @@ export default (opts) => ({
 			});
 			vm.$once('chosen', emoji => {
 				insertTextAtCursor(this.$refs.text, emoji);
+			});
+			this.$once('hook:beforeDestroy', () => {
+				vm.close();
 			});
 		},
 

--- a/src/client/app/common/views/components/media-image.vue
+++ b/src/client/app/common/views/components/media-image.vue
@@ -59,8 +59,11 @@ export default Vue.extend({
 	},
 	methods: {
 		onClick() {
-			this.$root.new(ImageViewer, {
+			const viewer = this.$root.new(ImageViewer, {
 				image: this.image
+			});
+			this.$once('hook:beforeDestroy', () => {
+				viewer.close();
 			});
 		}
 	}

--- a/src/client/app/common/views/deck/deck.user-column.vue
+++ b/src/client/app/common/views/deck/deck.user-column.vue
@@ -112,9 +112,12 @@ export default Vue.extend({
 		},
 
 		menu() {
-			this.$root.new(XUserMenu, {
+			const w = this.$root.new(XUserMenu, {
 				source: this.$refs.menu,
 				user: this.user
+			});
+			this.$once('hook:beforeDestroy', () => {
+				w.destroyDom();
 			});
 		}
 	}

--- a/src/client/app/desktop/views/components/media-video.vue
+++ b/src/client/app/desktop/views/components/media-video.vue
@@ -53,10 +53,13 @@ export default Vue.extend({
 				start = videoTag.currentTime
 				videoTag.pause()
 			}
-			this.$root.new(MkMediaVideoDialog, {
+			const viewer = this.$root.new(MkMediaVideoDialog, {
 				video: this.video,
 				start,
-			})
+			});
+			this.$once('hook:beforeDestroy', () => {
+				viewer.close();
+			});
 		}
 	}
 })

--- a/src/client/app/desktop/views/home/user/user.header.vue
+++ b/src/client/app/desktop/views/home/user/user.header.vue
@@ -106,9 +106,12 @@ export default Vue.extend({
 		},
 
 		menu() {
-			this.$root.new(XUserMenu, {
+			const w = this.$root.new(XUserMenu, {
 				source: this.$refs.menu,
 				user: this.user
+			});
+			this.$once('hook:beforeDestroy', () => {
+				w.destroyDom();
 			});
 		}
 	}


### PR DESCRIPTION
## Summary
Fix #5333, Fix #5495
Related https://github.com/syuilo/misskey/pull/5485#issuecomment-538729823

以下の閉じずに残ってしまうメニューなどをまとめて修正

絵文字ピッカー / 公開範囲メニュー がフォームが閉じたりしても残ってしまう
リアクションピッカー / ノートメニュー / ユーザーメニュー がページ移動しても残ってしまう
画像 / ビデオビューワー がページ移動しても残ってしまう