### PR TITLE
Use owner key in relay HTTP-Signature

### DIFF
--- a/src/services/relay.ts
+++ b/src/services/relay.ts
@@ -83,14 +83,12 @@ export async function deliverToRelays(user: ILocalUser, activity: any) {
 	});
 	if (relays.length === 0) return;
 
-	const relayActor = await getRelayActor();
-
 	const copy = JSON.parse(JSON.stringify(activity));
 	if (!copy.to) copy.to = ['https://www.w3.org/ns/activitystreams#Public'];
 
 	const signed = await attachLdSignature(copy, user);
 
 	for (const relay of relays) {
-		deliver(relayActor, signed, relay.inbox);
+		deliver(user, signed, relay.inbox);
 	}
 }


### PR DESCRIPTION
## Summary
Resolve #6354

リレー配信時の署名者が現在の方法だと一部の実装でうまくいかないみたいなので、Mastodonに寄せてます。

Current Misskey
```
HTTP-Signature signer: relay.actor
LD-Signature signer: Note's owner
```

Mastodon
```
HTTP-Signature signer: Note's owner
LD-Signature signer: Note's owner
```