### PR TITLE
Fix url type of AP object #6231

### DIFF
--- a/src/remote/activitypub/models/note.ts
+++ b/src/remote/activitypub/models/note.ts
@@ -17,7 +17,7 @@ import { deliverQuestionUpdate } from '../../../services/note/polls/update';
 import { extractDbHost, toPuny } from '../../../misc/convert-host';
 import { Notes, Emojis, Polls, MessagingMessages } from '../../../models';
 import { Note } from '../../../models/entities/note';
-import { IObject, getOneApId, getApId, validPost, IPost, isEmoji } from '../type';
+import { IObject, getOneApId, getApId, getOneApHrefNullable, validPost, IPost, isEmoji } from '../type';
 import { Emoji } from '../../../models/entities/emoji';
 import { genId } from '../../../misc/gen-id';
 import { fetchMeta } from '../../../misc/fetch-meta';
@@ -282,7 +282,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 		apEmojis,
 		poll,
 		uri: note.id,
-		url: note.url,
+		url: getOneApHrefNullable(note.url),
 	}, silent);
 }
 

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -3,7 +3,7 @@ import * as promiseLimit from 'promise-limit';
 import config from '../../../config';
 import Resolver from '../resolver';
 import { resolveImage } from './image';
-import { isCollectionOrOrderedCollection, isCollection, IPerson, getApId, IObject, isPropertyValue, IApPropertyValue } from '../type';
+import { isCollectionOrOrderedCollection, isCollection, IPerson, getApId, getOneApHrefNullable, IObject, isPropertyValue, IApPropertyValue } from '../type';
 import { fromHtml } from '../../../mfm/fromHtml';
 import { htmlToMfm } from '../misc/html-to-mfm';
 import { resolveNote, extractEmojis } from './note';
@@ -166,7 +166,7 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 			await transactionalEntityManager.save(new UserProfile({
 				userId: user.id,
 				description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
-				url: person.url,
+				url: getOneApHrefNullable(person.url),
 				fields,
 				userHost: host
 			}));
@@ -353,7 +353,7 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 	});
 
 	await UserProfiles.update({ userId: exist.id }, {
-		url: person.url,
+		url: getOneApHrefNullable(person.url),
 		fields,
 		description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
 	});

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -19,7 +19,7 @@ export interface IObject {
 	endTime?: Date;
 	icon?: any;
 	image?: any;
-	url?: string;
+	url?: ApObject;
 	href?: string;
 	tag?: IObject | IObject[];
 	sensitive?: boolean;
@@ -49,6 +49,17 @@ export function getApId(value: string | IObject): string {
 	if (typeof value === 'string') return value;
 	if (typeof value.id === 'string') return value.id;
 	throw new Error(`cannot detemine id`);
+}
+
+export function getOneApHrefNullable(value: ApObject | undefined): string | undefined {
+	const firstOne = Array.isArray(value) ? value[0] : value;
+	return getApHrefNullable(firstOne);
+}
+
+export function getApHrefNullable(value: string | IObject | undefined): string | undefined {
+	if (typeof value === 'string') return value;
+	if (typeof value?.href === 'string') return value.href;
+	return undefined;
 }
 
 export interface IActivity extends IObject {


### PR DESCRIPTION
## Summary
Related #6231

AP url で Arrayとかを想定
`url`: `string | undefined` => `IObject | string | (IObject | string)[] | undefined`

ArrayはDBに入れる場所がないので最初のだけ格納してます