### PR TITLE
Fix Oops!

### DIFF
--- a/src/client/mios.ts
+++ b/src/client/mios.ts
@@ -59,7 +59,7 @@ export default class MiOS extends EventEmitter {
 			let me = null;
 
 			// Return when not signed in
-			if (token == null) {
+			if (token == null || token === 'null') {
 				return done();
 			}
 


### PR DESCRIPTION
## Summary
v12アップデート後かなんだか知らないけど、トップページアクセスでOops!になっちゃうのを修正。

ローカルストレージで `i`が`null`で `vuex` (Vueのstate) がない時に起きます。

`token`のsourceは`localStorage.getItem('i')`なので`null`の時は文字列で返ってきます。