### PR TITLE
AP Actorの鍵とkeyIdのフォーマットの変更

### DIFF
--- a/src/remote/activitypub/renderer/key.ts
+++ b/src/remote/activitypub/renderer/key.ts
@@ -1,10 +1,14 @@
 import config from '../../../config';
 import { ILocalUser } from '../../../models/entities/user';
 import { UserKeypair } from '../../../models/entities/user-keypair';
+import { createPublicKey } from 'crypto';
 
 export default (user: ILocalUser, key: UserKeypair) => ({
 	id: `${config.url}/users/${user.id}/publickey`,
 	type: 'Key',
 	owner: `${config.url}/users/${user.id}`,
-	publicKeyPem: key.publicKey
+	publicKeyPem: createPublicKey(key.publicKey).export({
+		type: 'spki',
+		format: 'pem'
+	})
 });

--- a/src/remote/activitypub/renderer/key.ts
+++ b/src/remote/activitypub/renderer/key.ts
@@ -3,8 +3,8 @@ import { ILocalUser } from '../../../models/entities/user';
 import { UserKeypair } from '../../../models/entities/user-keypair';
 import { createPublicKey } from 'crypto';
 
-export default (user: ILocalUser, key: UserKeypair) => ({
-	id: `${config.url}/users/${user.id}/publickey`,
+export default (user: ILocalUser, key: UserKeypair, postfix?: string) => ({
+	id: `${config.url}/users/${user.id}${postfix || '/publickey'}`,
 	type: 'Key',
 	owner: `${config.url}/users/${user.id}`,
 	publicKeyPem: createPublicKey(key.publicKey).export({

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -108,7 +108,7 @@ export async function renderPerson(user: ILocalUser) {
 		image: banner ? renderImage(banner) : null,
 		tag,
 		manuallyApprovesFollowers: user.isLocked,
-		publicKey: renderKey(user, keypair),
+		publicKey: renderKey(user, keypair, `#main-key`),
 		isCat: user.isCat,
 		attachment: attachment.length ? attachment : undefined
 	};

--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -56,7 +56,7 @@ export default async (user: ILocalUser, url: string, object: any) => {
 		sign(req, {
 			authorizationHeaderName: 'Signature',
 			key: keypair.privateKey,
-			keyId: `${config.url}/users/${user.id}/publickey`,
+			keyId: `${config.url}/users/${user.id}#main-key`,
 			headers: ['date', 'host', 'digest']
 		});
 

--- a/src/server/api/private/signup.ts
+++ b/src/server/api/private/signup.ts
@@ -91,21 +91,21 @@ export default async (ctx: Koa.Context) => {
 		return;
 	}
 
-	const keyPair = await new Promise<string[]>((s, j) =>
+	const keyPair = await new Promise<string[]>((res, rej) =>
 		generateKeyPair('rsa', {
 			modulusLength: 4096,
 			publicKeyEncoding: {
-				type: 'pkcs1',
+				type: 'spki',
 				format: 'pem'
 			},
 			privateKeyEncoding: {
-				type: 'pkcs1',
+				type: 'pkcs8',
 				format: 'pem',
 				cipher: undefined,
 				passphrase: undefined
 			}
-		} as any, (e, publicKey, privateKey) =>
-			e ? j(e) : s([publicKey, privateKey])
+		} as any, (err, publicKey, privateKey) =>
+			err ? rej(err) : res([publicKey, privateKey])
 		));
 
 	let account!: User;


### PR DESCRIPTION
## Summary
Resolve #5720, Resovle #5721, Fix #2734, Fix #5725, Related #5715

AP Actorの`publicKeyPem`を`PKCS#1`から`PKCS#8`(publicKeyの場合は`SPKI`と呼ぶ？)に変更 #5720
もちろん既にkey生成済みの既存アカウントでも大丈夫です。
影響は、Mastodon, Misskey, Pleroma にはなさそう, PeerTubeはValidationにかかってたのがかからなくなる。

APでActivityを送る際の`keyId`のURLを変更 #5721
影響は、Mastodon, Pleroma はなし, Misskeyは`keyId`でUserテーブルを見ているけどひっかからなくてもActorを見るので問題なし、notestockは一時的に配信が503になるけどnotestockでログインするか一定時間 (数時間?) 経過のタイミングで正常になる模様。

この変更により、
投稿する度にMastodonから3つずつリクエストが飛んできてしまう問題 #2734 が解決して
双方の負荷が減って MastodonへのAP 配信所要時間が1/4~1/5になります。
また、PixelFedへの配信ができるようになるみたいです。