### PR TITLE
Deckのタイムラインカラムの初回種別選択でキャンセルが押されたらタイムラインカラムを消すように

### DIFF
--- a/src/client/components/deck/tl-column.vue
+++ b/src/client/components/deck/tl-column.vue
@@ -95,7 +95,7 @@ export default Vue.extend({
 			});
 			if (canceled) {
 				if (this.column.tl == null) {
-					this.setType();
+					this.$store.commit('deviceUser/removeDeckColumn', this.column.id);
 				}
 				return;
 			}


### PR DESCRIPTION
## Summary

Fix #6531

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->