### PR TITLE
リモート投稿にリモートでされたリアクションが表示されるように

### DIFF
--- a/src/remote/activitypub/kernel/like.ts
+++ b/src/remote/activitypub/kernel/like.ts
@@ -1,23 +1,14 @@
 import { IRemoteUser } from '../../../models/entities/user';
-import { ILike } from '../type';
+import { ILike, getApId } from '../type';
 import create from '../../../services/note/reaction/create';
-import { Notes } from '../../../models';
-import { apLogger } from '../logger';
+import { fetchNote } from '../models/note';
 
 export default async (actor: IRemoteUser, activity: ILike) => {
-	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
-	if (id == null) throw new Error('missing id');
+	const targetUri = getApId(activity.object);
 
-	// Transform:
-	// https://misskey.ex/notes/xxxx to
-	// xxxx
-	const noteId = id.split('/').pop();
-
-	const note = await Notes.findOne(noteId);
-	if (note == null) {
-		apLogger.warn(`Like activity recivied, but no such note: ${id}`, { id });
-		return;
-	}
+	const note = await fetchNote(targetUri);
+	if (!note) return `skip: target note not found ${targetUri}`;
 
 	await create(actor, note, activity._misskey_reaction || activity.content || activity.name);
+	return `ok`;
 };

--- a/src/remote/activitypub/kernel/like.ts
+++ b/src/remote/activitypub/kernel/like.ts
@@ -9,6 +9,8 @@ export default async (actor: IRemoteUser, activity: ILike) => {
 	const note = await fetchNote(targetUri);
 	if (!note) return `skip: target note not found ${targetUri}`;
 
+	if (actor.id === note.userId) return `skip: cannot react to my note`;
+
 	await create(actor, note, activity._misskey_reaction || activity.content || activity.name);
 	return `ok`;
 };

--- a/src/remote/activitypub/kernel/undo/like.ts
+++ b/src/remote/activitypub/kernel/undo/like.ts
@@ -1,21 +1,17 @@
 import { IRemoteUser } from '../../../../models/entities/user';
-import { ILike } from '../../type';
+import { ILike, getApId } from '../../type';
 import deleteReaction from '../../../../services/note/reaction/delete';
-import { Notes } from '../../../../models';
+import { fetchNote } from '../../models/note';
 
 /**
  * Process Undo.Like activity
  */
-export default async (actor: IRemoteUser, activity: ILike): Promise<void> => {
-	const id = typeof activity.object == 'string' ? activity.object : activity.object.id;
-	if (id == null) throw new Error('missing id');
+export default async (actor: IRemoteUser, activity: ILike) => {
+	const targetUri = getApId(activity.object);
 
-	const noteId = id.split('/').pop();
-
-	const note = await Notes.findOne(noteId);
-	if (note == null) {
-		throw new Error('note not found');
-	}
+	const note = await fetchNote(targetUri);
+	if (!note) return `skip: target note not found ${targetUri}`;
 
 	await deleteReaction(actor, note);
+	return `ok`;
 };

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -98,7 +98,7 @@ export default async (user: User, note: Note, reaction?: string) => {
 	if (Users.isLocalUser(user) && !note.localOnly) {
 		const content = renderActivity(renderLike(user, note, reaction));
 		const dm = new DeliverManager(user, content);
-		dm.addDirectRecipe(note.user as IRemoteUser);
+		if (note.userHost !== null) dm.addDirectRecipe(note.user as IRemoteUser);
 		dm.addFollowersRecipe();
 		dm.execute();
 	}

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -98,7 +98,10 @@ export default async (user: User, note: Note, reaction?: string) => {
 	if (Users.isLocalUser(user) && !note.localOnly) {
 		const content = renderActivity(renderLike(user, note, reaction));
 		const dm = new DeliverManager(user, content);
-		if (note.userHost !== null) dm.addDirectRecipe(note.user as IRemoteUser);
+		if (note.userHost !== null) {
+			const reactee = await Users.findOne(note.userId)
+			dm.addDirectRecipe(reactee as IRemoteUser);
+		}
 		dm.addFollowersRecipe();
 		dm.execute();
 	}

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -42,7 +42,10 @@ export default async (user: User, note: Note) => {
 	if (Users.isLocalUser(user) && !note.localOnly) {
 		const content = renderActivity(renderUndo(renderLike(user, note, exist.reaction), user));
 		const dm = new DeliverManager(user, content);
-		if (note.userHost !== null) dm.addDirectRecipe(note.user as IRemoteUser);
+		if (note.userHost !== null) {
+			const reactee = await Users.findOne(note.userId)
+			dm.addDirectRecipe(reactee as IRemoteUser);
+		}
 		dm.addFollowersRecipe();
 		dm.execute();
 	}

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -42,7 +42,7 @@ export default async (user: User, note: Note) => {
 	if (Users.isLocalUser(user) && !note.localOnly) {
 		const content = renderActivity(renderUndo(renderLike(user, note, exist.reaction), user));
 		const dm = new DeliverManager(user, content);
-		dm.addDirectRecipe(note.user as IRemoteUser);
+		if (note.userHost !== null) dm.addDirectRecipe(note.user as IRemoteUser);
 		dm.addFollowersRecipe();
 		dm.execute();
 	}

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -2,9 +2,9 @@ import { publishNoteStream } from '../../stream';
 import renderLike from '../../../remote/activitypub/renderer/like';
 import renderUndo from '../../../remote/activitypub/renderer/undo';
 import { renderActivity } from '../../../remote/activitypub/renderer';
-import { deliver } from '../../../queue';
+import DeliverManager from '../../../remote/activitypub/deliver-manager';
 import { IdentifiableError } from '../../../misc/identifiable-error';
-import { User } from '../../../models/entities/user';
+import { User, IRemoteUser } from '../../../models/entities/user';
 import { Note } from '../../../models/entities/note';
 import { NoteReactions, Users, Notes } from '../../../models';
 
@@ -39,12 +39,12 @@ export default async (user: User, note: Note) => {
 	});
 
 	//#region 配信
-	// リアクターがローカルユーザーかつリアクション対象がリモートユーザーの投稿なら配送
-	if (Users.isLocalUser(user) && (note.userHost !== null)) {
+	if (Users.isLocalUser(user) && !note.localOnly) {
 		const content = renderActivity(renderUndo(renderLike(user, note, exist.reaction), user));
-		Users.findOne(note.userId).then(u => {
-			deliver(user, content, u!.inbox);
-		});
+		const dm = new DeliverManager(user, content);
+		dm.addDirectRecipe(note.user as IRemoteUser);
+		dm.addFollowersRecipe();
+		dm.execute();
 	}
 	//#endregion
 };


### PR DESCRIPTION
## Summary
Resolve #5703
リモート投稿にリモートでされたリアクション (またはFavorite) は表示されなかったのを表示されるようにしています。

直接リアクションをされたユーザーのいない第3のインスタンス へのLike送信を行いと受信も許容するように変更しています。
Pleromaもこの仕様のようなので、Misskey, Pleroma同士ならば リモート投稿にリモートでされたリアクションが表示できるようになります。

また、リアクション済みのNote/Userに対してリアクションされたときは、エラーにしてリトライするのではなくて後で来たリアクションで置き換えるように変更しています。
(Pleromaはいくつでもリアクション出来るため現状だとリトライし続けてしまう)