### PR TITLE
media-listのgridの高さがsub-note-detailsのdetailsの中だと287pxになってしまっていたのを修正

### DIFF
--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -4,7 +4,7 @@
 		<x-banner :media="media" :key="media.id"/>
 	</template>
 	<div v-if="mediaList.filter(media => previewable(media)).length > 0" class="gird-container" ref="gridOuter">
-		<div :data-count="mediaList.filter(media => previewable(media)).length" :style="gridHeight !== null ? { height: `${gridHeight}px` } : {}">
+		<div :data-count="mediaList.filter(media => previewable(media)).length" :style="gridInnerStyle">
 			<template v-for="media in mediaList">
 				<x-video :video="media" :key="media.id" v-if="media.type.startsWith('video')"/>
 				<x-image :image="media" :key="media.id" v-else-if="media.type.startsWith('image')" :raw="raw"/>
@@ -37,37 +37,38 @@ export default Vue.extend({
 			type: Number
 		}
 	},
-	computed: {
-		gridHeight() {
-			if (this.$refs.gridOuter) {
-				if (this.$props.width) {
-					return this.$props.width * 9 / 16;
-				} else if (this.$refs.gridOuter.clientHeight) {
-					return this.$refs.gridOuter.clientHeight;
-				}
-				return 287;
-			}
-
-			return null;
+	data() {
+		return {
+			gridInnerStyle: {}
 		}
 	},
-	/*mounted() {
-		console.log(this.$props.width)
-		//#region for Safari bug
-		if (this.$refs.gridOuter) {
-			if (this.$props.width) {
-				this.$refs.gridInner.style.height = `${this.$props.width * 9 / 16}px`
-			} else if (this.$refs.gridOuter.clientHeight) {
-				this.$refs.gridInner.style.height = `${this.$refs.gridOuter.clientHeight}px`
-			} else {
-				this.$refs.gridInner.style.height = '287px';
-			}
+	mounted() {
+		// for Safari bug
+		if (this.$refs.gridOuter.clientHeight) {
+			this.gridInnerStyle = { height: `${this.$refs.gridOuter.clientHeight}px` }
 		}
-		//#endregion
-	},*/
+	}
 	methods: {
 		previewable(file) {
 			return file.type.startsWith('video') || file.type.startsWith('image');
+		}
+	},
+	watch: {
+		width(width) {
+			// for Safari bug
+			if (this.$refs.gridOuter) {
+				let height = 287
+
+				if (width) {
+					height = width * 9 / 16;
+				} else if (this.$refs.gridOuter.clientHeight) {
+					height = this.$refs.gridOuter.clientHeight;
+				}
+
+				this.gridInnerStyle = { height: `${height}px` }
+			} else {
+				this.gridInnerStyle = {}
+			}
 		}
 	}
 });

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -46,7 +46,6 @@ export default Vue.extend({
 	mounted() {
 		this.size();
 		window.addEventListener('resize', this.size);
-		this.$on('resize', this.size);
 	},
 	beforeDestroy() {
 		window.removeEventListener('resize', this.size);

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -3,8 +3,8 @@
 	<template v-for="media in mediaList.filter(media => !previewable(media))">
 		<x-banner :media="media" :key="media.id"/>
 	</template>
-	<div v-if="mediaList.filter(media => previewable(media)).length > 0" class="gird-container">
-		<div :data-count="mediaList.filter(media => previewable(media)).length" ref="grid">
+	<div v-if="mediaList.filter(media => previewable(media)).length > 0" class="gird-container" ref="gridOuter">
+		<div :data-count="mediaList.filter(media => previewable(media)).length" :style="gridHeight !== null ? { height: `${gridHeight}px` } : {}">
 			<template v-for="media in mediaList">
 				<x-video :video="media" :key="media.id" v-if="media.type.startsWith('video')"/>
 				<x-image :image="media" :key="media.id" v-else-if="media.type.startsWith('image')" :raw="raw"/>
@@ -32,16 +32,39 @@ export default Vue.extend({
 		},
 		raw: {
 			default: false
+		},
+		width: {
+			type: Number
 		}
 	},
-	mounted() {
+	computed: {
+		gridHeight() {
+			if (this.$refs.gridOuter) {
+				if (this.$props.width) {
+					return this.$props.width * 9 / 16;
+				} else if (this.$refs.gridOuter.clientHeight) {
+					return this.$refs.gridOuter.clientHeight;
+				}
+				return 287;
+			}
+
+			return null;
+		}
+	},
+	/*mounted() {
+		console.log(this.$props.width)
 		//#region for Safari bug
-		if (this.$refs.grid) {
-			this.$refs.grid.style.height = this.$refs.grid.clientHeight ? `${this.$refs.grid.clientHeight}px`
-				: '287px';
+		if (this.$refs.gridOuter) {
+			if (this.$props.width) {
+				this.$refs.gridInner.style.height = `${this.$props.width * 9 / 16}px`
+			} else if (this.$refs.gridOuter.clientHeight) {
+				this.$refs.gridInner.style.height = `${this.$refs.gridOuter.clientHeight}px`
+			} else {
+				this.$refs.gridInner.style.height = '287px';
+			}
 		}
 		//#endregion
-	},
+	},*/
 	methods: {
 		previewable(file) {
 			return file.type.startsWith('video') || file.type.startsWith('image');

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -33,8 +33,9 @@ export default Vue.extend({
 		raw: {
 			default: false
 		},
-		width: {
-			type: Number
+		// specify the parent element
+		parentElement: {
+			type: Object
 		}
 	},
 	data() {
@@ -43,31 +44,32 @@ export default Vue.extend({
 		}
 	},
 	mounted() {
-		// for Safari bug
-		if (this.$refs.gridOuter.clientHeight) {
-			this.gridInnerStyle = { height: `${this.$refs.gridOuter.clientHeight}px` }
-		}
-	}
+		this.size();
+		window.addEventListener('resize', this.size);
+		this.$on('resize', this.size);
+	},
+	beforeDestroy() {
+		window.removeEventListener('resize', this.size);
+	},
 	methods: {
 		previewable(file) {
 			return file.type.startsWith('video') || file.type.startsWith('image');
-		}
-	},
-	watch: {
-		width(width) {
+		},
+		size() {
 			// for Safari bug
 			if (this.$refs.gridOuter) {
-				let height = 287
+				let height = 287;
+				const parent = this.$props.parentElement || this.$parent.$el;
 
-				if (width) {
-					height = width * 9 / 16;
-				} else if (this.$refs.gridOuter.clientHeight) {
+				if (this.$refs.gridOuter.clientHeight) {
 					height = this.$refs.gridOuter.clientHeight;
+				} else if (parent) {
+					height = parent.getBoundingClientRect().width * 9 / 16;
 				}
 
-				this.gridInnerStyle = { height: `${height}px` }
+				this.gridInnerStyle = { height: `${height}px` };
 			} else {
-				this.gridInnerStyle = {}
+				this.gridInnerStyle = {};
 			}
 		}
 	}

--- a/src/client/components/sub-note-content.vue
+++ b/src/client/components/sub-note-content.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="wrmlmaau">
+<div class="wrmlmaau" ref="i">
 	<div class="body">
 		<span v-if="note.isHidden" style="opacity: 0.5">({{ $t('private') }})</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">({{ $t('deleted') }})</span>
@@ -9,7 +9,7 @@
 	</div>
 	<details v-if="note.files.length > 0">
 		<summary>({{ $t('withNFiles', { n: note.files.length }) }})</summary>
-		<x-media-list :media-list="note.files"/>
+		<x-media-list :media-list="note.files" :width="width"/>
 	</details>
 	<details v-if="note.poll">
 		<summary>{{ $t('poll') }}</summary>
@@ -39,8 +39,13 @@ export default Vue.extend({
 	},
 	data() {
 		return {
+			width: 0,
+
 			faReply
 		};
+	},
+	mounted() {
+		this.width = this.$refs.i.getBoundingClientRect().width
 	}
 });
 </script>

--- a/src/client/components/sub-note-content.vue
+++ b/src/client/components/sub-note-content.vue
@@ -45,6 +45,7 @@ export default Vue.extend({
 		};
 	},
 	mounted() {
+		// for Safari bug
 		this.width = this.$refs.i.getBoundingClientRect().width;
 	}
 });

--- a/src/client/components/sub-note-content.vue
+++ b/src/client/components/sub-note-content.vue
@@ -45,7 +45,7 @@ export default Vue.extend({
 		};
 	},
 	mounted() {
-		this.width = this.$refs.i.getBoundingClientRect().width
+		this.width = this.$refs.i.getBoundingClientRect().width;
 	}
 });
 </script>

--- a/src/client/components/sub-note-content.vue
+++ b/src/client/components/sub-note-content.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="wrmlmaau" ref="i">
+<div class="wrmlmaau">
 	<div class="body">
 		<span v-if="note.isHidden" style="opacity: 0.5">({{ $t('private') }})</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">({{ $t('deleted') }})</span>
@@ -39,14 +39,8 @@ export default Vue.extend({
 	},
 	data() {
 		return {
-			i: this.$refs.i,
-
 			faReply
 		};
-	},
-	mounted() {
-		// for Safari bug
-		this.width = this.$refs.i.getBoundingClientRect().width;
 	}
 });
 </script>

--- a/src/client/components/sub-note-content.vue
+++ b/src/client/components/sub-note-content.vue
@@ -9,7 +9,7 @@
 	</div>
 	<details v-if="note.files.length > 0">
 		<summary>({{ $t('withNFiles', { n: note.files.length }) }})</summary>
-		<x-media-list :media-list="note.files" :width="width"/>
+		<x-media-list :media-list="note.files"/>
 	</details>
 	<details v-if="note.poll">
 		<summary>{{ $t('poll') }}</summary>
@@ -39,7 +39,7 @@ export default Vue.extend({
 	},
 	data() {
 		return {
-			width: 0,
+			i: this.$refs.i,
 
 			faReply
 		};


### PR DESCRIPTION
## Summary
Issue番号不明

macOS Safari, Windows Firefox and Windows Chromeで動作確認済み