### PR TITLE
アプリ一覧に1回も使用していないアプリが表示されないのを修正

### DIFF
--- a/src/server/api/endpoints/auth/accept.ts
+++ b/src/server/api/endpoints/auth/accept.ts
@@ -60,6 +60,7 @@ export default define(meta, async (ps, user) => {
 		await AccessTokens.save({
 			id: genId(),
 			createdAt: new Date(),
+			lastUsedAt: new Date(),
 			appId: session.appId,
 			userId: user.id,
 			token: accessToken,

--- a/src/server/api/endpoints/i/apps.ts
+++ b/src/server/api/endpoints/i/apps.ts
@@ -26,8 +26,8 @@ export default define(meta, async (ps, user) => {
 	switch (ps.sort) {
 		case '+createdAt': query.orderBy('token.createdAt', 'DESC'); break;
 		case '-createdAt': query.orderBy('token.createdAt', 'ASC'); break;
-		case '+lastUsedAt': query.andWhere('token.lastUsedAt IS NOT NULL').orderBy('token.lastUsedAt', 'DESC'); break;
-		case '-lastUsedAt': query.andWhere('token.lastUsedAt IS NOT NULL').orderBy('token.lastUsedAt', 'ASC'); break;
+		case '+lastUsedAt': query.orderBy('token.lastUsedAt', 'DESC'); break;
+		case '-lastUsedAt': query.orderBy('token.lastUsedAt', 'ASC'); break;
 		default: query.orderBy('token.id', 'ASC'); break;
 	}
 


### PR DESCRIPTION
## Summary
Fix #6199
アプリ一覧に旧アプリ認証方式で追加されていて1回も使用されてないアプリが表示されないのを修正

このままだと旧アプリ認証方式で追加されてものが
APIで最近使用された順が指定された時に常に上に来てしまうので
新たに旧アプリ認証方式で追加されたものは
MiAuthと同じように`lastUsedAt`を入れるようにしています。

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
