### PR TITLE
非ログイン時にエラーが発生していたのを修正

### DIFF
--- a/src/client/app.vue
+++ b/src/client/app.vue
@@ -248,6 +248,8 @@ export default Vue.extend({
 		// https://stackoverflow.com/questions/33891709/when-flexbox-items-wrap-in-column-mode-container-does-not-grow-its-width
 		if (this.enableWidgets) {
 			setInterval(() => {
+				if (!this.$refs.widgetsEditButton) return;
+
 				const width = this.$refs.widgetsEditButton.offsetLeft + 300;
 				this.$refs.widgets.style.width = width + 'px';
 			}, 1000);
@@ -258,7 +260,7 @@ export default Vue.extend({
 		help() {
 			this.$router.push('/docs/keyboard-shortcut');
 		},
-		
+
 		back() {
 			if (this.canBack) window.history.back();
 		},


### PR DESCRIPTION
## Summary
非ログイン時かつウィジェットが有効になっている場合に下記のエラーが発生していたのを修正しました
```
Uncaught TypeError: Cannot read property 'offsetLeft' of undefined
```
