### PR TITLE
同じリアクション削除を同時に行うとリアクションカウントがおかしくなることがあるのを修正

### DIFF
--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -23,7 +23,7 @@ export default async (user: User, note: Note) => {
 	const result = await NoteReactions.delete(exist.id);
 
 	if (result.affected !== 1) {
-		throw `delete failed`;
+		throw 'delete failed';
 	}
 
 	// Decrement reactions count

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -20,7 +20,11 @@ export default async (user: User, note: Note) => {
 	}
 
 	// Delete reaction
-	await NoteReactions.delete(exist.id);
+	const result = await NoteReactions.delete(exist.id);
+
+	if (result.affected !== 1) {
+		throw `delete failed`;
+	}
 
 	// Decrement reactions count
 	const sql = `jsonb_set("reactions", '{${exist.reaction}}', (COALESCE("reactions"->>'${exist.reaction}', '0')::int - 1)::text::jsonb)`;

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -23,7 +23,7 @@ export default async (user: User, note: Note) => {
 	const result = await NoteReactions.delete(exist.id);
 
 	if (result.affected !== 1) {
-		throw 'delete failed';
+		throw new IdentifiableError('60527ec9-b4cb-4a88-a6bd-32d3ad26817d', 'not reacted');
 	}
 
 	// Decrement reactions count


### PR DESCRIPTION
## Summary
Fix #6252
Fix #6224

リアクションを連打すると他人のリアクションが消える (というかカウントがおかしくなる) ことがあるのを修正