### PR TITLE
Expose proxyAccountName

### DIFF
--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -99,6 +99,8 @@ export default define(meta, async (ps, me) => {
 		}
 	});
 
+	const proxyAccount = instance.proxyAccountId ? await Users.pack(instance.proxyAccountId).catch(() => null) : null;
+
 	const response: any = {
 		maintainerName: instance.maintainerName,
 		maintainerEmail: instance.maintainerEmail,
@@ -143,6 +145,8 @@ export default define(meta, async (ps, me) => {
 		enableDiscordIntegration: instance.enableDiscordIntegration,
 
 		enableServiceWorker: instance.enableServiceWorker,
+
+		proxyAccountName: proxyAccount ? proxyAccount.username : null,
 	};
 
 	if (ps.detail) {

--- a/src/server/nodeinfo.ts
+++ b/src/server/nodeinfo.ts
@@ -1,6 +1,7 @@
 import * as Router from '@koa/router';
 import config from '../config';
 import { fetchMeta } from '../misc/fetch-meta';
+import { Users } from '../models';
 // import User from '../models/user';
 // import Note from '../models/note';
 
@@ -33,6 +34,8 @@ const nodeinfo2 = async () => {
 		// Note.count({ '_user.host': null, replyId: null }),
 		// Note.count({ '_user.host': null, replyId: { $ne: null } })
 	]);
+
+	const proxyAccount = meta.proxyAccountId ? await Users.pack(meta.proxyAccountId).catch(() => null) : null;
 
 	return {
 		software: {
@@ -72,7 +75,8 @@ const nodeinfo2 = async () => {
 			enableGithubIntegration: meta.enableGithubIntegration,
 			enableDiscordIntegration: meta.enableDiscordIntegration,
 			enableEmail: meta.enableEmail,
-			enableServiceWorker: meta.enableServiceWorker
+			enableServiceWorker: meta.enableServiceWorker,
+			proxyAccountName: proxyAccount ? proxyAccount.username : null,
 		}
 	};
 };

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -326,6 +326,9 @@ router.get('/info', async ctx => {
 	const emojis = await Emojis.find({
 		where: { host: null }
 	});
+
+	const proxyAccount = meta.proxyAccountId ? await Users.pack(meta.proxyAccountId).catch(() => null) : null;
+
 	await ctx.render('info', {
 		version: config.version,
 		machine: os.hostname(),
@@ -339,6 +342,7 @@ router.get('/info', async ctx => {
 		},
 		emojis: emojis,
 		meta: meta,
+		proxyAccountName: proxyAccount ? proxyAccount.username : null,
 		originalUsersCount: await Users.count({ host: null }),
 		originalNotesCount: await Notes.count({ userHost: null })
 	});

--- a/src/server/web/views/info.pug
+++ b/src/server/web/views/info.pug
@@ -80,6 +80,9 @@ html
 						= meta.maintainerName
 						|  &lt;#{meta.maintainerEmail}&gt;
 				tr
+					th Proxy account name
+					td= proxyAccountName || '(none)'
+				tr
 					th System
 					td= os
 				tr


### PR DESCRIPTION
## Summary
プロキシアカウントぽいアカウントを作られても
そこのインスタンス管理者以外が本当にプロキシアカウントかを確認する手段がないので
meta API, nodeinfo, /info で プロキシアカウントの名前を明示するようにしてます。