### PR TITLE
無駄なAP deliverをしないように

### DIFF
--- a/src/remote/activitypub/deliver-manager.ts
+++ b/src/remote/activitypub/deliver-manager.ts
@@ -113,9 +113,9 @@ export default class DeliverManager {
  * @param from Followee
  */
 export async function deliverToFollowers(actor: ILocalUser, activity: any) {
-	const deliverer = new DeliverManager(actor, activity);
-	deliverer.addFollowersRecipe();
-	await deliverer.execute();
+	const manager = new DeliverManager(actor, activity);
+	manager.addFollowersRecipe();
+	await manager.execute();
 }
 
 /**
@@ -124,8 +124,8 @@ export async function deliverToFollowers(actor: ILocalUser, activity: any) {
  * @param to Target user
  */
 export async function deliverToUser(actor: ILocalUser, activity: any, to: IRemoteUser) {
-	const deliverer = new DeliverManager(actor, activity);
-	deliverer.addDirectRecipe(to);
-	await deliverer.execute();
+	const manager = new DeliverManager(actor, activity);
+	manager.addDirectRecipe(to);
+	await manager.execute();
 }
 //#endregion

--- a/src/remote/activitypub/deliver-manager.ts
+++ b/src/remote/activitypub/deliver-manager.ts
@@ -31,7 +31,7 @@ export default class DeliverManager {
 	/**
 	 * Constructor
 	 * @param actor Actor
-	 * @param activity Activity to send
+	 * @param activity Activity to deliver
 	 */
 	constructor(actor: ILocalUser, activity: any) {
 		this.actor = actor;

--- a/src/remote/activitypub/deliver-manager.ts
+++ b/src/remote/activitypub/deliver-manager.ts
@@ -1,0 +1,131 @@
+import { Users, Followings } from '../../models';
+import { ILocalUser, IRemoteUser } from '../../models/entities/user';
+import { deliver } from '../../queue';
+
+//#region types
+interface IQueue {
+	type: string;
+}
+
+interface IFollowersQueue extends IQueue {
+	type: 'Followers';
+}
+
+interface IDirectQueue extends IQueue {
+	type: 'Direct';
+	to: IRemoteUser;
+}
+
+const isFollowers = (queue: any): queue is IFollowersQueue =>
+	queue.type === 'Followers';
+
+const isDirect = (queue: any): queue is IDirectQueue =>
+	queue.type === 'Direct';
+//#endregion
+
+export default class DeliverManager {
+	private actor: ILocalUser;
+	private activity: any;
+	private queues: IQueue[] = [];
+
+	/**
+	 * Constructor
+	 * @param actor Actor
+	 * @param activity Activity to send
+	 */
+	constructor(actor: ILocalUser, activity: any) {
+		this.actor = actor;
+		this.activity = activity;
+	}
+
+	/**
+	 * Add queue for followers deliver
+	 */
+	public addFollowersQueue() {
+		const deliver = {
+			type: 'Followers'
+		} as IFollowersQueue;
+
+		this.addQueue(deliver);
+	}
+
+	/**
+	 * Add queue for direct deliver
+	 * @param to To
+	 */
+	public addDirectQueue(to: IRemoteUser) {
+		const queue = {
+			type: 'Direct',
+			to
+		} as IDirectQueue;
+
+		this.addQueue(queue);
+	}
+
+	/**
+	 * Add queue
+	 * @param queue Queue
+	 */
+	public addQueue(queue: IQueue) {
+		this.queues.push(queue);
+	}
+
+	/**
+	 * Execute delivers
+	 */
+	public async execute() {
+		if (!Users.isLocalUser(this.actor)) return;
+
+		const inboxes: string[] = [];
+
+		// build inbox list
+		for (const queue of this.queues) {
+			if (isFollowers(queue)) {
+				// followers deliver
+				const followers = await Followings.find({
+					followeeId: this.actor.id
+				});
+
+				for (const following of followers) {
+					if (Followings.isRemoteFollower(following)) {
+						const inbox = following.followerSharedInbox || following.followerInbox;
+						if (!inboxes.includes(inbox)) inboxes.push(inbox);
+					}
+				}
+			} else if (isDirect(queue)) {
+				// direct deliver
+				const inbox = queue.to.inbox;
+				if (inbox && !inboxes.includes(inbox)) inboxes.push(inbox);
+			}
+		}
+
+		// deliver
+		for (const inbox of inboxes) {
+			deliver(this.actor, this.activity, inbox);
+		}
+	}
+}
+
+//#region Utilities
+/**
+ * Deliver activity to followers
+ * @param activity Activity
+ * @param from Followee
+ */
+export async function deliverToFollowers(actor: ILocalUser, activity: any) {
+	const deliverer = new DeliverManager(actor, activity);
+	deliverer.addFollowersQueue();
+	await deliverer.execute();
+}
+
+/**
+ * Deliver activity to user
+ * @param activity Activity
+ * @param to Target user
+ */
+export async function deliverToUser(actor: ILocalUser, activity: any, to: IRemoteUser) {
+	const deliverer = new DeliverManager(actor, activity);
+	deliverer.addDirectQueue(to);
+	await deliverer.execute();
+}
+//#endregion

--- a/src/services/i/pin.ts
+++ b/src/services/i/pin.ts
@@ -2,13 +2,13 @@ import config from '../../config';
 import renderAdd from '../../remote/activitypub/renderer/add';
 import renderRemove from '../../remote/activitypub/renderer/remove';
 import { renderActivity } from '../../remote/activitypub/renderer';
-import { deliver } from '../../queue';
 import { IdentifiableError } from '../../misc/identifiable-error';
-import { User, ILocalUser } from '../../models/entities/user';
+import { User } from '../../models/entities/user';
 import { Note } from '../../models/entities/note';
-import { Notes, UserNotePinings, Users, Followings } from '../../models';
+import { Notes, UserNotePinings, Users } from '../../models';
 import { UserNotePining } from '../../models/entities/user-note-pinings';
 import { genId } from '../../misc/gen-id';
+import { deliverToFollowers } from '../../remote/activitypub/deliver-manager';
 
 /**
  * 指定した投稿をピン留めします
@@ -82,36 +82,9 @@ export async function deliverPinnedChange(userId: User['id'], noteId: Note['id']
 
 	if (!Users.isLocalUser(user)) return;
 
-	const queue = await CreateRemoteInboxes(user);
-
-	if (queue.length < 1) return;
-
 	const target = `${config.url}/users/${user.id}/collections/featured`;
-
 	const item = `${config.url}/notes/${noteId}`;
 	const content = renderActivity(isAddition ? renderAdd(user, target, item) : renderRemove(user, target, item));
-	for (const inbox of queue) {
-		deliver(user, content, inbox);
-	}
-}
 
-/**
- * ローカルユーザーのリモートフォロワーのinboxリストを作成する
- * @param user ローカルユーザー
- */
-async function CreateRemoteInboxes(user: ILocalUser): Promise<string[]> {
-	const followers = await Followings.find({
-		followeeId: user.id
-	});
-
-	const queue: string[] = [];
-
-	for (const following of followers) {
-		if (Followings.isRemoteFollower(following)) {
-			const inbox = following.followerSharedInbox || following.followerInbox;
-			if (!queue.includes(inbox)) queue.push(inbox);
-		}
-	}
-
-	return queue;
+	deliverToFollowers(user, content);
 }

--- a/src/services/i/update.ts
+++ b/src/services/i/update.ts
@@ -1,34 +1,17 @@
 import renderUpdate from '../../remote/activitypub/renderer/update';
 import { renderActivity } from '../../remote/activitypub/renderer';
-import { deliver } from '../../queue';
-import { Followings, Users } from '../../models';
+import { Users } from '../../models';
 import { User } from '../../models/entities/user';
 import { renderPerson } from '../../remote/activitypub/renderer/person';
+import { deliverToFollowers } from '../../remote/activitypub/deliver-manager';
 
 export async function publishToFollowers(userId: User['id']) {
 	const user = await Users.findOne(userId);
 	if (user == null) throw new Error('user not found');
 
-	const followers = await Followings.find({
-		followeeId: user.id
-	});
-
-	const queue: string[] = [];
-
 	// フォロワーがリモートユーザーかつ投稿者がローカルユーザーならUpdateを配信
 	if (Users.isLocalUser(user)) {
-		for (const following of followers) {
-			if (Followings.isRemoteFollower(following)) {
-				const inbox = following.followerSharedInbox || following.followerInbox;
-				if (!queue.includes(inbox)) queue.push(inbox);
-			}
-		}
-
-		if (queue.length > 0) {
-			const content = renderActivity(renderUpdate(await renderPerson(user), user));
-			for (const inbox of queue) {
-				deliver(user, content, inbox);
-			}
-		}
+		const content = renderActivity(renderUpdate(await renderPerson(user), user));
+		deliverToFollowers(user, content);
 	}
 }

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -1,6 +1,6 @@
 import es from '../../db/elasticsearch';
 import { publishMainStream, publishNotesStream } from '../stream';
-import { deliver } from '../../queue';
+import DeliverManager from '../../remote/activitypub/deliver-manager';
 import renderNote from '../../remote/activitypub/renderer/note';
 import renderCreate from '../../remote/activitypub/renderer/create';
 import renderAnnounce from '../../remote/activitypub/renderer/announce';
@@ -17,7 +17,7 @@ import extractMentions from '../../misc/extract-mentions';
 import extractEmojis from '../../misc/extract-emojis';
 import extractHashtags from '../../misc/extract-hashtags';
 import { Note, IMentionedRemoteUsers } from '../../models/entities/note';
-import { Mutings, Users, NoteWatchings, Followings, Notes, Instances, UserProfiles } from '../../models';
+import { Mutings, Users, NoteWatchings, Notes, Instances, UserProfiles } from '../../models';
 import { DriveFile } from '../../models/entities/drive-file';
 import { App } from '../../models/entities/app';
 import { Not, getConnection, In } from 'typeorm';
@@ -246,12 +246,6 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 
 		createMentionedEvents(mentionedUsers, note, nm);
 
-		const noteActivity = await renderNoteOrRenoteActivity(data, note);
-
-		if (Users.isLocalUser(user)) {
-			deliverNoteToMentionedRemoteUsers(mentionedUsers, user, noteActivity);
-		}
-
 		const profile = await UserProfiles.findOne(user.id).then(ensure);
 
 		// If has in reply to note
@@ -294,11 +288,45 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 			}
 		}
 
-		publish(user, note, data.reply, data.renote, noteActivity);
-
 		Promise.all(nmRelatedPromises).then(() => {
 			nm.deliver();
 		});
+
+		//#region AP deliver
+		if (Users.isLocalUser(user)) {
+			const noteActivity = await renderNoteOrRenoteActivity(data, note);
+
+			const dm = new DeliverManager(user, noteActivity);
+
+			// メンションされたリモートユーザーに配送
+			for (const u of mentionedUsers.filter(u => Users.isRemoteUser(u))) {
+				dm.addDirectQueue(u as IRemoteUser);
+			}
+
+			if (Users.isLocalUser(user)) {
+				// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
+				if (data.reply && data.reply.userHost !== null) {
+					Users.findOne(data.reply.userId).then(ensure).then(u => {
+						dm.addDirectQueue(u as IRemoteUser);
+					});
+				}
+
+				// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
+				if (data.renote && data.renote.userHost !== null) {
+					Users.findOne(data.renote.userId).then(ensure).then(u => {
+						dm.addDirectQueue(u as IRemoteUser);
+					});
+				}
+			}
+
+			// フォロワーに配送
+			if (['public', 'home', 'followers'].includes(note.visibility)) {
+				dm.addFollowersQueue();
+			}
+
+			dm.execute();
+		}
+		//#endregion
 	}
 
 	// Register to search database
@@ -318,29 +346,6 @@ async function renderNoteOrRenoteActivity(data: Option, note: Note) {
 function incRenoteCount(renote: Note) {
 	Notes.increment({ id: renote.id }, 'renoteCount', 1);
 	Notes.increment({ id: renote.id }, 'score', 1);
-}
-
-async function publish(user: User, note: Note, reply: Note | null | undefined, renote: Note | null | undefined, noteActivity: any) {
-	if (Users.isLocalUser(user)) {
-		// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
-		if (reply && reply.userHost !== null) {
-			Users.findOne(reply.userId).then(ensure).then(u => {
-				deliver(user, noteActivity, u.inbox);
-			});
-		}
-
-		// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
-		if (renote && renote.userHost !== null) {
-			Users.findOne(renote.userId).then(ensure).then(u => {
-				deliver(user, noteActivity, u.inbox);
-			});
-		}
-	}
-
-	if (['public', 'home', 'followers'].includes(note.visibility)) {
-		// フォロワーに配信
-		publishToFollowers(note, user, noteActivity);
-	}
 }
 
 async function insertNote(user: User, data: Option, tags: string[], emojis: string[], mentionedUsers: User[]) {
@@ -469,34 +474,6 @@ async function notifyToWatchersOfReplyee(reply: Note, user: User, nm: Notificati
 
 	for (const watcher of watchers) {
 		nm.push(watcher.userId, 'reply');
-	}
-}
-
-async function publishToFollowers(note: Note, user: User, noteActivity: any) {
-	const followers = await Followings.find({
-		followeeId: note.userId
-	});
-
-	const queue: string[] = [];
-
-	for (const following of followers) {
-		if (Followings.isRemoteFollower(following)) {
-			// フォロワーがリモートユーザーかつ投稿者がローカルユーザーなら投稿を配信
-			if (Users.isLocalUser(user)) {
-				const inbox = following.followerSharedInbox || following.followerInbox;
-				if (!queue.includes(inbox)) queue.push(inbox);
-			}
-		}
-	}
-
-	for (const inbox of queue) {
-		deliver(user as any, noteActivity, inbox);
-	}
-}
-
-function deliverNoteToMentionedRemoteUsers(mentionedUsers: User[], user: ILocalUser, noteActivity: any) {
-	for (const u of mentionedUsers.filter(u => Users.isRemoteUser(u))) {
-		deliver(user, noteActivity, (u as IRemoteUser).inbox);
 	}
 }
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -300,28 +300,28 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 
 			// メンションされたリモートユーザーに配送
 			for (const u of mentionedUsers.filter(u => Users.isRemoteUser(u))) {
-				dm.addDirectQueue(u as IRemoteUser);
+				dm.addDirectRecipe(u as IRemoteUser);
 			}
 
 			if (Users.isLocalUser(user)) {
 				// 投稿がリプライかつ投稿者がローカルユーザーかつリプライ先の投稿の投稿者がリモートユーザーなら配送
 				if (data.reply && data.reply.userHost !== null) {
 					Users.findOne(data.reply.userId).then(ensure).then(u => {
-						dm.addDirectQueue(u as IRemoteUser);
+						dm.addDirectRecipe(u as IRemoteUser);
 					});
 				}
 
 				// 投稿がRenoteかつ投稿者がローカルユーザーかつRenote元の投稿の投稿者がリモートユーザーなら配送
 				if (data.renote && data.renote.userHost !== null) {
 					Users.findOne(data.renote.userId).then(ensure).then(u => {
-						dm.addDirectQueue(u as IRemoteUser);
+						dm.addDirectRecipe(u as IRemoteUser);
 					});
 				}
 			}
 
 			// フォロワーに配送
 			if (['public', 'home', 'followers'].includes(note.visibility)) {
-				dm.addFollowersQueue();
+				dm.addFollowersRecipe();
 			}
 
 			dm.execute();

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -296,7 +296,6 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 		if (Users.isLocalUser(user)) {
 			(async () => {
 				const noteActivity = await renderNoteOrRenoteActivity(data, note);
-
 				const dm = new DeliverManager(user, noteActivity);
 
 				// メンションされたリモートユーザーに配送


### PR DESCRIPTION
## Summary
Fix #3939
同じActivityを同じinboxにdeliverしないように (inbox <=> sharedInbox 間で同じのを送るのは許容)
`note/create`を`DeliverManager`クラスで最終的に重複を排除してdeliverするように

また、フォロワーdeliver (ピン留め変更, プロフィール更新, 投稿削除, 投票更新) の重複コードを`deliverToFollowers`にまとめました