### PR TITLE
メッセージ (トーク/チャット) 削除の連合

### DIFF
--- a/src/remote/activitypub/db-resolver.ts
+++ b/src/remote/activitypub/db-resolver.ts
@@ -2,7 +2,8 @@ import config from '../../config';
 import { Note } from '../../models/entities/note';
 import { User, IRemoteUser } from '../../models/entities/user';
 import { UserPublickey } from '../../models/entities/user-publickey';
-import { Notes, Users, UserPublickeys } from '../../models';
+import { MessagingMessage } from '../../models/entities/messaging-message';
+import { Notes, Users, UserPublickeys, MessagingMessages } from '../../models';
 import { IObject, getApId } from './type';
 import { resolvePerson } from './models/person';
 import { ensure } from '../../prelude/ensure';
@@ -26,6 +27,24 @@ export default class DbResolver {
 
 		if (parsed.uri) {
 			return (await Notes.findOne({
+				uri: parsed.uri
+			})) || null;
+		}
+
+		return null;
+	}
+
+	public async getMessageFromApId(value: string | IObject): Promise<MessagingMessage | null> {
+		const parsed = this.parseUri(value);
+
+		if (parsed.id) {
+			return (await MessagingMessages.findOne({
+				id: parsed.id
+			})) || null;
+		}
+
+		if (parsed.uri) {
+			return (await MessagingMessages.findOne({
 				uri: parsed.uri
 			})) || null;
 		}

--- a/src/server/api/endpoints/messaging/messages/delete.ts
+++ b/src/server/api/endpoints/messaging/messages/delete.ts
@@ -1,10 +1,10 @@
 import $ from 'cafy';
 import { ID } from '../../../../../misc/cafy-id';
 import define from '../../../define';
-import { publishMessagingStream, publishGroupMessagingStream } from '../../../../../services/stream';
 import * as ms from 'ms';
 import { ApiError } from '../../../error';
 import { MessagingMessages } from '../../../../../models';
+import { deleteMessage } from '../../../../../services/messages/delete';
 
 export const meta = {
 	desc: {
@@ -53,12 +53,5 @@ export default define(meta, async (ps, user) => {
 		throw new ApiError(meta.errors.noSuchMessage);
 	}
 
-	await MessagingMessages.delete(message.id);
-
-	if (message.recipientId) {
-		publishMessagingStream(message.userId, message.recipientId, 'deleted', message.id);
-		publishMessagingStream(message.recipientId, message.userId, 'deleted', message.id);
-	} else if (message.groupId) {
-		publishGroupMessagingStream(message.groupId, 'deleted', message.id);
-	}
+	await deleteMessage(message);
 });

--- a/src/services/messages/delete.ts
+++ b/src/services/messages/delete.ts
@@ -1,0 +1,31 @@
+import config from '../../config';
+import { ensure } from '../../prelude/ensure';
+import { MessagingMessages, Users } from '../../models';
+import { MessagingMessage } from '../../models/entities/messaging-message';
+import { publishGroupMessagingStream, publishMessagingStream } from '../stream';
+import { renderActivity } from '../../remote/activitypub/renderer';
+import renderDelete from '../../remote/activitypub/renderer/delete';
+import renderTombstone from '../../remote/activitypub/renderer/tombstone';
+import { deliver } from '../../queue';
+
+export async function deleteMessage(message: MessagingMessage) {
+	await MessagingMessages.delete(message.id);
+	postDeleteMessage(message);
+}
+
+async function postDeleteMessage(message: MessagingMessage) {
+	if (message.recipientId) {
+		const user = await Users.findOne(message.userId).then(ensure);
+		const recipient = await Users.findOne(message.recipientId).then(ensure);
+
+		if (Users.isLocalUser(user)) publishMessagingStream(message.userId, message.recipientId, 'deleted', message.id);
+		if (Users.isLocalUser(recipient)) publishMessagingStream(message.recipientId, message.userId, 'deleted', message.id);
+
+		if (Users.isLocalUser(user) && Users.isRemoteUser(recipient)) {
+			const activity = renderActivity(renderDelete(renderTombstone(`${config.url}/notes/${message.id}`), user));
+			deliver(user, activity, recipient.inbox);
+		}
+	} else if (message.groupId) {
+		publishGroupMessagingStream(message.groupId, 'deleted', message.id);
+	}
+}


### PR DESCRIPTION
## Summary
Resove #6772
- メッセージ (トーク/チャット) 削除をリモートと送受信するように
- メッセージ削除時に無駄なリモートアカウント分のredis publishをしているのを修正