### PR TITLE
Increase download timeout to 60 sec

### DIFF
--- a/src/misc/download-url.ts
+++ b/src/misc/download-url.ts
@@ -17,7 +17,7 @@ export async function downloadUrl(url: string, path: string) {
 	const controller = new AbortController();
 	setTimeout(() => {
 		controller.abort();
-	}, 11 * 1000);
+	}, 60 * 1000);
 
 	const response = await fetch(new URL(url).href, {
 		headers: {


### PR DESCRIPTION
## Summary
ダウンロードタイムアウトを60秒に

レスポンスが返ってくるまでのタイムアウト: 10秒
最初から最後までのタイムアウト: 11秒
↓
レスポンスが返ってくるまでのタイムアウト: 10秒
最初から最後までのタイムアウト: 60秒

ダウンロードのread timeoutを10秒ちょいにしたつもりだっけど
よく見るとダウンロード開始から転送完了までのタイムアウトになってて
リモートの速度とファイルサイズによっては完了しないので、タイムアウトを増やしています。
