### PR TITLE
APの流量制限とリトライ期間の変更

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -129,6 +129,10 @@ autoAdmin: true
 # deliverJobPerSec: 128
 # inboxJobPerSec: 16
 
+# Job attempts
+# deliverJobMaxAttempts: 12
+# inboxJobMaxAttempts: 8
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -125,7 +125,7 @@ autoAdmin: true
 # deliverJobConcurrency: 128
 # inboxJobConcurrency: 16
 
-# Job late limiter
+# Job rate limiter
 # deliverJobPerSec: 128
 # inboxJobPerSec: 16
 

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -125,6 +125,10 @@ autoAdmin: true
 # deliverJobConcurrency: 128
 # inboxJobConcurrency: 16
 
+# Job late limiter
+# deliverJobPerSec: 128
+# inboxJobPerSec: 16
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,6 +49,8 @@ export type Source = {
 	inboxJobConcurrency?: number;
 	deliverJobPerSec?: number;
 	inboxJobPerSec?: number;
+	deliverJobMaxAttempts?: number;
+	inboxJobMaxAttempts?: number;
 
 	syslog: {
 		host: string;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -47,6 +47,8 @@ export type Source = {
 
 	deliverJobConcurrency?: number;
 	inboxJobConcurrency?: number;
+	deliverJobPerSec?: number;
+	inboxJobPerSec?: number;
 
 	syslog: {
 		host: string;

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -13,7 +13,7 @@ import { queueLogger } from './logger';
 import { DriveFile } from '../models/entities/drive-file';
 import { getJobInfo } from './get-job-info';
 
-function initializeQueue(name: string) {
+function initializeQueue(name: string, limitPerSec = -1) {
 	return new Queue(name, {
 		redis: {
 			port: config.redis.port,
@@ -21,7 +21,11 @@ function initializeQueue(name: string) {
 			password: config.redis.pass,
 			db: config.redis.db || 0,
 		},
-		prefix: config.redis.prefix ? `${config.redis.prefix}:queue` : 'queue'
+		prefix: config.redis.prefix ? `${config.redis.prefix}:queue` : 'queue',
+		limiter: limitPerSec > 0 ? {
+			max: limitPerSec * 5,
+			duration: 5000
+		} : undefined
 	});
 }
 
@@ -33,8 +37,8 @@ function renderError(e: Error): any {
 	};
 }
 
-export const deliverQueue = initializeQueue('deliver');
-export const inboxQueue = initializeQueue('inbox');
+export const deliverQueue = initializeQueue('deliver', config.deliverJobPerSec || 128);
+export const inboxQueue = initializeQueue('inbox', config.inboxJobPerSec || 16);
 export const dbQueue = initializeQueue('db');
 export const objectStorageQueue = initializeQueue('objectStorage');
 

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -89,7 +89,7 @@ export function deliver(user: ILocalUser, content: any, to: any) {
 	};
 
 	return deliverQueue.add(data, {
-		attempts: 8,
+		attempts: config.deliverJobMaxAttempts || 12,
 		backoff: {
 			type: 'exponential',
 			delay: 60 * 1000
@@ -106,7 +106,7 @@ export function inbox(activity: any, signature: httpSignature.IParsedSignature) 
 	};
 
 	return inboxQueue.add(data, {
-		attempts: 8,
+		attempts: config.inboxJobMaxAttempts || 8,
 		backoff: {
 			type: 'exponential',
 			delay: 1000


### PR DESCRIPTION
## Summary
Resolve #5718, Resolve #5719 

AP deliver/inbox 処理にインスタンス全体で流量制限をかけられるようにしています #5718

AP deliverのリトライ期間を長めにして、回数を変更できるようにしています #5719
デフォルトで
9回目 8.5時間後
10回目 17.1時間後
11回目 34.1時間後
12回目 68.3時間後
を追加
