### PR TITLE
Fix CASCADE-related problems

### DIFF
--- a/src/services/drive/delete-file.ts
+++ b/src/services/drive/delete-file.ts
@@ -13,6 +13,7 @@ import renderTombstone from '../../remote/activitypub/renderer/tombstone';
 import config from '../../config';
 import { deliverToFollowers } from '../../remote/activitypub/deliver-manager';
 import { Brackets } from 'typeorm';
+import { deliverToRelays } from '../relay';
 
 export async function deleteFile(file: DriveFile, isExpired = false) {
 	if (file.storedInternal) {
@@ -96,11 +97,13 @@ async function postProcess(file: DriveFile, isExpired = false) {
 				if (!Users.isLocalUser(cascadingNote.user)) continue;
 				const content = renderActivity(renderDelete(renderTombstone(`${config.url}/notes/${cascadingNote.id}`), cascadingNote.user));
 				deliverToFollowers(cascadingNote.user, content); // federate delete msg
+				deliverToRelays(cascadingNote.user, content);
 			}
 			if (!relatedNote.user) continue;
 			if (Users.isLocalUser(relatedNote.user)) {
 				const content = renderActivity(renderDelete(renderTombstone(`${config.url}/notes/${relatedNote.id}`), relatedNote.user));
 				deliverToFollowers(relatedNote.user, content);
+				deliverToRelays(relatedNote.user, content);
 			}
 		}
 		Notes.createQueryBuilder().delete()

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -13,6 +13,7 @@ import { notesChart, perUserNotesChart, instanceChart } from '../chart';
 import { deliverToFollowers } from '../../remote/activitypub/deliver-manager';
 import { countSameRenotes } from '../../misc/count-same-renotes';
 import { deliverToRelays } from '../relay';
+import { Brackets } from 'typeorm';
 
 /**
  * 投稿を削除します。
@@ -86,6 +87,10 @@ async function findCascadingNotes(note: Note) {
 	const recursive = async (noteId: string) => {
 		const query = Notes.createQueryBuilder('note')
 			.where('note.replyId = :noteId', { noteId })
+			.orWhere(new Brackets(q => {
+				q.where('note.renoteId = :noteId', { noteId })
+				.andWhere('note.text IS NOT NULL');
+			}))
 			.leftJoinAndSelect('note.user', 'user');
 		const replies = await query.getMany();
 		for (const reply of replies) {

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -60,6 +60,7 @@ export default async function(user: User, note: Note, quiet = false) {
 			if (!Users.isLocalUser(cascadingNote.user)) continue;
 			const content = renderActivity(renderDelete(renderTombstone(`${config.url}/notes/${cascadingNote.id}`), cascadingNote.user));
 			deliverToFollowers(cascadingNote.user, content);
+			deliverToRelays(cascadingNote.user, content);
 		}
 		//#endregion
 


### PR DESCRIPTION
## Summary
This PR fixes two problems:
1. Quoted renote deletions not being federated to remote servers when CASCADE is invoked. 
2. CASCADE-invoked deletions not being federated to relays.
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
