### PR TITLE
リモートからの通報の受信に対応

### DIFF
--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -289,7 +289,7 @@ export class UserRepository extends Repository<User> {
 
 	//#region Validators
 	public validateLocalUsername = $.str.match(/^\w{1,20}$/);
-	public validateRemoteUsername = $.str.match(/^\w([\w-]*\w)?$/);
+	public validateRemoteUsername = $.str.match(/^\w([\w-.]*\w)?$/);
 	public validatePassword = $.str.min(1);
 	public validateName = $.str.min(1).max(50);
 	public validateDescription = $.str.min(1).max(500);

--- a/src/remote/activitypub/kernel/flag/index.ts
+++ b/src/remote/activitypub/kernel/flag/index.ts
@@ -1,0 +1,28 @@
+import { IRemoteUser } from '../../../../models/entities/user';
+import config from '../../../../config';
+import { IFlag, getApIds } from '../../type';
+import { AbuseUserReports, Users } from '../../../../models';
+import { In } from 'typeorm';
+import { genId } from '../../../../misc/gen-id';
+
+export default async (actor: IRemoteUser, activity: IFlag): Promise<string> => {
+	// objectは `(User|Note) | (User|Note)[]` だけど、全パターンDBスキーマと対応させられないので
+	// 対象ユーザーは一番最初のユーザー として あとはコメントとして格納する
+	const uris = getApIds(activity.object);
+
+	const userIds = uris.filter(uri => uri.startsWith(config.url + '/users/')).map(uri => uri.split('/').pop());
+	const users = await Users.find({
+		id: In(userIds)
+	});
+	if (users.length < 1) return `skip`;
+
+	await AbuseUserReports.insert({
+		id: genId(),
+		createdAt: new Date(),
+		userId: users[0].id,
+		reporterId: actor.id,
+		comment: `${activity.content}\n${JSON.stringify(uris, null, 2)}`
+	});
+
+	return `ok`;
+};

--- a/src/remote/activitypub/kernel/index.ts
+++ b/src/remote/activitypub/kernel/index.ts
@@ -1,4 +1,4 @@
-import { IObject, isCreate, isDelete, isUpdate, isRead, isFollow, isAccept, isReject, isAdd, isRemove, isAnnounce, isLike, isUndo, isBlock, isCollectionOrOrderedCollection, isCollection } from '../type';
+import { IObject, isCreate, isDelete, isUpdate, isRead, isFollow, isAccept, isReject, isAdd, isRemove, isAnnounce, isLike, isUndo, isBlock, isCollectionOrOrderedCollection, isCollection, isFlag } from '../type';
 import { IRemoteUser } from '../../../models/entities/user';
 import create from './create';
 import performDeleteActivity from './delete';
@@ -13,6 +13,7 @@ import reject from './reject';
 import add from './add';
 import remove from './remove';
 import block from './block';
+import flag from './flag';
 import { apLogger } from '../logger';
 import Resolver from '../resolver';
 import { toArray } from '../../../prelude/array';
@@ -62,6 +63,8 @@ async function performOneActivity(actor: IRemoteUser, activity: IObject): Promis
 		await undo(actor, activity);
 	} else if (isBlock(activity)) {
 		await block(actor, activity);
+	} else if (isFlag(activity)) {
+		await flag(actor, activity);
 	} else {
 		apLogger.warn(`unknown activity type: ${(activity as any).type}`);
 	}

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -111,10 +111,10 @@ interface IQuestionChoice {
 	_misskey_votes?: number;
 }
 
-export const validActor = ['Person', 'Service', 'Group', 'Organization'];
+export const validActor = ['Person', 'Service', 'Group', 'Organization', 'Application'];
 
 export interface IPerson extends IObject {
-	type: 'Person';
+	type: 'Person' | 'Service' | 'Organization' | 'Group' | 'Application';
 	name?: string;
 	preferredUsername?: string;
 	manuallyApprovesFollowers?: boolean;
@@ -234,6 +234,10 @@ export interface IBlock extends IActivity {
 	type: 'Block';
 }
 
+export interface IFlag extends IActivity {
+	type: 'Flag';
+}
+
 export const isCreate = (object: IObject): object is ICreate => object.type === 'Create';
 export const isDelete = (object: IObject): object is IDelete => object.type === 'Delete';
 export const isUpdate = (object: IObject): object is IUpdate => object.type === 'Update';
@@ -247,3 +251,4 @@ export const isRemove = (object: IObject): object is IRemove => object.type === 
 export const isLike = (object: IObject): object is ILike => object.type === 'Like' || object.type === 'EmojiReaction' || object.type === 'EmojiReact';
 export const isAnnounce = (object: IObject): object is IAnnounce => object.type === 'Announce';
 export const isBlock = (object: IObject): object is IBlock => object.type === 'Block';
+export const isFlag = (object: IObject): object is IFlag => object.type === 'Flag';


### PR DESCRIPTION
## Summary
- Flag (通報) の受信に対応
- Actor type=Applicationや`.`付きのリモートユーザー名に対応
  「Actor typeやユーザー名が何だから特別なユーザー」とも言い切れないので特別なフラグ等は立てない。
  ローカルの`.`付きユーザーはそのうち特殊ユーザー扱いにして使用するかも。

なお、Mastodonなどから飛んでくるFlagは以下の用な感じ

Activity
```
"type": "Flag",
"actor": "https://example.com/actor",
"content": "あ",
"object": [
  "https://example.net/users/x",
  "https://example.net/notes/y",
  "https://example.net/notes/z"
]
```

Actor (`@example.com@example.com`)
```
"type": "Application",
"preferredUsername": "example.com",
```