### PR TITLE
チャンネル一覧でバナーが無いとチャンネル名が出ないのを修正

### DIFF
--- a/src/client/components/channel-preview.vue
+++ b/src/client/components/channel-preview.vue
@@ -1,6 +1,6 @@
 <template>
 <MkA :to="`/channels/${channel.id}`" class="eftoefju _panel" tabindex="-1">
-	<div class="banner" v-if="channel.bannerUrl" :style="`background-image: url('${channel.bannerUrl}')`">
+	<div class="banner" :style="bannerStyle">
 		<div class="fade"></div>
 		<div class="name"><Fa :icon="faSatelliteDish"/> {{ channel.name }}</div>
 		<div class="status">
@@ -43,6 +43,16 @@ export default defineComponent({
 			type: Object,
 			required: true
 		},
+	},
+
+	computed: {
+		bannerStyle() {
+			if (this.channel.bannerUrl) {
+				return { backgroundImage: `url(${this.channel.bannerUrl})` };
+			} else {
+				return { backgroundColor: '#4c5e6d' };
+			}
+		}
 	},
 
 	data() {


### PR DESCRIPTION
## Summary

チャンネル一覧ページにて、バナーが設定されていない場合にチャンネル名やユーザー・ノート数といった値まで見れなくなるのを改善します。

| Before | After |
| ----- | ----- |
| <img width="666" alt="Screen Shot 2020-09-21 at 22 42 49" src="https://user-images.githubusercontent.com/22152877/93775698-b3632a00-fc5d-11ea-8c5e-1621cf0db6f3.png"> | <img width="665" alt="Screen Shot 2020-09-21 at 22 52 28" src="https://user-images.githubusercontent.com/22152877/93775804-d2fa5280-fc5d-11ea-969b-8b4b5afd8bc3.png"> |