### PR TITLE
[MiAuth]認証できない問題の解消

### DIFF
--- a/src/server/api/authenticate.ts
+++ b/src/server/api/authenticate.ts
@@ -21,7 +21,7 @@ export default async (token: string): Promise<[User | null | undefined, AccessTo
 		return [user, null];
 	} else {
 		const accessToken = await AccessTokens.findOne({
-			hash: token.toLowerCase()
+			hash: token
 		});
 
 		if (accessToken == null) {


### PR DESCRIPTION
## Summary

Resolve #6419 

`toLowerCase`を削除したら動作したので、おそらくこれでMiAuthが使用できるはずです。
