### PR TITLE
Fix hashtags contained in private notes are shown in trends

### DIFF
--- a/src/server/api/endpoints/hashtags/trend.ts
+++ b/src/server/api/endpoints/hashtags/trend.ts
@@ -59,7 +59,10 @@ export default define(meta, async () => {
 
 	const tagNotes = await Notes.createQueryBuilder('note')
 		.where(`note.createdAt > :date`, { date: new Date(now.getTime() - rangeA) })
-		.andWhere('(note.visibility = \'public\') OR (note.visibility = \'home\')')
+		.andWhere(new Brackets(qb => { qb
+			.where(`note.visibility = 'public'`)
+			.orWhere(`note.visibility = 'home'`);
+		}))
 		.andWhere(`note.tags != '{}'`)
 		.select(['note.tags', 'note.userId'])
 		.cache(60000) // 1 min

--- a/src/server/api/endpoints/hashtags/trend.ts
+++ b/src/server/api/endpoints/hashtags/trend.ts
@@ -59,6 +59,7 @@ export default define(meta, async () => {
 
 	const tagNotes = await Notes.createQueryBuilder('note')
 		.where(`note.createdAt > :date`, { date: new Date(now.getTime() - rangeA) })
+		.andWhere('(note.visibility = \'public\') OR (note.visibility = \'home\')')
 		.andWhere(`note.tags != '{}'`)
 		.select(['note.tags', 'note.userId'])
 		.cache(60000) // 1 min

--- a/src/server/api/endpoints/hashtags/trend.ts
+++ b/src/server/api/endpoints/hashtags/trend.ts
@@ -1,3 +1,4 @@
+import { Brackets } from 'typeorm';
 import define from '../../define';
 import { fetchMeta } from '../../../../misc/fetch-meta';
 import { Notes } from '../../../../models';

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -203,7 +203,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 	}
 
 	// ハッシュタグ更新
-	if (data.visibility == 'public' || data.visibility == 'home') {
+	if (data.visibility === 'public' || data.visibility === 'home') {
 		updateHashtags(user, tags);
 	}
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -203,7 +203,9 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 	}
 
 	// ハッシュタグ更新
-	updateHashtags(user, tags);
+	if (data.visibility == 'public' || data.visibility == 'home') {
+		updateHashtags(user, tags);
+	}
 
 	// Increment notes count (user)
 	incNotesCountOfUser(user);


### PR DESCRIPTION
Summary
--

フォロワーのみ投稿などに含まれる投稿の `tags` がトレンドに集計されてしまうのはまずいかなと。
