### PR TITLE
補完でタブが効かなくなるケースを修正

### DIFF
--- a/src/client/components/autocomplete.vue
+++ b/src/client/components/autocomplete.vue
@@ -122,6 +122,7 @@ export default defineComponent({
 			users: [],
 			hashtags: [],
 			emojis: [],
+			items: [],
 			select: -1,
 			emojilist,
 			emojiDb: [] as EmojiDef[]
@@ -129,10 +130,6 @@ export default defineComponent({
 	},
 
 	computed: {
-		items(): HTMLCollection {
-			return (this.$refs.suggests as Element).children;
-		},
-
 		useOsNativeEmojis(): boolean {
 			return this.$store.state.device.useOsNativeEmojis;
 		}
@@ -148,6 +145,7 @@ export default defineComponent({
 
 	updated() {
 		this.setPosition();
+		this.items = (this.$refs.suggests as Element | undefined)?.children || [];
 	},
 
 	mounted() {
@@ -371,6 +369,7 @@ export default defineComponent({
 
 		selectNext() {
 			if (++this.select >= this.items.length) this.select = 0;
+			if (this.items.length === 0) this.select = -1;
 			this.applySelect();
 		},
 
@@ -384,8 +383,10 @@ export default defineComponent({
 				el.removeAttribute('data-selected');
 			}
 
-			this.items[this.select].setAttribute('data-selected', 'true');
-			(this.items[this.select] as any).focus();
+			if (this.select !== -1) {
+				this.items[this.select].setAttribute('data-selected', 'true');
+				(this.items[this.select] as any).focus();
+			}
 		},
 
 		chooseUser() {


### PR DESCRIPTION
## Summary

文章中の絵文字などの補完で、タブが効かなくなってしまうケースがあるのを修正します。

具体的には以下の手順で再現できます。

1. `:thumbs` などと書いて補完候補が出る (ここでタブを押すとそれが正しく選択される)
2. そこから `:thumbsaaa` などと補完候補が無くなるような文字を書く
3. 最後の `aaa` を消して `:thumbs` に戻ると再び補完候補が表示される
4. しかし、そこでタブを押しても候補が選択されず、背景色が変わらない

原因は

https://github.com/syuilo/misskey/blob/629b765abcab091c2a0d30ef5e881d28e2badf02/src/client/components/autocomplete.vue#L18

の行の `v-if` が false になるため、 `this.$refs.suggests` が示す要素が無くなり、その結果 computed である `items`

https://github.com/syuilo/misskey/blob/629b765abcab091c2a0d30ef5e881d28e2badf02/src/client/components/autocomplete.vue#L131-L134

が更新されなくなってしまうようです。