### PR TITLE
MFM のバッククオートで囲ったコードが表示されないのを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,6 @@
 		"vue-i18n": "9.0.0-beta.4",
 		"vue-json-pretty": "1.7.0",
 		"vue-loader": "16.0.0-beta.7",
-		"vue-prism-component": "1.2.0",
 		"vue-prism-editor": "1.2.2",
 		"vue-router": "4.0.0-beta.13",
 		"vue-style-loader": "4.1.2",

--- a/src/client/components/code-core.vue
+++ b/src/client/components/code-core.vue
@@ -1,17 +1,14 @@
 <template>
-<XPrism :inline="inline" :language="prismLang">{{ code }}</XPrism>
+<code v-if="inline" v-html="html" :class="`language-${prismLang}`"></code>
+<pre v-else :class="`language-${prismLang}`"><code v-html="html" :class="`language-${prismLang}`"></code></pre>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
 import 'prismjs';
 import 'prismjs/themes/prism-okaidia.css';
-import XPrism from 'vue-prism-component';import * as os from '@/os';
 
 export default defineComponent({
-	components: {
-		XPrism
-	},
 	props: {
 		code: {
 			type: String,
@@ -29,6 +26,9 @@ export default defineComponent({
 	computed: {
 		prismLang() {
 			return Prism.languages[this.lang] ? this.lang : 'js';
+		},
+		html() {
+			return Prism.highlight(this.code, Prism.languages[this.prismLang], this.prismLang);
 		}
 	}
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10401,11 +10401,6 @@ vue-loader@16.0.0-beta.7:
     merge-source-map "^1.1.0"
     source-map "^0.6.1"
 
-vue-prism-component@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/vue-prism-component/-/vue-prism-component-1.2.0.tgz#406252e16979def13b5d28827d95b2b6dc647825"
-  integrity sha512-0N9CNuQu+36CJpdsZHrhdq7d18oBvjVMjawyKdIr8xuzFWLfdxECZQYbFaYoopPBg3SvkEEMtkhYqdgTQl5Y+A==
-
 vue-prism-editor@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/vue-prism-editor/-/vue-prism-editor-1.2.2.tgz#023cfd4329848f191aac851f2f5e6c7a8c2e059f"


### PR DESCRIPTION
## Summary

ノート本文などMFM で inline code と block code 共に表示がされなかったのを修正します。
今まで使っていたライブラリ `vue-prism-component` が Vue.js 3.0 に対応していないのが原因だったので、それを使わず直接 prism を使ってハイライト処理を行うように変更しました。

Resolves #6739