### PR TITLE
Safariで投稿フォームを表示できない問題を修正 (Fix #6540)

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -327,7 +327,9 @@ export default Vue.extend({
 		},
 
 		focus() {
-			(this.$refs.text as any).focus();
+			this.$nextTick(() => {
+				(this.$refs.text as any).focus();
+			});
 		},
 
 		chooseFileFrom(ev) {


### PR DESCRIPTION
## Summary
Fix #6540

どうして今頃こういうバグが起きたのか詳しくはわからないけど、プラグインシステムのあおりを受けたっぽい？  
とりあえずnextTick使ったら動くようになりました