### PR TITLE
ドキュメントのNode.js最小バージョンを修正

### DIFF
--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -22,7 +22,7 @@ adduser --disabled-password --disabled-login misskey
 Please install and setup these softwares:
 
 #### Dependencies :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
+* **[Node.js](https://nodejs.org/en/)** >= 11.10.1
 * **[PostgreSQL](https://www.postgresql.org/)** >= 10
 * **[Redis](https://redis.io/)**
 

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -22,7 +22,7 @@ adduser --disabled-password --disabled-login misskey
 Installez les paquets suivants :
 
 #### Dépendences :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.7.0
+* **[Node.js](https://nodejs.org/en/)** >= 11.10.1
 * **[PostgreSQL](https://www.postgresql.org/)** >= 10
 * **[Redis](https://redis.io/)**
 

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -22,7 +22,7 @@ adduser --disabled-password --disabled-login misskey
 これらのソフトウェアをインストール・設定してください:
 
 #### 依存関係 :package:
-* **[Node.js](https://nodejs.org/en/)** (11.7.0以上)
+* **[Node.js](https://nodejs.org/en/)** (11.10.1以上)
 * **[PostgreSQL](https://www.postgresql.org/)** (10以上)
 * **[Redis](https://redis.io/)**
 


### PR DESCRIPTION
## Summary

@typescript-eslint/parserが11.10.1以上じゃないと入らない

> error @typescript-eslint/parser@2.3.3: The engine "node" is incompatible with this module. Expected version "^8.10.0 || ^10.13.0 || >=11.10.1". Got "11.7.0"

https://github.com/syuilo/misskey/runs/274115939
