### PR TITLE
fix(client): Fix style of input(type="search") on macOS Safari

### DIFF
--- a/src/client/app.vue
+++ b/src/client/app.vue
@@ -716,6 +716,7 @@ export default Vue.extend({
 					border-radius: 38px;
 					color: var(--fg);
 					background: var(--bg);
+					-webkit-appearance: textfield;
 
 					&:focus {
 						outline: none;

--- a/src/client/components/google.vue
+++ b/src/client/components/google.vue
@@ -44,10 +44,12 @@ export default Vue.extend({
 		font-size: 16px;
 		border: solid 1px var(--divider);
 		border-radius: 4px 0 0 4px;
+		-webkit-appearance: textfield;
 	}
 
 	> button {
 		flex-shrink: 0;
+		margin: 0;
 		padding: 0 16px;
 		border: solid 1px var(--divider);
 		border-left: none;


### PR DESCRIPTION
## Summary
- macOS Safariで、input(type="search")にスタイルが適用されていないのを修正。
- macOS Safariで、MFM検索構文のボタンのマージンが取れていなかったのを修正

![2020-07-02 18-14-54 1](https://user-images.githubusercontent.com/7973572/86341060-bd920f80-bc90-11ea-8512-b0c483c3c8d6.png)
