### PR TITLE
ノートページのタイトルで、名前が空のときIDを使う

### DIFF
--- a/src/client/pages/note.vue
+++ b/src/client/pages/note.vue
@@ -1,7 +1,12 @@
 <template>
 <div class="mk-note-page">
 	<portal to="avatar" v-if="note"><mk-avatar class="avatar" :user="note.user" :disable-preview="true"/></portal>
-	<portal to="title" v-if="note">{{ $t('noteOf', { user: note.user.name }) }}</portal>
+	<portal to="title" v-if="note">
+		<mfm 
+			:text="$t('noteOf', { user: note.user.name || note.user.username })"
+			:plain="true" :nowrap="true" :custom-emojis="note.user.emojis" :is-note="false"
+		/>
+	</portal>
 
 	<transition :name="$store.state.device.animation ? 'zoom' : ''" mode="out-in">
 		<div v-if="note">


### PR DESCRIPTION
## Summary

fix #6156 
![image](https://user-images.githubusercontent.com/19502796/76918517-d1944a00-6909-11ea-8b64-42a0f419b2ce.png)
