### PR TITLE
Redisの設定のexampleにprefix, dbを追加

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -79,6 +79,8 @@ redis:
   host: localhost
   port: 6379
   #pass: example-pass
+  #prefix: example-prefix
+  #db: 1
 
 #   ┌─────────────────────────────┐
 #───┘ Elasticsearch configuration └─────────────────────────────


### PR DESCRIPTION
Redisの設定のexampleに`prefix`, `db`を追加
