### PR TITLE
Update recaptcha's host

### DIFF
--- a/src/client/components/captcha.vue
+++ b/src/client/components/captcha.vue
@@ -57,7 +57,7 @@ export default defineComponent({
 		src() {
 			const endpoint = ({
 				hcaptcha: 'https://hcaptcha.com/1',
-				grecaptcha: 'https://www.google.com/recaptcha',
+				grecaptcha: 'https://www.recaptcha.net/recaptcha',
 			} as Record<PropertyKey, unknown>)[this.provider];
 
 			return `${typeof endpoint == 'string' ? endpoint : 'about:invalid'}/api.js?render=explicit`;


### PR DESCRIPTION
Changed to recaptcha.net because google.com are blocked in some region

## Summary

   Hi there. "google.com" is blocked in some regions like China mainland, as a result, users from those area cannot access Misskey instance if Recaptcha is on. Alternatively, "recaptcha.net" is available.

  Thanks.

<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
