### PR TITLE
ダイレクトでメンションされたユーザーが投稿を読めないのを修正など

### DIFF
--- a/src/server/api/common/generate-visibility-query.ts
+++ b/src/server/api/common/generate-visibility-query.ts
@@ -23,6 +23,8 @@ export function generateVisibilityQuery(q: SelectQueryBuilder<any>, me?: User | 
 			.orWhere('note.userId = :userId1', { userId1: me.id })
 			// または 自分宛て
 			.orWhere(':userId2 = ANY(note.visibleUserIds)', { userId2: me.id })
+			// または 自分にメンションされている
+			.orWhere(':userId3 = ANY(note.mentions)', { userId3: me.id })
 			.orWhere(new Brackets(qb => { qb
 				// または フォロワー宛ての投稿であり、
 				.where('note.visibility = \'followers\'')

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -174,6 +174,7 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 
 	tags = tags.filter(tag => Array.from(tag || '').length <= 128).splice(0, 32);
 
+	// リプライされていればメンションされていることにする
 	if (data.reply && (user.id !== data.reply.userId) && !mentionedUsers.some(u => u.id === data.reply!.userId)) {
 		mentionedUsers.push(await Users.findOne(data.reply.userId).then(ensure));
 	}
@@ -192,11 +193,6 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 			if (!data.visibleUsers.some(x => x.id === u.id)) {
 				data.visibleUsers.push(u);
 			}
-		}
-
-		// リプライされていれば投稿を読める
-		if (data.reply && !data.visibleUsers.some(x => x.id === data.reply!.userId)) {
-			data.visibleUsers.push(await Users.findOne(data.reply.userId).then(ensure));
 		}
 	}
 

--- a/src/services/note/create.ts
+++ b/src/services/note/create.ts
@@ -187,6 +187,14 @@ export default async (user: User, data: Option, silent = false) => new Promise<N
 			}
 		}
 
+		// メンションされていれば投稿を読める
+		for (const u of mentionedUsers) {
+			if (!data.visibleUsers.some(x => x.id === u.id)) {
+				data.visibleUsers.push(u);
+			}
+		}
+
+		// リプライされていれば投稿を読める
 		if (data.reply && !data.visibleUsers.some(x => x.id === data.reply!.userId)) {
 			data.visibleUsers.push(await Users.findOne(data.reply.userId).then(ensure));
 		}

--- a/test/api-visibility.ts
+++ b/test/api-visibility.ts
@@ -103,10 +103,10 @@ describe('API visibility', () => {
 			speR  = await post(alice, { text: 'x', replyId: tgt.id, visibility: 'specified' });
 
 			// mentions
-			pubM  = await post(alice, { text: '@target x', replyId: tgt.id, visibility: 'public' });
-			homeM = await post(alice, { text: '@target x', replyId: tgt.id, visibility: 'home' });
-			folM  = await post(alice, { text: '@target x', replyId: tgt.id, visibility: 'followers' });
-			speM  = await post(alice, { text: '@target2 x', replyId: tgt.id, visibility: 'specified' });
+			pubM  = await post(alice, { text: '@target x', visibility: 'public' });
+			homeM = await post(alice, { text: '@target x', visibility: 'home' });
+			folM  = await post(alice, { text: '@target x', visibility: 'followers' });
+			speM  = await post(alice, { text: '@target2 x', visibility: 'specified' });
 			//#endregion
 		});
 
@@ -398,12 +398,12 @@ describe('API visibility', () => {
 		}));
 
 		it('[show] specified-mentionを指定ユーザーが見れる', async(async () => {
-			const res = await show(speM.id, target);
+			const res = await show(speM.id, target2);
 			assert.strictEqual(res.body.text, '@target2 x');
 		}));
 
 		it('[show] specified-mentionをされた人が指定されてなかったら見れない', async(async () => {
-			const res = await show(speM.id, target2);
+			const res = await show(speM.id, target);
 			assert.strictEqual(res.body.isHidden, true);
 		}));
 


### PR DESCRIPTION
## Summary
Fix #6112 ローカルユーザーにダイレクトでメンションされた時に投稿が読めない
Fix あなた宛てタイムラインにフォローしてないユーザーからフォロワー限定でメンションされた投稿が表示されない
テストの修正
