### PR TITLE
Ability to set header image for a Page

### DIFF
--- a/src/client/components/page-preview.vue
+++ b/src/client/components/page-preview.vue
@@ -35,6 +35,7 @@ export default Vue.extend({
 	border: solid var(--lineWidth) var(--urlPreviewBorder);
 	border-radius: 4px;
 	overflow: hidden;
+	border: 1px solid var(--divider);
 
 	&:hover {
 		text-decoration: none;
@@ -42,9 +43,8 @@ export default Vue.extend({
 	}
 
 	> .thumbnail {
-		position: absolute;
-		width: 100px;
-		height: 100%;
+		width: 100%;
+		height: 200px;
 		background-position: center;
 		background-size: cover;
 		display: flex;

--- a/src/client/components/page/page.image.vue
+++ b/src/client/components/page/page.image.vue
@@ -22,12 +22,10 @@ export default Vue.extend({
 		};
 	},
 	created() {
-		if (this.value.hasOwnProperty('fieldId')) {
-			// media
-			this.image = this.page.attachedFiles.find(x => x.id === this.value.fileId);
-		} else {
-			// plain image
-			this.image = this.value
+		this.image = this.page.attachedFiles.find(x => x.id === this.value.fileId);
+
+		if (typeof this.image === "undefined") {
+			this.image = this.value;
 		}
 	}
 });

--- a/src/client/components/page/page.image.vue
+++ b/src/client/components/page/page.image.vue
@@ -22,7 +22,13 @@ export default Vue.extend({
 		};
 	},
 	created() {
-		this.image = this.page.attachedFiles.find(x => x.id === this.value.fileId);
+		if (this.value.hasOwnProperty('fieldId')) {
+			// media
+			this.image = this.page.attachedFiles.find(x => x.id === this.value.fileId);
+		} else {
+			// plain image
+			this.image = this.value
+		}
 	}
 });
 </script>

--- a/src/client/components/page/page.image.vue
+++ b/src/client/components/page/page.image.vue
@@ -23,10 +23,6 @@ export default Vue.extend({
 	},
 	created() {
 		this.image = this.page.attachedFiles.find(x => x.id === this.value.fileId);
-
-		if (typeof this.image === "undefined") {
-			this.image = this.value;
-		}
 	}
 });
 </script>

--- a/src/client/pages/page-editor/page-editor.vue
+++ b/src/client/pages/page-editor/page-editor.vue
@@ -102,6 +102,7 @@ import { blockDefs } from '../../scripts/aiscript/index';
 import { ASTypeChecker } from '../../scripts/aiscript/type-checker';
 import { url } from '../../config';
 import { collectPageVars } from '../../scripts/collect-page-vars';
+import { selectDriveFile } from '../../scripts/select-drive-file';
 
 export default Vue.extend({
 	i18n,
@@ -405,9 +406,7 @@ export default Vue.extend({
 		},
 
 		setEyeCatchingImage() {
-			this.$chooseDriveFile({
-				multiple: false
-			}).then(file => {
+			selectDriveFile(this.$root, false).then(file => {
 				this.eyeCatchingImageId = file.id;
 			});
 		},

--- a/src/client/pages/page.vue
+++ b/src/client/pages/page.vue
@@ -5,7 +5,7 @@
 
 	<div class="_card" v-if="page" :key="page.id">
 		<div class="_title">{{ page.title }}</div>
-		<img class="_header_image" :src="page.eyeCatchingImage.url" v-if="page.eyeCatchingImageId" />
+		<img class="header" :src="page.eyeCatchingImage.url" v-if="page.eyeCatchingImageId" />
 		<div class="_content">
 			<x-page :page="page"/>
 		</div>
@@ -116,8 +116,7 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .xcukqgmh {
-
-	._header_image {
+	> ._card > .header {
 		max-width: 100%;
 	}
 }

--- a/src/client/pages/page.vue
+++ b/src/client/pages/page.vue
@@ -5,7 +5,7 @@
 
 	<div class="_card" v-if="page" :key="page.id">
 		<div class="_title">{{ page.title }}</div>
-		<x-image :value="page.eyeCatchingImage" :key="page.eyeCatchingImage.fileId" :page="page" v-if="page.eyeCatchingImageId" />
+		<img src="page.eyeCatchingImage.url" v-if="page.eyeCatchingImageId" />
 		<div class="_content">
 			<x-page :page="page"/>
 		</div>
@@ -32,12 +32,10 @@ import Vue from 'vue';
 import { faHeart as faHeartS } from '@fortawesome/free-solid-svg-icons';
 import { faHeart as faHeartR } from '@fortawesome/free-regular-svg-icons';
 import XPage from '../components/page/page.vue';
-import XImage from '../components/page/page.image.vue';
 
 export default Vue.extend({
 	components: {
-		XPage,
-		XImage
+		XPage
 	},
 
 	props: {

--- a/src/client/pages/page.vue
+++ b/src/client/pages/page.vue
@@ -5,7 +5,7 @@
 
 	<div class="_card" v-if="page" :key="page.id">
 		<div class="_title">{{ page.title }}</div>
-		<img src="page.eyeCatchingImage.url" v-if="page.eyeCatchingImageId" />
+		<img class="_header_image" :src="page.eyeCatchingImage.url" v-if="page.eyeCatchingImageId" />
 		<div class="_content">
 			<x-page :page="page"/>
 		</div>
@@ -117,5 +117,8 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .xcukqgmh {
 
+	._header_image {
+		max-width: 100%;
+	}
 }
 </style>

--- a/src/client/pages/page.vue
+++ b/src/client/pages/page.vue
@@ -5,6 +5,7 @@
 
 	<div class="_card" v-if="page" :key="page.id">
 		<div class="_title">{{ page.title }}</div>
+		<x-image :value="page.eyeCatchingImage" :key="page.eyeCatchingImage.fileId" :page="page" v-if="page.eyeCatchingImageId" />
 		<div class="_content">
 			<x-page :page="page"/>
 		</div>
@@ -31,10 +32,12 @@ import Vue from 'vue';
 import { faHeart as faHeartS } from '@fortawesome/free-solid-svg-icons';
 import { faHeart as faHeartR } from '@fortawesome/free-regular-svg-icons';
 import XPage from '../components/page/page.vue';
+import XImage from '../components/page/page.image.vue';
 
 export default Vue.extend({
 	components: {
-		XPage
+		XPage,
+		XImage
 	},
 
 	props: {


### PR DESCRIPTION
## Summary

 - Add header image to Page
 - Show it on Page view
 - Show correctly it on Page list view
 - On the Page list view, pages have a light border
   to make it easier to see an image belongs to a page

Fix #6185 