### PR TITLE
Showusers order by updateAt NULL considered as max

### DIFF
--- a/src/server/api/endpoints/admin/show-users.ts
+++ b/src/server/api/endpoints/admin/show-users.ts
@@ -95,8 +95,8 @@ export default define(meta, async (ps, me) => {
 		case '-follower': query.orderBy('user.followersCount', 'ASC'); break;
 		case '+createdAt': query.orderBy('user.createdAt', 'DESC'); break;
 		case '-createdAt': query.orderBy('user.createdAt', 'ASC'); break;
-		case '+updatedAt': query.orderBy('user.updatedAt', 'DESC'); break;
-		case '-updatedAt': query.orderBy('user.updatedAt', 'ASC'); break;
+		case '+updatedAt': query.orderBy('user.updatedAt', 'DESC', 'NULLS LAST'); break;
+		case '-updatedAt': query.orderBy('user.updatedAt', 'ASC', 'NULLS FIRST'); break;
 		default: query.orderBy('user.id', 'ASC'); break;
 	}
 


### PR DESCRIPTION
## Summary

In the admin user page, when select order by last update time, the null value should conceded as oldest update.

Resolve #7014

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
