### PR TITLE
PixelFedのハッシュタグをハッシュタグ扱いできるように

### DIFF
--- a/src/mfm/fromHtml.ts
+++ b/src/mfm/fromHtml.ts
@@ -36,7 +36,8 @@ export function fromHtml(html: string): string {
 				const txt = getText(node);
 				const rel = node.attrs.find((x: any) => x.name == 'rel');
 				const href = node.attrs.find((x: any) => x.name == 'href');
-				const isHashtag = rel && rel.value.match('tag') !== null;
+				const _class = node.attrs.find((x: any) => x.name == 'class');
+				const isHashtag = rel?.value?.match('tag') || _class?.value?.match('hashtag');
 
 				// ハッシュタグ / hrefがない / txtがURL
 				if (isHashtag || !href || href.value == txt) {


### PR DESCRIPTION
## Summary
Fix #5729

classに`hashtag`があったらハッシュタグ扱いにする
```html
 <a href="https://exabple/discover/tags/TAG?src=hash"
  title="#TAG" class="u-url hashtag" rel="external nofollow noopener">#TAG</a>
```
