### PR TITLE
Fix nyaize 2

### DIFF
--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -10,7 +10,8 @@ export function nyaize(text: string): string {
 		// ko-KR
 		.replace(/[나-낳]/g, match => String.fromCharCode(
 			match.charCodeAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)
-		)).replace(/(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm, '다냥')
+		))
+		.replace(/(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm, '다냥')
 		.replace(/(야(?=\?))|(야$)|(야(?= ))/gm, '냥');
 	return replaceExceptions(nyaized, exclusionMap);
 }

--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -7,25 +7,12 @@ export function nyaize(text: string): string {
 		.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
 		// en-US
 		.replace(/morning/gi, 'mornyan').replace(/everyone/gi, 'everynyan')
-		.replace(/o/g, 'owo').replace(/u/g, 'uwu')
 		// ko-KR
 		.replace(/[나-낳]/g, match => String.fromCharCode(
 			match.charCodeAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)
 		)).replace(/(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm, '다냥')
 		.replace(/(야(?=\?))|(야$)|(야(?= ))/gm, '냥');
 	return replaceExceptions(nyaized, exclusionMap);
-}
-
-export function denyaize(text: string): string {
-	return text
-		.replace(/にゃ/g, 'な').replace(/ニャ/g, 'ナ').replace(/ﾆｬ/g, 'ﾅ')
-		.replace(/owo/g, 'o').replace(/uwu/g, 'u')
-		.replace(/mornyan/gi, 'morning').replace(/everynyan/gi, 'everyone') // this will result in case related bug
-		.replace(/(다냥$)|(다냥(?=\.))|(다냥(?= ))|(다냥(?=!))|(다냥(?=\?))/gm, '다')
-		.replace(/(냥(?=\?))|(냥$)|(냥(?= ))/gm, '야')
-		.replace(/[냐-냫]/g, match => String.fromCharCode(
-			match.charCodeAt(0)! + '나'.charCodeAt(0) - '냐'.charCodeAt(0)
-		));
 }
 
 function exclude(text: string): [string, Record<string, string>] {

--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -1,13 +1,57 @@
+import rndstr from 'rndstr';
+
 export function nyaize(text: string): string {
-	return text
+	const [toNyaize, exclusionMap] = exclude(text);
+	const nyaized = toNyaize
 		// ja-JP
 		.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
 		// en-US
 		.replace(/morning/gi, 'mornyan').replace(/everyone/gi, 'everynyan')
+		.replace(/o/g, 'owo').replace(/u/g, 'uwu')
 		// ko-KR
 		.replace(/[나-낳]/g, match => String.fromCharCode(
-			match.codePointAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)
-		))
-		.replace(/(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm, '다냥')
+			match.charCodeAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)
+		)).replace(/(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm, '다냥')
 		.replace(/(야(?=\?))|(야$)|(야(?= ))/gm, '냥');
+	return replaceExceptions(nyaized, exclusionMap);
+}
+
+export function denyaize(text: string): string {
+	return text
+		.replace(/にゃ/g, 'な').replace(/ニャ/g, 'ナ').replace(/ﾆｬ/g, 'ﾅ')
+		.replace(/owo/g, 'o').replace(/uwu/g, 'u')
+		.replace(/mornyan/gi, 'morning').replace(/everynyan/gi, 'everyone') // this will result in case related bug
+		.replace(/(다냥$)|(다냥(?=\.))|(다냥(?= ))|(다냥(?=!))|(다냥(?=\?))/gm, '다')
+		.replace(/(냥(?=\?))|(냥$)|(냥(?= ))/gm, '야')
+		.replace(/[냐-냫]/g, match => String.fromCharCode(
+			match.charCodeAt(0)! + '나'.charCodeAt(0) - '냐'.charCodeAt(0)
+		));
+}
+
+function exclude(text: string): [string, Record<string, string>] {
+	const map: Record<string, string> = {};
+	function substitute(match: string): string {
+		let randomstr: string;
+		do {
+			randomstr = rndstr({ length: 16, chars: '🀀-🀫' });
+		} while(Object.prototype.hasOwnProperty.call(map, randomstr));
+		map[randomstr] = match;
+		return randomstr;
+	}
+	const replaced = text
+		.replace(/(https?:\/\/.*?)(?= |$)/gm, match => substitute(match)) // URL
+		.replace(/:([a-z0-9_+-]+):/gim, match => substitute(match)) // emoji
+		.replace(/#([^\s.,!?'"#:\/\[\]【】]+)/gm, match => substitute(match)) // hashtag
+		.replace(/@\w([\w-]*\w)?(?:@[\w.\-]+\w)?/gm, match => substitute(match)) // mention
+		.replace(/<\/?[a-zA-Z]*?>/g, match => substitute(match)) // <jump>, <motion>, etc.
+		.replace(/`([^`\n]+?)`/g, match => substitute(match)) // inline code
+		.replace(/```(.+?)?\n([\s\S]+?)```(\n|$)/gm, match => substitute(match)); // code block
+	return [replaced, map];
+}
+
+function replaceExceptions(text: string, map: Record<string, string>): string {	
+	for(const rule in map)
+		if(Object.prototype.hasOwnProperty.call(map, rule))
+			text = text.replace(rule, map[rule]);
+	return text;
 }

--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -32,13 +32,15 @@ function exclude(text: string): [string, Record<string, string>] {
 		.replace(/(https?:\/\/.*?)(?= |$)/gm, match => substitute(match)) // URL
 		.replace(/:([a-z0-9_+-]+):/gim, match => substitute(match)) // emoji
 		.replace(/#([^\s.,!?'"#:\/\[\]【】]+)/gm, match => substitute(match)) // hashtag
-		.replace(/@\w([\w-]*\w)?(?:@[\w.\-]+\w)?/gm, match => substitute(match)) // mention
+		.replace(/@\w([\w-]*\w)?(?:@[\w.\-]+\w)?/gm, match => substitute(match)); // mention
 	return [replaced, map];
 }
 
-function replaceExceptions(text: string, map: Record<string, string>): string {	
-	for(const rule in map)
-		if(Object.prototype.hasOwnProperty.call(map, rule))
+function replaceExceptions(text: string, map: Record<string, string>): string {
+	for (const rule in map) {
+		if (Object.prototype.hasOwnProperty.call(map, rule)) {
 			text = text.replace(rule, map[rule]);
+		}
+	}
 	return text;
 }

--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -26,13 +26,12 @@ function exclude(text: string): [string, Record<string, string>] {
 		return randomstr;
 	}
 	const replaced = text
+		.replace(/```(.+?)?\n([\s\S]+?)```(\n|$)/gm, match => substitute(match)) // code block
+		.replace(/`([^`\n]+?)`/g, match => substitute(match)) // inline code
 		.replace(/(https?:\/\/.*?)(?= |$)/gm, match => substitute(match)) // URL
 		.replace(/:([a-z0-9_+-]+):/gim, match => substitute(match)) // emoji
 		.replace(/#([^\s.,!?'"#:\/\[\]【】]+)/gm, match => substitute(match)) // hashtag
 		.replace(/@\w([\w-]*\w)?(?:@[\w.\-]+\w)?/gm, match => substitute(match)) // mention
-		.replace(/<\/?[a-zA-Z]*?>/g, match => substitute(match)) // <jump>, <motion>, etc.
-		.replace(/`([^`\n]+?)`/g, match => substitute(match)) // inline code
-		.replace(/```(.+?)?\n([\s\S]+?)```(\n|$)/gm, match => substitute(match)); // code block
 	return [replaced, map];
 }
 


### PR DESCRIPTION
## Summary
Fix #5837
Fix #2280
Fix #5388

Fix korean nyaize

#5813 をたぶんいい感じに修正
- exclude順を変更
  block code => inline code => other
- tagみたいなシーケンスのexcludeは `o`, `u` の nyaize がなければ不要なので削除

![image](https://user-images.githubusercontent.com/30769358/73878996-fb843680-489e-11ea-81f4-0dd00b16bbda.png)

