### PR TITLE
[wip] フォルダー名の変更と削除機能を実装

### DIFF
--- a/src/client/components/drive.vue
+++ b/src/client/components/drive.vue
@@ -319,6 +319,21 @@ export default Vue.extend({
 			});
 		},
 
+		deleteFolder(folder) {
+			this.$root.dialog({
+				type: 'warning',
+				title: this.$t('deleteFolderConfirm'),
+				showCancelButton: true
+			}).then(({ canceled, result: name }) => {
+				if (canceled) return;
+				this.$root.api('drive/folders/delete', {
+					folderId: folder.id
+				}).then(() => {
+					this.move(folder.parentId);
+				});
+			});
+		},
+
 		onChangeFileInput() {
 			for (const file of Array.from((this.$refs.fileInput as any).files)) {
 				this.upload(file, this.folder);

--- a/src/client/components/drive.vue
+++ b/src/client/components/drive.vue
@@ -321,9 +321,9 @@ export default Vue.extend({
 
 		renameFolder(folder) {
 			this.$root.dialog({
-				title: this.$t('rename-folder'),
+				title: this.$t('contextmenu.rename-folder'),
 				input: {
-					placeholder: this.$t('folder-name'),
+					placeholder: this.$t('contextmenu.input-new-folder-name'),
 					default: folder.name
 				}
 			}).then(({ canceled, result: name }) => {
@@ -332,6 +332,7 @@ export default Vue.extend({
 					folderId: folder.id,
 					name: name
 				}).then(folder => {
+					// FIXME: 画面を更新するために自分自身に移動
 					this.move(folder);
 				});
 			});
@@ -341,6 +342,7 @@ export default Vue.extend({
 			this.$root.api('drive/folders/delete', {
 				folderId: folder.id
 			}).then(() => {
+				// 削除時に親フォルダに移動
 				this.move(folder.parentId);
 			}).catch(err => {
 				switch(err.id) {

--- a/src/client/components/drive.vue
+++ b/src/client/components/drive.vue
@@ -338,17 +338,25 @@ export default Vue.extend({
 		},
 
 		deleteFolder(folder) {
-			this.$root.dialog({
-				type: 'warning',
-				title: this.$t('deleteFolderConfirm'),
-				showCancelButton: true
-			}).then(({ canceled, result: name }) => {
-				if (canceled) return;
-				this.$root.api('drive/folders/delete', {
-					folderId: folder.id
-				}).then(() => {
-					this.move(folder.parentId);
-				});
+			this.$root.api('drive/folders/delete', {
+				folderId: folder.id
+			}).then(() => {
+				this.move(folder.parentId);
+			}).catch(err => {
+				switch(err.id) {
+					case 'b0fc8a17-963c-405d-bfbc-859a487295e1':
+						this.$root.dialog({
+							type: 'error',
+							title: this.$t('unable-to-delete'),
+							text: this.$t('has-child-files-or-folders')
+						});
+						break;
+					default:
+						this.$root.dialog({
+							type: 'error',
+							text: this.$t('unable-to-delete')
+						});
+					}
 			});
 		},
 

--- a/src/client/components/drive.vue
+++ b/src/client/components/drive.vue
@@ -319,6 +319,24 @@ export default Vue.extend({
 			});
 		},
 
+		renameFolder(folder) {
+			this.$root.dialog({
+				title: this.$t('rename-folder'),
+				input: {
+					placeholder: this.$t('folder-name'),
+					default: folder.name
+				}
+			}).then(({ canceled, result: name }) => {
+				if (canceled) return;
+				this.$root.api('drive/folders/update', {
+					folderId: folder.id,
+					name: name
+				}).then(folder => {
+					this.move(folder);
+				});
+			});
+		},
+
 		deleteFolder(folder) {
 			this.$root.dialog({
 				type: 'warning',

--- a/src/client/pages/drive.vue
+++ b/src/client/pages/drive.vue
@@ -61,7 +61,7 @@ export default Vue.extend({
 				} : undefined, this.folder ? {
 					text: this.$t('deleteFolder'),
 					icon: faTrashAlt,
-					action: () => { this.$refs.drive.deleteFolder(); }
+					action: () => { this.$refs.drive.deleteFolder(this.folder); }
 				} : undefined, {
 					text: this.$t('createFolder'),
 					icon: faFolderPlus,

--- a/src/client/pages/drive.vue
+++ b/src/client/pages/drive.vue
@@ -57,7 +57,7 @@ export default Vue.extend({
 				}, this.folder ? {
 					text: this.$t('renameFolder'),
 					icon: faICursor,
-					action: () => { this.$refs.drive.renameFolder(); }
+					action: () => { this.$refs.drive.renameFolder(this.folder); }
 				} : undefined, this.folder ? {
 					text: this.$t('deleteFolder'),
 					icon: faTrashAlt,


### PR DESCRIPTION
## Summary

ドライブのフォルダー名の変更と削除機能が壊れてしまっていたので既存のコードなどを参考に動作するように調整を行いました。
が、下記の問題点が残っており自分だけでは判断できない部分もあるのでレビューなどよろしくおねがいします。
- `drive.folder.vue`とコードが重複してしまっている（どこかにまとめてしまった方が良い？）
- 直したほうが良さそうな[箇所](https://github.com/mfmfuyu/misskey/blob/055db9cac88c34f1deaceacc041110a944154be2/src/client/components/drive.vue#L335-L336)がある（いい方法が思いつきませんでした）
- テキストがv11と同じkeypathになっているので調整が必要そう