### PR TITLE
Add ssl to elasticsearch config settings

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -29,6 +29,7 @@ export type Source = {
 		port: number;
 		pass: string;
 		index?: string;
+		ssl?: boolean;
 	};
 
 	autoAdmin?: boolean;

--- a/src/db/elasticsearch.ts
+++ b/src/db/elasticsearch.ts
@@ -32,7 +32,7 @@ const index = {
 
 // Init ElasticSearch connection
 const client = config.elasticsearch ? new elasticsearch.Client({
-	node: `http://${config.elasticsearch.host}:${config.elasticsearch.port}`,
+	node: `${config.elasticsearch.ssl ? 'https://' : 'http://'}${config.elasticsearch.host}:${config.elasticsearch.port}`,
 	pingTimeout: 30000
 }) : null;
 


### PR DESCRIPTION
## Summary

Elasticsearchを別サーバに置いている時など、httpsで接続したいことがあるので、設定を追加しました。