### PR TITLE
投稿詳細でTwitterウィジェットが表示されなくなっているのを修正 Fix #6487

### DIFF
--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -53,7 +53,7 @@
 						<x-media-list :media-list="appearNote.files" :parent-element="noteBody"/>
 					</div>
 					<x-poll v-if="appearNote.poll" :note="appearNote" ref="pollViewer" class="poll"/>
-					<mk-url-preview v-for="url in urls" :url="url" :key="url" :compact="true" class="url-preview"/>
+					<mk-url-preview v-for="url in urls" :url="url" :key="url" :compact="true" :detail="detail" class="url-preview"/>
 					<div class="renote" v-if="appearNote.renote"><x-note-preview :note="appearNote.renote"/></div>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
Fix #6487
投稿詳細でTwitterウィジェットが表示されなくなっているのを修正 
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
