### PR TITLE
コンポーネントの活性時に再計算するように

### DIFF
--- a/src/client/directives/size.ts
+++ b/src/client/directives/size.ts
@@ -1,5 +1,5 @@
 export default {
-	inserted(el, binding) {
+	inserted(el, binding, vn) {
 		const query = binding.value;
 
 		/*
@@ -31,7 +31,7 @@ export default {
 
 		const calc = () => {
 			const width = el.clientWidth;
-			
+
 			for (const q of query) {
 				if (q.max) {
 					if (width <= q.max) {
@@ -55,6 +55,7 @@ export default {
 		el._sizeResizeCb_ = calc;
 
 		window.addEventListener('resize', calc);
+		vn.context.$on('hook:activated', calc);
 	},
 
 	unbind(el, binding, vn) {


### PR DESCRIPTION
## Summary
`v-size`ディレクティブの計算が非活性時に`width`を取得できない影響で不要なクラスが付与され活性時にスタイルがおかしくなっていたので活性時に再計算するように調整しました。

![screen-capture](https://user-images.githubusercontent.com/54523771/73751110-c0500d80-47a1-11ea-9271-c32576d3b3cf.PNG)
↑ 別ページからタイムラインに戻った際、新規投稿があった場合のキャプチャ

