### PR TITLE
Drop support for Node v11, v13

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [11.10.x, 12.x, 13.x, 14.x]
+        node-version: [12.x, 14.x]
 
     services:
       postgres:

--- a/docs/setup.en.md
+++ b/docs/setup.en.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Please install and setup these softwares:
 
 #### Dependencies :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.10.1
-* **[PostgreSQL](https://www.postgresql.org/)** >= 10
+* **[Node.js](https://nodejs.org/en/)** (12.x, 14.x)
+* **[PostgreSQL](https://www.postgresql.org/)** (>= 10)
 * **[Redis](https://redis.io/)**
 
 ##### Optional

--- a/docs/setup.fr.md
+++ b/docs/setup.fr.md
@@ -22,8 +22,8 @@ adduser --disabled-password --disabled-login misskey
 Installez les paquets suivants :
 
 #### Dépendences :package:
-* **[Node.js](https://nodejs.org/en/)** >= 11.10.1
-* **[PostgreSQL](https://www.postgresql.org/)** >= 10
+* **[Node.js](https://nodejs.org/en/)** (12.x, 14.x)
+* **[PostgreSQL](https://www.postgresql.org/)** (>= 10)
 * **[Redis](https://redis.io/)**
 
 ##### Optionnels

--- a/docs/setup.ja.md
+++ b/docs/setup.ja.md
@@ -22,7 +22,7 @@ adduser --disabled-password --disabled-login misskey
 これらのソフトウェアをインストール・設定してください:
 
 #### 依存関係 :package:
-* **[Node.js](https://nodejs.org/en/)** (11.10.1以上)
+* **[Node.js](https://nodejs.org/en/)** (12.x, 14.x)
 * **[PostgreSQL](https://www.postgresql.org/)** (10以上)
 * **[Redis](https://redis.io/)**
 


### PR DESCRIPTION
## Summary
Node v11, v13をドキュメントとCIから削除
ドキュメントの推奨バージョンは、動くLTSバージョンのみを表記するように。

Node v11 => 既にEOL
Node v13 => 今月でEOL
https://nodejs.org/en/about/releases/

`@typescript-eslint/parser`は3.0.0からNode v11はサポート外

https://github.com/syuilo/misskey/pull/6401 `Object.fromEntries()`使いたい

などのため