### PR TITLE
管理者はモデレーターに変更できないように

### DIFF
--- a/src/client/components/user-moderate-dialog.vue
+++ b/src/client/components/user-moderate-dialog.vue
@@ -3,7 +3,7 @@
 	<template #header><mk-user-name :user="user"/></template>
 	<div class="vrcsvlkm">
 		<mk-button @click="resetPassword()" primary>{{ $t('resetPassword') }}</mk-button>
-		<mk-switch v-if="$store.state.i.isAdmin" @change="toggleModerator()" v-model="moderator">{{ $t('moderator') }}</mk-switch>
+		<mk-switch v-if="$store.state.i.isAdmin && !user.isAdmin" @change="toggleModerator()" v-model="moderator">{{ $t('moderator') }}</mk-switch>
 		<mk-switch @change="toggleSilence()" v-model="silenced">{{ $t('silence') }}</mk-switch>
 		<mk-switch @change="toggleSuspend()" v-model="suspended">{{ $t('suspend') }}</mk-switch>
 	</div>
@@ -47,7 +47,7 @@ export default Vue.extend({
 				type: 'waiting',
 				iconOnly: true
 			});
-			
+
 			this.$root.api('admin/reset-password', {
 				userId: this.user.id,
 			}).then(({ password }) => {

--- a/src/server/api/endpoints/admin/moderators/add.ts
+++ b/src/server/api/endpoints/admin/moderators/add.ts
@@ -32,6 +32,10 @@ export default define(meta, async (ps) => {
 		throw new Error('user not found');
 	}
 
+	if (user.isAdmin) {
+		throw new Error('cannot mark as moderator while admin');
+	}
+
 	await Users.update(user.id, {
 		isModerator: true
 	});

--- a/src/server/api/endpoints/admin/moderators/add.ts
+++ b/src/server/api/endpoints/admin/moderators/add.ts
@@ -33,7 +33,7 @@ export default define(meta, async (ps) => {
 	}
 
 	if (user.isAdmin) {
-		throw new Error('cannot mark as moderator while admin');
+		throw new Error('cannot mark as moderator if admin user');
 	}
 
 	await Users.update(user.id, {


### PR DESCRIPTION
## Summary

管理者がインスタンスのユーザーページで自分自身をモデレーターに変更してしまうと`/api/admin/show-user`が利用できなくなってしまうのが原因でモーダルを表示できず元に戻すことができなくなってしまうので管理者をモデレーターに変更できないようにAPIとモーダルを変更しました。