### PR TITLE
フォロワーではないリモートユーザーに削除通知が配信されない問題を修正

### DIFF
--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -103,12 +103,27 @@ async function findCascadingNotes(note: Note) {
 }
 
 async function getMentionedRemoteUsers(note: Note) {
-	const mentions = (JSON.parse(note.mentionedRemoteUsers) as IMentionedRemoteUsers).map(x => x.uri);
+	const where = [] as any[];
+
+	// mention / reply / dm
+	const uris = (JSON.parse(note.mentionedRemoteUsers) as IMentionedRemoteUsers).map(x => x.uri);
+	if (uris.length > 0) {
+		where.push(
+			{ uri: In(uris) }
+		);
+	}
+
+	// renote / quote
+	if (note.renoteUserId) {
+		where.push({
+			id: note.renoteUserId
+		});
+	}
+
+	if (where.length === 0) return [];
 
 	return await Users.find({
-		where: {
-			uri: In(mentions)
-		}
+		where
 	}) as IRemoteUser[];
 }
 


### PR DESCRIPTION
## Summary
フォローされていないリモートユーザーへのメンションを含む投稿を削除すると削除通知が配信されない問題を修正しました。
Misskey(0d36b144cfea16496ee9157205ed309ce44ab918)同士、Misskey(12.39.1)とMastodon(3.1.4)で上記の問題が発生している事を確認しました。
~MastodonやPleromaなどとのテスト~やユニットテストが不十分なので一度Draftで作成いたします。
EDIT: Mastodon / Pleromaで問題ない事を確認
