### PR TITLE
ドライブファイルURL生成などの修正

### DIFF
--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -43,7 +43,9 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			}
 		}
 
-		return thumbnail ? (file.thumbnailUrl || file.webpublicUrl || null) : (file.webpublicUrl || file.url);
+		const isImage = file.type && ['image/png', 'image/apng', 'image/gif', 'image/jpeg', 'image/webp', 'image/svg+xml'].includes(file.type);
+
+		return thumbnail ? (file.thumbnailUrl || (isImage ? (file.webpublicUrl || file.url) : null)) : (file.webpublicUrl || file.url);
 	}
 
 	public async clacDriveUsageOf(user: User['id'] | User): Promise<number> {

--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -39,21 +39,7 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			const key = thumbnail ? file.thumbnailAccessKey : file.webpublicAccessKey;
 
 			if (key && !key.match('/')) {	// 古いものはここにオブジェクトストレージキーが入ってるので除外
-				let ext = '';
-
-				if (file.name) {
-					[ext] = (file.name.match(/\.(\w+)$/) || ['']);
-				}
-
-				if (ext === '') {
-					if (file.type === 'image/jpeg') ext = '.jpg';
-					if (file.type === 'image/png') ext = '.png';
-					if (file.type === 'image/webp') ext = '.webp';
-					if (file.type === 'image/apng') ext = '.apng';
-					if (file.type === 'image/vnd.mozilla.apng') ext = '.apng';
-				}
-
-				return `/files/${key}/${key}${ext}`;
+				return `/files/${key}`;
 			}
 		}
 

--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -78,7 +78,7 @@ export default async function(ctx: Koa.Context) {
 
 				const image = await convertFile();
 				ctx.body = image.data;
-				ctx.set('Content-Type', file.type);
+				ctx.set('Content-Type', image.type);
 				ctx.set('Cache-Control', 'max-age=31536000, immutable');
 			} catch (e) {
 				serverLogger.error(e);

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -10,7 +10,7 @@ import { deleteFile } from './delete-file';
 import { fetchMeta } from '../../misc/fetch-meta';
 import { GenerateVideoThumbnail } from './generate-video-thumbnail';
 import { driveLogger } from './logger';
-import { IImage, convertToJpeg, convertToWebp, convertToPng, convertToGif, convertToApng } from './image-processor';
+import { IImage, convertToJpeg, convertToWebp, convertToPng } from './image-processor';
 import { contentDisposition } from '../../misc/content-disposition';
 import { detectMine } from '../../misc/detect-mine';
 import { DriveFiles, DriveFolders, Users, Instances, UserProfiles } from '../../models';
@@ -159,12 +159,6 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 				webpublic = await convertToWebp(path, 2048, 2048);
 			} else if (['image/png'].includes(type)) {
 				webpublic = await convertToPng(path, 2048, 2048);
-			} else if (['image/apng', 'image/vnd.mozilla.apng'].includes(type)) {
-				webpublic = await convertToApng(path);
-			} else if (['image/gif'].includes(type)) {
-				webpublic = await convertToGif(path);
-			} else {
-				logger.info(`web image not created (not an image)`);
 			}
 		} catch (e) {
 			logger.warn(`web image not created (an error occured)`, e);
@@ -182,10 +176,6 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 			thumbnail = await convertToJpeg(path, 498, 280);
 		} else if (['image/png'].includes(type)) {
 			thumbnail = await convertToPng(path, 498, 280);
-		} else if (['image/gif'].includes(type)) {
-			thumbnail = await convertToGif(path);
-		} else if (['image/apng', 'image/vnd.mozilla.apng'].includes(type)) {
-			thumbnail = await convertToApng(path);
 		} else if (type.startsWith('video/')) {
 			try {
 				thumbnail = await GenerateVideoThumbnail(path);
@@ -422,8 +412,6 @@ export default async function(
 
 		if (isLink) {
 			file.url = url;
-			file.thumbnailUrl = url;
-			file.webpublicUrl = url;
 			// ローカルプロキシ用
 			file.accessKey = uuid();
 			file.thumbnailAccessKey = 'thumbnail-' + uuid();

--- a/src/services/drive/delete-file.ts
+++ b/src/services/drive/delete-file.ts
@@ -69,8 +69,8 @@ function postProcess(file: DriveFile, isExpired = false) {
 		DriveFiles.update(file.id, {
 			isLink: true,
 			url: file.uri,
-			thumbnailUrl: file.uri,
-			webpublicUrl: file.uri,
+			thumbnailUrl: null,
+			webpublicUrl: null,
 			size: 0,
 			// ローカルプロキシ用
 			accessKey: uuid(),

--- a/src/services/drive/image-processor.ts
+++ b/src/services/drive/image-processor.ts
@@ -74,29 +74,3 @@ export async function convertToPng(path: string, width: number, height: number):
 		type: 'image/png'
 	};
 }
-
-/**
- * Convert to GIF (Actually just NOP)
- */
-export async function convertToGif(path: string): Promise<IImage> {
-	const data = await fs.promises.readFile(path);
-
-	return {
-		data,
-		ext: 'gif',
-		type: 'image/gif'
-	};
-}
-
-/**
- * Convert to APNG (Actually just NOP)
- */
-export async function convertToApng(path: string): Promise<IImage> {
-	const data = await fs.promises.readFile(path);
-
-	return {
-		data,
-		ext: 'apng',
-		type: 'image/apng'
-	};
-}


### PR DESCRIPTION
## Summary
Fix #5648
Fix #5670
Fix 動画のサムネイル作成に失敗した時にthumbnailとしてoriginalが返ってきそう
アニメーション画像等で同じファイルを複数作成したり別のURLを生成しないように
#5669 を含む

サムネイル等のURLを
未作成理由 (リモートファイル期限切れ / アニメーション等なので作成不要 / 画像でも動画でもない) 関係なしに、未作成ならnullにしてURL生成時にまとめてfallbackするようにしています。

Related #5667