### PR TITLE
新規投稿のMFMをHTMLに変換する際、リモートユーザーへのメンションのリンク先を(できれば)urlに

### DIFF
--- a/src/mfm/toHtml.ts
+++ b/src/mfm/toHtml.ts
@@ -135,7 +135,7 @@ export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: IMentione
 					break;
 				default:
 					const remoteUserInfo = mentionedRemoteUsers.find(remoteUser => remoteUser.username === username && remoteUser.host === host);
-					a.href = remoteUserInfo ? remoteUserInfo.uri : `${config.url}/${acct}`;
+					a.href = remoteUserInfo ? (remoteUserInfo.url ? remoteUserInfo.url : remoteUserInfo.uri) : `${config.url}/${acct}`;
 					a.className = 'mention';
 					break;
 			}

--- a/src/models/entities/note.ts
+++ b/src/models/entities/note.ts
@@ -228,6 +228,7 @@ export class Note {
 
 export type IMentionedRemoteUsers = {
 	uri: string;
+	url?: string;
 	username: string;
 	host: string;
 }[];

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -393,8 +393,7 @@ async function insertNote(user: User, data: Option, tags: string[], emojis: stri
 				username: u.username,
 				host: u.host
 			} as IMentionedRemoteUsers[0];
-		}
-		));
+		}));
 	}
 
 	// 投稿を作成

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -16,11 +16,11 @@ import { registerOrFetchInstanceDoc } from '../register-or-fetch-instance-doc';
 import extractMentions from '../../misc/extract-mentions';
 import extractEmojis from '../../misc/extract-emojis';
 import extractHashtags from '../../misc/extract-hashtags';
-import { Note } from '../../models/entities/note';
+import { Note, IMentionedRemoteUsers } from '../../models/entities/note';
 import { Mutings, Users, NoteWatchings, Followings, Notes, Instances, UserProfiles } from '../../models';
 import { DriveFile } from '../../models/entities/drive-file';
 import { App } from '../../models/entities/app';
-import { Not, getConnection } from 'typeorm';
+import { Not, getConnection, getRepository, In } from 'typeorm';
 import { User, ILocalUser, IRemoteUser } from '../../models/entities/user';
 import { genId } from '../../misc/gen-id';
 import { notesChart, perUserNotesChart, activeUsersChart, instanceChart } from '../chart';
@@ -383,11 +383,18 @@ async function insertNote(user: User, data: Option, tags: string[], emojis: stri
 	// Append mentions data
 	if (mentionedUsers.length > 0) {
 		insert.mentions = mentionedUsers.map(u => u.id);
-		insert.mentionedRemoteUsers = JSON.stringify(mentionedUsers.filter(u => Users.isRemoteUser(u)).map(u => ({
-			uri: (u as IRemoteUser).uri,
-			username: u.username,
-			host: u.host
-		})));
+		const profiles = await UserProfiles.find({userId: In(insert.mentions)});
+		insert.mentionedRemoteUsers = JSON.stringify(mentionedUsers.filter(u => Users.isRemoteUser(u)).map(u => {
+			const profile = profiles.find(p => p.userId == u.id);
+			const url = profile != null ? profile.url : null;
+			return {
+				uri: u.uri,
+				url: url == null ? undefined : url,
+				username: u.username,
+				host: u.host
+			} as IMentionedRemoteUsers[0];
+		}
+		));
 	}
 
 	// 投稿を作成

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -383,7 +383,7 @@ async function insertNote(user: User, data: Option, tags: string[], emojis: stri
 	// Append mentions data
 	if (mentionedUsers.length > 0) {
 		insert.mentions = mentionedUsers.map(u => u.id);
-		const profiles = await UserProfiles.find({userId: In(insert.mentions)});
+		const profiles = await UserProfiles.find({ userId: In(insert.mentions) });
 		insert.mentionedRemoteUsers = JSON.stringify(mentionedUsers.filter(u => Users.isRemoteUser(u)).map(u => {
 			const profile = profiles.find(p => p.userId == u.id);
 			const url = profile != null ? profile.url : null;

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -20,7 +20,7 @@ import { Note, IMentionedRemoteUsers } from '../../models/entities/note';
 import { Mutings, Users, NoteWatchings, Followings, Notes, Instances, UserProfiles } from '../../models';
 import { DriveFile } from '../../models/entities/drive-file';
 import { App } from '../../models/entities/app';
-import { Not, getConnection, getRepository, In } from 'typeorm';
+import { Not, getConnection, In } from 'typeorm';
 import { User, ILocalUser, IRemoteUser } from '../../models/entities/user';
 import { genId } from '../../misc/gen-id';
 import { notesChart, perUserNotesChart, activeUsersChart, instanceChart } from '../chart';


### PR DESCRIPTION
Fix #2467
Related #5560

## Summary

<blockquote>
URIはActivityPubだとhttpsなURLなはずだし、Mastodon側でURIでもmentionリンクとして処理すればいいというアレもあるかもしれないけど、それはそれとしてリンク先のhrefには`url`を用いたほうが親切な気がする (`url`は <q>A link to the actor's "profile web page", if not equal to the value of id. </q>なので https://www.w3.org/TR/activitypub/#as2-actor-properties )

<cite> https://github.com/syuilo/misskey/issues/5560#issuecomment-547160476 </cite>
</blockquote>

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
