### PR TITLE
Fix: リモートプロキシ時にサムネイルのContent-Typeがおかしい

### DIFF
--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -39,21 +39,7 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			const key = thumbnail ? file.thumbnailAccessKey : file.webpublicAccessKey;
 
 			if (key && !key.match('/')) {	// 古いものはここにオブジェクトストレージキーが入ってるので除外
-				let ext = '';
-
-				if (file.name) {
-					[ext] = (file.name.match(/\.(\w+)$/) || ['']);
-				}
-
-				if (ext === '') {
-					if (file.type === 'image/jpeg') ext = '.jpg';
-					if (file.type === 'image/png') ext = '.png';
-					if (file.type === 'image/webp') ext = '.webp';
-					if (file.type === 'image/apng') ext = '.apng';
-					if (file.type === 'image/vnd.mozilla.apng') ext = '.apng';
-				}
-
-				return `/files/${key}/${key}${ext}`;
+				return `/files/${key}`;
 			}
 		}
 

--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -78,7 +78,7 @@ export default async function(ctx: Koa.Context) {
 
 				const image = await convertFile();
 				ctx.body = image.data;
-				ctx.set('Content-Type', file.type);
+				ctx.set('Content-Type', image.type);
 				ctx.set('Cache-Control', 'max-age=31536000, immutable');
 			} catch (e) {
 				serverLogger.error(e);


### PR DESCRIPTION
## Summary
未保存ファイルのリモートプロキシ時にサムネイルの場合に
サムネイルのContent-Typeじゃなくて常にオリジナルのContent-Typeが返ってきてしまうのを修正。

またリモートプロキシのURLとして拡張子を補っていましたが
実際のtypeを正確に予期することが難しくややこしいだけなので無くしています。
(通常のファイルシステム保存の場合のURLと一緒になる)
`/files/${key}/${key}${ext}` => `/files/${key}` 
