### PR TITLE
Redis prefixにホスト名を使用するように

### DIFF
--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -43,6 +43,8 @@ export default function load() {
 
 	if (config.autoAdmin == null) config.autoAdmin = false;
 
+	if (!config.redis.prefix) config.redis.prefix = mixin.host;
+
 	return Object.assign(config, mixin);
 }
 

--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -155,7 +155,7 @@ export function initDb(justBorrow = false, sync = false, log = false) {
 				host: config.redis.host,
 				port: config.redis.port,
 				password: config.redis.pass,
-				prefix: config.redis.prefix,
+				prefix: `${config.redis.prefix}:query:`,
 				db: config.redis.db || 0
 			}
 		} : false,


### PR DESCRIPTION
## Summary
Resolve #5639

Redisのprefixが指定されていない時はインスタンスホスト名を使用するようにしています。
また、DBクエリキャッシュ別のprefixにするようにしています。
```
キュー:
"queue:inbox:814" => "example.com:queue:inbox:814"

DBクエリキャッシュ:
"SELECT ..." => "example.com:query:SELECT ..."

名前付きDBクエリキャッシュ:
"meta_emojis" => "example.com:query:meta_emojis"

レートリミット:
"limit:816ec140fcd5ca45bcae03e0:notes/create" => "example.comlimit:816ec140fcd5ca45bcae03e0:notes/create"
```

レートリミットの`:`がなくなってくっついちゃうところは
redis prefix側に`:`付けたりしてみたけどどうしようもなかったです。