### PR TITLE
Add "files/" to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ docker-compose.yml
 elasticsearch/
 node_modules/
 redis/
+files/


### PR DESCRIPTION
## Summary

#6598 によって `files` にアップロードされたファイルが保存されるようになりましたが、
このままだと更新時に Docker イメージをビルドすると Docker イメージ内にそのアップロードされたファイルも含まれてしまうので `.dockerignore` で除外するようにします。
