### PR TITLE
リバーシで相手のターンでも置くことができるのを修正

### DIFF
--- a/src/client/pages/reversi/game.board.vue
+++ b/src/client/pages/reversi/game.board.vue
@@ -231,7 +231,7 @@ export default defineComponent({
 		set(pos) {
 			if (this.game.isEnded) return;
 			if (!this.iAmPlayer) return;
-			if (!this.isMyTurn) return;
+			if (!this.isMyTurn()) return;
 			if (!this.o.canPut(this.myColor, pos)) return;
 
 			this.o.put(this.myColor, pos);


### PR DESCRIPTION
## Summary

リバーシで、相手のターンでも置けてしまうバグを修正します。
相手のターンで置いた場合、自分の画面では置かれたものとしてアップデートされますが、相手には反映されない状態になるようです。