### PR TITLE
Fix channels list pagination

### DIFF
--- a/src/client/pages/channels.vue
+++ b/src/client/pages/channels.vue
@@ -44,7 +44,7 @@ export default Vue.extend({
 			tab: 'featured',
 			featuredPagination: {
 				endpoint: 'channels/featured',
-				limit: 5,
+				noPaging: true,
 			},
 			followingPagination: {
 				endpoint: 'channels/followed',


### PR DESCRIPTION
## Summary

トレンド/フォロー中/管理中のチャンネル数がそれぞれ6件以上になると同じ項目が2度以上出現する問題を修正しました。
原因はクライアント側ではページネーションをしようと limit と untilId をつけてリクエストしますが、サーバーがそれらを無視して全件レスポンスしていたためです。
トレンド (featured) は必ず10件までのためページネーションは必要無いと判断して無効化、フォロー中と管理中のチャンネルについては5件単位でページネーションされるようにしました。