### PR TITLE
Allow CORS requests in /.well-known/* routes

### DIFF
--- a/src/server/well-known.ts
+++ b/src/server/well-known.ts
@@ -19,9 +19,21 @@ const XRD = (...x: { element: string, value?: string, attributes?: Record<string
 		typeof value === 'string' ? `>${escapeValue(value)}</${element}` : '/'
 	}>`).reduce((a, c) => a + c, '')}</XRD>`;
 
+const allPath = '/.well-known/*';
 const webFingerPath = '/.well-known/webfinger';
 const jrd = 'application/jrd+json';
 const xrd = 'application/xrd+xml';
+
+router.use(allPath, (ctx, next) => (ctx.set({
+	'Access-Control-Allow-Headers': 'Accept',
+	'Access-Control-Allow-Methods': 'GET, OPTIONS',
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Expose-Headers': 'Vary',
+}), next));
+
+router.options(allPath, async ctx => {
+	ctx.status = 204;
+});
 
 router.get('/.well-known/host-meta', async ctx => {
 	ctx.set('Content-Type', xrd);
@@ -123,7 +135,7 @@ router.get(webFingerPath, async ctx => {
 });
 
 // Return 404 for other .well-known
-router.all('/.well-known/*', async ctx => {
+router.all(allPath, async ctx => {
 	ctx.status = 404;
 });
 

--- a/src/server/well-known.ts
+++ b/src/server/well-known.ts
@@ -24,12 +24,15 @@ const webFingerPath = '/.well-known/webfinger';
 const jrd = 'application/jrd+json';
 const xrd = 'application/xrd+xml';
 
-router.use(allPath, (ctx, next) => (ctx.set({
-	'Access-Control-Allow-Headers': 'Accept',
-	'Access-Control-Allow-Methods': 'GET, OPTIONS',
-	'Access-Control-Allow-Origin': '*',
-	'Access-Control-Expose-Headers': 'Vary',
-}), next));
+router.use(allPath, async (ctx, next) => {
+	ctx.set({
+		'Access-Control-Allow-Headers': 'Accept',
+		'Access-Control-Allow-Methods': 'GET, OPTIONS',
+		'Access-Control-Allow-Origin': '*',
+		'Access-Control-Expose-Headers': 'Vary',
+	});
+	await next();
+});
 
 router.options(allPath, async ctx => {
 	ctx.status = 204;


### PR DESCRIPTION
Summary
--

Fixes: follow requests fail from the web client of PeerTube.
Related to Chocobozzz/PeerTube#1498
