### PR TITLE
フォローリクエストがなくてもフォロー承認が出来てしまうのを修正

### DIFF
--- a/src/server/api/endpoints/following/requests/accept.ts
+++ b/src/server/api/endpoints/following/requests/accept.ts
@@ -33,6 +33,11 @@ export const meta = {
 			code: 'NO_SUCH_USER',
 			id: '66ce1645-d66c-46bb-8b79-96739af885bd'
 		},
+		noFollowRequest: {
+			message: 'No follow request.',
+			code: 'NO_FOLLOW_REQUEST',
+			id: 'bcde4f8b-0913-4614-8881-614e522fb041'
+		},
 	}
 };
 
@@ -43,7 +48,10 @@ export default define(meta, async (ps, user) => {
 		throw e;
 	});
 
-	await acceptFollowRequest(user, follower);
+	await acceptFollowRequest(user, follower).catch(e => {
+		if (e.id === '8884c2dd-5795-4ac9-b27e-6a01d38190f9') throw new ApiError(meta.errors.noFollowRequest);
+		throw e;
+	});
 
 	return;
 });

--- a/src/services/following/requests/accept.ts
+++ b/src/services/following/requests/accept.ts
@@ -6,6 +6,7 @@ import { publishMainStream } from '../../stream';
 import { insertFollowingDoc } from '../create';
 import { User, ILocalUser } from '../../../models/entities/user';
 import { FollowRequests, Users } from '../../../models';
+import { IdentifiableError } from '../../../misc/identifiable-error';
 
 export default async function(followee: User, follower: User) {
 	const request = await FollowRequests.findOne({
@@ -13,9 +14,13 @@ export default async function(followee: User, follower: User) {
 		followerId: follower.id
 	});
 
+	if (request == null) {
+		throw new IdentifiableError('8884c2dd-5795-4ac9-b27e-6a01d38190f9', 'No follow request.');
+	}
+
 	await insertFollowingDoc(followee, follower);
 
-	if (Users.isRemoteUser(follower) && request) {
+	if (Users.isRemoteUser(follower)) {
 		const content = renderActivity(renderAccept(renderFollow(follower, followee, request.requestId!), followee as ILocalUser));
 		deliver(followee as ILocalUser, content, follower.inbox);
 	}

--- a/src/services/user-list/push.ts
+++ b/src/services/user-list/push.ts
@@ -1,6 +1,3 @@
-import { renderActivity } from '../../remote/activitypub/renderer';
-import { deliver } from '../../queue';
-import renderFollow from '../../remote/activitypub/renderer/follow';
 import { publishUserListStream } from '../stream';
 import { User } from '../../models/entities/user';
 import { UserList } from '../../models/entities/user-list';
@@ -8,6 +5,7 @@ import { UserListJoinings, Users } from '../../models';
 import { UserListJoining } from '../../models/entities/user-list-joining';
 import { genId } from '../../misc/gen-id';
 import { fetchProxyAccount } from '../../misc/fetch-proxy-account';
+import createFollowing from '../following/create';
 
 export async function pushUserToUserList(target: User, list: UserList) {
 	await UserListJoinings.save({
@@ -23,8 +21,7 @@ export async function pushUserToUserList(target: User, list: UserList) {
 	if (Users.isRemoteUser(target)) {
 		const proxy = await fetchProxyAccount();
 		if (proxy) {
-			const content = renderActivity(renderFollow(proxy, target));
-			deliver(proxy, content, target.inbox);
+			createFollowing(proxy, target);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Fix #7012
フォローリクエストがなくてもフォロー承認が出来てしまうのを修正。
これをなおすと別のバグでプロキシアカウントが動かなくなるので、プロキシアカウントの処理も修正しています。