### PR TITLE
「すべて既読にする」でグループメッセージが既読にならない問題を修正

### DIFF
--- a/src/server/api/endpoints/i/read-all-messaging-messages.ts
+++ b/src/server/api/endpoints/i/read-all-messaging-messages.ts
@@ -1,6 +1,6 @@
 import { publishMainStream } from '../../../../services/stream';
 import define from '../../define';
-import { MessagingMessages } from '../../../../models';
+import { MessagingMessages, UserGroupJoinings } from '../../../../models';
 
 export const meta = {
 	desc: {
@@ -26,6 +26,17 @@ export default define(meta, async (ps, user) => {
 	}, {
 		isRead: true
 	});
+
+	const joinings = await UserGroupJoinings.find({ userId: user.id });
+
+	await Promise.all(joinings.map(j => MessagingMessages.createQueryBuilder().update()
+		.set({
+			reads: (() => `array_append("reads", '${user.id}')`) as any
+		})
+		.where(`groupId = :groupId`, { groupId: j.userGroupId })
+		.andWhere('userId != :userId', { userId: user.id })
+		.andWhere('NOT (:userId = ANY(reads))', { userId: user.id })
+		.execute()));
 
 	publishMainStream(user.id, 'readAllMessagingMessages');
 });


### PR DESCRIPTION
## Summary

まず #5064 の問題についてですが、チャット一覧画面で表示されるバッジは、最新のメッセージを読んでいない場合に表示されるので、最新のメッセージを読んでいても過去に読まれていないメッセージがある場合にはバッジが表示されないので、一覧画面上ではすべて読んだように見えても実際には全て読んでいないので、サイドバー側の通知バッジが表示され続ける現象が発生しているのではと思います。

https://github.com/syuilo/misskey/issues/5064#issuecomment-636229675
そして、上記のコメントのバグはおそらくですがグループチャットのメッセージは「すべてのチャットを既読にする」で既読にならないのが関係していそうなので修正を行ってみました。