### PR TITLE
グループの編集画面をウィンドウで開けないバグを修正

### DIFF
--- a/src/client/pages/my-groups/group.vue
+++ b/src/client/pages/my-groups/group.vue
@@ -45,6 +45,13 @@ export default defineComponent({
 		MkButton
 	},
 
+	props: {
+		groupId: {
+			type: String,
+			required: true,
+		},
+	},
+
 	data() {
 		return {
 			INFO: computed(() => this.group ? {
@@ -58,7 +65,7 @@ export default defineComponent({
 	},
 
 	watch: {
-		$route: 'fetch'
+		groupId: 'fetch',
 	},
 
 	created() {
@@ -69,7 +76,7 @@ export default defineComponent({
 		fetch() {
 			Progress.start();
 			os.api('users/groups/show', {
-				groupId: this.$route.params.group
+				groupId: this.groupId
 			}).then(group => {
 				this.group = group;
 				os.api('users/show', {

--- a/src/client/router.ts
+++ b/src/client/router.ts
@@ -55,7 +55,7 @@ export const router = createRouter({
 		{ path: '/my/lists', component: page('my-lists/index') },
 		{ path: '/my/lists/:list', component: page('my-lists/list') },
 		{ path: '/my/groups', component: page('my-groups/index') },
-		{ path: '/my/groups/:group', component: page('my-groups/group') },
+		{ path: '/my/groups/:group', component: page('my-groups/group'), props: route => ({ groupId: route.params.group }) },
 		{ path: '/my/antennas', component: page('my-antennas/index') },
 		{ path: '/my/clips', component: page('my-clips/index') },
 		{ path: '/scratchpad', component: page('scratchpad') },


### PR DESCRIPTION
## Summary

グループの編集画面をウィンドウで開けないバグを修正しました。

再現方法は以下の通りです。
「もっと！」→「グループ」（ウィンドウで表示）→ 存在するグループをクリック → 何も表示されない（本来はメンバー一覧など）

アクセスしているパスから `groupId` を取得しようとするものの、ウィンドウで開いているがゆえにパスが `/` などになっており失敗するので、他の実装を参考に `props` で渡すようにしました。

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
