### PR TITLE
Fix #6397 Mastodon v2.5.0未満からのActivityが受け取れない

### DIFF
--- a/docs/examples/misskey.nginx
+++ b/docs/examples/misskey.nginx
@@ -53,7 +53,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header Accept-Encoding "";
         proxy_http_version 1.1;
         proxy_redirect off;
 


### PR DESCRIPTION
## Summary
Fix #6397
nginxのconfigにより、Mastodon v2.5.0未満からのActivityが受け取れないのを修正