### PR TITLE
APメンションはaudienceじゃなくてtagを参照するなど

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.21.0",
+	"version": "12.21.0-20200322182626",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.21.0-20200322182626",
+	"version": "12.21.0",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.21.0",
+	"version": "12.21.0-20200322201939",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.21.0-20200322201939",
+	"version": "12.21.0",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/src/mfm/fromHtml.ts
+++ b/src/mfm/fromHtml.ts
@@ -1,6 +1,6 @@
 import { parseFragment, DefaultTreeDocumentFragment } from 'parse5';
 
-export function fromHtml(html: string, mentionHrefs?: string[], hashtagHrefs?: string[]): string {
+export function fromHtml(html: string, hashtagNames?: string[]): string {
 	const dom = parseFragment(html) as DefaultTreeDocumentFragment;
 
 	let text = '';
@@ -37,7 +37,7 @@ export function fromHtml(html: string, mentionHrefs?: string[], hashtagHrefs?: s
 				const href = node.attrs.find((x: any) => x.name == 'href');
 
 				// ハッシュタグ
-				if (hashtagHrefs && href && hashtagHrefs.map(x => x.toLowerCase()).includes((href.value as string).toLowerCase())) {
+				if (hashtagNames && href && hashtagNames.map(x => x.toLowerCase()).includes(txt.toLowerCase())) {
 					text += txt;
 				// メンション
 				} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {

--- a/src/mfm/fromHtml.ts
+++ b/src/mfm/fromHtml.ts
@@ -1,7 +1,6 @@
 import { parseFragment, DefaultTreeDocumentFragment } from 'parse5';
-import { urlRegex } from './prelude';
 
-export function fromHtml(html: string): string {
+export function fromHtml(html: string, mentionHrefs?: string[], hashtagHrefs?: string[]): string {
 	const dom = parseFragment(html) as DefaultTreeDocumentFragment;
 
 	let text = '';
@@ -36,14 +35,12 @@ export function fromHtml(html: string): string {
 				const txt = getText(node);
 				const rel = node.attrs.find((x: any) => x.name == 'rel');
 				const href = node.attrs.find((x: any) => x.name == 'href');
-				const _class = node.attrs.find((x: any) => x.name == 'class');
-				const isHashtag = rel?.value?.match('tag') || _class?.value?.match('hashtag');
 
-				// ハッシュタグ / hrefがない / txtがURL
-				if (isHashtag || !href || href.value == txt) {
-					text += isHashtag || txt.match(urlRegex) ? txt : `<${txt}>`;
+				// ハッシュタグ
+				if (hashtagHrefs && href && hashtagHrefs.map(x => x.toLowerCase()).includes((href.value as string).toLowerCase())) {
+					text += txt;
 				// メンション
-				} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {
+			} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {
 					const part = txt.split('@');
 
 					if (part.length == 2) {
@@ -56,7 +53,7 @@ export function fromHtml(html: string): string {
 					}
 				// その他
 				} else {
-					text += `[${txt}](${href.value})`;
+					text += (!href || txt === href.value) ? `<${txt}>` : `[${txt}](${href.value})`;
 				}
 				break;
 

--- a/src/mfm/fromHtml.ts
+++ b/src/mfm/fromHtml.ts
@@ -40,7 +40,7 @@ export function fromHtml(html: string, mentionHrefs?: string[], hashtagHrefs?: s
 				if (hashtagHrefs && href && hashtagHrefs.map(x => x.toLowerCase()).includes((href.value as string).toLowerCase())) {
 					text += txt;
 				// メンション
-			} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {
+				} else if (txt.startsWith('@') && !(rel && rel.value.match(/^me /))) {
 					const part = txt.split('@');
 
 					if (part.length == 2) {

--- a/src/mfm/fromHtml.ts
+++ b/src/mfm/fromHtml.ts
@@ -1,4 +1,5 @@
 import { parseFragment, DefaultTreeDocumentFragment } from 'parse5';
+import { urlRegex } from './prelude';
 
 export function fromHtml(html: string, hashtagNames?: string[]): string {
 	const dom = parseFragment(html) as DefaultTreeDocumentFragment;
@@ -53,7 +54,7 @@ export function fromHtml(html: string, hashtagNames?: string[]): string {
 					}
 				// その他
 				} else {
-					text += (!href || txt === href.value) ? `<${txt}>` : `[${txt}](${href.value})`;
+					text += (!href || (txt === href.value && txt.match(urlRegex))) ? txt : `[${txt}](${href.value})`;
 				}
 				break;
 

--- a/src/remote/activitypub/misc/html-to-mfm.ts
+++ b/src/remote/activitypub/misc/html-to-mfm.ts
@@ -1,0 +1,11 @@
+import { IObject } from '../type';
+import { extractApMentionObjects } from '../models/mention';
+import { extractApHashtagObjects } from '../models/tag';
+import { fromHtml } from '../../../mfm/fromHtml';
+
+export function htmlToMfm(html: string, tag?: IObject | IObject[]) {
+	const mentionHrefs = extractApMentionObjects(tag).map(x => x.href).filter((x): x is string => x != null);
+	const hashtagHrefs = extractApHashtagObjects(tag).map(x => x.href).filter((x): x is string => x != null);
+
+	return fromHtml(html, mentionHrefs, hashtagHrefs);
+}

--- a/src/remote/activitypub/misc/html-to-mfm.ts
+++ b/src/remote/activitypub/misc/html-to-mfm.ts
@@ -1,11 +1,9 @@
 import { IObject } from '../type';
-import { extractApMentionObjects } from '../models/mention';
 import { extractApHashtagObjects } from '../models/tag';
 import { fromHtml } from '../../../mfm/fromHtml';
 
 export function htmlToMfm(html: string, tag?: IObject | IObject[]) {
-	const mentionHrefs = extractApMentionObjects(tag).map(x => x.href).filter((x): x is string => x != null);
-	const hashtagHrefs = extractApHashtagObjects(tag).map(x => x.href).filter((x): x is string => x != null);
+	const hashtagNames = extractApHashtagObjects(tag).map(x => x.name).filter((x): x is string => x != null);
 
-	return fromHtml(html, mentionHrefs, hashtagHrefs);
+	return fromHtml(html, hashtagNames);
 }

--- a/src/remote/activitypub/models/mention.ts
+++ b/src/remote/activitypub/models/mention.ts
@@ -1,14 +1,12 @@
 import { toArray, unique } from '../../../prelude/array';
-import { IObject, isMention } from '../type';
+import { IObject, isMention, IApMention } from '../type';
 import { resolvePerson } from './person';
 import * as promiseLimit from 'promise-limit';
 import Resolver from '../resolver';
 import { User } from '../../../models/entities/user';
 
 export async function extractApMentions(tags: IObject | IObject[] | null | undefined) {
-	if (tags == null) return [];
-
-	const hrefs = unique(toArray(tags).filter(isMention).map(x => x.href as string));
+	const hrefs = unique(extractApMentionObjects(tags).map(x => x.href as string));
 
 	const resolver = new Resolver();
 
@@ -18,4 +16,9 @@ export async function extractApMentions(tags: IObject | IObject[] | null | undef
 	)).filter((x): x is User => x != null);
 
 	return mentionedUsers;
+}
+
+export function extractApMentionObjects(tags: IObject | IObject[] | null | undefined): IApMention[] {
+	if (tags == null) return [];
+	return toArray(tags).filter(isMention);
 }

--- a/src/remote/activitypub/models/mention.ts
+++ b/src/remote/activitypub/models/mention.ts
@@ -1,0 +1,21 @@
+import { toArray, unique } from '../../../prelude/array';
+import { IObject, isMention } from '../type';
+import { resolvePerson } from './person';
+import * as promiseLimit from 'promise-limit';
+import Resolver from '../resolver';
+import { User } from '../../../models/entities/user';
+
+export async function extractApMentions(tags: IObject | IObject[] | null | undefined) {
+	if (tags == null) return [];
+
+	const hrefs = unique(toArray(tags).filter(isMention).map(x => x.href as string));
+
+	const resolver = new Resolver();
+
+	const limit = promiseLimit<User | null>(2);
+	const mentionedUsers = (await Promise.all(
+		hrefs.map(x => limit(() => resolvePerson(x, resolver).catch(() => null)))
+	)).filter((x): x is User => x != null);
+
+	return mentionedUsers;
+}

--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -6,7 +6,7 @@ import post from '../../../services/note/create';
 import { resolvePerson, updatePerson } from './person';
 import { resolveImage } from './image';
 import { IRemoteUser } from '../../../models/entities/user';
-import { fromHtml } from '../../../mfm/fromHtml';
+import { htmlToMfm } from '../misc/html-to-mfm';
 import { extractApHashtags } from './tag';
 import { unique, toArray, toSingle } from '../../../prelude/array';
 import { extractPollFromQuestion } from './question';
@@ -211,7 +211,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	const cw = note.summary === '' ? null : note.summary;
 
 	// テキストのパース
-	const text = note._misskey_content || (note.content ? fromHtml(note.content) : null);
+	const text = note._misskey_content || (note.content ? htmlToMfm(note.content, note.tag) : null);
 
 	// vote
 	if (reply && reply.hasPoll) {

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -5,6 +5,7 @@ import Resolver from '../resolver';
 import { resolveImage } from './image';
 import { isCollectionOrOrderedCollection, isCollection, IPerson, getApId, IObject, isPropertyValue, IApPropertyValue } from '../type';
 import { fromHtml } from '../../../mfm/fromHtml';
+import { htmlToMfm } from '../misc/html-to-mfm';
 import { resolveNote, extractEmojis } from './note';
 import { registerOrFetchInstanceDoc } from '../../../services/register-or-fetch-instance-doc';
 import { extractApHashtags } from './tag';
@@ -164,7 +165,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 
 			await transactionalEntityManager.save(new UserProfile({
 				userId: user.id,
-				description: person.summary ? fromHtml(person.summary) : null,
+				description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
 				url: person.url,
 				fields,
 				userHost: host
@@ -354,7 +355,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 	await UserProfiles.update({ userId: exist.id }, {
 		url: person.url,
 		fields,
-		description: person.summary ? fromHtml(person.summary) : null,
+		description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
 	});
 
 	// ハッシュタグ更新

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -179,11 +179,20 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 	} catch (e) {
 		// duplicate key error
 		if (isDuplicateKeyValueError(e)) {
-			throw new Error('already registered');
-		}
+			// /users/@a => /users/:id のように入力がaliasなときにエラーになることがあるのを対応
+			const u = await Users.findOne({
+				uri: person.id
+			});
 
-		logger.error(e);
-		throw e;
+			if (u) {
+				user = u as IRemoteUser;
+			} else {
+				throw new Error('already registered');
+			}
+		} else {
+			logger.error(e);
+			throw e;
+		}
 	}
 
 	// Register host

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -3,12 +3,11 @@ import * as promiseLimit from 'promise-limit';
 import config from '../../../config';
 import Resolver from '../resolver';
 import { resolveImage } from './image';
-import { isCollectionOrOrderedCollection, isCollection, IPerson, getApId } from '../type';
+import { isCollectionOrOrderedCollection, isCollection, IPerson, getApId, IObject, isPropertyValue, IApPropertyValue } from '../type';
 import { fromHtml } from '../../../mfm/fromHtml';
 import { resolveNote, extractEmojis } from './note';
 import { registerOrFetchInstanceDoc } from '../../../services/register-or-fetch-instance-doc';
-import { ITag, extractHashtags } from './tag';
-import { IIdentifier } from './identifier';
+import { extractApHashtags } from './tag';
 import { apLogger } from '../logger';
 import { Note } from '../../../models/entities/note';
 import { updateUsertags } from '../../../services/update-hashtag';
@@ -134,7 +133,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 
 	const { fields } = analyzeAttachments(person.attachment || []);
 
-	const tags = extractHashtags(person.tag).map(tag => tag.toLowerCase()).splice(0, 32);
+	const tags = extractApHashtags(person.tag).map(tag => tag.toLowerCase()).splice(0, 32);
 
 	const isBot = object.type == 'Service';
 
@@ -308,7 +307,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 
 	const { fields } = analyzeAttachments(person.attachment || []);
 
-	const tags = extractHashtags(person.tag).map(tag => tag.toLowerCase()).splice(0, 32);
+	const tags = extractApHashtags(person.tag).map(tag => tag.toLowerCase()).splice(0, 32);
 
 	const updates = {
 		lastFetchedAt: new Date(),
@@ -384,16 +383,6 @@ export async function resolvePerson(uri: string, resolver?: Resolver): Promise<U
 	return await createPerson(uri, resolver);
 }
 
-const isPropertyValue = (x: {
-		type: string,
-		name?: string,
-		value?: string
-	}) =>
-		x &&
-		x.type === 'PropertyValue' &&
-		typeof x.name === 'string' &&
-		typeof x.value === 'string';
-
 const services: {
 		[x: string]: (id: string, username: string) => any
 	} = {
@@ -409,7 +398,7 @@ const $discord = (id: string, name: string) => {
 	return { id, username, discriminator };
 };
 
-function addService(target: { [x: string]: any }, source: IIdentifier) {
+function addService(target: { [x: string]: any }, source: IApPropertyValue) {
 	const service = services[source.name];
 
 	if (typeof source.value !== 'string')
@@ -421,7 +410,7 @@ function addService(target: { [x: string]: any }, source: IIdentifier) {
 		target[source.name.split(':')[2]] = service(id, username);
 }
 
-export function analyzeAttachments(attachments: ITag[]) {
+export function analyzeAttachments(attachments: IObject | IObject[] | undefined) {
 	const fields: {
 		name: string,
 		value: string
@@ -430,12 +419,12 @@ export function analyzeAttachments(attachments: ITag[]) {
 
 	if (Array.isArray(attachments)) {
 		for (const attachment of attachments.filter(isPropertyValue)) {
-			if (isPropertyValue(attachment.identifier!)) {
-				addService(services, attachment.identifier!);
+			if (isPropertyValue(attachment.identifier)) {
+				addService(services, attachment.identifier);
 			} else {
 				fields.push({
-					name: attachment.name!,
-					value: fromHtml(attachment.value!)
+					name: attachment.name,
+					value: fromHtml(attachment.value)
 				});
 			}
 		}

--- a/src/remote/activitypub/models/tag.ts
+++ b/src/remote/activitypub/models/tag.ts
@@ -1,13 +1,18 @@
 import { toArray } from '../../../prelude/array';
-import { IObject, isHashtag } from '../type';
+import { IObject, isHashtag, IApHashtag } from '../type';
 
 export function extractApHashtags(tags: IObject | IObject[] | null | undefined) {
 	if (tags == null) return [];
 
-	const hashtags = toArray(tags).filter(isHashtag);
+	const hashtags = extractApHashtagObjects(tags);
 
 	return hashtags.map(tag => {
 		const m = tag.name.match(/^#(.+)/);
 		return m ? m[1] : null;
 	}).filter((x): x is string => x != null);
+}
+
+export function extractApHashtagObjects(tags: IObject | IObject[] | null | undefined): IApHashtag[] {
+	if (tags == null) return [];
+	return toArray(tags).filter(isHashtag);
 }

--- a/src/remote/activitypub/models/tag.ts
+++ b/src/remote/activitypub/models/tag.ts
@@ -1,26 +1,13 @@
-import { IIcon } from './icon';
-import { IIdentifier } from './identifier';
+import { toArray } from '../../../prelude/array';
+import { IObject, isHashtag } from '../type';
 
-/***
- * tag (ActivityPub)
- */
-export type ITag = {
-	id: string;
-	type: string;
-	name?: string;
-	value?: string;
-	updated?: Date;
-	icon?: IIcon;
-	identifier?: IIdentifier;
-};
-
-export function extractHashtags(tags: ITag[] | null | undefined): string[] {
+export function extractApHashtags(tags: IObject | IObject[] | null | undefined) {
 	if (tags == null) return [];
 
-	const hashtags = tags.filter(tag => tag.type === 'Hashtag' && typeof tag.name == 'string');
+	const hashtags = toArray(tags).filter(isHashtag);
 
 	return hashtags.map(tag => {
-		const m = tag.name ? tag.name.match(/^#(.+)/) : null;
+		const m = tag.name.match(/^#(.+)/);
 		return m ? m[1] : null;
-	}).filter(x => x != null) as string[];
+	}).filter((x): x is string => x != null);
 }

--- a/src/remote/activitypub/renderer/mention.ts
+++ b/src/remote/activitypub/renderer/mention.ts
@@ -4,6 +4,6 @@ import { Users } from '../../../models';
 
 export default (mention: User) => ({
 	type: 'Mention',
-	href: Users.isRemoteUser(mention) ? mention.uri : `${config.url}/@${(mention as ILocalUser).username}`,
+	href: Users.isRemoteUser(mention) ? mention.uri : `${config.url}/users/${(mention as ILocalUser).id}`,
 	name: Users.isRemoteUser(mention) ? `@${mention.username}@${mention.host}` : `@${(mention as ILocalUser).username}`,
 });

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -20,7 +20,8 @@ export interface IObject {
 	icon?: any;
 	image?: any;
 	url?: string;
-	tag?: any[];
+	href?: string;
+	tag?: IObject | IObject[];
 	sensitive?: boolean;
 }
 
@@ -129,6 +130,45 @@ export const isOrderedCollection = (object: IObject): object is IOrderedCollecti
 
 export const isCollectionOrOrderedCollection = (object: IObject): object is ICollection | IOrderedCollection =>
 	isCollection(object) || isOrderedCollection(object);
+
+export interface IApPropertyValue extends IObject {
+	type: 'PropertyValue';
+	identifier: IApPropertyValue;
+	name: string;
+	value: string;
+}
+
+export const isPropertyValue = (object: IObject): object is IApPropertyValue =>
+	object &&
+	object.type === 'PropertyValue' &&
+	typeof object.name === 'string' &&
+	typeof (object as any).value === 'string';
+
+export interface IApMention extends IObject {
+	type: 'Mention';
+	href: string;
+}
+
+export const isMention = (object: IObject): object is IApMention=>
+	object.type === 'Mention' &&
+	typeof object.href === 'string';
+
+export interface IApHashtag extends IObject {
+	type: 'Hashtag';
+	name: string;
+}
+
+export const isHashtag = (object: IObject): object is IApHashtag =>
+	object.type === 'Hashtag' &&
+	typeof object.name === 'string';
+
+export interface IApEmoji extends IObject {
+	type: 'Emoji';
+	updated: Date;
+}
+
+export const isEmoji = (object: IObject): object is IApEmoji =>
+	object.type === 'Emoji' && !Array.isArray(object.icon) && object.icon.url != null;
 
 export interface ICreate extends IActivity {
 	type: 'Create';


### PR DESCRIPTION
## Summary
Resolve #6135 AP Mentionメンション判定はaudienceでなくてtagを見るように
APのtypeの修正
Resolve #6177 AP Hashtag/Mention/Link の判定を修正

Hashtag かどうかを判定するのにHTML属性を見ているが
```
  Misskey: rel=tag is Hashtag
  Glitch: rel=tag is Mention | Hashtag
```
があるため完全な判定が不可能なので
```
  tag: [
    {
      type: 'Hashtag',
      href: 'https://example.com/tags/tag',
      name: '#tag'
    }
```
の方を見るようにしています。
