### PR TITLE
note_reaction.reactionカラムの長さを修正

### DIFF
--- a/migration/1582875306439-note-reaction-length.ts
+++ b/migration/1582875306439-note-reaction-length.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class noteReactionLength1582875306439 implements MigrationInterface {
+    name = 'noteReactionLength1582875306439'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "note_reaction" ALTER COLUMN "reaction" TYPE character varying(130)`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "note_reaction" ALTER COLUMN "reaction" TYPE character varying(128)`, undefined);
+    }
+
+}

--- a/src/models/entities/note-reaction.ts
+++ b/src/models/entities/note-reaction.ts
@@ -36,7 +36,7 @@ export class NoteReaction {
 	public note: Note | null;
 
 	@Column('varchar', {
-		length: 128
+		length: 130
 	})
 	public reaction: string;
 }


### PR DESCRIPTION
## Summary
Fix #4723
Fix #6104

https://github.com/syuilo/misskey/commit/8a55bdd89da6aa1228612ed7a2449ad96d965b60 でマイグレーションを作成してないので作成
note-reaction.reaction を 130文字 (128 + カスタム絵文字のコロン2つ) に修正

動作確認はしているけどマイグレーションは手で修正したのでちょっと自身がない