### PR TITLE
タイムラインが複数存在するときにリアクションカウント等がおかしくなるのを修正

### DIFF
--- a/src/client/components/timeline.vue
+++ b/src/client/components/timeline.vue
@@ -50,7 +50,8 @@ export default Vue.extend({
 		});
 
 		const prepend = note => {
-			(this.$refs.tl as any).prepend(note);
+			const _note = JSON.parse(JSON.stringify(note));	// deepcopy
+			(this.$refs.tl as any).prepend(_note);
 
 			if (this.sound) {
 				this.$root.sound(note.userId === this.$store.state.i.id ? 'noteMy' : 'note');


### PR DESCRIPTION
## Summary
Fix #6080

同種タイムラインが複数存在するときに、リアクションや投票のカウントがおかしくなるのを修正。
TLにNoteを追加する時にdeepcopyするように。