### PR TITLE
APIリファレンスのカテゴリ処理の修正

### DIFF
--- a/src/server/api/endpoints/admin/get-table-stats.ts
+++ b/src/server/api/endpoints/admin/get-table-stats.ts
@@ -9,7 +9,7 @@ export const meta = {
 		'en-US': 'Get table stats'
 	},
 
-	tags: ['meta'],
+	tags: ['admin'],
 
 	params: {
 	},

--- a/src/server/api/endpoints/admin/promo/create.ts
+++ b/src/server/api/endpoints/admin/promo/create.ts
@@ -6,6 +6,8 @@ import { getNote } from '../../../common/getters';
 import { PromoNotes } from '../../../../../models';
 
 export const meta = {
+	tags: ['admin'],
+
 	requireCredential: true as const,
 	requireModerator: true,
 

--- a/src/server/api/endpoints/admin/server-info.ts
+++ b/src/server/api/endpoints/admin/server-info.ts
@@ -11,7 +11,7 @@ export const meta = {
 	desc: {
 	},
 
-	tags: ['meta'],
+	tags: ['admin', 'meta'],
 
 	params: {
 	},

--- a/src/server/api/endpoints/announcements.ts
+++ b/src/server/api/endpoints/announcements.ts
@@ -5,6 +5,8 @@ import { Announcements, AnnouncementReads } from '../../../models';
 import { makePaginationQuery } from '../common/make-pagination-query';
 
 export const meta = {
+	tags: ['meta'],
+
 	requireCredential: false as const,
 
 	params: {

--- a/src/server/api/endpoints/antennas/notes.ts
+++ b/src/server/api/endpoints/antennas/notes.ts
@@ -8,7 +8,7 @@ import { generateMuteQuery } from '../../common/generate-mute-query';
 import { ApiError } from '../../error';
 
 export const meta = {
-	tags: ['account', 'notes', 'antennas'],
+	tags: ['antennas', 'account', 'notes'],
 
 	requireCredential: true as const,
 

--- a/src/server/api/endpoints/blocking/create.ts
+++ b/src/server/api/endpoints/blocking/create.ts
@@ -13,7 +13,7 @@ export const meta = {
 		'en-US': 'Block a user.'
 	},
 
-	tags: ['blocking', 'users'],
+	tags: ['account'],
 
 	limit: {
 		duration: ms('1hour'),

--- a/src/server/api/endpoints/blocking/delete.ts
+++ b/src/server/api/endpoints/blocking/delete.ts
@@ -13,7 +13,7 @@ export const meta = {
 		'en-US': 'Unblock a user.'
 	},
 
-	tags: ['blocking', 'users'],
+	tags: ['account'],
 
 	limit: {
 		duration: ms('1hour'),

--- a/src/server/api/endpoints/blocking/list.ts
+++ b/src/server/api/endpoints/blocking/list.ts
@@ -10,7 +10,7 @@ export const meta = {
 		'en-US': 'Get blocking users.'
 	},
 
-	tags: ['blocking', 'account'],
+	tags: ['account'],
 
 	requireCredential: true as const,
 

--- a/src/server/api/endpoints/federation/followers.ts
+++ b/src/server/api/endpoints/federation/followers.ts
@@ -5,7 +5,7 @@ import { Followings } from '../../../../models';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 
 export const meta = {
-	tags: ['users'],
+	tags: ['federation'],
 
 	requireCredential: false as const,
 

--- a/src/server/api/endpoints/federation/following.ts
+++ b/src/server/api/endpoints/federation/following.ts
@@ -5,7 +5,7 @@ import { Followings } from '../../../../models';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 
 export const meta = {
-	tags: ['users'],
+	tags: ['federation'],
 
 	requireCredential: false as const,
 

--- a/src/server/api/endpoints/federation/users.ts
+++ b/src/server/api/endpoints/federation/users.ts
@@ -5,7 +5,7 @@ import { Users } from '../../../../models';
 import { makePaginationQuery } from '../../common/make-pagination-query';
 
 export const meta = {
-	tags: ['users'],
+	tags: ['federation'],
 
 	requireCredential: false as const,
 

--- a/src/server/api/endpoints/mute/create.ts
+++ b/src/server/api/endpoints/mute/create.ts
@@ -13,7 +13,7 @@ export const meta = {
 		'en-US': 'Mute a user'
 	},
 
-	tags: ['mute', 'users'],
+	tags: ['account'],
 
 	requireCredential: true as const,
 

--- a/src/server/api/endpoints/mute/delete.ts
+++ b/src/server/api/endpoints/mute/delete.ts
@@ -11,7 +11,7 @@ export const meta = {
 		'en-US': 'Unmute a user'
 	},
 
-	tags: ['mute', 'users'],
+	tags: ['account'],
 
 	requireCredential: true as const,
 

--- a/src/server/api/endpoints/mute/list.ts
+++ b/src/server/api/endpoints/mute/list.ts
@@ -10,7 +10,7 @@ export const meta = {
 		'en-US': 'Get muted users.'
 	},
 
-	tags: ['mute', 'account'],
+	tags: ['account'],
 
 	requireCredential: true as const,
 

--- a/src/server/api/endpoints/room/update.ts
+++ b/src/server/api/endpoints/room/update.ts
@@ -4,6 +4,8 @@ import define from '../../define';
 import { Users, UserProfiles } from '../../../../models';
 
 export const meta = {
+	tags: ['room'],
+
 	requireCredential: true as const,
 
 	params: {

--- a/src/server/api/openapi/gen-spec.ts
+++ b/src/server/api/openapi/gen-spec.ts
@@ -123,7 +123,7 @@ export function genOpenapiSpec(lang = 'ja-JP') {
 				url: `https://github.com/syuilo/misskey/blob/develop/src/server/api/endpoints/${endpoint.name}.ts`
 			},
 			...(endpoint.meta.tags ? {
-				tags: endpoint.meta.tags
+				tags: [endpoint.meta.tags[0]]
 			} : {}),
 			...(endpoint.meta.requireCredential ? {
 				security: [{


### PR DESCRIPTION
## Summary
検索でダブって出てくるのを修正
![image](https://user-images.githubusercontent.com/30769358/78308241-f1bb3e80-7582-11ea-813c-041ced44fd75.png)
複数のカテゴリに存在するエンドポイントのリンクをクリックすると、別のカテゴリのツリーの同名のツリーにワープするのを修正
chartsが他のカテゴリにも表示されて邪魔くさいのを修正
これら、複数のタグを与えるとこうなるみたいなので、最初のタグのみ与えるようにしています。（タグの順番も調整しています）

未分類のカテゴリ, 全体から見ると変なカテゴリ, 冗長なカテゴリを修正

なお、読み込み速度が2, 3割速くなった気がします Related #6215
