### PR TITLE
リンクをコピーでパスしかコピーされない問題を修正

### DIFF
--- a/src/client/components/ui/a.vue
+++ b/src/client/components/ui/a.vue
@@ -10,7 +10,7 @@ import { faExpandAlt, faColumns, faExternalLinkAlt, faLink, faWindowMaximize } f
 import * as os from '@/os';
 import copyToClipboard from '@/scripts/copy-to-clipboard';
 import { router } from '@/router';
-import { deckmode } from '@/config';
+import { deckmode, url } from '@/config';
 
 export default defineComponent({
 	inject: {
@@ -82,7 +82,7 @@ export default defineComponent({
 				icon: faLink,
 				text: this.$t('copyLink'),
 				action: () => {
-					copyToClipboard(this.to);
+					copyToClipboard(`${url}${this.to}`);
 				}
 			}], e);
 		},


### PR DESCRIPTION
## Summary

サイドバーなどで右クリックしたときに表示される「リンクをコピー」で、パスしかコピーされない問題を修正しました。

具体的には、`to`は`/featured`などのパスだけなので、configからパス前の部分を補完するようにしました。

Resolve #6770 
