### PR TITLE
ServiceWorker: onfetchで何もしないように

### DIFF
--- a/src/client/sw/sw.ts
+++ b/src/client/sw/sw.ts
@@ -10,7 +10,6 @@ import { I18n } from '@/scripts/i18n';
 //#region Variables
 const version = _VERSION_;
 const cacheName = `mk-cache-${version}`;
-const apiUrl = `${location.origin}/api/`;
 
 let lang: string;
 let i18n: I18n<any>;

--- a/src/client/sw/sw.ts
+++ b/src/client/sw/sw.ts
@@ -27,7 +27,7 @@ get('lang').then(async prelang => {
 
 //#region Lifecycle: Install
 self.addEventListener('install', ev => {
-	// Nothing to do
+	self.skipWaiting()
 });
 //#endregion
 

--- a/src/client/sw/sw.ts
+++ b/src/client/sw/sw.ts
@@ -27,15 +27,7 @@ get('lang').then(async prelang => {
 
 //#region Lifecycle: Install
 self.addEventListener('install', ev => {
-	ev.waitUntil(
-		caches.open(cacheName)
-			.then(cache => {
-				return cache.addAll([
-					`/?v=${version}`
-				]);
-			})
-			.then(() => self.skipWaiting())
-	);
+	// Nothing to do
 });
 //#endregion
 
@@ -53,19 +45,9 @@ self.addEventListener('activate', ev => {
 });
 //#endregion
 
-// TODO: 消せるかも ref. https://github.com/syuilo/misskey/pull/7108#issuecomment-774573666
 //#region When: Fetching
 self.addEventListener('fetch', ev => {
-	if (ev.request.method !== 'GET' || ev.request.url.startsWith(apiUrl)) return;
-	ev.respondWith(
-		caches.match(ev.request)
-			.then(response => {
-				return response || fetch(ev.request);
-			})
-			.catch(() => {
-				return caches.match(`/?v=${version}`);
-			})
-	);
+	// Nothing to do
 });
 //#endregion
 

--- a/src/client/sw/sw.ts
+++ b/src/client/sw/sw.ts
@@ -27,7 +27,7 @@ get('lang').then(async prelang => {
 
 //#region Lifecycle: Install
 self.addEventListener('install', ev => {
-	self.skipWaiting()
+	self.skipWaiting();
 });
 //#endregion
 


### PR DESCRIPTION
## Summary
Resolve #7192

onfetchに空関数を指定してもPWAとして認識されることが判明したので、下手なキャッシュをしないようにする

（SW内ではCache Storageを使いたいのでactivateのキャッシュパージ処理は残す）
