### PR TITLE
brotli圧縮の無効化など Resolve #6325

### DIFF
--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -53,6 +53,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Accept-Encoding "";
         proxy_http_version 1.1;
         proxy_redirect off;
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,7 +10,7 @@ import * as zlib from 'zlib';
 import * as Koa from 'koa';
 import * as Router from '@koa/router';
 import * as mount from 'koa-mount';
-import * as compress from 'koa-compress';
+const compress = require('koa-compress');
 import * as koaLogger from 'koa-logger';
 import * as requestStats from 'request-stats';
 import * as slow from 'koa-slow';
@@ -50,7 +50,8 @@ if (!['production', 'test'].includes(process.env.NODE_ENV || '')) {
 
 // Compress response
 app.use(compress({
-	flush: zlib.constants.Z_SYNC_FLUSH
+	flush: zlib.constants.Z_SYNC_FLUSH,
+	br: false
 }));
 
 // HSTS


### PR DESCRIPTION
## Summary
Fix #6325

挙動があやしいのでbrotliを無効に

nginxとapp間では圧縮をしないように
appで圧縮しなくてもたぶんnginxでしてくれるし
`ブラウザ <=圧縮= CDN <=非圧縮= nginx <=圧縮= Node` みたいになったりして無駄なので
