### PR TITLE
optional chainingにより一部ブラウザで動かないのを修正

### DIFF
--- a/src/client/components/image-viewer.vue
+++ b/src/client/components/image-viewer.vue
@@ -6,7 +6,7 @@
 		<footer>
 			<span>{{ image.type }}</span>
 			<span>{{ bytes(image.size) }}</span>
-			<span v-if="image.properties?.width">{{ number(image.properties.width) }}px × {{ number(image.properties.height) }}px</span>
+			<span v-if="image.properties && image.properties.width">{{ number(image.properties.width) }}px × {{ number(image.properties.height) }}px</span>
 		</footer>
 	</div>
 </MkModal>


### PR DESCRIPTION
## Summary
.vueのインラインのoptional chainingのせいで一部ブラウザで動かないのを修正
https://caniuse.com/mdn-javascript_operators_optional_chaining

.ts や .vueの`<script lang="ts">`下 ならちゃんとトランスパイルされるけど
ここに書いたのはそのまま出てきちゃうみたい。