### PR TITLE
In HTML to MFM, use angle bracket if needed

### DIFF
--- a/src/mfm/from-html.ts
+++ b/src/mfm/from-html.ts
@@ -1,5 +1,5 @@
 import { parseFragment, DefaultTreeDocumentFragment } from 'parse5';
-import { urlRegex } from './prelude';
+import { urlRegexFull } from './prelude';
 
 export function fromHtml(html: string, hashtagNames?: string[]): string {
 	const dom = parseFragment(html) as DefaultTreeDocumentFragment;
@@ -54,7 +54,11 @@ export function fromHtml(html: string, hashtagNames?: string[]): string {
 					}
 				// その他
 				} else {
-					text += (!href || (txt === href.value && txt.match(urlRegex))) ? txt : `[${txt}](${href.value})`;
+					text += !href ? txt
+						: txt === href.value
+							? txt.match(urlRegexFull) ? txt
+							: `<${txt}>`
+						: `[${txt}](${href.value})`;
 				}
 				break;
 

--- a/src/mfm/prelude.ts
+++ b/src/mfm/prelude.ts
@@ -36,4 +36,5 @@ export function createTree(type: string, children: MfmForest, props: any): MfmTr
 	return T.createTree({ type, props }, children);
 }
 
-export const urlRegex = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+/;
+export const urlRegex     = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+/;
+export const urlRegexFull = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+$/;

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -12,6 +12,7 @@ import * as assert from 'assert';
 
 import { parse, parsePlain } from '../src/mfm/parse';
 import { toHtml } from '../src/mfm/to-html';
+import { fromHtml } from '../src/mfm/from-html';
 import { toString } from '../src/mfm/to-string';
 import { createTree as tree, createLeaf as leaf, MfmTree } from '../src/mfm/prelude';
 import { removeOrphanedBrackets } from '../src/mfm/language';
@@ -1364,5 +1365,39 @@ describe('MFM', () => {
 		it('ブロック数式', () => {
 			assert.deepStrictEqual(toString(parse('\\\[\nブロック数式\n\]\\')), '\\\[\nブロック数式\n\]\\');
 		});
+	});
+});
+
+describe('fromHtml', () => {
+	it('br', () => {
+		assert.deepStrictEqual(fromHtml('<p>abc<br><br/>d</p>'), 'abc\n\nd');
+	});
+
+	it('link with different text', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="https://example.com/b">c</a> d</p>'), 'a [c](https://example.com/b) d');
+	});
+
+	it('link with same text', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="https://example.com/b">https://example.com/b</a> d</p>'), 'a https://example.com/b d');
+	});
+
+	it('link with same text, but not encoded', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="https://example.com/ä">https://example.com/ä</a> d</p>'), 'a <https://example.com/ä> d');
+	});
+
+	it('link with no url', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="b">c</a> d</p>'), 'a [c](b) d');
+	});
+
+	it('link without href', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a>c</a> d</p>'), 'a c d');
+	});
+
+	it('mention', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="https://example.com/@user" class="u-url mention">@user</a> d</p>'), 'a @user@example.com d');
+	});
+
+	it('hashtag', () => {
+		assert.deepStrictEqual(fromHtml('<p>a <a href="https://example.com/tags/a">#a</a> d</p>', ['#a']), 'a #a d');
 	});
 });


### PR DESCRIPTION
## Summary
Fix #6815
HTMLからMFMに変換する際、
hrefとtextとが同じでhrefがエンコードされていない場合に、
ベタテキストのURLに変換してしまっていたものを`<URL>`を使用するように。

以下の前方一致用のパターンを全体のバリデーションに使っちゃってたから実はバグ
https://github.com/syuilo/misskey/blob/9d405b45812438841be6496ec4622264ca886a4c/src/mfm/prelude.ts#L39

before
```
<a href="https://example.com/ä">https://example.com/ä</a>
↓
https://example.com/ä
```

after
```
<a href="https://example.com/ä">https://example.com/ä</a>
↓
<https://example.com/ä>
```
