### PR TITLE
連携ログインができないのなどを修正

### DIFF
--- a/src/client/mios.ts
+++ b/src/client/mios.ts
@@ -123,7 +123,13 @@ export default class MiOS extends EventEmitter {
 			});
 		} else {
 			// Get token from localStorage
-			const i = localStorage.getItem('i');
+			let i = localStorage.getItem('i');
+
+			// 連携ログインの場合用にCookieを参照する
+			// Cookieを先に評価すると上位ドメインからiが流れてきた場合に無限ループになる
+			if (i == null || i === 'null') {
+				i = (document.cookie.match(/i=(\w+)/) || [null, null])[1];
+			}
 
 			fetchme(i, me => {
 				if (me) {

--- a/src/client/mios.ts
+++ b/src/client/mios.ts
@@ -126,9 +126,8 @@ export default class MiOS extends EventEmitter {
 			let i = localStorage.getItem('i');
 
 			// 連携ログインの場合用にCookieを参照する
-			// Cookieを先に評価すると上位ドメインからiが流れてきた場合に無限ループになる
 			if (i == null || i === 'null') {
-				i = (document.cookie.match(/i=(\w+)/) || [null, null])[1];
+				i = (document.cookie.match(/igi=(\w+)/) || [null, null])[1];
 			}
 
 			fetchme(i, me => {

--- a/src/client/pages/my-settings/integration.vue
+++ b/src/client/pages/my-settings/integration.vue
@@ -71,6 +71,7 @@ export default Vue.extend({
 
 	mounted() {
 		document.cookie = `igi=${this.$store.state.i.token}; path=/;` +
+			` max-age=31536000;` +
 			(document.location.protocol.startsWith('https') ? ' secure' : '');
 
 		this.$watch('integrations', () => {

--- a/src/client/pages/my-settings/integration.vue
+++ b/src/client/pages/my-settings/integration.vue
@@ -70,11 +70,10 @@ export default Vue.extend({
 	},
 
 	mounted() {
-		if (!document.cookie.match(/i=(\w+)/)) {
-			document.cookie = `i=${this.$store.state.i.token}; path=/;` +
-			` domain=${document.location.hostname}; max-age=31536000;` +
+		document.cookie = `i=${this.$store.state.i.token}; path=/;` +
+			` max-age=31536000;` +
 			(document.location.protocol.startsWith('https') ? ' secure' : '');
-		}
+
 		this.$watch('integrations', () => {
 			if (this.integrations.twitter) {
 				if (this.twitterForm) this.twitterForm.close();

--- a/src/client/pages/my-settings/integration.vue
+++ b/src/client/pages/my-settings/integration.vue
@@ -70,8 +70,7 @@ export default Vue.extend({
 	},
 
 	mounted() {
-		document.cookie = `i=${this.$store.state.i.token}; path=/;` +
-			` max-age=31536000;` +
+		document.cookie = `igi=${this.$store.state.i.token}; path=/;` +
 			(document.location.protocol.startsWith('https') ? ' secure' : '');
 
 		this.$watch('integrations', () => {

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -101,8 +101,7 @@ export default (os: MiOS) => new Vuex.Store({
 			ctx.commit('settings/init', {});
 			ctx.commit('deviceUser/init', {});
 			localStorage.removeItem('i');
-			document.cookie = `i=; path=/`;
-			document.cookie = `i=; domain=${document.location.hostname}; path=/`;	// バグで誤発行したCookieもクリアする
+			document.cookie = `igi=; path=/`;
 		},
 
 		async switchAccount(ctx, i) {

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -101,6 +101,8 @@ export default (os: MiOS) => new Vuex.Store({
 			ctx.commit('settings/init', {});
 			ctx.commit('deviceUser/init', {});
 			localStorage.removeItem('i');
+			document.cookie = `i=; path=/`;
+			document.cookie = `i=; domain=${document.location.hostname}; path=/`;	// バグで誤発行したCookieもクリアする
 		},
 
 		async switchAccount(ctx, i) {

--- a/src/server/api/common/signin.ts
+++ b/src/server/api/common/signin.ts
@@ -12,7 +12,6 @@ export default function(ctx: Koa.Context, user: ILocalUser, redirect = false) {
 		const expires = 1000 * 60 * 60 * 24 * 365; // One Year
 		ctx.cookies.set('i', user.token, {
 			path: '/',
-			domain: config.hostname,
 			// SEE: https://github.com/koajs/koa/issues/974
 			// When using a SSL proxy it should be configured to add the "X-Forwarded-Proto: https" header
 			secure: config.url.startsWith('https'),

--- a/src/server/api/common/signin.ts
+++ b/src/server/api/common/signin.ts
@@ -9,15 +9,12 @@ import { publishMainStream } from '../../../services/stream';
 export default function(ctx: Koa.Context, user: ILocalUser, redirect = false) {
 	if (redirect) {
 		//#region Cookie
-		const expires = 1000 * 60 * 60 * 24 * 365; // One Year
-		ctx.cookies.set('i', user.token, {
+		ctx.cookies.set('igi', user.token, {
 			path: '/',
 			// SEE: https://github.com/koajs/koa/issues/974
 			// When using a SSL proxy it should be configured to add the "X-Forwarded-Proto: https" header
 			secure: config.url.startsWith('https'),
-			httpOnly: false,
-			expires: new Date(Date.now() + expires),
-			maxAge: expires
+			httpOnly: false
 		});
 		//#endregion
 

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -114,9 +114,8 @@ router.get('/signin/discord', async ctx => {
 	};
 
 	const expires = 1000 * 60 * 60; // 1h
-	ctx.cookies.set('signin_with_discord_session_id', sessid, {
+	ctx.cookies.set('signin_with_discord_sid', sessid, {
 		path: '/',
-		domain: config.host,
 		secure: config.url.startsWith('https'),
 		httpOnly: true,
 		expires: new Date(Date.now() + expires),
@@ -135,7 +134,7 @@ router.get('/dc/cb', async ctx => {
 	const oauth2 = await getOAuth2();
 
 	if (!userToken) {
-		const sessid = ctx.cookies.get('signin_with_discord_session_id');
+		const sessid = ctx.cookies.get('signin_with_discord_sid');
 
 		if (!sessid) {
 			ctx.throw(400, 'invalid session');
@@ -199,7 +198,7 @@ router.get('/dc/cb', async ctx => {
 		}
 
 		const profile = await UserProfiles.createQueryBuilder()
-			.where('"integrations"->"discord"->"id" = :id', { id: id })
+			.where(`"integrations"->'discord'->>'id' = :id`, { id: id })
 			.andWhere('"userHost" IS NULL')
 			.getOne();
 

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -208,6 +208,7 @@ router.get('/dc/cb', async ctx => {
 			integrations: {
 				...profile.integrations,
 				discord: {
+					id: id,
 					accessToken: accessToken,
 					refreshToken: refreshToken,
 					expiresDate: expiresDate,

--- a/src/server/api/service/discord.ts
+++ b/src/server/api/service/discord.ts
@@ -13,7 +13,7 @@ import { ILocalUser } from '../../../models/entities/user';
 import { ensure } from '../../../prelude/ensure';
 
 function getUserToken(ctx: Koa.Context) {
-	return ((ctx.headers['cookie'] || '').match(/i=(\w+)/) || [null, null])[1];
+	return ((ctx.headers['cookie'] || '').match(/igi=(\w+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.Context) {
@@ -113,13 +113,10 @@ router.get('/signin/discord', async ctx => {
 		response_type: 'code'
 	};
 
-	const expires = 1000 * 60 * 60; // 1h
 	ctx.cookies.set('signin_with_discord_sid', sessid, {
 		path: '/',
 		secure: config.url.startsWith('https'),
-		httpOnly: true,
-		expires: new Date(Date.now() + expires),
-		maxAge: expires
+		httpOnly: true
 	});
 
 	redis.set(sessid, JSON.stringify(params));

--- a/src/server/api/service/github.ts
+++ b/src/server/api/service/github.ts
@@ -112,9 +112,8 @@ router.get('/signin/github', async ctx => {
 	};
 
 	const expires = 1000 * 60 * 60; // 1h
-	ctx.cookies.set('signin_with_github_session_id', sessid, {
+	ctx.cookies.set('signin_with_github_sid', sessid, {
 		path: '/',
-		domain: config.host,
 		secure: config.url.startsWith('https'),
 		httpOnly: true,
 		expires: new Date(Date.now() + expires),
@@ -133,7 +132,7 @@ router.get('/gh/cb', async ctx => {
 	const oauth2 = await getOath2();
 
 	if (!userToken) {
-		const sessid = ctx.cookies.get('signin_with_github_session_id');
+		const sessid = ctx.cookies.get('signin_with_github_sid');
 
 		if (!sessid) {
 			ctx.throw(400, 'invalid session');
@@ -192,7 +191,7 @@ router.get('/gh/cb', async ctx => {
 		}
 
 		const link = await UserProfiles.createQueryBuilder()
-			.where('"integrations"->"github"->"id" = :id', { id: id })
+			.where(`"integrations"->'github'->>'id' = :id`, { id: id })
 			.andWhere('"userHost" IS NULL')
 			.getOne();
 

--- a/src/server/api/service/github.ts
+++ b/src/server/api/service/github.ts
@@ -13,7 +13,7 @@ import { ILocalUser } from '../../../models/entities/user';
 import { ensure } from '../../../prelude/ensure';
 
 function getUserToken(ctx: Koa.Context) {
-	return ((ctx.headers['cookie'] || '').match(/i=(\w+)/) || [null, null])[1];
+	return ((ctx.headers['cookie'] || '').match(/igi=(\w+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.Context) {
@@ -111,13 +111,10 @@ router.get('/signin/github', async ctx => {
 		state: uuid()
 	};
 
-	const expires = 1000 * 60 * 60; // 1h
 	ctx.cookies.set('signin_with_github_sid', sessid, {
 		path: '/',
 		secure: config.url.startsWith('https'),
-		httpOnly: true,
-		expires: new Date(Date.now() + expires),
-		maxAge: expires
+		httpOnly: true
 	});
 
 	redis.set(sessid, JSON.stringify(params));

--- a/src/server/api/service/twitter.ts
+++ b/src/server/api/service/twitter.ts
@@ -103,9 +103,8 @@ router.get('/signin/twitter', async ctx => {
 	redis.set(sessid, JSON.stringify(twCtx));
 
 	const expires = 1000 * 60 * 60; // 1h
-	ctx.cookies.set('signin_with_twitter_session_id', sessid, {
+	ctx.cookies.set('signin_with_twitter_sid', sessid, {
 		path: '/',
-		domain: config.host,
 		secure: config.url.startsWith('https'),
 		httpOnly: true,
 		expires: new Date(Date.now() + expires),
@@ -121,7 +120,7 @@ router.get('/tw/cb', async ctx => {
 	const twAuth = await getTwAuth();
 
 	if (userToken == null) {
-		const sessid = ctx.cookies.get('signin_with_twitter_session_id');
+		const sessid = ctx.cookies.get('signin_with_twitter_sid');
 
 		if (sessid == null) {
 			ctx.throw(400, 'invalid session');
@@ -139,7 +138,7 @@ router.get('/tw/cb', async ctx => {
 		const result = await twAuth!.done(JSON.parse(twCtx), ctx.query.oauth_verifier);
 
 		const link = await UserProfiles.createQueryBuilder()
-			.where('"integrations"->"twitter"->"userId" = :id', { id: result.userId })
+			.where(`"integrations"->'twitter'->>'userId' = :id`, { id: result.userId })
 			.andWhere('"userHost" IS NULL')
 			.getOne();
 

--- a/src/server/api/service/twitter.ts
+++ b/src/server/api/service/twitter.ts
@@ -12,7 +12,7 @@ import { ILocalUser } from '../../../models/entities/user';
 import { ensure } from '../../../prelude/ensure';
 
 function getUserToken(ctx: Koa.Context) {
-	return ((ctx.headers['cookie'] || '').match(/i=(\w+)/) || [null, null])[1];
+	return ((ctx.headers['cookie'] || '').match(/igi=(\w+)/) || [null, null])[1];
 }
 
 function compareOrigin(ctx: Koa.Context) {
@@ -102,13 +102,10 @@ router.get('/signin/twitter', async ctx => {
 
 	redis.set(sessid, JSON.stringify(twCtx));
 
-	const expires = 1000 * 60 * 60; // 1h
 	ctx.cookies.set('signin_with_twitter_sid', sessid, {
 		path: '/',
 		secure: config.url.startsWith('https'),
-		httpOnly: true,
-		expires: new Date(Date.now() + expires),
-		maxAge: expires
+		httpOnly: true
 	});
 
 	ctx.redirect(twCtx.url);


### PR DESCRIPTION
## Summary
Fix #6094 連携ログインができないのを修正
Fix #6161 サブドメインにもCookieが送信されてしまうのを修正
2回目以降Discordログインできなくなるのを修正

サブドメインに対して誤発行したCookieが混ざると挙動がめんどくさくなるので
`signin_with_`のCookieの名称を変更しています。またセッションCookieに変更しています。

GitHubログインができるようになったことを確認済み。

サブドメインにもCookieが送信されてしまうバグのせいで
サブドメインに追加Misskeyを構築することは不可能だったけど
v12で連携ログインが壊れている間にサブドメインにMisskeyを構築しちゃったところがあって
普通にCookieを読むように修正するとサブドメインのMisskeyが壊れてしまうので
iのCookie名をigiに変えています。

