### PR TITLE
APIリファレンスでレスポンスのスキーマを見るのにいちいち2回クリックさせられるのを修正

### DIFF
--- a/src/client/assets/redoc.html
+++ b/src/client/assets/redoc.html
@@ -18,7 +18,7 @@
 		</style>
 	</head>
 	<body>
-		<redoc spec-url='/api.json'></redoc>
+		<redoc spec-url="/api.json" expand-responses="200" expand-single-schema-field="true"></redoc>
 		<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 	</body>
 </html>


### PR DESCRIPTION
## Summary
APIリファレンスでレスポンスのスキーマを見るのにいちいち2回クリックさせられるし、レスポンスの部分がクリックできることに気づかないと（特に2階層目以下のクリック箇所はかなり見つけづらい）右側に表示されているろくに使えないサンプルしか見えずに使えないドキュメントに見えたりするのを修正。

レスポンススキーマを最初から展開しておくようにしています。
遅くなるって書いてありましたが元々遅いので変わりませんでした。
![image](https://user-images.githubusercontent.com/30769358/78303165-1f01ef80-7577-11ea-8d97-ee44a3f7f63c.png)
