### PR TITLE
ドライブ関連の修正

### DIFF
--- a/src/client/app/common/views/components/media-list.vue
+++ b/src/client/app/common/views/components/media-list.vue
@@ -42,7 +42,7 @@ export default Vue.extend({
 	},
 	methods: {
 		previewable(file) {
-			return file.type.startsWith('video') || file.type.startsWith('image');
+			return (file.type.startsWith('video') || file.type.startsWith('image')) && file.thumbnailUrl;
 		}
 	}
 });

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -378,15 +378,21 @@ export default async function(
 			logger.debug('calculating average color...');
 
 			try {
-				const info = await sharp(await img.flatten({background: '#fff'}).toBuffer()).stats();
+				const info = await img.stats();
 
-				const r = Math.round(info.channels[0].mean);
-				const g = Math.round(info.channels[1].mean);
-				const b = Math.round(info.channels[2].mean);
+				if (info.isOpaque) {
+					const r = Math.round(info.channels[0].mean);
+					const g = Math.round(info.channels[1].mean);
+					const b = Math.round(info.channels[2].mean);
 
-				logger.debug(`average color is calculated: ${r}, ${g}, ${b}`);
+					logger.debug(`average color is calculated: ${r}, ${g}, ${b}`);
 
-				properties['avgColor'] = `rgb(${r},${g},${b})`;
+					properties['avgColor'] = `rgb(${r},${g},${b})`;
+				} else {
+					logger.debug(`this image is not opaque so average color is 255, 255, 255`);
+
+					properties['avgColor'] = `rgb(255,255,255)`;
+				}
 			} catch (e) { }
 		};
 

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -159,6 +159,8 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 				webpublic = await convertToWebp(path, 2048, 2048);
 			} else if (['image/png'].includes(type)) {
 				webpublic = await convertToPng(path, 2048, 2048);
+			} else {
+				logger.info(`web image not created (not an required image)`);
 			}
 		} catch (e) {
 			logger.warn(`web image not created (an error occured)`, e);
@@ -182,6 +184,8 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 			} catch (e) {
 				logger.error(`GenerateVideoThumbnail failed: ${e}`);
 			}
+		} else {
+			logger.info(`thumbnail not created (not an required file)`);
 		}
 	} catch (e) {
 		logger.warn(`thumbnail not created (an error occured)`, e);
@@ -351,7 +355,7 @@ export default async function(
 
 	let propPromises: Promise<void>[] = [];
 
-	const isImage = ['image/jpeg', 'image/gif', 'image/png', 'image/apng', 'image/vnd.mozilla.apng', 'image/webp'].includes(mime);
+	const isImage = ['image/jpeg', 'image/gif', 'image/png', 'image/apng', 'image/vnd.mozilla.apng', 'image/webp', 'image/svg+xml'].includes(mime);
 
 	if (isImage) {
 		const img = sharp(path);
@@ -374,7 +378,7 @@ export default async function(
 			logger.debug('calculating average color...');
 
 			try {
-				const info = await (img as any).stats();
+				const info = await sharp(await img.flatten({background: '#fff'}).toBuffer()).stats();
 
 				const r = Math.round(info.channels[0].mean);
 				const g = Math.round(info.channels[1].mean);

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -160,7 +160,7 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 			} else if (['image/png'].includes(type)) {
 				webpublic = await convertToPng(path, 2048, 2048);
 			} else {
-				logger.info(`web image not created (not an required image)`);
+				logger.debug(`web image not created (not an required image)`);
 			}
 		} catch (e) {
 			logger.warn(`web image not created (an error occured)`, e);
@@ -182,10 +182,10 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 			try {
 				thumbnail = await GenerateVideoThumbnail(path);
 			} catch (e) {
-				logger.error(`GenerateVideoThumbnail failed: ${e}`);
+				logger.warn(`GenerateVideoThumbnail failed: ${e}`);
 			}
 		} else {
-			logger.info(`thumbnail not created (not an required file)`);
+			logger.debug(`thumbnail not created (not an required file)`);
 		}
 	} catch (e) {
 		logger.warn(`thumbnail not created (an error occured)`, e);

--- a/src/services/drive/image-processor.ts
+++ b/src/services/drive/image-processor.ts
@@ -1,5 +1,4 @@
 import * as sharp from 'sharp';
-import * as fs from 'fs';
 
 export type IImage = {
 	data: Buffer;

--- a/src/services/drive/internal-storage.ts
+++ b/src/services/drive/internal-storage.ts
@@ -3,25 +3,27 @@ import * as Path from 'path';
 import config from '../../config';
 
 export class InternalStorage {
-	private static readonly path = Path.resolve(`${__dirname}/../../../files`);
+	private static readonly path = Path.resolve(__dirname, '../../../files');
+
+	public static resolvePath = (key: string) => Path.resolve(InternalStorage.path, key);
 
 	public static read(key: string) {
-		return fs.createReadStream(`${InternalStorage.path}/${key}`);
+		return fs.createReadStream(InternalStorage.resolvePath(key));
 	}
 
 	public static saveFromPath(key: string, srcPath: string) {
 		fs.mkdirSync(InternalStorage.path, { recursive: true });
-		fs.copyFileSync(srcPath, `${InternalStorage.path}/${key}`);
+		fs.copyFileSync(srcPath, InternalStorage.resolvePath(key));
 		return `${config.url}/files/${key}`;
 	}
 
 	public static saveFromBuffer(key: string, data: Buffer) {
 		fs.mkdirSync(InternalStorage.path, { recursive: true });
-		fs.writeFileSync(`${InternalStorage.path}/${key}`, data);
+		fs.writeFileSync(InternalStorage.resolvePath(key), data);
 		return `${config.url}/files/${key}`;
 	}
 
 	public static del(key: string) {
-		fs.unlink(`${InternalStorage.path}/${key}`, () => {});
+		fs.unlink(InternalStorage.resolvePath(key), () => {});
 	}
 }


### PR DESCRIPTION
## Summary
#5667 を整理・復活

- クライアントで、thumbanilUrlが提供されていない画像はプレビューしないように
- [send-drive-file.tsのエラー](https://github.com/syuilo/misskey/pull/5671#issuecomment-570072583)を修正
- サムネイル/webpublicのファイル形式がjpeg/pngに固定されていたのをファイルを基に送出するように
- ドライブのファイル保存時、サムネイル・webpublic画像の生成が不要だったときにログを出力するように
- svgでも画像の平均色を計算するように
- 画像の平均色を計算するとき、透過部分のある画像では一律で背景を`#fff`（白）に
- リファクタリング

