### PR TITLE
Add ZWSP when federating emojis for Mastodon compatibility

### DIFF
--- a/src/mfm/toHtml.ts
+++ b/src/mfm/toHtml.ts
@@ -87,7 +87,7 @@ export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: IMentione
 		},
 
 		emoji(token) {
-			return doc.createTextNode(token.node.props.emoji ? token.node.props.emoji : `​:${token.node.props.name}:​`);
+			return doc.createTextNode(token.node.props.emoji ? token.node.props.emoji : `\u200B:${token.node.props.name}:\u200B`);
 		},
 
 		hashtag(token) {

--- a/src/mfm/toHtml.ts
+++ b/src/mfm/toHtml.ts
@@ -87,7 +87,7 @@ export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: IMentione
 		},
 
 		emoji(token) {
-			return doc.createTextNode(token.node.props.emoji ? token.node.props.emoji : `:${token.node.props.name}:`);
+			return doc.createTextNode(token.node.props.emoji ? token.node.props.emoji : `​:${token.node.props.name}:​`);
 		},
 
 		hashtag(token) {


### PR DESCRIPTION
## Summary
When inserting two custom emojis simultaneously, Misskey specification does :custom_1::custom_2:. This causes a problem on some other ActivityPub implements (especially Mastodon), due to some weird RegEx issues. (They expect a space to be in between them, like :custom_1: :custom_2:)

This patch resolves that issue by adding a zero-width space before and end of the colon (:) when federating. This does not change how emojis in a note is stored in Misskey's DB.


<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
