### PR TITLE
Mapping files folder outside the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     networks:
       - internal_network
       - external_network
+    volumes:
+      - ./files:/misskey/files
 
   redis:
     restart: always


### PR DESCRIPTION
# Summary

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->

In order to prevent the loss of files uploaded by users when upgrading Misskey deployed with Docker.
**But** it might be necessary to create an accessible folder before `docker-compose up -d` (Not fully tested)