### PR TITLE
AP Signatureヘッダの特殊処理を削除

### DIFF
--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -60,11 +60,6 @@ export default async (user: ILocalUser, url: string, object: any) => {
 			headers: ['date', 'host', 'digest']
 		});
 
-		// Signature: Signature ... => Signature: ...
-		let sig = req.getHeader('Signature')!.toString();
-		sig = sig.replace(/^Signature /, '');
-		req.setHeader('Signature', sig);
-
 		req.on('timeout', () => req.abort());
 
 		req.on('error', e => {

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -26,8 +26,6 @@ const router = new Router();
 function inbox(ctx: Router.RouterContext) {
 	let signature;
 
-	ctx.req.headers.authorization = `Signature ${ctx.req.headers.signature}`;
-
 	try {
 		signature = httpSignature.parseRequest(ctx.req, { 'headers': [] });
 	} catch (e) {


### PR DESCRIPTION
## Summary
今まで、`http-signature`モジュールがAPで必要な`Signature`ヘッダに対応していなかったので 特別な処理を行っていましたが
`Signature: keyId=...` <=> `Authorization: Signature keyId=...` の変換処理

`http-signature`が`Signature`ヘッダに正式対応して ( https://github.com/joyent/node-http-signature/blob/master/CHANGES.md#130 ) この処理が不要になったので削除しています。

※ v1.3.x へは f7a328d66e8f0ddb5d7b6ca815bf86bba98895bb でupdate済み