### PR TITLE
userListチャンネルのオーナーチェック Fix #5772

### DIFF
--- a/src/server/api/stream/channels/user-list.ts
+++ b/src/server/api/stream/channels/user-list.ts
@@ -17,7 +17,7 @@ export default class extends Channel {
 	public async init(params: any) {
 		this.listId = params.listId as string;
 
-		// Check owner and existence
+		// Check existence and owner
 		const list = await UserLists.findOne({
 			id: this.listId,
 			userId: this.user!.id

--- a/src/server/api/stream/channels/user-list.ts
+++ b/src/server/api/stream/channels/user-list.ts
@@ -1,6 +1,6 @@
 import autobind from 'autobind-decorator';
 import Channel from '../channel';
-import { Notes, UserListJoinings } from '../../../../models';
+import { Notes, UserListJoinings, UserLists } from '../../../../models';
 import shouldMuteThisNote from '../../../../misc/should-mute-this-note';
 import { User } from '../../../../models/entities/user';
 import { PackedNote } from '../../../../models/repositories/note';
@@ -16,6 +16,13 @@ export default class extends Channel {
 	@autobind
 	public async init(params: any) {
 		this.listId = params.listId as string;
+
+		// Check owner and existence
+		const list = await UserLists.findOne({
+			id: this.listId,
+			userId: this.user!.id
+		});
+		if (!list) return;
 
 		// Subscribe stream
 		this.subscriber.on(`userListStream:${this.listId}`, this.send);


### PR DESCRIPTION
## Summary
Fix #5772
リストのチャンネルでリストの存在とオーナーをチェックをするように
いまのところエラーを返す仕組みはないので単純にスルーするように