### PR TITLE
みつけるの微修正

### DIFF
--- a/src/client/app/common/views/pages/explore.vue
+++ b/src/client/app/common/views/pages/explore.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
 	<div class="localfedi7" v-if="meta && stats && tag == null" :style="{ backgroundImage: meta.bannerUrl ? `url(${meta.bannerUrl})` : null }">
-		<header>{{ $t('explore', { host: meta.name }) }}</header>
+		<header>{{ $t('explore', { host: meta.name || 'Misskey' }) }}</header>
 		<div>{{ $t('users-info', { users: num(stats.originalUsersCount) }) }}</div>
 	</div>
 

--- a/src/client/app/common/views/pages/explore.vue
+++ b/src/client/app/common/views/pages/explore.vue
@@ -91,7 +91,7 @@ export default Vue.extend({
 			} },
 			popularUsersF: { endpoint: 'users', limit: 10, params: {
 				state: 'alive',
-				origin: 'combined',
+				origin: 'remote',
 				sort: '+follower',
 			} },
 			recentlyUpdatedUsersF: { endpoint: 'users', limit: 10, params: {


### PR DESCRIPTION
## Summary
#5490 の微修正

インスタンス名が未設定の時にタイトルが変になってたのを修正
![image](https://user-images.githubusercontent.com/30769358/66850597-18c18c00-efb4-11e9-9999-f0901450cc34.png)

https://github.com/syuilo/misskey/pull/5490#issuecomment-541453340
Fediverse分の人気のユーザーが
集計方法の違いによりたいていローカルが上に出てきてしまうので
とりあえずリモート分のみを表示するように修正