### PR TITLE
Preserve the attached order in AP

### DIFF
--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -13,10 +13,6 @@ import { Poll } from '../../../models/entities/poll';
 import { ensure } from '../../../prelude/ensure';
 
 export default async function renderNote(note: Note, dive = true): Promise<any> {
-	const promisedFiles: Promise<DriveFile[]> = note.fileIds.length > 0
-		? DriveFiles.find({ id: In(note.fileIds) })
-		: Promise.resolve([]);
-
 	let inReplyTo;
 	let inReplyToNote: Note | undefined;
 
@@ -81,7 +77,7 @@ export default async function renderNote(note: Note, dive = true): Promise<any> 
 	const hashtagTags = (note.tags || []).map(tag => renderHashtag(tag));
 	const mentionTags = mentionedUsers.map(u => renderMention(u));
 
-	const files = await promisedFiles;
+	const files = (await Promise.all((note.fileIds || []).map(x => DriveFiles.findOne(x)))).filter(x => x != null) as DriveFile[];
 
 	let text = note.text;
 	let poll: Poll | undefined;

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -13,9 +13,11 @@ import { Poll } from '../../../models/entities/poll';
 import { ensure } from '../../../prelude/ensure';
 
 export default async function renderNote(note: Note, dive = true): Promise<any> {
-	const promisedFiles: Promise<DriveFile[]> = note.fileIds.length > 0
-		? DriveFiles.find({ id: In(note.fileIds) })
-		: Promise.resolve([]);
+	const getPromisedFiles = async (ids: string[]) => {
+		if (!ids || ids.length === 0) return [];
+		const items = await DriveFiles.find({ id: In(ids) });
+		return ids.map(id => items.find(item => item.id === id)).filter(item => item != null) as DriveFile[];
+	};
 
 	let inReplyTo;
 	let inReplyToNote: Note | undefined;
@@ -81,7 +83,7 @@ export default async function renderNote(note: Note, dive = true): Promise<any> 
 	const hashtagTags = (note.tags || []).map(tag => renderHashtag(tag));
 	const mentionTags = mentionedUsers.map(u => renderMention(u));
 
-	const files = await promisedFiles;
+	const files = await getPromisedFiles(note.fileIds);
 
 	let text = note.text;
 	let poll: Poll | undefined;

--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -13,6 +13,10 @@ import { Poll } from '../../../models/entities/poll';
 import { ensure } from '../../../prelude/ensure';
 
 export default async function renderNote(note: Note, dive = true): Promise<any> {
+	const promisedFiles: Promise<DriveFile[]> = note.fileIds.length > 0
+		? DriveFiles.find({ id: In(note.fileIds) })
+		: Promise.resolve([]);
+
 	let inReplyTo;
 	let inReplyToNote: Note | undefined;
 
@@ -77,7 +81,7 @@ export default async function renderNote(note: Note, dive = true): Promise<any> 
 	const hashtagTags = (note.tags || []).map(tag => renderHashtag(tag));
 	const mentionTags = mentionedUsers.map(u => renderMention(u));
 
-	const files = (await Promise.all((note.fileIds || []).map(x => DriveFiles.findOne(x)))).filter(x => x != null) as DriveFile[];
+	const files = await promisedFiles;
 
 	let text = note.text;
 	let poll: Poll | undefined;


### PR DESCRIPTION
## Summary
Fix: #5550, Fix: #5558

APでNoteの添付ファイルを提示する時に添付順を保持するように