### PR TITLE
ElasticSearchで認証ができるように

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -88,7 +88,9 @@ redis:
 #elasticsearch:
 #  host: localhost
 #  port: 9200
-#  pass: null
+#  ssl: false
+#  user: 
+#  pass: 
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -27,9 +27,10 @@ export type Source = {
 	elasticsearch: {
 		host: string;
 		port: number;
-		pass: string;
-		index?: string;
 		ssl?: boolean;
+		user?: string;
+		pass?: string;
+		index?: string;
 	};
 
 	proxy?: string;

--- a/src/db/elasticsearch.ts
+++ b/src/db/elasticsearch.ts
@@ -33,6 +33,10 @@ const index = {
 // Init ElasticSearch connection
 const client = config.elasticsearch ? new elasticsearch.Client({
 	node: `${config.elasticsearch.ssl ? 'https://' : 'http://'}${config.elasticsearch.host}:${config.elasticsearch.port}`,
+	auth: (config.elasticsearch.user && config.elasticsearch.pass) ? {
+		username: config.elasticsearch.user,
+		password: config.elasticsearch.pass
+	} : undefined,
 	pingTimeout: 30000
 }) : null;
 


### PR DESCRIPTION
## Summary
Related: https://github.com/syuilo/misskey/issues/6157#issuecomment-599195675
ElasticSearchで認証ができるように＋exampleとtypeの修正
テストしてません