### PR TITLE
同じホットキーが連続で発動しないように

### DIFF
--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -10,14 +10,17 @@ type pattern = {
 
 type action = {
 	patterns: pattern[];
-
+	
 	callback: Function;
+
+	lastActed: number;
 };
 
 const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): action => {
 	const result = {
 		patterns: [],
-		callback: callback
+		callback: callback,
+		lastActed: 0
 	} as action;
 
 	result.patterns = patterns.split('|').map(part => {
@@ -74,6 +77,9 @@ export default {
 					if (document.activeElement && ignoreElemens.some(el => document.activeElement.matches(el))) return;
 
 					for (const action of actions) {
+
+						if(Date.now() - action.lastActed < 500) continue;
+
 						const matched = match(e, action.patterns);
 
 						if (matched) {
@@ -82,6 +88,8 @@ export default {
 							e.preventDefault();
 							e.stopPropagation();
 							action.callback(e);
+
+							action.lastActed = Date.now();
 							break;
 						}
 					}

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -12,13 +12,21 @@ type action = {
 	patterns: pattern[];
 
 	callback: Function;
+
+	allowRepeat: boolean | undefined;
 };
 
 const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): action => {
 	const result = {
 		patterns: [],
-		callback: callback
+		callback: callback,
+		allowRepeat: true
 	} as action;
+
+	if (patterns.match(/^\(.*\)$/) !== null) {
+		result.allowRepeat = false;
+		patterns = patterns.slice(1, -1);
+	}
 
 	result.patterns = patterns.split('|').map(part => {
 		const pattern = {
@@ -76,7 +84,8 @@ export default {
 					for (const action of actions) {
 						const matched = match(e, action.patterns);
 
-						if (matched && !e.repeat) {
+						if (matched) {
+							if (!action.allowRepeat && e.repeat) return;
 							if (el._hotkey_global && match(e, targetReservedKeys)) return;
 
 							e.preventDefault();

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -28,8 +28,6 @@ const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): a
 		patterns = patterns.slice(1, -1);
 	}
 
-	console.log(patterns);
-
 	result.patterns = patterns.split('|').map(part => {
 		const pattern = {
 			which: [],

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -17,7 +17,7 @@ type action = {
 const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): action => {
 	const result = {
 		patterns: [],
-		callback: callback,
+		callback: callback
 	} as action;
 
 	result.patterns = patterns.split('|').map(part => {
@@ -74,7 +74,6 @@ export default {
 					if (document.activeElement && ignoreElemens.some(el => document.activeElement.matches(el))) return;
 
 					for (const action of actions) {
-
 						const matched = match(e, action.patterns);
 
 						if (matched && !e.repeat) {
@@ -83,7 +82,6 @@ export default {
 							e.preventDefault();
 							e.stopPropagation();
 							action.callback(e);
-
 							break;
 						}
 					}

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -13,7 +13,7 @@ type action = {
 
 	callback: Function;
 
-	allowRepeat: boolean | undefined;
+	allowRepeat: boolean;
 };
 
 const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): action => {
@@ -27,6 +27,8 @@ const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): a
 		result.allowRepeat = false;
 		patterns = patterns.slice(1, -1);
 	}
+
+	console.log(patterns);
 
 	result.patterns = patterns.split('|').map(part => {
 		const pattern = {

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -12,15 +12,12 @@ type action = {
 	patterns: pattern[];
 
 	callback: Function;
-
-	lastActed: number;
 };
 
 const getKeyMap = keymap => Object.entries(keymap).map(([patterns, callback]): action => {
 	const result = {
 		patterns: [],
 		callback: callback,
-		lastActed: 0
 	} as action;
 
 	result.patterns = patterns.split('|').map(part => {
@@ -78,18 +75,15 @@ export default {
 
 					for (const action of actions) {
 
-						if(Date.now() - action.lastActed < 500) continue;
-
 						const matched = match(e, action.patterns);
 
-						if (matched) {
+						if (matched && !e.repeat) {
 							if (el._hotkey_global && match(e, targetReservedKeys)) return;
 
 							e.preventDefault();
 							e.stopPropagation();
 							action.callback(e);
 
-							action.lastActed = Date.now();
 							break;
 						}
 					}

--- a/src/client/scripts/hotkey.ts
+++ b/src/client/scripts/hotkey.ts
@@ -10,7 +10,7 @@ type pattern = {
 
 type action = {
 	patterns: pattern[];
-	
+
 	callback: Function;
 
 	lastActed: number;


### PR DESCRIPTION
## Summary
resolve #6081 

ホットキーはそれぞれが500msのクールダウンを持っており、一度アクションが起こってから500ms間は何もできない。