### PR TITLE
Create ActivityでattributedToの補完とaudienceのコピーを行うように

### DIFF
--- a/src/remote/activitypub/kernel/create/index.ts
+++ b/src/remote/activitypub/kernel/create/index.ts
@@ -11,6 +11,10 @@ export default async (actor: IRemoteUser, activity: ICreate): Promise<void> => {
 
 	logger.info(`Create: ${uri}`);
 
+	if (typeof activity.object === 'object' && !activity.object.attributedTo) {
+		activity.object.attributedTo = activity.actor;
+	}
+
 	const resolver = new Resolver();
 
 	const object = await resolver.resolve(activity.object).catch(e => {

--- a/src/remote/activitypub/kernel/create/index.ts
+++ b/src/remote/activitypub/kernel/create/index.ts
@@ -3,6 +3,7 @@ import { IRemoteUser } from '../../../../models/entities/user';
 import createNote from './note';
 import { ICreate, getApId, validPost } from '../../type';
 import { apLogger } from '../../logger';
+import { toArray, concat, unique } from '../../../../prelude/array';
 
 const logger = apLogger;
 
@@ -11,6 +12,18 @@ export default async (actor: IRemoteUser, activity: ICreate): Promise<void> => {
 
 	logger.info(`Create: ${uri}`);
 
+	// copy audiences between activity <=> object.
+	if (typeof activity.object === 'object') {
+		const to = unique(concat([toArray(activity.to), toArray(activity.object.to)]));
+		const cc = unique(concat([toArray(activity.cc), toArray(activity.object.cc)]));
+
+		activity.to = to;
+		activity.cc = cc;
+		activity.object.to = to;
+		activity.object.cc = cc;
+	}
+
+	// If there is no attributedTo, use Activity actor.
 	if (typeof activity.object === 'object' && !activity.object.attributedTo) {
 		activity.object.attributedTo = activity.actor;
 	}

--- a/src/remote/activitypub/kernel/create/note.ts
+++ b/src/remote/activitypub/kernel/create/note.ts
@@ -15,7 +15,7 @@ export default async function(resolver: Resolver, actor: IRemoteUser, note: IObj
 	try {
 		const exist = await fetchNote(note);
 		if (exist == null) {
-			await createNote(note, resolver, silent, activity);
+			await createNote(note, resolver, silent);
 		}
 	} finally {
 		unlock();

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -82,6 +82,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	if (resolver == null) resolver = new Resolver();
 
 	const object: any = await resolver.resolve(value);
+	if (object && !object.attributedTo) object.attributedTo = activity?.actor;
 
 	const entryUri = getApId(value);
 	const err = validateNote(object, entryUri);

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -111,9 +111,17 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	}
 
 	const noteAudience = await parseAudience(actor, note.to, note.cc);
-	const visibility = noteAudience.visibility;
+	let visibility = noteAudience.visibility;
 	const visibleUsers = noteAudience.visibleUsers;
 	const apMentions = noteAudience.mentionedUsers;
+
+	// Audience (to, cc) が指定されてなかった場合
+	if (visibility === 'specified' && visibleUsers.length === 0) {
+		if (typeof value === 'string') {	// 入力がstringならばresolverでGETが発生している
+			// こちらから匿名GET出来たものならばpublic
+			visibility = 'public';
+		}
+	}
 
 	let isTalk = note._misskey_talk && visibility === 'specified';
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -17,7 +17,7 @@ import { deliverQuestionUpdate } from '../../../services/note/polls/update';
 import { extractDbHost, toPuny } from '../../../misc/convert-host';
 import { Notes, Emojis, Polls, MessagingMessages } from '../../../models';
 import { Note } from '../../../models/entities/note';
-import { IObject, getOneApId, getApId, validPost, ICreate, isCreate, IPost } from '../type';
+import { IObject, getOneApId, getApId, validPost, IPost } from '../type';
 import { Emoji } from '../../../models/entities/emoji';
 import { genId } from '../../../misc/gen-id';
 import { fetchMeta } from '../../../misc/fetch-meta';
@@ -78,7 +78,7 @@ export async function fetchNote(value: string | IObject, resolver?: Resolver): P
 /**
  * Noteを作成します。
  */
-export async function createNote(value: string | IObject, resolver?: Resolver, silent = false, activity?: ICreate): Promise<Note | null> {
+export async function createNote(value: string | IObject, resolver?: Resolver, silent = false): Promise<Note | null> {
 	if (resolver == null) resolver = new Resolver();
 
 	const object: any = await resolver.resolve(value);
@@ -111,23 +111,9 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	}
 
 	const noteAudience = await parseAudience(actor, note.to, note.cc);
-	let visibility = noteAudience.visibility;
-	let visibleUsers = noteAudience.visibleUsers;
-	let apMentions = noteAudience.mentionedUsers;
-
-	// Audience (to, cc) が指定されてなかった場合
-	if (visibility === 'specified' && visibleUsers.length === 0) {
-		if (activity && isCreate(activity)) {
-			// Create 起因ならば Activity を見る
-			const activityAudience = await parseAudience(actor, activity.to, activity.cc);
-			visibility = activityAudience.visibility;
-			visibleUsers = activityAudience.visibleUsers;
-			apMentions = activityAudience.mentionedUsers;
-		} else if (typeof value === 'string') {	// 入力がstringならばresolverでGETが発生している
-			// こちらから匿名GET出来たものならばpublic
-			visibility = 'public';
-		}
-	}
+	const visibility = noteAudience.visibility;
+	const visibleUsers = noteAudience.visibleUsers;
+	const apMentions = noteAudience.mentionedUsers;
 
 	let isTalk = note._misskey_talk && visibility === 'specified';
 

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -82,7 +82,6 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	if (resolver == null) resolver = new Resolver();
 
 	const object: any = await resolver.resolve(value);
-	if (object && !object.attributedTo) object.attributedTo = activity?.actor;
 
 	const entryUri = getApId(value);
 	const err = validateNote(object, entryUri);


### PR DESCRIPTION
## Summary
1. Create受信時に、objectにattributedToがなかったらActivity actorで補うように
2. Create受信時に、Activityのaudienceとobjectのaudienceをマージ (論理和) してそれぞれにコピーするように
   Noteの処理で行っていたのをCreate受信時に移動しています。
   Activity=>object への一方向のコピーではなく、双方向へのマージに変更しています。

以下のようなActivityに対応しています
https://github.com/mei23/misskey/issues/745#issuecomment-583218952

audienceを双方向論理和マージにした根拠はこの辺
https://www.w3.org/TR/activitypub/#create-activity-outbox

Related #5768 #5767 #5783 #5078