### PR TITLE
管理画面のジョブキュー一覧の修正

### DIFF
--- a/src/client/app/admin/views/queue.vue
+++ b/src/client/app/admin/views/queue.vue
@@ -48,13 +48,13 @@
 				</ui-select>
 			</ui-horizon-group>
 			<sequential-entrance animation="entranceFromTop" delay="25">
-				<div class="xvvuvgsv" v-for="job in jobs">
+				<div class="xvvuvgsv" v-for="job in jobs" :key="job.id">
 					<b>{{ job.id }}</b>
 					<template v-if="domain === 'deliver'">
 						<span>{{ job.data.to }}</span>
 					</template>
 					<template v-if="domain === 'inbox'">
-						<span>{{ job.activity.id }}</span>
+						<span>{{ job.data.activity.id }}</span>
 					</template>
 				</div>
 			</sequential-entrance>

--- a/src/client/app/admin/views/queue.vue
+++ b/src/client/app/admin/views/queue.vue
@@ -56,6 +56,7 @@
 					<template v-if="domain === 'inbox'">
 						<span>{{ job.data.activity.id }}</span>
 					</template>
+					<span>{{ `(${job.attempts}/${job.maxAttempts}, ${Math.floor((jobsFetched - job.timestamp) / 1000 / 60)}min)` }}</span>
 				</div>
 			</sequential-entrance>
 			<ui-info v-if="jobs.length == jobsLimit">{{ $t('result-is-truncated', { n: jobsLimit }) }}</ui-info>
@@ -84,6 +85,7 @@ export default Vue.extend({
 			chartLimit: 200,
 			jobs: [],
 			jobsLimit: 50,
+			jobsFetched: Date.now(),
 			domain: 'deliver',
 			state: 'delayed',
 			faTasks, faPaperPlane, faInbox, faChartBar, faDatabase, faCloud
@@ -140,6 +142,7 @@ export default Vue.extend({
 				state: this.state,
 				limit: this.jobsLimit
 			}).then(jobs => {
+				this.jobsFetched = Date.now(),
 				this.jobs = jobs;
 			});
 		},
@@ -149,7 +152,8 @@ export default Vue.extend({
 
 <style lang="stylus" scoped>
 .xvvuvgsv
-	> b
-		margin-right 16px
+	margin-left -6px
+	> b, span
+		margin 0 6px
 
 </style>

--- a/src/server/api/endpoints/admin/queue/jobs.ts
+++ b/src/server/api/endpoints/admin/queue/jobs.ts
@@ -32,9 +32,16 @@ export default define(meta, async (ps) => {
 
 	const jobs = await queue.getJobs([ps.state], 0, ps.limit!);
 
-	return jobs.map(job => ({
-		id: job.id,
-		data: job.data,
-		attempts: job.attemptsMade,
-	}));
+	return jobs.map(job => {
+		const data = job.data;
+		delete data.content;
+		delete data.user;
+		return {
+			id: job.id,
+			data,
+			attempts: job.attemptsMade,
+			maxAttempts: job.opts ? job.opts.attempts : 0,
+			timestamp: job.timestamp,
+		};
+	});
 });

--- a/src/server/api/endpoints/admin/queue/jobs.ts
+++ b/src/server/api/endpoints/admin/queue/jobs.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy';
 import define from '../../../define';
-import { deliverQueue, inboxQueue } from '../../../../../queue';
+import { deliverQueue, inboxQueue, dbQueue, objectStorageQueue } from '../../../../../queue';
 
 export const meta = {
 	tags: ['admin'],
@@ -10,11 +10,11 @@ export const meta = {
 
 	params: {
 		domain: {
-			validator: $.str,
+			validator: $.str.or(['deliver', 'inbox', 'db', 'objectStorage']),
 		},
 
 		state: {
-			validator: $.str,
+			validator: $.str.or(['active', 'waiting', 'delayed']),
 		},
 
 		limit: {
@@ -28,6 +28,8 @@ export default define(meta, async (ps) => {
 	const queue =
 		ps.domain === 'deliver' ? deliverQueue :
 		ps.domain === 'inbox' ? inboxQueue :
+		ps.domain === 'db' ? dbQueue :
+		ps.domain === 'objectStorage' ? objectStorageQueue :
 		null as never;
 
 	const jobs = await queue.getJobs([ps.state], 0, ps.limit!);


### PR DESCRIPTION
## Summary
受信のジョブ一覧がエラーで表示されないのを修正
ジョブ一覧で試行回数と経過時間を表示するように
DBとオブジェクトストレージのジョブ一覧が実装されてないのを修正
いくつかの表示に使用していないジョブの詳細データはAPIから返さないように

![image](https://user-images.githubusercontent.com/30769358/68335881-a1010000-0120-11ea-8675-5ef0a9fcfe8c.png)
