### PR TITLE
add line-height

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -252,6 +252,7 @@ common:
     font-size-medium: "普通"
     font-size-large: "少し大きい"
     font-size-x-large: "大きい"
+    line-height: "行の高さ"
     deck-column-align: "デッキのカラムの配置"
     deck-column-align-center: "中央"
     deck-column-align-left: "左"

--- a/src/client/app/common/views/components/settings/settings.vue
+++ b/src/client/app/common/views/components/settings/settings.vue
@@ -63,6 +63,18 @@
 				<ui-radio v-model="fontSize" :value="1">{{ $t('@._settings.font-size-large') }}</ui-radio>
 				<ui-radio v-model="fontSize" :value="2">{{ $t('@._settings.font-size-x-large') }}</ui-radio>
 			</section>
+			<section>
+				<header>{{ $t('@._settings.line-height') }}</header>
+				<div style="display: flex">
+					<input type="range"
+						v-model="lineHeight"
+						min="1.2"
+						max="1.7"
+						step="0.05"
+					/>
+					<div>&nbsp;{{ lineHeight }}</div>
+				</div>
+			</section>
 			<section v-if="$root.isMobile">
 				<header>{{ $t('@._settings.post-style') }}</header>
 				<ui-radio v-model="postStyle" value="standard">{{ $t('@._settings.post-style-standard') }}</ui-radio>
@@ -438,6 +450,11 @@ export default Vue.extend({
 		fontSize: {
 			get() { return this.$store.state.device.fontSize; },
 			set(value) { this.$store.commit('device/set', { key: 'fontSize', value }); }
+		},
+
+		lineHeight: {
+			get() { return this.$store.state.device.lineHeight; },
+			set(value) { this.$store.commit('device/set', { key: 'lineHeight', value }); }
 		},
 
 		fetchOnScroll: {

--- a/src/client/app/desktop/views/components/note.vue
+++ b/src/client/app/desktop/views/components/note.vue
@@ -210,7 +210,7 @@ export default Vue.extend({
 			min-width 0
 
 			> .header
-				margin-bottom 4px
+				margin-bottom 2px
 
 			> .body
 

--- a/src/client/app/init.ts
+++ b/src/client/app/init.ts
@@ -421,6 +421,15 @@ export default (callback: (launch: (router: VueRouter) => [Vue, MiOS], os: MiOS)
 			});
 			//#endregion
 
+			//#region lineHeight
+			document.documentElement.style.setProperty('--lineHeight', `${os.store.state.device.lineHeight}`);
+			os.store.watch(s => {
+				return s.device.lineHeight;
+			}, v => {
+				document.documentElement.style.setProperty('--lineHeight', `${os.store.state.device.lineHeight}`);
+			});
+			//#endregion
+
 			document.addEventListener('visibilitychange', () => {
 				if (!document.hidden) {
 					os.store.commit('clearBehindNotes');

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -153,6 +153,9 @@ export default Vue.extend({
 			@media (min-width 600px)
 				padding 32px 32px 22px
 
+			> header
+				margin-bottom 1px
+
 			> .avatar
 				@media (min-width 350px)
 					width 48px

--- a/src/client/app/mobile/views/components/note.vue
+++ b/src/client/app/mobile/views/components/note.vue
@@ -153,9 +153,6 @@ export default Vue.extend({
 			@media (min-width 600px)
 				padding 32px 32px 22px
 
-			> header
-				margin-bottom 1px
-
 			> .avatar
 				@media (min-width 350px)
 					width 48px

--- a/src/client/app/store.ts
+++ b/src/client/app/store.ts
@@ -59,6 +59,7 @@ const defaultDeviceSettings = {
 	lightTheme: 'light',
 	lineWidth: 1,
 	fontSize: 0,
+	lineHeight: 1.5,
 	themes: [],
 	enableSounds: true,
 	soundVolume: 0.5,

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -19,7 +19,7 @@ html, body
 	scroll-behavior smooth
 	text-size-adjust 100%
 	font-family Roboto, HelveticaNeue, Arial, sans-serif
-	line-height: 1.4
+	line-height 1.4
 
 html.changing-theme
 	&, *

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -19,7 +19,7 @@ html, body
 	scroll-behavior smooth
 	text-size-adjust 100%
 	font-family Roboto, HelveticaNeue, Arial, sans-serif
-	line-height 1.3
+	line-height var(--lineHeight)
 
 html.changing-theme
 	&, *

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -19,7 +19,7 @@ html, body
 	scroll-behavior smooth
 	text-size-adjust 100%
 	font-family Roboto, HelveticaNeue, Arial, sans-serif
-	line-height 1.4
+	line-height 1.3
 
 html.changing-theme
 	&, *

--- a/src/client/style.styl
+++ b/src/client/style.styl
@@ -19,6 +19,7 @@ html, body
 	scroll-behavior smooth
 	text-size-adjust 100%
 	font-family Roboto, HelveticaNeue, Arial, sans-serif
+	line-height: 1.4
 
 html.changing-theme
 	&, *


### PR DESCRIPTION
## Summary
Resolve #5657

UIに`line-height 1.3`を適用します。デザインを微調整。

適用前 / 適用後  
<img src="https://d20bb5quu0uyhd.cloudfront.net/m/webpublic-a273abb8-92a3-439a-9aeb-a4ae03ca8f2c.png" width="320"><img src="https://d20bb5quu0uyhd.cloudfront.net/m/webpublic-f046da27-a603-4654-a3ea-444b39e98e9b.png" width="320">

特に管理画面は行間が開いて見易くなった（個人の感想）
![image](https://user-images.githubusercontent.com/7973572/71412525-6122b780-2691-11ea-9ebb-cc56c61670f4.png)
![image](https://user-images.githubusercontent.com/7973572/71412534-6f70d380-2691-11ea-8819-a509c0f1bac5.png)
