### PR TITLE
/streamingに非WebSocketリクエストが来るとおかしくなるのを修正 Fix #6718

### DIFF
--- a/src/client/scripts/stream.ts
+++ b/src/client/scripts/stream.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'eventemitter3';
 import ReconnectingWebsocket from 'reconnecting-websocket';
 import { wsUrl } from '../config';
 import MiOS from '../mios';
+import { query as urlQuery } from '../../prelude/url';
 
 /**
  * Misskey stream connection
@@ -21,7 +22,12 @@ export default class Stream extends EventEmitter {
 
 		const user = os.store.state.i;
 
-		this.stream = new ReconnectingWebsocket(wsUrl + (user ? `?i=${user.token}` : ''), '', { minReconnectionDelay: 1 }); // https://github.com/pladaria/reconnecting-websocket/issues/91
+		const query = urlQuery({
+			i: user?.token,
+			_t: Date.now(),
+		});
+
+		this.stream = new ReconnectingWebsocket(`${wsUrl}?${query}`, '', { minReconnectionDelay: 1 }); // https://github.com/pladaria/reconnecting-websocket/issues/91
 		this.stream.addEventListener('open', this.onOpen);
 		this.stream.addEventListener('close', this.onClose);
 		this.stream.addEventListener('message', this.onMessage);

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -358,6 +358,12 @@ router.get('/flush', async ctx => {
 	await ctx.render('flush');
 });
 
+// streamingに非WebSocketリクエストが来た場合にbase htmlをキャシュ付きで返すと、Proxy等でそのパスがキャッシュされておかしくなる
+router.get('/streaming', async ctx => {
+	ctx.status = 503;
+	ctx.set('Cache-Control', 'private, max-age=0');
+});
+
 // Render base html for all requests
 router.get('(.*)', async ctx => {
 	const meta = await fetchMeta();


### PR DESCRIPTION
## Summary
Fix #6718

/streamingに非WebSocketリクエストが来てしまった場合にキャッシュしないように、
起因がクライアント側だけではなくサーバー側にもありそうなので4xxじゃなくて5xxにしてます。

すでにキャッシュされてしまっていた場合にすぐに改善されるように、
クライアント側でキャッシュ抑制のためにtimeを添えています。