### PR TITLE
モデレーターになってしまっている場合は解除できるように

### DIFF
--- a/src/client/components/user-moderate-dialog.vue
+++ b/src/client/components/user-moderate-dialog.vue
@@ -3,7 +3,7 @@
 	<template #header><mk-user-name :user="user"/></template>
 	<div class="vrcsvlkm">
 		<mk-button @click="resetPassword()" primary>{{ $t('resetPassword') }}</mk-button>
-		<mk-switch v-if="$store.state.i.isAdmin && !user.isAdmin" @change="toggleModerator()" v-model="moderator">{{ $t('moderator') }}</mk-switch>
+		<mk-switch v-if="$store.state.i.isAdmin && (this.moderator || !user.isAdmin)" @change="toggleModerator()" v-model="moderator">{{ $t('moderator') }}</mk-switch>
 		<mk-switch @change="toggleSilence()" v-model="silenced">{{ $t('silence') }}</mk-switch>
 		<mk-switch @change="toggleSuspend()" v-model="suspended">{{ $t('suspend') }}</mk-switch>
 	</div>


### PR DESCRIPTION
## Summary

Related #5970 
上記の変更によりモデレーターになってしまった管理者はモデレーターを解除することができなくなってしまっていたので、モデレーターになってしまっている場合のみトグルボタンを表示するように変更しました。
