### PR TITLE
タップ不可能なリアクションを押してもパーティクルが出るバグを修正

### DIFF
--- a/src/client/components/reactions-viewer.reaction.vue
+++ b/src/client/components/reactions-viewer.reaction.vue
@@ -1,7 +1,7 @@
 <template>
 <button
 	class="hkzvhatu _button"
-	:class="{ reacted: note.myReaction == reaction, canToggle }"
+	:class="{ reacted: note.myReaction == reaction, canToggle: canToggle && !isMe }"
 	@click="toggleReaction(reaction)"
 	v-if="count > 0"
 	@touchstart="onMouseover"
@@ -9,9 +9,9 @@
 	@mouseleave="onMouseleave"
 	@touchend="onMouseleave"
 	ref="reaction"
-	v-particle
+	v-particle="canToggle && !isMe"
 >
-	<x-reaction-icon :reaction="reaction" :customEmojis="note.emojis" ref="icon"/>
+	<x-reaction-icon :reaction="reaction" :custom-emojis="note.emojis" ref="icon"/>
 	<span>{{ count }}</span>
 </button>
 </template>
@@ -58,14 +58,14 @@ export default Vue.extend({
 			return !this.reaction.match(/@\w/);
 		},
 	},
-	mounted() {
-		if (!this.isInitial) this.anime();
-	},
 	watch: {
 		count(newCount, oldCount) {
 			if (oldCount < newCount) this.anime();
 			if (this.details != null) this.openDetails();
 		},
+	},
+	mounted() {
+		if (!this.isInitial) this.anime();
 	},
 	methods: {
 		toggleReaction() {

--- a/src/client/components/reactions-viewer.reaction.vue
+++ b/src/client/components/reactions-viewer.reaction.vue
@@ -1,7 +1,7 @@
 <template>
 <button
 	class="hkzvhatu _button"
-	:class="{ reacted: note.myReaction == reaction, canToggle: canToggle && !isMe }"
+	:class="{ reacted: note.myReaction == reaction, canToggle }"
 	@click="toggleReaction(reaction)"
 	v-if="count > 0"
 	@touchstart="onMouseover"
@@ -9,7 +9,7 @@
 	@mouseleave="onMouseleave"
 	@touchend="onMouseleave"
 	ref="reaction"
-	v-particle="canToggle && !isMe"
+	v-particle="canToggle"
 >
 	<x-reaction-icon :reaction="reaction" :custom-emojis="note.emojis" ref="icon"/>
 	<span>{{ count }}</span>
@@ -55,7 +55,7 @@ export default Vue.extend({
 			return this.$store.getters.isSignedIn && this.$store.state.i.id === this.note.userId;
 		},
 		canToggle(): boolean {
-			return !this.reaction.match(/@\w/);
+			return !this.reaction.match(/@\w/) && !this.isMe && this.$store.getters.isSignedIn;
 		},
 	},
 	watch: {
@@ -69,7 +69,6 @@ export default Vue.extend({
 	},
 	methods: {
 		toggleReaction() {
-			if (this.isMe) return;
 			if (!this.canToggle) return;
 
 			const oldReaction = this.note.myReaction;

--- a/src/client/directives/particle.ts
+++ b/src/client/directives/particle.ts
@@ -2,6 +2,8 @@ import Particle from '../components/particle.vue';
 
 export default {
 	bind(el, binding, vn) {
+		// 明示的に false であればバインドしない
+		if (binding.value === false) return;
 		el.addEventListener('click', () => {
 			const rect = el.getBoundingClientRect();
 


### PR DESCRIPTION
Resolve #6453

- v-particle に引数 `false` を渡すことでパーティクルを表示しない仕組みを追加
  - 引数無し or true なら表示
- リアクションがリモート絵文字 or 自分のノートである
  - ボタンのような濃淡をつけない
  - パーティクルが出ない
- あと非ログイン時にAPIを呼ばない&上記の対応をした