### PR TITLE
リストの管理ページのリンク先の修正

### DIFF
--- a/src/client/pages/my-lists/index.vue
+++ b/src/client/pages/my-lists/index.vue
@@ -7,7 +7,7 @@
 
 	<mk-pagination :pagination="pagination" #default="{items}" class="lists" ref="list">
 		<div class="list _panel" v-for="(list, i) in items" :key="list.id">
-			<router-link :to="`/lists/${ list.id }`">{{ list.name }}</router-link>
+			<router-link :to="`/my/lists/${ list.id }`">{{ list.name }}</router-link>
 		</div>
 	</mk-pagination>
 </div>


### PR DESCRIPTION
## Summary

リストの管理ページのリンク先が間違っており、404になっていたので修正しました。