### PR TITLE
いくつかのスタイルを調整

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -153,7 +153,7 @@ export default Vue.extend({
 				this.$t('_postForm._placeholders.f')
 			];
 			const x = xs[Math.floor(Math.random() * xs.length)];
-			
+
 			return this.renote
 				? this.$t('_postForm.quotePlaceholder')
 				: this.reply
@@ -713,7 +713,7 @@ export default Vue.extend({
 			border-radius: 0;
 			background: transparent;
 			color: var(--fg);
-			font-family: initial;
+			font-family: inherit;
 
 			@media (max-width: 500px) {
 				padding: 0 16px;

--- a/src/client/components/ui/input.vue
+++ b/src/client/components/ui/input.vue
@@ -254,7 +254,7 @@ export default Vue.extend({
 
 	> .input {
 		position: relative;
-		
+
 		&:before {
 			content: '';
 			display: block;
@@ -327,14 +327,16 @@ export default Vue.extend({
 		}
 
 		> input {
+			$height: 32px;
 			display: block;
+			height: $height;
 			width: 100%;
 			margin: 0;
 			padding: 0;
 			font: inherit;
 			font-weight: normal;
 			font-size: 16px;
-			line-height: 32px;
+			line-height: $height;
 			color: var(--inputText);
 			background: transparent;
 			border: none;

--- a/src/client/pages/messaging-room.form.vue
+++ b/src/client/pages/messaging-room.form.vue
@@ -247,6 +247,7 @@ export default Vue.extend({
 		padding: 16px 16px 0 16px;
 		resize: none;
 		font-size: 1em;
+		font-family: inherit;
 		outline: none;
 		border: none;
 		border-radius: 0;


### PR DESCRIPTION
## Summary
以下のスタイルを調整しました。
 - Chrome(Android)で誕生日の入力欄が崩れていたのを修正
 - トークの入力欄のフォントがブラウザデフォルトの物になっていたので親要素から継承するように変更
 - 投稿の入力欄も同時に親要素から継承するように変更しました

また、入力欄はフォントを親から継承するように変更したことによりユーザーがカスタムCSSを利用している際などにページ全体の統一感をより高める事ができるかなと思います。
