### PR TITLE
ワードミュート機能を実装

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -434,6 +434,11 @@ none: "なし"
 volume: "音量"
 details: "詳細"
 chooseEmoji: "絵文字を選択"
+wordMute: "ワードミュート"
+noMutedWord: "ミュートしている単語はありません。"
+wordMuteDescription: "不快に思う話題にお困りですか？この項目にて単語を設定すると、その単語が含まれる投稿がタイムラインなどから表示されないようになります。"
+inputWordToMute: "ミュートしたい単語を入力して下さい..."
+inputWordToMuteDescription: "複数の単語をスペースで区切ることで、それらの単語を全て含む投稿をミュートできます。"
 
 _sfx:
   note: "ノート"

--- a/migration/1583765594830-word-mute.ts
+++ b/migration/1583765594830-word-mute.ts
@@ -1,0 +1,17 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class wordMute1583765594830 implements MigrationInterface {
+    name = 'wordMute1583765594830'
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`CREATE TABLE "muted_word" ("id" character varying(32) NOT NULL, "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL, "condition" text NOT NULL, "userId" character varying(32) NOT NULL, CONSTRAINT "PK_c976cc52c3ba4843ce099c89891" PRIMARY KEY ("id"))`, undefined);
+        await queryRunner.query(`CREATE INDEX "IDX_d073fdc9863bb368bad4f2d798" ON "muted_word" ("userId") `, undefined);
+        await queryRunner.query(`ALTER TABLE "muted_word" ADD CONSTRAINT "FK_d073fdc9863bb368bad4f2d7983" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`, undefined);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "muted_word" DROP CONSTRAINT "FK_d073fdc9863bb368bad4f2d7983"`, undefined);
+        await queryRunner.query(`DROP TABLE "muted_word"`, undefined);
+    }
+
+}

--- a/src/client/pages/my-settings/index.vue
+++ b/src/client/pages/my-settings/index.vue
@@ -27,6 +27,7 @@
 	<x-import-export/>
 	<x-drive/>
 	<x-mute-block/>
+	<x-word-mute/>
 	<x-security/>
 	<x-2fa/>
 	<x-integration/>
@@ -45,6 +46,7 @@ import XImportExport from './import-export.vue';
 import XDrive from './drive.vue';
 import XReactionSetting from './reaction.vue';
 import XMuteBlock from './mute-block.vue';
+import XWordMute from './word-mute.vue';
 import XSecurity from './security.vue';
 import X2fa from './2fa.vue';
 import XIntegration from './integration.vue';
@@ -66,6 +68,7 @@ export default Vue.extend({
 		XDrive,
 		XReactionSetting,
 		XMuteBlock,
+		XWordMute,
 		XSecurity,
 		X2fa,
 		XIntegration,

--- a/src/client/pages/my-settings/word-mute.vue
+++ b/src/client/pages/my-settings/word-mute.vue
@@ -1,0 +1,117 @@
+<template>
+	<section class="rrfwjxfl _card">
+		<div class="_title"><fa :icon="faFilter"/> {{ $t('wordMute') }}</div>
+		<div class="_content">
+			<small>{{ $t('wordMuteDescription') }}</small>
+            
+            <mk-pagination :pagination="mutedWordsPagination" class="mutedWord" ref="list">
+                <template #empty><p>{{ $t('noMutedWord') }}</p></template>
+                <template #default="{items}">
+                    <div class="record" v-for="mutedWord in items" :key="mutedWord.id">
+                        <button class="_textButton del" @click="del(mutedWord.id)"><fa :icon="faTimes" /></button>
+                        <div>{{ mutedWord.condition.join(' ') }}</div>
+                    </div>
+                </template>
+            </mk-pagination>
+		</div>
+        <div class="_footer">
+            <mk-input v-model="inputWordToMute" @keydown="onKeydown">
+                {{ $t('inputWordToMute') }}
+                <template #desc>{{ $t('inputWordToMuteDescription') }}</template>
+            </mk-input>
+            <mk-button @click="add()" primary inline :disabled="!inputWordToMute"><fa :icon="faPlus"/>{{ $t('add') }}</mk-button>
+        </div>
+	</section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { faTimes, faFilter, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faSave } from '@fortawesome/free-regular-svg-icons';
+import MkPagination from '../../components/ui/pagination.vue';
+import MkInput from '../../components/ui/input.vue';
+import MkButton from '../../components/ui/button.vue';
+
+export default Vue.extend({
+    components: {
+        MkPagination,
+        MkInput,
+        MkButton,
+    },
+    data () {
+        return {
+			mutedWordsPagination: {
+				endpoint: 'mute/words/list',
+				limit: 10,
+            },
+            inputWordToMute: '',
+            changed: false,
+			faTimes, faSave, faFilter, faPlus
+        };
+    },
+    watch: {
+        mutedWords () {
+            this.changed = true;
+        }
+    },
+	methods: {
+		add() {
+            const condition = this.inputWordToMute.split(/\s+/g);
+			this.$root.api('mute/words/create', {
+                condition,
+			}).then(() => {
+                this.inputWordToMute = '';
+                this.$nextTick(() => this.$refs.list.reload());
+			}).catch((err) => {
+				this.$root.dialog({
+					type: 'error',
+					text: err.id
+				});
+            });
+		},
+		del(id: string) {
+			this.$root.api('mute/words/delete', {
+                id,
+			}).then(() => {
+                this.$refs.list.reload();
+			}).catch((err) => {
+				this.$root.dialog({
+					type: 'error',
+					text: err.id
+				});
+            });
+        },
+        onKeydown(ev: KeyboardEvent) {
+            if (ev.keyCode === 13 && this.inputWordToMute) {
+                this.add();
+            }
+        }
+	}
+})
+</script>
+
+<style lang="scss" scoped>
+.rrfwjxfl {
+	> ._content {
+		max-height: 350px;
+		overflow: auto;
+
+        > .mutedWord {
+            > .record {
+                display: flex;
+                align-items: center;
+                border-bottom: 1px solid var(--divider);
+                height: 48px;
+
+                > .del {
+                    margin-right: 8px;
+                }
+            }
+
+			> .empty {
+				opacity: 0.5 !important;
+			}
+        }
+	}
+}
+</style>

--- a/src/db/postgre.ts
+++ b/src/db/postgre.ts
@@ -57,6 +57,7 @@ import { Antenna } from '../models/entities/antenna';
 import { AntennaNote } from '../models/entities/antenna-note';
 import { PromoNote } from '../models/entities/promo-note';
 import { PromoRead } from '../models/entities/promo-read';
+import { MutedWord } from '../models/entities/muted-word';
 
 const sqlLogger = dbLogger.createSubLogger('sql', 'white', false);
 
@@ -146,6 +147,7 @@ export const entities = [
 	PromoRead,
 	ReversiGame,
 	ReversiMatching,
+	MutedWord,
 	...charts as any
 ];
 

--- a/src/models/entities/muted-word.ts
+++ b/src/models/entities/muted-word.ts
@@ -1,0 +1,26 @@
+import { PrimaryColumn, Entity, Index, JoinColumn, Column, ManyToOne } from 'typeorm';
+import { User } from './user';
+import { id } from '../id';
+
+@Entity()
+@Index(['userId'], { unique: true })
+export class MutedWord {
+	@PrimaryColumn(id())
+	public id: string;
+
+	@Column('timestamp with time zone')
+	public createdAt: Date;
+
+	@Column('simple-array')
+	public condition: string[];
+
+	@Index()
+	@Column(id())
+	public userId: User['id'];
+
+	@ManyToOne(type => User, {
+		onDelete: 'CASCADE'
+	})
+	@JoinColumn()
+	public user: User | null;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,7 @@ import { UserGroupInvitationRepository } from './repositories/user-group-invitat
 import { FollowRequestRepository } from './repositories/follow-request';
 import { MutingRepository } from './repositories/muting';
 import { BlockingRepository } from './repositories/blocking';
+import { MutedWordRepository } from './repositories/muted-word';
 import { NoteReactionRepository } from './repositories/note-reaction';
 import { NotificationRepository } from './repositories/notification';
 import { NoteFavoriteRepository } from './repositories/note-favorite';
@@ -85,6 +86,7 @@ export const DriveFolders = getCustomRepository(DriveFolderRepository);
 export const Notifications = getCustomRepository(NotificationRepository);
 export const Metas = getRepository(Meta);
 export const Mutings = getCustomRepository(MutingRepository);
+export const MutedWords = getCustomRepository(MutedWordRepository);
 export const Blockings = getCustomRepository(BlockingRepository);
 export const SwSubscriptions = getRepository(SwSubscription);
 export const Hashtags = getCustomRepository(HashtagRepository);

--- a/src/models/repositories/muted-word.ts
+++ b/src/models/repositories/muted-word.ts
@@ -1,0 +1,52 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { MutedWord } from '../entities/muted-word';
+import { ensure } from '../../prelude/ensure';
+import { SchemaType } from '../../misc/schema';
+
+export type PackedMutedWord = SchemaType<typeof packedMutedWordSchema>;
+
+@EntityRepository(MutedWord)
+export class MutedWordRepository extends Repository<MutedWord> {
+	public async pack(
+		src: MutedWord['id'] | MutedWord,
+	): Promise<PackedMutedWord> {
+		const mutedWord = typeof src === 'object' ? src : await this.findOne(src).then(ensure);
+
+		return {
+			id: mutedWord.id,
+			createdAt: mutedWord.createdAt.toISOString(),
+			condition: mutedWord.condition,
+		};
+	}
+
+	public packMany(
+		mutedWords: any[]
+	) {
+		return Promise.all(mutedWords.map(x => this.pack(x)));
+	}
+}
+
+export const packedMutedWordSchema = {
+	type: 'object' as const,
+	optional: false as const, nullable: false as const,
+	properties: {
+		id: {
+			type: 'string' as const,
+			optional: false as const, nullable: false as const,
+			format: 'id',
+			description: 'The unique identifier for this MutedWord.',
+			example: 'xxxxxxxxxx',
+		},
+		createdAt: {
+			type: 'string' as const,
+			optional: false as const, nullable: false as const,
+			format: 'date-time',
+			description: 'The date that the MutedWord was created.'
+		},
+		condition: {
+			type: 'array' as const,
+			optional: false as const, nullable: false as const,
+			description: 'The condition of the MutedWord.'
+		},
+	},
+};

--- a/src/server/api/common/filter-by-words.ts
+++ b/src/server/api/common/filter-by-words.ts
@@ -1,0 +1,27 @@
+import { Note } from '../../../models/entities/note';
+import { MutedWord } from '../../../models/entities/muted-word';
+import { User } from '../../../models/entities/user';
+import { getMutedList } from './get-muted-list';
+
+export function shouldBeFilteredTextByWords(text: string | null, mutedList: MutedWord[]) {
+	// フィルタリングされるべきであれば true
+	return !!text && mutedList.some(record => record.condition.every(word => text.includes(word)))
+}
+
+export function shouldBeFilteredNoteByWords(note: Note | null, mutedList: MutedWord[]) {
+	return !!note && (
+		shouldBeFilteredTextByWords(note.text, mutedList) ||
+		shouldBeFilteredTextByWords(note.cw, mutedList) ||
+		shouldBeFilteredTextByWords(note.renote ? note.renote.text : null, mutedList) ||
+		shouldBeFilteredTextByWords(note.reply ? note.reply.text : null, mutedList)
+	);
+}
+
+export async function filterNotesByWords(notes: Note[], user: User, mutedList?: MutedWord[]) {
+	const list = mutedList || await getMutedList(user);
+	return notes.filter(note =>
+		// 自分の投稿はフィルターしない
+		note.userId === (user ? user.id : null) ||
+		!shouldBeFilteredNoteByWords(note, list)
+	);
+}

--- a/src/server/api/common/get-muted-list.ts
+++ b/src/server/api/common/get-muted-list.ts
@@ -1,0 +1,4 @@
+import { User } from '../../../models/entities/user';
+import { MutedWords } from '../../../models/';
+
+export const getMutedList = (user: User) => MutedWords.find({ where: { userId: user.id } });

--- a/src/server/api/endpoints/mute/words/create.ts
+++ b/src/server/api/endpoints/mute/words/create.ts
@@ -1,0 +1,38 @@
+import $ from 'cafy';
+import define from '../../../define';
+import { genId } from '../../../../../misc/gen-id';
+import { MutedWords } from '../../../../../models/';
+
+export const meta = {
+	desc: {
+		'ja-JP': 'ワードミュートを追加します。',
+		'en-US': 'Add a muted keyword.'
+	},
+
+	tags: ['mute'],
+
+	requireCredential: true as const,
+
+	kind: 'write:mutes',
+
+	params: {
+		condition: {
+			validator: $.arr($.str),
+			desc: {
+				'ja-JP': '条件となる単語の配列',
+				'en-US': 'An array of words as a condition'
+			}
+		},
+	},
+};
+
+export default define(meta, async (ps, user) => {
+	const muter = user;
+
+	MutedWords.save({
+		id: genId(),
+		createdAt: new Date(),
+		userId: muter.id,
+		condition: ps.condition,
+	});
+});

--- a/src/server/api/endpoints/mute/words/delete.ts
+++ b/src/server/api/endpoints/mute/words/delete.ts
@@ -1,0 +1,49 @@
+import $ from 'cafy';
+import { ID } from '../../../../../misc/cafy-id';
+import define from '../../../define';
+import { ApiError } from '../../../error';
+import { MutedWords } from '../../../../../models';
+
+export const meta = {
+	desc: {
+		'ja-JP': 'ワードミュートを削除します。',
+		'en-US': 'Remove a muted keyword.'
+	},
+
+	tags: ['mute'],
+
+	requireCredential: true as const,
+
+	kind: 'write:mutes',
+
+	params: {
+		id: {
+			validator: $.type(ID),
+			desc: {
+				'ja-JP': '対象とするレコードのID',
+				'en-US': 'Target record ID'
+			}
+		},
+	},
+
+	errors: {
+		noSuchRecord: {
+			message: 'No such record.',
+			code: 'NO_SUCH_RECORD',
+			id: '5b3d979a-d395-4889-8cf1-d51d35a23dbb'
+		},
+	}
+};
+
+export default define(meta, async (ps, user) => {
+	const exist = await MutedWords.findOne(ps.id);
+
+	if (exist == null) {
+		throw new ApiError(meta.errors.noSuchRecord);
+	}
+
+	// Delete mute
+	await MutedWords.delete({
+		id: exist.id
+	});
+});

--- a/src/server/api/endpoints/mute/words/list.ts
+++ b/src/server/api/endpoints/mute/words/list.ts
@@ -1,0 +1,54 @@
+import $ from 'cafy';
+import { ID } from '../../../../../misc/cafy-id';
+import define from '../../../define';
+import { makePaginationQuery } from '../../../common/make-pagination-query';
+import { MutedWords } from '../../../../../models';
+
+export const meta = {
+	desc: {
+		'ja-JP': 'ミュートしているワード一覧を取得します。',
+		'en-US': 'Get muted-words.'
+	},
+
+	tags: ['mute'],
+
+	requireCredential: true as const,
+
+	kind: 'read:mutes',
+
+	params: {
+		limit: {
+			validator: $.optional.num.range(1, 100),
+			default: 30
+		},
+
+		sinceId: {
+			validator: $.optional.type(ID),
+		},
+
+		untilId: {
+			validator: $.optional.type(ID),
+		},
+	},
+
+	res: {
+		type: 'array' as const,
+		optional: false as const, nullable: false as const,
+		items: {
+			type: 'object' as const,
+			optional: false as const, nullable: false as const,
+			ref: 'MutedWord',
+		}
+	},
+};
+
+export default define(meta, async (ps, me) => {
+	const query = makePaginationQuery(MutedWords.createQueryBuilder('mutedWords'), ps.sinceId, ps.untilId)
+		.andWhere(`mutedWords.userId = :meId`, { meId: me.id });
+
+	const mutings = await query
+		.take(ps.limit!)
+		.getMany();
+
+	return await MutedWords.packMany(mutings);
+});

--- a/src/server/api/endpoints/notes/children.ts
+++ b/src/server/api/endpoints/notes/children.ts
@@ -6,6 +6,7 @@ import { generateVisibilityQuery } from '../../common/generate-visibility-query'
 import { generateMuteQuery } from '../../common/generate-mute-query';
 import { Brackets } from 'typeorm';
 import { Notes } from '../../../../models';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -69,7 +70,8 @@ export default define(meta, async (ps, user) => {
 	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
-	const notes = await query.take(ps.limit!).getMany();
+	let notes = await query.take(ps.limit!).getMany();
+	if (user) notes = await filterNotesByWords(notes, user);
 
 	return await Notes.packMany(notes, user);
 });

--- a/src/server/api/endpoints/notes/featured.ts
+++ b/src/server/api/endpoints/notes/featured.ts
@@ -1,6 +1,7 @@
 import $ from 'cafy';
 import define from '../../define';
 import { generateMuteQuery } from '../../common/generate-mute-query';
+import { filterNotesByWords } from '../../common/filter-by-words';
 import { Notes } from '../../../../models';
 
 export const meta = {
@@ -61,6 +62,8 @@ export default define(meta, async (ps, user) => {
 	notes.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
 
 	notes = notes.slice(ps.offset, ps.offset + ps.limit);
+
+	if (user) notes = await filterNotesByWords(notes);
 
 	return await Notes.packMany(notes, user);
 });

--- a/src/server/api/endpoints/notes/global-timeline.ts
+++ b/src/server/api/endpoints/notes/global-timeline.ts
@@ -10,6 +10,7 @@ import { activeUsersChart } from '../../../../services/chart';
 import { generateRepliesQuery } from '../../common/generate-replies-query';
 import { injectPromo } from '../../common/inject-promo';
 import { injectFeatured } from '../../common/inject-featured';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -89,7 +90,10 @@ export default define(meta, async (ps, user) => {
 	}
 	//#endregion
 
-	const timeline = await query.take(ps.limit!).getMany();
+	let timeline = await query.take(ps.limit!).getMany();
+	if (user) {
+		timeline = await filterNotesByWords(timeline, user);
+	}
 
 	await injectPromo(timeline, user);
 	await injectFeatured(timeline, user);

--- a/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -12,6 +12,7 @@ import { activeUsersChart } from '../../../../services/chart';
 import { generateRepliesQuery } from '../../common/generate-replies-query';
 import { injectPromo } from '../../common/inject-promo';
 import { injectFeatured } from '../../common/inject-featured';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -169,7 +170,7 @@ export default define(meta, async (ps, user) => {
 	}
 	//#endregion
 
-	const timeline = await query.take(ps.limit!).getMany();
+	const timeline = await filterNotesByWords(await query.take(ps.limit!).getMany(), user);
 
 	await injectPromo(timeline, user);
 	await injectFeatured(timeline, user);

--- a/src/server/api/endpoints/notes/local-timeline.ts
+++ b/src/server/api/endpoints/notes/local-timeline.ts
@@ -12,6 +12,7 @@ import { Brackets } from 'typeorm';
 import { generateRepliesQuery } from '../../common/generate-replies-query';
 import { injectPromo } from '../../common/inject-promo';
 import { injectFeatured } from '../../common/inject-featured';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -122,8 +123,10 @@ export default define(meta, async (ps, user) => {
 	}
 	//#endregion
 
-	const timeline = await query.take(ps.limit!).getMany();
-
+	let timeline = await query.take(ps.limit!).getMany();
+	if (user) {
+		timeline = await filterNotesByWords(timeline, user);
+	}
 	await injectPromo(timeline, user);
 	await injectFeatured(timeline, user);
 

--- a/src/server/api/endpoints/notes/mentions.ts
+++ b/src/server/api/endpoints/notes/mentions.ts
@@ -5,6 +5,7 @@ import read from '../../../../services/note/read';
 import { Notes, Followings } from '../../../../models';
 import { generateVisibilityQuery } from '../../common/generate-visibility-query';
 import { generateMuteQuery } from '../../common/generate-mute-query';
+import { filterNotesByWords } from '../../common/filter-by-words';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 import { Brackets } from 'typeorm';
 
@@ -77,11 +78,13 @@ export default define(meta, async (ps, user) => {
 		query.setParameters(followingQuery.getParameters());
 	}
 
-	const mentions = await query.take(ps.limit!).getMany();
+	let mentions = await query.take(ps.limit!).getMany();
 
 	for (const note of mentions) {
 		read(user.id, note.id);
 	}
+
+	mentions = await filterNotesByWords(mentions, user);
 
 	return await Notes.packMany(mentions, user);
 });

--- a/src/server/api/endpoints/notes/renotes.ts
+++ b/src/server/api/endpoints/notes/renotes.ts
@@ -7,6 +7,7 @@ import { generateVisibilityQuery } from '../../common/generate-visibility-query'
 import { generateMuteQuery } from '../../common/generate-mute-query';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 import { Notes } from '../../../../models';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -73,7 +74,8 @@ export default define(meta, async (ps, user) => {
 	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
-	const renotes = await query.take(ps.limit!).getMany();
+	let renotes = await query.take(ps.limit!).getMany();
+	if (user) renotes = await filterNotesByWords(renotes, user);
 
 	return await Notes.packMany(renotes, user);
 });

--- a/src/server/api/endpoints/notes/replies.ts
+++ b/src/server/api/endpoints/notes/replies.ts
@@ -5,6 +5,7 @@ import { Notes } from '../../../../models';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 import { generateVisibilityQuery } from '../../common/generate-visibility-query';
 import { generateMuteQuery } from '../../common/generate-mute-query';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -64,7 +65,8 @@ export default define(meta, async (ps, user) => {
 	generateVisibilityQuery(query, user);
 	if (user) generateMuteQuery(query, user);
 
-	const timeline = await query.take(ps.limit!).getMany();
+	let timeline = await query.take(ps.limit!).getMany();
+	if (user) timeline = await filterNotesByWords(timeline, user);
 
 	return await Notes.packMany(timeline, user);
 });

--- a/src/server/api/endpoints/notes/search-by-tag.ts
+++ b/src/server/api/endpoints/notes/search-by-tag.ts
@@ -7,6 +7,7 @@ import { generateMuteQuery } from '../../common/generate-mute-query';
 import { generateVisibilityQuery } from '../../common/generate-visibility-query';
 import { Brackets } from 'typeorm';
 import { safeForSql } from '../../../../misc/safe-for-sql';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -146,7 +147,8 @@ export default define(meta, async (ps, me) => {
 	}
 
 	// Search notes
-	const notes = await query.take(ps.limit!).getMany();
+	let notes = await query.take(ps.limit!).getMany();
+	if (me) notes = await filterNotesByWords(notes, me);
 
 	return await Notes.packMany(notes, me);
 });

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -8,6 +8,7 @@ import config from '../../../../config';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 import { generateVisibilityQuery } from '../../common/generate-visibility-query';
 import { generateMuteQuery } from '../../common/generate-mute-query';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -124,7 +125,7 @@ export default define(meta, async (ps, me) => {
 		if (hits.length === 0) return [];
 
 		// Fetch found notes
-		const notes = await Notes.find({
+		let notes = await Notes.find({
 			where: {
 				id: In(hits)
 			},
@@ -132,6 +133,8 @@ export default define(meta, async (ps, me) => {
 				id: -1
 			}
 		});
+
+		if (me) notes = await filterNotesByWords(notes, me);
 
 		return await Notes.packMany(notes, me);
 	}

--- a/src/server/api/endpoints/notes/timeline.ts
+++ b/src/server/api/endpoints/notes/timeline.ts
@@ -10,6 +10,7 @@ import { Brackets } from 'typeorm';
 import { generateRepliesQuery } from '../../common/generate-replies-query';
 import { injectPromo } from '../../common/inject-promo';
 import { injectFeatured } from '../../common/inject-featured';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -155,7 +156,7 @@ export default define(meta, async (ps, user) => {
 	}
 	//#endregion
 
-	const timeline = await query.take(ps.limit!).getMany();
+	const timeline = await filterNotesByWords(await query.take(ps.limit!).getMany(), user);
 
 	await injectPromo(timeline, user);
 	await injectFeatured(timeline, user);

--- a/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -7,6 +7,7 @@ import { makePaginationQuery } from '../../common/make-pagination-query';
 import { generateVisibilityQuery } from '../../common/generate-visibility-query';
 import { activeUsersChart } from '../../../../services/chart';
 import { Brackets } from 'typeorm';
+import { filterNotesByWords } from '../../common/filter-by-words';
 
 export const meta = {
 	desc: {
@@ -170,7 +171,7 @@ export default define(meta, async (ps, user) => {
 	}
 	//#endregion
 
-	const timeline = await query.take(ps.limit!).getMany();
+	const timeline = await filterNotesByWords(await query.take(ps.limit!).getMany(), user);
 
 	activeUsersChart.update(user);
 


### PR DESCRIPTION
## Summary

Resolve #6092 

- v11 以前のワードミュートに近い挙動をサーバーサイドで実現するようにしました
- DBへのクエリで実現するのは苦行だったので、配列操作でなんとかしています
- 足りない分を追加のクエリで埋めようとすると、無限ループに陥る可能性があるので、とりあえずしていません