### PR TITLE
プロフィールの「場所」「誕生日」を連合するように Resove #6461

### DIFF
--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -170,8 +170,8 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 				description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
 				url: getOneApHrefNullable(person.url),
 				fields,
-				birthday: bday ? bday[0] : undefined,
-				location: person['vcard:Address'] || undefined,
+				birthday: bday ? bday[0] : null,
+				location: person['vcard:Address'] || null,
 				userHost: host
 			}));
 
@@ -362,8 +362,8 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 		url: getOneApHrefNullable(person.url),
 		fields,
 		description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
-		birthday: bday ? bday[0] : undefined,
-		location: person['vcard:Address'] || undefined,
+		birthday: bday ? bday[0] : null,
+		location: person['vcard:Address'] || null,
 	});
 
 	// ハッシュタグ更新

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -138,6 +138,8 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 
 	const isBot = object.type === 'Service';
 
+	const bday = person['vcard:bday']?.match(/^\d{4}-\d{2}-\d{2}/);
+
 	// Create user
 	let user: IRemoteUser;
 	try {
@@ -168,6 +170,8 @@ export async function createPerson(uri: string, resolver?: Resolver): Promise<Us
 				description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
 				url: getOneApHrefNullable(person.url),
 				fields,
+				birthday: bday ? bday[0] : undefined,
+				location: person['vcard:Address'] || undefined,
 				userHost: host
 			}));
 
@@ -319,6 +323,8 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 
 	const tags = extractApHashtags(person.tag).map(tag => tag.toLowerCase()).splice(0, 32);
 
+	const bday = person['vcard:bday']?.match(/^\d{4}-\d{2}-\d{2}/);
+
 	const updates = {
 		lastFetchedAt: new Date(),
 		inbox: person.inbox,
@@ -356,6 +362,8 @@ export async function updatePerson(uri: string, resolver?: Resolver | null, hint
 		url: getOneApHrefNullable(person.url),
 		fields,
 		description: person.summary ? htmlToMfm(person.summary, person.tag) : null,
+		birthday: bday ? bday[0] : undefined,
+		location: person['vcard:Address'] || undefined,
 	});
 
 	// ハッシュタグ更新

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -49,6 +49,8 @@ export const attachLdSignature = async (activity: any, user: ILocalUser): Promis
 		'_misskey_reaction': 'misskey:_misskey_reaction',
 		'_misskey_votes': 'misskey:_misskey_votes',
 		'_misskey_talk': 'misskey:_misskey_talk',
+		// vcard
+		vcard: 'http://www.w3.org/2006/vcard/ns#',
 	};
 
 	activity['@context'].push(obj);

--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -49,6 +49,7 @@ export const attachLdSignature = async (activity: any, user: ILocalUser): Promis
 		'_misskey_reaction': 'misskey:_misskey_reaction',
 		'_misskey_votes': 'misskey:_misskey_votes',
 		'_misskey_talk': 'misskey:_misskey_talk',
+		'isCat': 'misskey:isCat',
 		// vcard
 		vcard: 'http://www.w3.org/2006/vcard/ns#',
 	};

--- a/src/remote/activitypub/renderer/person.ts
+++ b/src/remote/activitypub/renderer/person.ts
@@ -52,7 +52,7 @@ export async function renderPerson(user: ILocalUser) {
 
 	const keypair = await UserKeypairs.findOne(user.id).then(ensure);
 
-	return {
+	const person = {
 		type: isSystem ? 'Application' : user.isBot ? 'Service' : 'Person',
 		id,
 		inbox: `${id}/inbox`,
@@ -73,5 +73,15 @@ export async function renderPerson(user: ILocalUser) {
 		publicKey: renderKey(user, keypair, `#main-key`),
 		isCat: user.isCat,
 		attachment: attachment.length ? attachment : undefined
-	};
+	} as any;
+
+	if (profile?.birthday) {
+		person['vcard:bday'] = profile.birthday;
+	}
+
+	if (profile?.location) {
+		person['vcard:Address'] = profile.location;
+	}
+
+	return person;
 }

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -140,6 +140,8 @@ export interface IPerson extends IObject {
 	endpoints?: {
 		sharedInbox?: string;
 	};
+	'vcard:bday'?: string;
+	'vcard:Address'?: string;
 }
 
 export const isCollection = (object: IObject): object is ICollection =>


### PR DESCRIPTION
## Summary
Resove #6461
プロフィールの「場所」「誕生日」を連合するように 
`isCat`がLD-Signatureの対象になってないのを修正
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
