### PR TITLE
ダークテーマ利用時にセレクトが使いにくくなる問題を修正

### DIFF
--- a/src/client/components/ui/select.vue
+++ b/src/client/components/ui/select.vue
@@ -158,6 +158,11 @@ export default Vue.extend({
 			outline: none;
 			box-shadow: none;
 			color: var(--fg);
+
+			option,
+			optgroup {
+				background: var(--bg);
+			}
 		}
 
 		> .prefix,


### PR DESCRIPTION
## Summary

Resolves #6070

ダークテーマだと、下記の画像のように白背景+白に近い文字色が多く（TweetDeckだとほぼ白なので全くわからない）選択時に使いにくくなるのを修正しました。

![image](https://user-images.githubusercontent.com/54523771/75621948-3481a380-5bde-11ea-9915-ac544e56e9b1.png)

![image](https://user-images.githubusercontent.com/54523771/75621956-4ebb8180-5bde-11ea-88d5-f0c2712889dc.png)


