### PR TITLE
ダークテーマを利用中だとウィジェット編集画面が見づらい問題を修正

### DIFF
--- a/src/client/app.vue
+++ b/src/client/app.vue
@@ -1022,7 +1022,6 @@ export default Vue.extend({
 
 			.customize-container {
 				margin: 8px 0;
-				background: #fff;
 
 				> header {
 					position: relative;


### PR DESCRIPTION
## Summary
ダークテーマを使用中にウィジェット編集画面を開くと、ウィジェット部分の背景が下記のように白色になって見づらくなっていたのを
![image](https://user-images.githubusercontent.com/54523771/86526979-4d280000-bed5-11ea-9dc4-3a7e21841c15.png)
下記のように修正しました。
![image](https://user-images.githubusercontent.com/54523771/86526983-587b2b80-bed5-11ea-92dc-d5185b9424be.png)


