### PR TITLE
Implement UI to remove renote

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -35,6 +35,7 @@ common:
   fetching-as-ap-object: "連合に照会中"
   unfollow-confirm: "{name}さんをフォロー解除しますか？"
   delete-confirm: "この投稿を削除しますか？"
+  unrenote-confirm: "このRenoteを削除しますか？"
   signin-required: "ログインしてください"
   notification-type: "通知の種類"
   notification-types:
@@ -604,8 +605,8 @@ common/views/components/note-menu.vue:
   unwatch: "ウォッチ解除"
   pin: "ピン留め"
   unpin: "ピン留め解除"
-  delete: "削除"
-  delete-confirm: "この投稿を削除しますか？"
+  unrenote: "Renoteを削除"
+  delete: "投稿を削除"
   delete-and-edit: "削除して編集"
   delete-and-edit-confirm: "この投稿を削除してもう一度編集しますか？この投稿へのリアクション、Renote、返信も全て削除されます。"
   remote: "投稿元で見る"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -35,7 +35,7 @@ common:
   fetching-as-ap-object: "連合に照会中"
   unfollow-confirm: "{name}さんをフォロー解除しますか？"
   delete-confirm: "この投稿を削除しますか？"
-  unrenote-confirm: "このRenoteを削除しますか？"
+  remove-renote-confirm: "このRenoteを削除しますか？"
   signin-required: "ログインしてください"
   notification-type: "通知の種類"
   notification-types:
@@ -605,7 +605,7 @@ common/views/components/note-menu.vue:
   unwatch: "ウォッチ解除"
   pin: "ピン留め"
   unpin: "ピン留め解除"
-  unrenote: "Renoteを削除"
+  remove-renote: "Renoteを削除"
   delete: "投稿を削除"
   delete-and-edit: "削除して編集"
   delete-and-edit-confirm: "この投稿を削除してもう一度編集しますか？この投稿へのリアクション、Renote、返信も全て削除されます。"

--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -76,7 +76,7 @@ export default (opts: Opts = {}) => ({
 
 		reactionsCount(): number {
 			return this.appearNote.reactions
-				? sum(Object.values(this.note.reactions))
+				? sum(Object.values(this.appearNote.reactions))
 				: 0;
 		},
 

--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -71,12 +71,12 @@ export default (opts: Opts = {}) => ({
 		},
 
 		isMyNote(): boolean {
-			return this.$store.getters.isSignedIn && (this.$store.state.i.id === this.appearNote.userId);
+			return this.$store.getters.isSignedIn && (this.$store.state.i.id === this.note.userId);
 		},
 
 		reactionsCount(): number {
 			return this.appearNote.reactions
-				? sum(Object.values(this.appearNote.reactions))
+				? sum(Object.values(this.note.reactions))
 				: 0;
 		},
 
@@ -187,15 +187,17 @@ export default (opts: Opts = {}) => ({
 		},
 
 		del() {
+			if (!(this.note.userId == this.$store.state.i.id || this.$store.state.i.isAdmin || this.$store.state.i.isModerator)) return;
+
 			this.$root.dialog({
 				type: 'warning',
-				text: this.$t('@.delete-confirm'),
+				text: this.isRenote ? this.$t('@.unrenote-confirm') : this.$t('@.delete-confirm'),
 				showCancelButton: true
 			}).then(({ canceled }) => {
 				if (canceled) return;
 
 				this.$root.api('notes/delete', {
-					noteId: this.appearNote.id
+					noteId: this.note.id
 				});
 			});
 		},
@@ -205,7 +207,7 @@ export default (opts: Opts = {}) => ({
 			this.openingMenu = true;
 			const w = this.$root.new(MkNoteMenu, {
 				source: this.$refs.menuButton,
-				note: this.appearNote,
+				note: this.note,
 				animation: !viaKeyboard
 			}).$once('closed', () => {
 				this.openingMenu = false;

--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -71,7 +71,7 @@ export default (opts: Opts = {}) => ({
 		},
 
 		isMyNote(): boolean {
-			return this.$store.getters.isSignedIn && (this.$store.state.i.id === this.note.userId);
+			return this.$store.getters.isSignedIn && (this.$store.state.i.id === this.appearNote.userId);
 		},
 
 		reactionsCount(): number {

--- a/src/client/app/common/scripts/note-mixin.ts
+++ b/src/client/app/common/scripts/note-mixin.ts
@@ -191,7 +191,7 @@ export default (opts: Opts = {}) => ({
 
 			this.$root.dialog({
 				type: 'warning',
-				text: this.isRenote ? this.$t('@.unrenote-confirm') : this.$t('@.delete-confirm'),
+				text: this.isRenote ? this.$t('@.remove-renote-confirm') : this.$t('@.delete-confirm'),
 				showCancelButton: true
 			}).then(({ canceled }) => {
 				if (canceled) return;

--- a/src/client/app/common/views/components/note-menu.vue
+++ b/src/client/app/common/views/components/note-menu.vue
@@ -79,7 +79,7 @@ export default Vue.extend({
 				? null : undefined,
 				this.isRenote && this.note.userId == this.$store.state.i.id ? {
 					icon: faMinusSquare,
-					text: this.$t('unrenote'),
+					text: this.$t('remove-renote'),
 					action: () => this.del(false)
 				} : undefined,
 				...(this.appearNote.userId == this.$store.state.i.id || this.$store.state.i.isAdmin || this.$store.state.i.isModerator ? [
@@ -188,7 +188,7 @@ export default Vue.extend({
 		del(appear: boolean = true) {
 			this.$root.dialog({
 				type: 'warning',
-				text: appear ? this.$t('@.delete-confirm') : this.$t('@.unrenote-confirm'),
+				text: appear ? this.$t('@.delete-confirm') : this.$t('@.remove-renote-confirm'),
 				showCancelButton: true
 			}).then(({ canceled }) => {
 				if (canceled) return;


### PR DESCRIPTION
## Summary
Resolve #2231

1つのRenoteを削除する機能をMisskey Webに追加します。

- Renoteのノートメニューに「Renoteを削除」を追加しRenoteを削除できるように。
- Renoteを選択して<kbd>Delete</kbd>もしくは<kbd>Ctrl</kbd>+<kbd>D</kbd>を押下した場合、Renoteした投稿ではなくRenoteを削除するように。  
  また、どちらも削除できない場合にもダイアログが表示されていたのを表示されないようにしました。

![image](https://user-images.githubusercontent.com/7973572/70431223-e9189700-1abf-11ea-9924-c4e0ead44e23.png)
![image](https://user-images.githubusercontent.com/7973572/70431488-82e04400-1ac0-11ea-8ebd-97d8b5c01897.png)
