### PR TITLE
three.jsをr117に巻き戻す

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
 		"systeminformation": "4.26.9",
 		"syuilo-password-strength": "0.0.1",
 		"textarea-caret": "3.1.0",
-		"three": "0.118.1",
+		"three": "0.117.1",
 		"tinycolor2": "1.4.1",
 		"tmp": "0.2.1",
 		"ts-loader": "7.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9226,10 +9226,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@0.118.1:
-  version "0.118.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.118.1.tgz#c038be33250de15e80e78b9751dbca85964e9307"
-  integrity sha512-NYziIWAJg1ON5YJosT4eWCe/kmEOXC9pMJjqwsVtfIMrlP5qqassS0y99zs9INJUYtmxLsrNCdi9FzUWBKE6XQ==
+three@0.117.1:
+  version "0.117.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.117.1.tgz#a49bcb1a6ddea2f250003e42585dc3e78e92b9d3"
+  integrity sha512-t4zeJhlNzUIj9+ub0l6nICVimSuRTZJOqvk3Rmlu+YGdTOJ49Wna8p7aumpkXJakJfITiybfpYE1XN1o1Z34UQ==
 
 through2-filter@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Summary

three r118 に含まれているtrailing commaがTerserを妨げているのため、正常にビルド可能な前バージョンに戻す。

なお、当該箇所は https://github.com/mrdoob/three.js/commit/4165bea60e1ef68152338f69f1dbc3d3e473ed66 にて修正されているためr119ではなおっているはず。

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
