### PR TITLE
Cache extra AP objects

### DIFF
--- a/src/server/activitypub/featured.ts
+++ b/src/server/activitypub/featured.ts
@@ -37,6 +37,6 @@ export default async (ctx: Router.RouterContext) => {
 	);
 
 	ctx.body = renderActivity(rendered);
-	ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
+	ctx.set('Cache-Control', 'public, max-age=180');
 	setResponseType(ctx);
 };

--- a/src/server/activitypub/followers.ts
+++ b/src/server/activitypub/followers.ts
@@ -82,7 +82,7 @@ export default async (ctx: Router.RouterContext) => {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followersCount, `${partOf}?page=true`);
 		ctx.body = renderActivity(rendered);
-		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
+		ctx.set('Cache-Control', 'public, max-age=180');
 		setResponseType(ctx);
 	}
 };

--- a/src/server/activitypub/following.ts
+++ b/src/server/activitypub/following.ts
@@ -83,7 +83,7 @@ export default async (ctx: Router.RouterContext) => {
 		// index page
 		const rendered = renderOrderedCollection(partOf, user.followingCount, `${partOf}?page=true`);
 		ctx.body = renderActivity(rendered);
-		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
+		ctx.set('Cache-Control', 'public, max-age=180');
 		setResponseType(ctx);
 	}
 };

--- a/src/server/activitypub/outbox.ts
+++ b/src/server/activitypub/outbox.ts
@@ -82,7 +82,6 @@ export default async (ctx: Router.RouterContext) => {
 		);
 
 		ctx.body = renderActivity(rendered);
-		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
 		setResponseType(ctx);
 	} else {
 		// index page
@@ -91,7 +90,7 @@ export default async (ctx: Router.RouterContext) => {
 			`${partOf}?page=true&since_id=000000000000000000000000`
 		);
 		ctx.body = renderActivity(rendered);
-		ctx.set('Cache-Control', 'private, max-age=0, must-revalidate');
+		ctx.set('Cache-Control', 'public, max-age=180');
 		setResponseType(ctx);
 	}
 };

--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -81,6 +81,7 @@ router.get(nodeinfo2_1path, async ctx => {
 	const base = await nodeinfo2();
 
 	ctx.body = { version: '2.1', ...base };
+	ctx.set('Cache-Control', 'public, max-age=600');
 });
 
 router.get(nodeinfo2_0path, async ctx => {
@@ -89,6 +90,7 @@ router.get(nodeinfo2_0path, async ctx => {
 	delete base.software.repository;
 
 	ctx.body = { version: '2.0', ...base };
+	ctx.set('Cache-Control', 'public, max-age=600');
 });
 
 export default router;


### PR DESCRIPTION
## Summary
Resolve #6348

追加のAPオブジェクトをキャッシュ出来るように
outbox等のindex以外のページには来ないので特にキャッシュなし
nodeinfoのキャッシュ指定も追加 (今無効にしているけど、統計はちょっと重いので長めに)