### PR TITLE
ページのセクション内などが表示されない問題を修正

### DIFF
--- a/src/client/components/page/page.if.vue
+++ b/src/client/components/page/page.if.vue
@@ -5,9 +5,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, defineAsyncComponent } from 'vue';
 
 export default defineComponent({
+	components: {
+		XBlock: defineAsyncComponent(() => import('./page.block.vue'))
+	},
 	props: {
 		value: {
 			required: true
@@ -21,9 +24,6 @@ export default defineComponent({
 		h: {
 			required: true
 		}
-	},
-	beforeCreate() {
-		this.$options.components.XBlock = require('./page.block.vue').default;
 	},
 });
 </script>

--- a/src/client/components/page/page.section.vue
+++ b/src/client/components/page/page.section.vue
@@ -9,10 +9,13 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, defineAsyncComponent } from 'vue';
 import * as os from '@/os';
 
 export default defineComponent({
+	components: {
+		XBlock: defineAsyncComponent(() => import('./page.block.vue'))
+	},
 	props: {
 		value: {
 			required: true
@@ -26,9 +29,6 @@ export default defineComponent({
 		h: {
 			required: true
 		}
-	},
-	beforeCreate() {
-		this.$options.components.XBlock = require('./page.block.vue').default;
 	},
 });
 </script>

--- a/src/client/pages/page-editor/els/page-editor.el.if.vue
+++ b/src/client/pages/page-editor/els/page-editor.el.if.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, defineAsyncComponent } from 'vue';
 import { v4 as uuid } from 'uuid';
 import { faPlus, faQuestion } from '@fortawesome/free-solid-svg-icons';
 import XContainer from '../page-editor.container.vue';
@@ -34,7 +34,8 @@ import * as os from '@/os';
 
 export default defineComponent({
 	components: {
-		XContainer, MkSelect
+		XContainer, MkSelect,
+		XBlocks: defineAsyncComponent(() => import('../page-editor.blocks.vue')),
 	},
 
 	inject: ['getPageBlockList'],
@@ -52,10 +53,6 @@ export default defineComponent({
 		return {
 			faPlus, faQuestion
 		};
-	},
-
-	beforeCreate() {
-		this.$options.components.XBlocks = require('../page-editor.blocks.vue').default
 	},
 
 	created() {

--- a/src/client/pages/page-editor/els/page-editor.el.section.vue
+++ b/src/client/pages/page-editor/els/page-editor.el.section.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, defineAsyncComponent } from 'vue';
 import { v4 as uuid } from 'uuid';
 import { faPlus, faPencilAlt } from '@fortawesome/free-solid-svg-icons';
 import { faStickyNote } from '@fortawesome/free-regular-svg-icons';
@@ -26,7 +26,8 @@ import * as os from '@/os';
 
 export default defineComponent({
 	components: {
-		XContainer
+		XContainer,
+		XBlocks: defineAsyncComponent(() => import('../page-editor.blocks.vue')),
 	},
 
 	inject: ['getPageBlockList'],
@@ -44,10 +45,6 @@ export default defineComponent({
 		return {
 			faStickyNote, faPlus, faPencilAlt
 		};
-	},
-
-	beforeCreate() {
-		this.$options.components.XBlocks = require('../page-editor.blocks.vue').default
 	},
 
 	created() {


### PR DESCRIPTION
## Summary

セクションを使ったページで `TypeError: Cannot set property 'XBlock' of undefined` が発生してセクションの内側が表示されないバグを修正しました。
Vue.js 3.0 で `this.$options.components` が使えなくなったのが原因だと思われるので `defineAsyncComponent` に置き換えています。 `this.$options.components` を使っている箇所はまとめて対応をしました。