### PR TITLE
Redis Pub/Subのchannelにホスト名を使用するように

### DIFF
--- a/src/server/api/streaming.ts
+++ b/src/server/api/streaming.ts
@@ -26,7 +26,7 @@ module.exports = (server: http.Server) => {
 		const subscriber = redis.createClient(
 			config.redis.port, config.redis.host);
 
-		subscriber.subscribe('misskey');
+		subscriber.subscribe(config.host);
 
 		ev = new EventEmitter();
 

--- a/src/services/stream.ts
+++ b/src/services/stream.ts
@@ -4,6 +4,7 @@ import { Note } from '../models/entities/note';
 import { UserList } from '../models/entities/user-list';
 import { ReversiGame } from '../models/entities/games/reversi/game';
 import { UserGroup } from '../models/entities/user-group';
+import config from '../config';
 
 class Publisher {
 	private publish = (channel: string, type: string | null, value?: any): void => {
@@ -11,7 +12,7 @@ class Publisher {
 			{ type: type, body: null } :
 			{ type: type, body: value };
 
-		redis.publish('misskey', JSON.stringify({
+		redis.publish(config.host, JSON.stringify({
 			channel: channel,
 			message: message
 		}));


### PR DESCRIPTION
## Summary
Fix #5637

Pub/Subのchannelを`misskey`固定ではなく
ホスト名 (example.com, localhost:3000 等) に変更しています