### PR TITLE
Update english nyaize

### DIFF
--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -3,9 +3,9 @@ export function nyaize(text: string): string {
 		// ja-JP
 		.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
 		// en-US
-		.replace(/Na/g, 'Nya').replace(/na/g, 'nya')
-		.replace(/Morning/g, 'Mornyan').replace(/morning/g, 'mornyan')
-		.replace(/Everyone/g, 'Everynyan').replace(/everyone/g, 'everynyan')
+		.replace(/(?<=n)a/gi, x => x === 'A' ? 'YA' : 'ya')
+		.replace(/(?<=morn)ing/gi, x => x === 'ING' ? 'YAN' : 'yan')
+		.replace(/(?<=every)one/gi, x => x === 'ONE' ? 'NYAN' : 'nyan')
 		// ko-KR
 		.replace(/[나-낳]/g, match => String.fromCharCode(
 			match.charCodeAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)

--- a/src/misc/nyaize.ts
+++ b/src/misc/nyaize.ts
@@ -3,7 +3,9 @@ export function nyaize(text: string): string {
 		// ja-JP
 		.replace(/な/g, 'にゃ').replace(/ナ/g, 'ニャ').replace(/ﾅ/g, 'ﾆｬ')
 		// en-US
-		.replace(/morning/gi, 'mornyan').replace(/everyone/gi, 'everynyan')
+		.replace(/Na/g, 'Nya').replace(/na/g, 'nya')
+		.replace(/Morning/g, 'Mornyan').replace(/morning/g, 'mornyan')
+		.replace(/Everyone/g, 'Everynyan').replace(/everyone/g, 'everynyan')
 		// ko-KR
 		.replace(/[나-낳]/g, match => String.fromCharCode(
 			match.charCodeAt(0)! + '냐'.charCodeAt(0) - '나'.charCodeAt(0)


### PR DESCRIPTION
## Summary

日本語の語句がしりません、ですから英語でかいます、すみません。

I've updated the english nyaize functionality. I had some other ideas, but decided to only implement the "na" to "nya" parts. The RegEx case insensitive flag ``i`` does not work here because it would replace e.g. "Naturally" with "nyaturally", which would be incorrect. Therefore two separate replacements have been implemented.

In addition, I fixed the existing replacements. For example, "Morning everyone!" was replaced with "mornyan everynyan!" when it should have been "Mornyan everynyan!" (see above problem).
