### PR TITLE
PNGのサムネイルをJPEGで生成するように

### DIFF
--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -9,7 +9,7 @@ import { DriveFiles } from '../../models';
 import { InternalStorage } from '../../services/drive/internal-storage';
 import { downloadUrl } from '../../misc/donwload-url';
 import { detectType } from '../../misc/get-file-info';
-import { convertToJpeg, convertToPng } from '../../services/drive/image-processor';
+import { convertToJpeg, convertToPngOrJpeg } from '../../services/drive/image-processor';
 import { GenerateVideoThumbnail } from '../../services/drive/generate-video-thumbnail';
 
 const assets = `${__dirname}/../../server/file/assets/`;
@@ -59,7 +59,7 @@ export default async function(ctx: Koa.Context) {
 						if (['image/jpeg', 'image/webp'].includes(mime)) {
 							return await convertToJpeg(path, 498, 280);
 						} else if (['image/png'].includes(mime)) {
-							return await convertToPng(path, 498, 280);
+							return await convertToPngOrJpeg(path, 498, 280);
 						} else if (mime.startsWith('video/')) {
 							return await GenerateVideoThumbnail(path);
 						}

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -7,7 +7,7 @@ import { deleteFile } from './delete-file';
 import { fetchMeta } from '../../misc/fetch-meta';
 import { GenerateVideoThumbnail } from './generate-video-thumbnail';
 import { driveLogger } from './logger';
-import { IImage, convertToJpeg, convertToWebp, convertToPng } from './image-processor';
+import { IImage, convertToJpeg, convertToWebp, convertToPng, convertToPngOrJpeg } from './image-processor';
 import { contentDisposition } from '../../misc/content-disposition';
 import { getFileInfo } from '../../misc/get-file-info';
 import { DriveFiles, DriveFolders, Users, Instances, UserProfiles } from '../../models';
@@ -174,7 +174,7 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 		if (['image/jpeg', 'image/webp'].includes(type)) {
 			thumbnail = await convertToJpeg(path, 498, 280);
 		} else if (['image/png'].includes(type)) {
-			thumbnail = await convertToPng(path, 498, 280);
+			thumbnail = await convertToPngOrJpeg(path, 498, 280);
 		} else if (type.startsWith('video/')) {
 			try {
 				thumbnail = await GenerateVideoThumbnail(path);

--- a/src/services/drive/image-processor.ts
+++ b/src/services/drive/image-processor.ts
@@ -11,7 +11,11 @@ export type IImage = {
  *   with resize, remove metadata, resolve orientation, stop animation
  */
 export async function convertToJpeg(path: string, width: number, height: number): Promise<IImage> {
-	const data = await sharp(path)
+	return convertSharpToJpeg(await sharp(path), width, height);
+}
+
+export async function convertSharpToJpeg(sharp: sharp.Sharp, width: number, height: number): Promise<IImage> {
+	const data = await sharp
 		.resize(width, height, {
 			fit: 'inside',
 			withoutEnlargement: true
@@ -35,7 +39,11 @@ export async function convertToJpeg(path: string, width: number, height: number)
  *   with resize, remove metadata, resolve orientation, stop animation
  */
 export async function convertToWebp(path: string, width: number, height: number): Promise<IImage> {
-	const data = await sharp(path)
+	return convertSharpToWebp(await sharp(path), width, height);
+}
+
+export async function convertSharpToWebp(sharp: sharp.Sharp, width: number, height: number): Promise<IImage> {
+	const data = await sharp
 		.resize(width, height, {
 			fit: 'inside',
 			withoutEnlargement: true
@@ -58,7 +66,11 @@ export async function convertToWebp(path: string, width: number, height: number)
  *   with resize, remove metadata, resolve orientation, stop animation
  */
 export async function convertToPng(path: string, width: number, height: number): Promise<IImage> {
-	const data = await sharp(path)
+	return convertSharpToPng(await sharp(path), width, height);
+}
+
+export async function convertSharpToPng(sharp: sharp.Sharp, width: number, height: number): Promise<IImage> {
+	const data = await sharp
 		.resize(width, height, {
 			fit: 'inside',
 			withoutEnlargement: true
@@ -72,4 +84,24 @@ export async function convertToPng(path: string, width: number, height: number):
 		ext: 'png',
 		type: 'image/png'
 	};
+}
+
+/**
+ * Convert to PNG or JPEG
+ *   with resize, remove metadata, resolve orientation, stop animation
+ */
+export async function convertToPngOrJpeg(path: string, width: number, height: number): Promise<IImage> {
+	return convertSharpToPngOrJpeg(await sharp(path), width, height);
+}
+
+export async function convertSharpToPngOrJpeg(sharp: sharp.Sharp, width: number, height: number): Promise<IImage> {
+	const stats = await sharp.stats();
+	const metadata = await sharp.metadata();
+
+	// 不透明で300x300pxの範囲を超えていればJPEG
+	if (stats.isOpaque && ((metadata.width && metadata.width >= 300) || (metadata.height && metadata!.height >= 300))) {
+		return await convertSharpToJpeg(sharp, width, height);
+	} else {
+		return await convertSharpToPng(sharp, width, height);
+	}
 }


### PR DESCRIPTION
## Summary
PNGのサムネイルが1MBとか結構でかいものがあるのでJPEGで生成するように
ただし、透過, 小さいサイズはJPEGにしない (アバターがあるのと効果が薄いので)
APNGも元からサムネイル生成しないので対象外