### PR TITLE
Fix to wait for the removal of item in i/registry/remove

### DIFF
--- a/src/server/api/endpoints/i/registry/remove.ts
+++ b/src/server/api/endpoints/i/registry/remove.ts
@@ -41,5 +41,5 @@ export default define(meta, async (ps, user) => {
 		throw new ApiError(meta.errors.noSuchKey);
 	}
 
-	RegistryItems.remove(item);
+	await RegistryItems.remove(item);
 });


### PR DESCRIPTION
## Summary

`i/registry/remove` エンドポイントがレスポンスを返した時点でキーが残っている可能性があります。 `await` することで、レスポンスが返った時点で必ず指定されたキーが削除されているようにします。