### PR TITLE
Dockerのビルド時にgitを入れるように

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache \
     autoconf \
     automake \
     file \
+		git \
     g++ \
     gcc \
     libc-dev \


### PR DESCRIPTION
## Summary
https://github.com/syuilo/misskey/commit/917d3d0bd3e7746b722f154860c604c4d6c92c69 でgitの依存関係が追加されたのにgitが入っていないのでコケていた

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
