### PR TITLE
検索のタイトルが変更されない問題を修正

### DIFF
--- a/src/client/pages/search.vue
+++ b/src/client/pages/search.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import { faSearch } from '@fortawesome/free-solid-svg-icons';
 import Progress from '@/scripts/loading';
 import XNotes from '@/components/notes.vue';
@@ -20,7 +20,7 @@ export default defineComponent({
 	data() {
 		return {
 			INFO: {
-				title: this.$t('searchWith', { q: this.$route.query.q }),
+				title: computed(() => this.$t('searchWith', { q: this.$route.query.q })),
 				icon: faSearch
 			},
 			pagination: {


### PR DESCRIPTION
## Summary

キーワード「A」の検索画面から続けてキーワード「B」を検索すると、タイトルバーの検索キーワードがBに変更されないバグを修正しました。

[src/client/pages/channel.vue#L56](https://github.com/syuilo/misskey/blob/12.65.7/src/client/pages/channel.vue#L56) あたりを参考に `computed()` を使用し、検索クエリの変化に対応しました。
<!-- 
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
