### PR TITLE
Update https-proxy-agent など

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"resolutions": {
 		"gulp-cssnano/cssnano/postcss-svgo/svgo/js-yaml": "^3.13.1",
+		"https-proxy-agent": "^3.0.0",
 		"lodash": "^4.17.13"
 	},
 	"dependencies": {
@@ -146,7 +147,7 @@
 		"hard-source-webpack-plugin": "0.13.1",
 		"html-minifier": "4.0.0",
 		"http-signature": "1.2.0",
-		"https-proxy-agent": "2.2.2",
+		"https-proxy-agent": "3.0.0",
 		"insert-text-at-cursor": "0.3.0",
 		"is-root": "2.1.0",
 		"is-svg": "4.2.0",

--- a/src/services/push-notification.ts
+++ b/src/services/push-notification.ts
@@ -29,7 +29,9 @@ export default async function(userId: string, type: string, body?: any) {
 
 		push.sendNotification(pushSubscription, JSON.stringify({
 			type, body
-		})).catch((err: any) => {
+		}), {
+			proxy: config.proxy
+		}).catch((err: any) => {
 			//swLogger.info(err.statusCode);
 			//swLogger.info(err.headers);
 			//swLogger.info(err.body);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5402,10 +5402,10 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@2.2.2, https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+https-proxy-agent@3.0.0, https-proxy-agent@^2.2.1, https-proxy-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz#0106efa5d63d6d6f3ab87c999fa4877a3fd1ff97"
+  integrity sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"


### PR DESCRIPTION
## Summary
web-pushでProxyを使用するように
https://github.com/syuilo/misskey/issues/2894#issuecomment-540052834

https-proxy-agentの脆弱性の対応
https://github.com/syuilo/misskey/issues/5099#issuecomment-538580300
https://github.com/syuilo/misskey/issues/5099#issuecomment-539536172

いちおうweb-push, AP request, ObjectStorageで動作確認済み