### PR TITLE
GitHub Actionsでテストが動かなくなっているのを修正

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10-alpine
+        image: postgres:10.8
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - develop
+      - mei23-ci
   pull_request:
 
 jobs:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,6 +22,7 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_DB: test-misskey
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
         image: redis:alpine
         ports:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8-alpine
+        image: postgres:10.11-alpine
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,12 +17,11 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:10.8
         ports:
           - 5432:5432
         env:
           POSTGRES_DB: test-misskey
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
         image: redis:alpine
         ports:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,7 +22,6 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_DB: test-misskey
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
         image: redis:alpine
         ports:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:10
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:10.8
+        image: postgres:10.8-alpine
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - develop
-      - mei23-ci
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
GitHub Actionsでテストが動かなくなっているのを修正

x postgres:10
x postgres:10-alpine
o postgres:10.8
o postgres:10.8-alpine

`postgres:10`が`10.12`に解決されるようになってから
`Error: connect ECONNREFUSED 127.0.0.1:5432`でテストが動かなくなっています
※ なおローカルの10.12では普通に動く

とりあえず直近で正常動作していた`10.11`に固定しています。