### PR TITLE
Fix not to reject non-image file uploads

### DIFF
--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -168,12 +168,22 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 		};
 	}
 
-	const img = sharp(path);
-	const metadata = await img.metadata();
-	const isAnimated = metadata.pages && metadata.pages > 1;
+	let img: sharp.Sharp | null = null;
 
-	// skip animated
-	if (isAnimated) {
+	try {
+		img = sharp(path);
+		const metadata = await img.metadata();
+		const isAnimated = metadata.pages && metadata.pages > 1;
+
+		// skip animated
+		if (isAnimated) {
+			return {
+				webpublic: null,
+				thumbnail: null
+			};
+		}
+	} catch (e) {
+		logger.warn(`sharp failed: ${e}`);
 		return {
 			webpublic: null,
 			thumbnail: null

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -160,6 +160,14 @@ export async function generateAlts(path: string, type: string, generateWeb: bool
 		}
 	}
 
+	if (!['image/jpeg', 'image/png', 'image/webp'].includes(type)) {
+		logger.debug(`web image and thumbnail not created (not an required file)`);
+		return {
+			webpublic: null,
+			thumbnail: null
+		};
+	}
+
 	const img = sharp(path);
 	const metadata = await img.metadata();
 	const isAnimated = metadata.pages && metadata.pages > 1;


### PR DESCRIPTION
## Summary

12.47.0 で画像ではないファイルをアップロードしようとすると `INTERNAL_ERROR` で失敗してしまいます。

<details><summary>修正前に発生したサーバー側のエラーログの例</summary>

```
web_1        | DONE 1   [download]      Download finished: http://example.com/index.html
web_1        | ERR  1   [drive downloader]      Failed to create drive file: Error: Input file contains unsupported image format
web_1        | ERR  1   [api]   Internal error occurred in drive/files/upload-from-url: Input file contains unsupported image format
web_1        | INFO 1   [drive register]        {"size":1256,"md5":"84238dfc8092e5d9c0dac8ef93371a07","type":{"mime":"application/octet-stream","ext":null},"warnings":[]}
web_1        | ERR  1   [drive downloader]      Failed to create drive file: Error: Input file contains unsupported image format
web_1        | ERR  1   [api]   Internal error occurred in drive/files/upload-from-url: Input file contains unsupported image format
web_1        | INFO 1   [drive register]        {"size":4,"md5":"098f6bcd4621d373cade4e832627b4f6","type":{"mime":"application/octet-stream","ext":null},"warnings":[]}
web_1        | INFO 1   [drive register]        {"size":4,"md5":"098f6bcd4621d373cade4e832627b4f6","type":{"mime":"application/octet-stream","ext":null},"warnings":[]}
web_1        | ERR  1   [api]   Error: Input file contains unsupported image format
web_1        | ERR  1   [api]   Error: Input file contains unsupported image format
web_1        | INFO 1   [drive register]        {"size":4,"md5":"098f6bcd4621d373cade4e832627b4f6","type":{"mime":"application/octet-stream","ext":null},"warnings":[]}
web_1        | ERR  1   [api]   Error: Input file contains unsupported image format
```

</details>

この PR はこのエラーを修正し、画像ではないファイルをこれまで通りアップロードできるようにします。