### PR TITLE
投稿の文字数制限の初期値をmeta側と合わせる

### DIFF
--- a/src/server/api/endpoints/notes/create.ts
+++ b/src/server/api/endpoints/notes/create.ts
@@ -12,7 +12,7 @@ import { DriveFile } from '../../../../models/entities/drive-file';
 import { Note } from '../../../../models/entities/note';
 import { DB_MAX_NOTE_TEXT_LENGTH } from '../../../../misc/hard-limits';
 
-let maxNoteTextLength = 1000;
+let maxNoteTextLength = 500;
 
 setInterval(() => {
 	fetchMeta().then(m => {


### PR DESCRIPTION
## Summary

https://github.com/syuilo/misskey/blob/e0433c6b89706b3cc04b7217161f3025f63aaf3c/src/models/entities/meta.ts#L153-L157

と一緒にしないと、起動直後の時にタイミングによっては制限が適応されない (そしてその影響でテストがマシンの調子によってコケる :P )

本当はちゃんと毎回metaを読み込むべきだが、現在のバリデーターを使うとこうするしかない気がする
