### PR TITLE
ノートの中身がはみ出ないように

### DIFF
--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -684,6 +684,7 @@ export default Vue.extend({
 .note {
 	position: relative;
 	transition: box-shadow 0.1s ease;
+	overflow: hidden;
 
 	&.max-width_500px {
 		font-size: 0.9em;


### PR DESCRIPTION
## Summary

fix #6123 

とりあえずのoverflow: hidden;
