### PR TITLE
システム所有のドライブファイルが参照できないのを修正

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -601,6 +601,7 @@ editTheseSettingsMayBreakAccount: "これらの設定を編集するとアカウ
 instanceTicker: "ノートのインスタンス情報"
 waitingFor: "{x}を待っています"
 random: "ランダム"
+system: "システム"
 
 _reversi:
   reversi: "リバーシ"

--- a/src/client/pages/instance/files.vue
+++ b/src/client/pages/instance/files.vue
@@ -42,7 +42,8 @@
 							<small style="opacity: 0.7;">{{ file.name }}</small>
 						</div>
 						<div>
-							<MkAcct :user="file.user"/>
+							<MkAcct v-if="file.user" :user="file.user"/>
+							<div v-else>{{ $t('system') }}</div>
 						</div>
 						<div>
 							<span style="margin-right: 1em;">{{ file.type }}</span>

--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -124,8 +124,8 @@ export class DriveFileRepository extends Repository<DriveFile> {
 			folder: opts.detail && file.folderId ? DriveFolders.pack(file.folderId, {
 				detail: true
 			}) : null,
-			userId: opts.withUser ? file.userId! : null,
-			user: opts.withUser ? Users.pack(file.userId!) : null
+			userId: opts.withUser ? file.userId : null,
+			user: (opts.withUser && file.userId) ? Users.pack(file.userId) : null
 		});
 	}
 


### PR DESCRIPTION
## Summary
カスタム絵文字など`userId: null`で格納されたドライブファイルを参照するとエラーになるのを修正