### PR TITLE
Add option to use HardSourceWebpackPlugin

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as webpack from 'webpack';
 import chalk from 'chalk';
 const { VueLoaderPlugin } = require('vue-loader');
-//const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 
@@ -20,6 +20,7 @@ class WebpackOnBuildPlugin {
 }
 
 const isProduction = process.env.NODE_ENV == 'production';
+const useHardSource = process.env.MISSKEY_USE_HARD_SOURCE;
 
 const constants = require('./src/const.json');
 
@@ -113,7 +114,7 @@ module.exports = {
 		}]
 	},
 	plugins: [
-		//new HardSourceWebpackPlugin(),
+		...(useHardSource ? [new HardSourceWebpackPlugin()] : []),
 		new ProgressBarPlugin({
 			format: chalk`  {cyan.bold yes we can} {bold [}:bar{bold ]} {green.bold :percent} {gray (:current/:total)} :elapseds`,
 			clear: false


### PR DESCRIPTION
Summary
--

Resolve #5498
CC: @MarchWorks

Set a truthy value to a machine environment called `MISSKEY_USE_HARD_SOURCE` to use `HardSourceWebpackPlugin`.
