### PR TITLE
チャンネルページから別チャンネルページに移動時にタイムラインが切り替わらないのを修正

### DIFF
--- a/src/client/pages/channel.vue
+++ b/src/client/pages/channel.vue
@@ -22,7 +22,7 @@
 
 	<XPostForm :channel="channel" class="post-form _content _panel _vMargin" fixed v-if="$i"/>
 
-	<XTimeline class="_content _vMargin _noGap_" src="channel" :channel="channelId" @before="before" @after="after"/>
+	<XTimeline class="_content _vMargin _noGap_" src="channel" :key="channelId" :channel="channelId" @before="before" @after="after"/>
 </div>
 </template>
 


### PR DESCRIPTION
## Summary

チャンネルの個別ページ (`/channels/:id`) から別のチャンネルの個別ページに移動した際に、ヘッダーなどは更新されるがタイムラインの表示が移動前のチャンネルから切り替わらないバグを修正しました。

チャンネルに別チャンネルページへのリンクをノートし、そのリンクをクリックなどするとバグを再現できるはずです。