### PR TITLE
Embedded all attachment, renotes and discussion history into rss feed content & improve title

### DIFF
--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -44,8 +44,8 @@ export default async function(user: User) {
 		const files = note.fileIds.length > 0 ? await DriveFiles.find({
 			id: In(note.fileIds)
 		}) : [];
-		var fileEle = ""
-		files.forEach(function(file){
+		let fileEle = '';
+		for (const file of files){
 			if(file.type.startsWith('image/')){
 				fileEle += ` <br><img src="${DriveFiles.getPublicUrl(file)}">`;
 			}else if(file.type.startsWith('audio/')){
@@ -55,14 +55,14 @@ export default async function(user: User) {
 			}else{
 				fileEle += ` <br><a href="${DriveFiles.getPublicUrl(file)}" download="${file.name}">${file.name}</a>`;
 			}
-		});
+		}
 
 		feed.addItem({
-			title: `${author.name}: ${(note.text ? note.text : "empty").substring(0,50)}`,
+			title: `${author.name}: ${(note.text ? note.text : 'post a new note').substring(0,50)}`,
 			link: `${config.url}/notes/${note.id}`,
 			date: note.createdAt,
 			description: note.cw || undefined,
-			content: `${note.text || ""}${fileEle}`
+			content: `${note.text || ''}${fileEle}`
 		});
 	}
 

--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -8,6 +8,7 @@ import { ensure } from '../../prelude/ensure';
 export default async function(user: User) {
 	const author = {
 		link: `${config.url}/@${user.username}`,
+		email: `${user.username}@${config.host}`,
 		name: user.name || user.username
 	};
 
@@ -43,15 +44,25 @@ export default async function(user: User) {
 		const files = note.fileIds.length > 0 ? await DriveFiles.find({
 			id: In(note.fileIds)
 		}) : [];
-		const file = files.find(file => file.type.startsWith('image/'));
+		var fileEle = ""
+		files.forEach(function(file){
+			if(file.type.startsWith('image/')){
+				fileEle += ` <br><img src="${DriveFiles.getPublicUrl(file)}">`;
+			}else if(file.type.startsWith('audio/')){
+				fileEle += ` <br><audio controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
+			}else if(file.type.startsWith('video/')){
+				fileEle += ` <br><video controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
+			}else{
+				fileEle += ` <br><a href="${DriveFiles.getPublicUrl(file)}" download="${file.name}">${file.name}</a>`;
+			}
+		});
 
 		feed.addItem({
-			title: `New note by ${author.name}`,
+			title: `${author.name}: ${(note.text ? note.text : "empty").substring(0,50)}`,
 			link: `${config.url}/notes/${note.id}`,
 			date: note.createdAt,
 			description: note.cw || undefined,
-			content: note.text || undefined,
-			image: file ? DriveFiles.getPublicUrl(file) || undefined : undefined
+			content: `${note.text || ""}${fileEle}`
 		});
 	}
 

--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -43,9 +43,9 @@ export default async function(user: User) {
 	for (const note of notes) {
 		let contentStr = await noteToString(note, true);
 		let next = note.renoteId ? note.renoteId : note.replyId;
-		let depth = 5
+		let depth = 5;
 		while(depth > 0 && next){
-			let finding = await findById(next);
+			const finding = await findById(next);
 			contentStr += finding.text;
 			next = finding.next;
 			depth -= 1;
@@ -59,10 +59,10 @@ export default async function(user: User) {
 			content: `${contentStr}`
 		});
 	}
-	
+
 	async function noteToString(note, isTheNote = false){
-		let author = await Users.findOne({id: note.userId});
-		let outstr = author ? `${author.name}(@${author.username}@${author.host ? author.host : config.host}) ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}: <br>` : "";
+		const author = await Users.findOne({id: note.userId});
+		let outstr = author ? `${author.name}(@${author.username}@${author.host ? author.host : config.host}) ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}: <br>` : '';
 		const files = note.fileIds.length > 0 ? await DriveFiles.find({
 			id: In(note.fileIds)
 		}) : [];
@@ -80,13 +80,13 @@ export default async function(user: User) {
 		}
 		outstr += `${note.text || ''}${fileEle}`;
 		if(isTheNote){
-			outstr += ` <span class="${(note.renoteId ? 'renote' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf("img src") != -1 ? 'with_img' : 'without_img')}"></span>`;
+			outstr += ` <span class="${(note.renoteId ? 'renote' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') != -1 ? 'with_img' : 'without_img')}"></span>`;
 		}
 		return outstr;
 	}
-	
+
 	async function findById(id){
-		let text = "";
+		let text = '';
 		let next = null;
 		const findings = await Notes.find({where: {id: id, visibility: In(['public', 'home'])}, order: { createdAt: -1 }, take: 20});
 		for (const aFind of findings){

--- a/src/server/web/feed.ts
+++ b/src/server/web/feed.ts
@@ -61,7 +61,7 @@ export default async function(user: User) {
 	}
 
 	async function noteToString(note, isTheNote = false){
-		const author = await Users.findOne({id: note.userId});
+		const author = isTheNote ? null : await Users.findOne({id: note.userId});
 		let outstr = author ? `${author.name}(@${author.username}@${author.host ? author.host : config.host}) ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}: <br>` : '';
 		const files = note.fileIds.length > 0 ? await DriveFiles.find({
 			id: In(note.fileIds)
@@ -80,7 +80,7 @@ export default async function(user: User) {
 		}
 		outstr += `${note.text || ''}${fileEle}`;
 		if(isTheNote){
-			outstr += ` <span class="${(note.renoteId ? 'renote' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') != -1 ? 'with_img' : 'without_img')}"></span>`;
+			outstr += ` <span class="${(note.renoteId ? 'renote_note' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') != -1 ? 'with_img' : 'without_img')}"></span>`;
 		}
 		return outstr;
 	}


### PR DESCRIPTION
The feed npm module dose not support multiple files, and enclosure format may not parse correct by apps, so that embedding all files into content. Also the email field is required by some app, so add a dummy one, could improved by use user email if have one.

## Summary

Resolve #7004

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
