### PR TITLE
ノートをウォッチした後にメニューが開けなくなるのを修正

### DIFF
--- a/src/client/components/note-menu.vue
+++ b/src/client/components/note-menu.vue
@@ -184,6 +184,7 @@ export default Vue.extend({
 					type: 'success',
 					iconOnly: true, autoClose: true
 				});
+				this.$emit('closed');
 				this.destroyDom();
 			});
 		},


### PR DESCRIPTION
## Summary
ノート下部のメニューからノートのウォッチをtoggleすると`note`にcloseされたことが通知されていなくて同ノートのメニューが再度開けなくなるので他アクション同様に通知するように。

![Peek 2020-02-01 12-07](https://user-images.githubusercontent.com/5253290/73586039-7d651000-44eb-11ea-8a7f-5a337a036c66.gif)

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
