### PR TITLE
scrollbar-widthを設定するように

### DIFF
--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -27,6 +27,10 @@ html {
 	overflow: auto;
 	overflow-y: scroll;
 
+	&, div, textarea {
+		scrollbar-width: thin;
+	}
+
 	&, * {
 		scrollbar-color: var(--scrollbarHandle) var(--panel);
 

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -27,12 +27,9 @@ html {
 	overflow: auto;
 	overflow-y: scroll;
 
-	&, div, textarea {
-		scrollbar-width: thin;
-	}
-
 	&, * {
 		scrollbar-color: var(--scrollbarHandle) var(--panel);
+		scrollbar-width: thin;
 
 		&:hover {
 			scrollbar-color: var(--scrollbarHandleHover) var(--panel);


### PR DESCRIPTION
## Summary
Firefoxでスクロールバーが太いままでダサいのを修正
![image](https://user-images.githubusercontent.com/30769358/86524084-fb6d7e80-beb0-11ea-93fd-e7ffcd3ab4b9.png)
