### PR TITLE
リモートからのDeleteがうまく出来ないことがあるのを修正

### DIFF
--- a/src/remote/activitypub/kernel/delete/index.ts
+++ b/src/remote/activitypub/kernel/delete/index.ts
@@ -1,26 +1,48 @@
-import Resolver from '../../resolver';
 import deleteNote from './note';
 import { IRemoteUser } from '../../../../models/entities/user';
-import { IDelete, getApId, validPost } from '../../type';
-import { apLogger } from '../../logger';
+import { IDelete, getApId, isTombstone, IObject, validPost, validActor } from '../../type';
+import { toSingle } from '../../../../prelude/array';
 
 /**
  * 削除アクティビティを捌きます
  */
-export default async (actor: IRemoteUser, activity: IDelete): Promise<void> => {
+export default async (actor: IRemoteUser, activity: IDelete): Promise<string> => {
 	if ('actor' in activity && actor.uri !== activity.actor) {
 		throw new Error('invalid actor');
 	}
 
-	const resolver = new Resolver();
+	// 削除対象objectのtype
+	let formarType: string | undefined;
 
-	const object = await resolver.resolve(activity.object);
-
-	const uri = getApId(object);
-
-	if (validPost.includes(object.type) || object.type === 'Tombstone') {
-		deleteNote(actor, uri);
+	if (typeof activity.object === 'string') {
+		// typeが不明だけど、どうせ消えてるのでremote resolveしない
+		formarType = undefined;
 	} else {
-		apLogger.warn(`Unknown type: ${object.type}`);
+		const object = activity.object as IObject;
+		if (isTombstone(object)) {
+			formarType = toSingle(object.formerType);
+		} else {
+			formarType = toSingle(object.type);
+		}
+	}
+
+	const uri = getApId(activity.object);
+
+	// type不明でもactorとobjectが同じならばそれはPersonに違いない
+	if (!formarType && actor.uri === uri) {
+		formarType = 'Person';
+	}
+
+	// それでもなかったらおそらくNote
+	if (!formarType) {
+		formarType = 'Note';
+	}
+
+	if (validPost.includes(formarType)) {
+		return await deleteNote(actor, uri);
+	} else if (validActor.includes(formarType)) {
+		return `Delete Actor is not implanted`;
+	} else {
+		return `Unknown type ${formarType}`;
 	}
 };

--- a/src/remote/activitypub/type.ts
+++ b/src/remote/activitypub/type.ts
@@ -119,6 +119,14 @@ interface IQuestionChoice {
 	replies?: ICollection;
 	_misskey_votes?: number;
 }
+export interface ITombstone extends IObject {
+	type: 'Tombstone';
+	formerType?: string;
+	deleted?: Date;
+}
+
+export const isTombstone = (object: IObject): object is ITombstone =>
+	object.type === 'Tombstone';
 
 export const validActor = ['Person', 'Service', 'Group', 'Organization', 'Application'];
 


### PR DESCRIPTION
## Summary
Fix #5642
Fix #6505
リモートからのDeleteで対象がstringで指定されてきた時に
リモートResolveでエラーになって削除できないことがあるのを修正

動きはこんな感じ
https://github.com/syuilo/misskey/issues/6505#issuecomment-654383654

動作は https://github.com/mei23/misskey/tree/mei-m544 でかなり永らく動いているので大丈夫かなと。