### PR TITLE
Fix: mainStreamのミュート情報が再接続まで反映されない

### DIFF
--- a/src/server/api/stream/channels/main.ts
+++ b/src/server/api/stream/channels/main.ts
@@ -1,6 +1,6 @@
 import autobind from 'autobind-decorator';
 import Channel from '../channel';
-import { Mutings, Notes } from '../../../../models';
+import { Notes } from '../../../../models';
 
 export default class extends Channel {
 	public readonly chName = 'main';
@@ -9,15 +9,13 @@ export default class extends Channel {
 
 	@autobind
 	public async init(params: any) {
-		const mute = await Mutings.find({ muterId: this.user!.id });
-
 		// Subscribe main stream channel
 		this.subscriber.on(`mainStream:${this.user!.id}`, async data => {
 			let { type, body } = data;
 
 			switch (type) {
 				case 'notification': {
-					if (mute.map(m => m.muteeId).includes(body.userId)) return;
+					if (this.muting.includes(body.userId)) return;
 					if (body.note && body.note.isHidden) {
 						body.note = await Notes.pack(body.note.id, this.user, {
 							detail: true
@@ -26,7 +24,7 @@ export default class extends Channel {
 					break;
 				}
 				case 'mention': {
-					if (mute.map(m => m.muteeId).includes(body.userId)) return;
+					if (this.muting.includes(body.userId)) return;
 					if (body.isHidden) {
 						body = await Notes.pack(body.id, this.user, {
 							detail: true


### PR DESCRIPTION
## Summary
mainStreamの通知などにミュート情報が再接続まで反映されないので
自動更新されるstream共通のミュート情報を利用してされるように
