### PR TITLE
検索ショートカットが使えないのを修正

### DIFF
--- a/src/client/ui/default.vue
+++ b/src/client/ui/default.vue
@@ -110,7 +110,7 @@ export default defineComponent({
 				},
 				'p': os.post,
 				'n': os.post,
-				's': search,
+				's': () => search(),
 				'h|/': this.help
 			};
 		},


### PR DESCRIPTION
## Summary

<kbd>S</kbd> を押して検索ができるショートカットキーが使えなくなっていたので修正します。

https://github.com/syuilo/misskey/blob/629b765abcab091c2a0d30ef5e881d28e2badf02/src/client/scripts/search.ts#L6-L18

search は引数が指定されたらその文字列を、 null か undefined であれば検索ダイアログを出す仕様になっていますが、どうやら KeyboardEvent が引数に入ってくるため、それを文字列として処理しようとしてエラーになっていました。