### PR TITLE
Federate image names as comments

### DIFF
--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -29,7 +29,7 @@ export async function createImage(actor: IRemoteUser, value: any): Promise<Drive
 	const instance = await fetchMeta();
 	const cache = instance.cacheRemoteFiles;
 
-	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache);
+	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache, image.name);
 
 	if (file.isLink) {
 		// URLが異なっている場合、同じ画像が以前に異なるURLで登録されていたということなので、

--- a/src/remote/activitypub/renderer/document.ts
+++ b/src/remote/activitypub/renderer/document.ts
@@ -4,5 +4,6 @@ import { DriveFiles } from '../../../models';
 export default (file: DriveFile) => ({
 	type: 'Document',
 	mediaType: file.type,
+	name: file.comment || file.name,
 	url: DriveFiles.getPublicUrl(file)
 });


### PR DESCRIPTION
## Summary

* Saves the remote alt text "name" field **from** services like Mastodon as the "comment" field locally 109c744.
* Additionally, sends the local "comment" or "name" field  **to** the other services as "name". Note: this is not technically part of #6606, let me know if you would like me to remove 973c65a. I know that comments are currently not in use, but I have a fork that uses them and this works nicely.

Resolve #6606