### PR TITLE
AP向けのアンケートのfallbackリンクなどを削除

### DIFF
--- a/src/remote/activitypub/renderer/note.ts
+++ b/src/remote/activitypub/renderer/note.ts
@@ -85,31 +85,15 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 
 	const files = await getPromisedFiles(note.fileIds);
 
-	let text = note.text;
+	const text = note.text;
 	let poll: Poll | undefined;
 
 	if (note.hasPoll) {
 		poll = await Polls.findOne({ noteId: note.id });
 	}
 
-	if (poll) {
-		if (text == null) text = '';
-		const url = `${config.url}/notes/${note.id}`;
-		// TODO: i18n
-		text += `\n[リモートで結果を表示](${url})`;
-	}
-
 	let apText = text;
 	if (apText == null) apText = '';
-
-	// Provides choices as text for AP
-	if (poll) {
-		const cs = poll.choices.map((c, i) => `${i}: ${c}`);
-		apText += '\n----------------------------------------\n';
-		apText += cs.join('\n');
-		apText += '\n----------------------------------------\n';
-		apText += '番号を返信して投票';
-	}
 
 	if (quote) {
 		apText += `\n\nRE: ${quote}`;
@@ -135,7 +119,6 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		content: toHtml(Object.assign({}, note, {
 			text: text
 		})),
-		_misskey_fallback_content: content,
 		[poll.expiresAt && poll.expiresAt < new Date() ? 'closed' : 'endTime']: poll.expiresAt,
 		[poll.multiple ? 'anyOf' : 'oneOf']: poll.choices.map((text, i) => ({
 			type: 'Note',


### PR DESCRIPTION
## Summary
Related #6464

リモートに飛んだアンケートに表示される`リモートで結果を表示`は
アンケートが連合しないときの名残でもういらないと思うので削除。

`番号を返信して投票`, `_misskey_fallback_content`は使ってないので削除
これらは、Questionに対応してないインスタンスのためにNoteでもActivityを送る処理のために使ってた。この処理はもうないし、リモートでも`_misskey_fallback_content`を見る処理はない。
