### PR TITLE
プレビューがたまに消えなくなるのを修正

### DIFF
--- a/src/client/components/url.vue
+++ b/src/client/components/url.vue
@@ -51,6 +51,7 @@ export default Vue.extend({
 			target: self ? null : '_blank',
 			showTimer: null,
 			hideTimer: null,
+			checkTimer: null,
 			preview: null,
 			faExternalLinkSquareAlt
 		};
@@ -78,9 +79,14 @@ export default Vue.extend({
 			}).$mount();
 
 			document.body.appendChild(this.preview.$el);
+
+			this.checkTimer = setInterval(() => {
+				if (!document.body.contains(this.$el)) this.closePreview();
+			}, 1000);
 		},
 		closePreview() {
 			if (this.preview) {
+				clearInterval(this.checkTimer);
 				this.preview.destroyDom();
 				this.preview = null;
 			}

--- a/src/client/directives/user-preview.ts
+++ b/src/client/directives/user-preview.ts
@@ -8,9 +8,11 @@ export default {
 		self.tag = null;
 		self.showTimer = null;
 		self.hideTimer = null;
+		self.checkTimer = null;
 
 		self.close = () => {
 			if (self.tag) {
+				clearInterval(self.checkTimer);
 				self.tag.close();
 				self.tag = null;
 			}
@@ -37,6 +39,10 @@ export default {
 				self.hideTimer = setTimeout(self.close, 500);
 			});
 
+			self.checkTimer = setInterval(() => {
+				if (!document.body.contains(el)) self.close();
+			}, 1000);
+
 			document.body.appendChild(self.tag.$el);
 		};
 
@@ -62,6 +68,7 @@ export default {
 		const self = el._userPreviewDirective_;
 		clearTimeout(self.showTimer);
 		clearTimeout(self.hideTimer);
+		clearInterval(self.checkTimer);
 		self.close();
 	}
 };


### PR DESCRIPTION
## Summary
Fix #5943

なお、たぶん以下の手順などで発生する
- タイムラインを表示する
- ユーザーアイコンをクリックしてユーザーページに移動
- 戻る
- マウスオーバーでプレビューを表示する
- キーボード`Alt+→`でHistory移動
