### PR TITLE
CIでDockerイメージのpushが正しく行われるよう修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   docker:
     working_directory: /tmp/workspace
     docker:
-      - image: docker:latest
+      - image: docker:12.10.1
 
 jobs:
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
                     apk update && apk add jq
                     docker tag misskey/misskey misskey/misskey:$(cat package.json | jq -r .version)
                     docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
-                    docker push misskey/misskey
+                    docker push -a misskey/misskey
                    else
                     echo -e '\033[0;33mAborted deploying to Docker Hub\033[0;39m'
                   fi


### PR DESCRIPTION
## Summary

Docker CLI が 20.10.0 になった際に `docker push` のデフォルトの挙動が変わり（https://github.com/docker/cli/commit/9e620e990fe8a763ce147c23f4d8ab1e12f7156b ）、`-a` をつけないと全てのタグを push しなくなりました。おそらくその変更によって`misskey/misskey:12.36.0` のイメージが push されず、latest だけが更新されています（ [ログ](https://app.circleci.com/pipelines/github/syuilo/misskey/18548/workflows/fd74c16d-7724-40ae-bdd2-da254324f1f8/jobs/9708) ）。この PR では `-a` をつけることで今まで通りイメージが push されるように修正しつつ、CI で使うイメージのバージョンを固定することで今後も同じバージョンの Docker CLI を使い続けるように変更しています。