### PR TITLE
Allow 'internal' device in WebAuthN

### DIFF
--- a/src/client/app/common/views/components/signin.vue
+++ b/src/client/app/common/views/components/signin.vue
@@ -107,7 +107,7 @@ export default Vue.extend({
 					allowCredentials: this.challengeData.securityKeys.map(key => ({
 						id: Buffer.from(key.id, 'hex'),
 						type: 'public-key',
-						transports: ['usb', 'ble', 'nfc']
+						transports: ['usb', 'nfc', 'ble', 'internal']
 					})),
 					timeout: 60 * 1000
 				}


### PR DESCRIPTION
## Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
internal というタイプもあるようなのでそれも使えるように
https://www.w3.org/TR/webauthn/#transport