### PR TITLE
AP inbox Announce の処理の修正

### DIFF
--- a/src/remote/activitypub/kernel/announce/index.ts
+++ b/src/remote/activitypub/kernel/announce/index.ts
@@ -1,7 +1,7 @@
 import Resolver from '../../resolver';
 import { IRemoteUser } from '../../../../models/entities/user';
 import announceNote from './note';
-import { IAnnounce, validPost, getApId } from '../../type';
+import { IAnnounce, getApId } from '../../type';
 import { apLogger } from '../../logger';
 
 const logger = apLogger;
@@ -13,14 +13,7 @@ export default async (actor: IRemoteUser, activity: IAnnounce): Promise<void> =>
 
 	const resolver = new Resolver();
 
-	const object = await resolver.resolve(activity.object).catch(e => {
-		logger.error(`Resolution failed: ${e}`);
-		throw e;
-	});
+	const targetUri = getApId(activity.object);
 
-	if (validPost.includes(object.type)) {
-		announceNote(resolver, actor, activity, object);
-	} else {
-		logger.warn(`Unknown announce type: ${object.type}`);
-	}
+	announceNote(resolver, actor, activity, targetUri);
 };

--- a/src/remote/activitypub/kernel/announce/note.ts
+++ b/src/remote/activitypub/kernel/announce/note.ts
@@ -1,7 +1,7 @@
 import Resolver from '../../resolver';
 import post from '../../../../services/note/create';
 import { IRemoteUser, User } from '../../../../models/entities/user';
-import { IAnnounce, IObject, getApId, getApIds } from '../../type';
+import { IAnnounce, getApId, getApIds } from '../../type';
 import { fetchNote, resolveNote } from '../../models/note';
 import { resolvePerson } from '../../models/person';
 import { apLogger } from '../../logger';
@@ -14,7 +14,7 @@ const logger = apLogger;
 /**
  * アナウンスアクティビティを捌きます
  */
-export default async function(resolver: Resolver, actor: IRemoteUser, activity: IAnnounce, note: IObject): Promise<void> {
+export default async function(resolver: Resolver, actor: IRemoteUser, activity: IAnnounce, targetUri: string): Promise<void> {
 	const uri = getApId(activity);
 
 	// アナウンサーが凍結されていたらスキップ
@@ -38,14 +38,14 @@ export default async function(resolver: Resolver, actor: IRemoteUser, activity: 
 		// Announce対象をresolve
 		let renote;
 		try {
-			renote = await resolveNote(note);
+			renote = await resolveNote(targetUri);
 		} catch (e) {
 			// 対象が4xxならスキップ
 			if (e.statusCode >= 400 && e.statusCode < 500) {
-				logger.warn(`Ignored announce target ${note.inReplyTo} - ${e.statusCode}`);
+				logger.warn(`Ignored announce target ${targetUri} - ${e.statusCode}`);
 				return;
 			}
-			logger.warn(`Error in announce target ${note.inReplyTo} - ${e.statusCode || e}`);
+			logger.warn(`Error in announce target ${targetUri} - ${e.statusCode || e}`);
 			throw e;
 		}
 


### PR DESCRIPTION
## Summary
APでAnnounceを受け取ったときの処理を改善

- 既知のNoteに対するAnnounceを受け取った場合でも
  必ず (object typeを調べるために) リモートリクエストが発生してしまうのを修正。
- Announce targetが4xxの場合はリトライしないはずが
  (上のリモートリクエストのタイミングで例外になるので) リトライしてしまうのを修正。
- Announce targetのエラーメッセージが間違ってるのを修正