### PR TITLE
Fix an error on /api-doc

### DIFF
--- a/src/server/api/openapi/schemas.ts
+++ b/src/server/api/openapi/schemas.ts
@@ -15,6 +15,7 @@ import { packedHashtagSchema } from '../../../models/repositories/hashtag';
 import { packedPageSchema } from '../../../models/repositories/page';
 import { packedUserGroupSchema } from '../../../models/repositories/user-group';
 import { packedNoteFavoriteSchema } from '../../../models/repositories/note-favorite';
+import { packedChannelSchema } from '../../../models/repositories/channel';
 
 export function convertSchemaToOpenApiSchema(schema: Schema) {
 	const res: any = schema;
@@ -82,4 +83,5 @@ export const schemas = {
 	Blocking: convertSchemaToOpenApiSchema(packedBlockingSchema),
 	Hashtag: convertSchemaToOpenApiSchema(packedHashtagSchema),
 	Page: convertSchemaToOpenApiSchema(packedPageSchema),
+	Channel: convertSchemaToOpenApiSchema(packedChannelSchema),
 };


### PR DESCRIPTION
## Summary

`/api-doc` が下のようなエラーで表示されなくなっているので、修正して正常に表示されるようにします。

<img width="991" alt="スクリーンショット 2020-08-21 11 58 02" src="https://user-images.githubusercontent.com/16184855/90847980-bfca3d80-e3a6-11ea-868f-765b84c5af0d.png">
