### PR TITLE
Fix #6513 キャッシュされてないリモートファイルのURLが相対URLで返ってくる

### DIFF
--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -39,7 +39,7 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			const key = thumbnail ? file.thumbnailAccessKey : file.webpublicAccessKey;
 
 			if (key && !key.match('/')) {	// 古いものはここにオブジェクトストレージキーが入ってるので除外
-				return `/files/${key}`;
+				return `${config.url}/files/${key}`;
 			}
 		}
 


### PR DESCRIPTION
## Summary
Fix #6513 キャッシュされてないリモートファイルのURLが相対URLで返ってくる
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
