### PR TITLE
 Correct Like id generation

### DIFF
--- a/src/remote/activitypub/renderer/like.ts
+++ b/src/remote/activitypub/renderer/like.ts
@@ -1,10 +1,12 @@
 import config from '../../../config';
-import { ILocalUser } from '../../../models/entities/user';
+import { NoteReaction } from '../../../models/entities/note-reaction';
 import { Note } from '../../../models/entities/note';
 
-export default (user: ILocalUser, note: Note, reaction: string) => ({
+export const renderLike = (noteReaction: NoteReaction, note: Note) => ({
 	type: 'Like',
-	actor: `${config.url}/users/${user.id}`,
-	object: note.uri ? note.uri : `${config.url}/notes/${note.id}`,
-	_misskey_reaction: reaction
+	id: `${config.url}/likes/${noteReaction.id}`,
+	actor: `${config.url}/users/${noteReaction.userId}`,
+	object: note.uri ? note.uri : `${config.url}/notes/${noteReaction.noteId}`,
+	content: noteReaction.reaction,
+	_misskey_reaction: noteReaction.reaction
 });

--- a/src/server/activitypub.ts
+++ b/src/server/activitypub.ts
@@ -13,10 +13,11 @@ import Following from './activitypub/following';
 import Featured from './activitypub/featured';
 import { inbox as processInbox } from '../queue';
 import { isSelfHost } from '../misc/convert-host';
-import { Notes, Users, Emojis, UserKeypairs } from '../models';
+import { Notes, Users, Emojis, UserKeypairs, NoteReactions } from '../models';
 import { ILocalUser, User } from '../models/entities/user';
 import { In } from 'typeorm';
 import { ensure } from '../prelude/ensure';
+import { renderLike } from '../remote/activitypub/renderer/like';
 
 // Init router
 const router = new Router();
@@ -198,6 +199,27 @@ router.get('/emojis/:emoji', async ctx => {
 	}
 
 	ctx.body = renderActivity(await renderEmoji(emoji));
+	ctx.set('Cache-Control', 'public, max-age=180');
+	setResponseType(ctx);
+});
+
+// like
+router.get('/likes/:like', async ctx => {
+	const reaction = await NoteReactions.findOne(ctx.params.like);
+
+	if (reaction == null) {
+		ctx.status = 404;
+		return;
+	}
+
+	const note = await Notes.findOne(reaction.noteId);
+
+	if (note == null) {
+		ctx.status = 404;
+		return;
+	}
+
+	ctx.body = renderActivity(await renderLike(reaction, note));
 	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 });

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -1,6 +1,6 @@
 import { publishNoteStream } from '../../stream';
 import watch from '../watch';
-import renderLike from '../../../remote/activitypub/renderer/like';
+import { renderLike } from '../../../remote/activitypub/renderer/like';
 import DeliverManager from '../../../remote/activitypub/deliver-manager';
 import { renderActivity } from '../../../remote/activitypub/renderer';
 import { IdentifiableError } from '../../../misc/identifiable-error';
@@ -38,7 +38,7 @@ export default async (user: User, note: Note, reaction?: string) => {
 	}
 
 	// Create reaction
-	await NoteReactions.save({
+	const inserted = await NoteReactions.save({
 		id: genId(),
 		createdAt: new Date(),
 		noteId: note.id,
@@ -94,7 +94,7 @@ export default async (user: User, note: Note, reaction?: string) => {
 
 	//#region 配信
 	if (Users.isLocalUser(user) && !note.localOnly) {
-		const content = renderActivity(renderLike(user, note, reaction));
+		const content = renderActivity(renderLike(inserted, note));
 		const dm = new DeliverManager(user, content);
 		if (note.userHost !== null) {
 			const reactee = await Users.findOne(note.userId)

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -1,5 +1,5 @@
 import { publishNoteStream } from '../../stream';
-import renderLike from '../../../remote/activitypub/renderer/like';
+import { renderLike } from '../../../remote/activitypub/renderer/like';
 import renderUndo from '../../../remote/activitypub/renderer/undo';
 import { renderActivity } from '../../../remote/activitypub/renderer';
 import DeliverManager from '../../../remote/activitypub/deliver-manager';
@@ -40,7 +40,7 @@ export default async (user: User, note: Note) => {
 
 	//#region 配信
 	if (Users.isLocalUser(user) && !note.localOnly) {
-		const content = renderActivity(renderUndo(renderLike(user, note, exist.reaction), user));
+		const content = renderActivity(renderUndo(renderLike(exist, note), user));
 		const dm = new DeliverManager(user, content);
 		if (note.userHost !== null) {
 			const reactee = await Users.findOne(note.userId)


### PR DESCRIPTION
## Summary
APの`Like`で正しいActivity IDを提示するように修正
- `Undo Like`で`Like`と同じ元のActivity IDを提示するように
- `Like`のActivityのURIでActivityが参照できるように
- `_misskey_reaction`だけではなく`content`でもリアクションを送るように

**Before - Like**
```json
{
  "id": "https://SELF_HOST/810e213d-5fec-483b-9cc4-fed1216b1a13",
  "type": "Like",
  "actor": "https://SELF_HOST/users/ACTOR_ID",
  "object": "https://TARGET_HOST/objects/53384d81-7bda-4a4e-83ff-c1998ef0ec25",
  "_misskey_reaction": "👍",
}
```

**Before - Undo Like**
object内に元のActivity ID がない
```json
{
  "id": "https://SELF_HOST/6c0c7e7c-2b1c-4388-8c43-e84429b52adf",
  "type": "Undo",
  "actor": "https://SELF_HOST/users/ACTOR_ID",
  "object": {
    "type": "Like",
    "actor": "https://SELF_HOST/users/ACTOR_ID",
    "object": "https://TARGET_HOST/objects/53384d81-7bda-4a4e-83ff-c1998ef0ec25",
    "_misskey_reaction": "👍"
  },
```

**After - Like**
```json
{
  "id": "https://SELF_HOST/likes/LIKE_ID",
  "type": "Like",
  "actor": "https://SELF_HOST/users/ACTOR_ID",
  "object": "https://TARGET_HOST/objects/53384d81-7bda-4a4e-83ff-c1998ef0ec25",
  "content": "👍",
  "_misskey_reaction": "👍"
}
```
**After - Undo Like**
object内で元のLikeのIDを提示するように
```json
  "id": "https://SELF_HOST/7dde44ce-b921-4c67-b2d4-af68680fe9f5"
  "type": "Undo",
  "actor": "https://SELF_HOST/users/ACTOR_ID",
  "object": {
    "id": "https://SELF_HOST/likes/LIKE_ID",
    "type": "Like",
    "actor": "https://SELF_HOST/users/ACTOR_ID",
    "object": "https://TARGET_HOST/objects/53384d81-7bda-4a4e-83ff-c1998ef0ec25",
    "content": "👍",
    "_misskey_reaction": "👍"
  },

```
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
