### PR TITLE
Fix SNYK-JS-THENIFY-571690 (CVE-2020-7677)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9220,9 +9220,9 @@ thenify-all@^1.0.0:
     thenify ">= 3.1.0 < 4"
 
 "thenify@>= 3.1.0 < 4":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
-  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
 


### PR DESCRIPTION
## Summary
lockファイルに残ってるdependenciesの脆弱性の修正
https://app.snyk.io/vuln/SNYK-JS-THENIFY-571690

ぱっと見Misskeyで悪用は出来なそうに見えるけどいちおう