### PR TITLE
Fix #4800

### DIFF
--- a/src/server/api/endpoints/notes/children.ts
+++ b/src/server/api/endpoints/notes/children.ts
@@ -66,7 +66,7 @@ export default define(meta, async (ps, user) => {
 		}))
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (user) generateVisibilityQuery(query, user);
+	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
 	const notes = await query.take(ps.limit!).getMany();

--- a/src/server/api/endpoints/notes/local-timeline.ts
+++ b/src/server/api/endpoints/notes/local-timeline.ts
@@ -95,7 +95,7 @@ export default define(meta, async (ps, user) => {
 		.andWhere('(note.visibility = \'public\') AND (note.userHost IS NULL)')
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (user) generateVisibilityQuery(query, user);
+	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
 	if (ps.withFiles) {

--- a/src/server/api/endpoints/notes/renotes.ts
+++ b/src/server/api/endpoints/notes/renotes.ts
@@ -70,7 +70,7 @@ export default define(meta, async (ps, user) => {
 		.andWhere(`note.renoteId = :renoteId`, { renoteId: note.id })
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (user) generateVisibilityQuery(query, user);
+	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
 	const renotes = await query.take(ps.limit!).getMany();

--- a/src/server/api/endpoints/notes/replies.ts
+++ b/src/server/api/endpoints/notes/replies.ts
@@ -61,7 +61,7 @@ export default define(meta, async (ps, user) => {
 		.andWhere('note.replyId = :replyId', { replyId: ps.noteId })
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (user) generateVisibilityQuery(query, user);
+	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
 	const timeline = await query.take(ps.limit!).getMany();

--- a/src/server/api/endpoints/notes/search-by-tag.ts
+++ b/src/server/api/endpoints/notes/search-by-tag.ts
@@ -95,7 +95,7 @@ export default define(meta, async (ps, me) => {
 	const query = makePaginationQuery(Notes.createQueryBuilder('note'), ps.sinceId, ps.untilId)
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (me) generateVisibilityQuery(query, me);
+	generateVisibilityQuery(query, me);
 	if (me) generateMuteQuery(query, me);
 
 	if (ps.tag) {

--- a/src/server/api/endpoints/users/notes.ts
+++ b/src/server/api/endpoints/users/notes.ts
@@ -133,7 +133,7 @@ export default define(meta, async (ps, me) => {
 		.andWhere('note.userId = :userId', { userId: user.id })
 		.leftJoinAndSelect('note.user', 'user');
 
-	if (me) generateVisibilityQuery(query, me);
+	generateVisibilityQuery(query, me);
 	if (me) generateMuteQuery(query, me, user);
 
 	if (ps.withFiles) {


### PR DESCRIPTION
## Summary
Fix #4800
いくつかのタイムラインAPIに未認証でアクセスしたときに、フォロワー限定以下がフィルタされないのを修正