### PR TITLE
HTTP-Signatureで対象ヘッダーに(request-target)を追加 Resolve #6652

### DIFF
--- a/src/remote/activitypub/request.ts
+++ b/src/remote/activitypub/request.ts
@@ -49,7 +49,7 @@ export default async (user: ILocalUser, url: string, object: any) => {
 			authorizationHeaderName: 'Signature',
 			key: keypair.privateKey,
 			keyId: `${config.url}/users/${user.id}#main-key`,
-			headers: ['date', 'host', 'digest']
+			headers: ['(request-target)', 'date', 'host', 'digest']
 		});
 
 		req.on('timeout', () => req.abort());


### PR DESCRIPTION
## Summary
Resolve #6652
これを必須としている実装があるので、
Mastodonなどと同じようにHTTP-Signatureで対象ヘッダーに`(request-target)`を追加

とりあえず Misskey, Mastodon 相手でActivityがとどくのは確認済み。