### PR TITLE
カスタム絵文字リアクションの絵文字がNoteに添付されないのを修正

### DIFF
--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -129,25 +129,6 @@ export class NoteRepository extends Repository<Note> {
 			};
 		}
 
-		async function populateMyReaction() {
-			const reaction = await NoteReactions.findOne({
-				userId: meId!,
-				noteId: note.id,
-			});
-
-			if (reaction) {
-				return reaction.reaction;
-			}
-
-			return undefined;
-		}
-
-		let text = note.text;
-
-		if (note.name && note.uri) {
-			text = `【${note.name}】\n${(note.text || '').trim()}\n${note.uri}`;
-		}
-
 		async function populateEmojis(emojiNames: string[], noteUserHost: string | null, reactionNames: string[]) {
 			const where = [] as {}[];
 
@@ -171,6 +152,25 @@ export class NoteRepository extends Repository<Note> {
 				where,
 				select: ['name', 'host', 'url', 'aliases']
 			});
+		}
+
+		async function populateMyReaction() {
+			const reaction = await NoteReactions.findOne({
+				userId: meId!,
+				noteId: note.id,
+			});
+
+			if (reaction) {
+				return reaction.reaction;
+			}
+
+			return undefined;
+		}
+
+		let text = note.text;
+
+		if (note.name && note.uri) {
+			text = `【${note.name}】\n${(note.text || '').trim()}\n${note.uri}`;
 		}
 
 		const packed = await awaitAll({

--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -151,14 +151,14 @@ export class NoteRepository extends Repository<Note> {
 		async function populateEmojis(emojiNames: string[], noteUserHost: string | null, reactionNames: string[]) {
 			const where = [] as {}[];
 
-			if (emojiNames.length > 0) {
+			if (emojiNames?.length > 0) {
 				where.push({
 					name: In(emojiNames),
 					host: noteUserHost
 				});
 			}
 
-			if (reactionNames.length > 0) {
+			if (reactionNames?.length > 0) {
 				where.push({
 					name: In(reactionNames.map(x => x.replace(/:/g, ''))),
 					host: null

--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -148,7 +148,30 @@ export class NoteRepository extends Repository<Note> {
 			text = `【${note.name}】\n${(note.text || '').trim()}\n${note.uri}`;
 		}
 
-		const reactionEmojis = unique(concat([note.emojis, Object.keys(note.reactions)]));
+		async function populateEmojis(emojiNames: string[], noteUserHost: string | null, reactionNames: string[]) {
+			const where = [] as {}[];
+
+			if (emojiNames.length > 0) {
+				where.push({
+					name: In(emojiNames),
+					host: noteUserHost
+				});
+			}
+
+			if (reactionNames.length > 0) {
+				where.push({
+					name: In(reactionNames.map(x => x.replace(/:/g, ''))),
+					host: null
+				});
+			}
+
+			if (where.length === 0) return [];
+
+			return Emojis.find({
+				where,
+				select: ['name', 'host', 'url', 'aliases']
+			});
+		}
 
 		const packed = await awaitAll({
 			id: note.id,
@@ -166,10 +189,7 @@ export class NoteRepository extends Repository<Note> {
 			repliesCount: note.repliesCount,
 			reactions: note.reactions,
 			tags: note.tags.length > 0 ? note.tags : undefined,
-			emojis: reactionEmojis.length > 0 ? Emojis.find({
-				name: In(reactionEmojis),
-				host: host
-			}) : [],
+			emojis: populateEmojis(note.emojis, host, Object.keys(note.reactions)),
 			fileIds: note.fileIds,
 			files: DriveFiles.packMany(note.fileIds),
 			replyId: note.replyId,


### PR DESCRIPTION
## Summary
Fix #5685 
カスタム絵文字リアクションの絵文字が`Note.emojis`に添付されないのを修正
Note.emojisに不要なプロパティが含まれるのを修正

※たぶんカスタム絵文字リアクション分のクエリが常に`host: null`なのは間違いですが、今の`meta.emojis`を見るWeb UIの挙動もそれ相当になるのでそうしてます。