### PR TITLE
/files/ 下のヘッダ設定タイミングを修正

### DIFF
--- a/src/server/file/index.ts
+++ b/src/server/file/index.ts
@@ -12,19 +12,14 @@ import sendDriveFile from './send-drive-file';
 const app = new Koa();
 app.use(cors());
 
-app.use(async (ctx, next) => {
-	// Cache 365days
-	ctx.set('Cache-Control', 'max-age=31536000, immutable');
-	await next();
-});
-
 // Init router
 const router = new Router();
 
 router.get('/app-default.jpg', ctx => {
 	const file = fs.createReadStream(`${__dirname}/assets/dummy.png`);
-	ctx.set('Content-Type', 'image/jpeg');
 	ctx.body = file;
+	ctx.set('Content-Type', 'image/jpeg');
+	ctx.set('Cache-Control', 'max-age=31536000, immutable');
 });
 
 router.get('/:key', sendDriveFile);


### PR DESCRIPTION
## Summary
`/files/`以下のアクセスで500になっても`Cache-Control: max-age=31536000, immutable`が送られてしまったりするのを修正

### immutableの一括指定 の修正
最初に`/files/`以下を`ctx.set('Cache-Control', 'max-age=31536000, immutable');`
→ 例外で500になっても送られてしまうので 送出時に設定するように修正

### Content-Type指定の後のbody設定 の修正
```ts
ctx.set('Content-Type', 'image/jpeg');
ctx.body = file;
```
→ `body`設定タイミングで`Content-Type`が自動設定されることがあるので`Content-Type`設定は後に

### body読み系処理の前のヘッダ－設定 の修正
```ts
ctx.set('Content-Type', file.type === 'image/apng' ? 'image/png' : file.type);
ctx.set('Content-Disposition', contentDisposition('inline', `${rename(file.name, { suffix: '-web' })}`));
ctx.body = InternalStorage.read(key);
```
→ 例外で500になっても送られてしまうので 後で設定するように修正