### PR TITLE
Revert "perf: use overflow: clip instead of hidden"

### DIFF
--- a/src/client/components/autocomplete.vue
+++ b/src/client/components/autocomplete.vue
@@ -401,8 +401,7 @@ export default defineComponent({
 	z-index: 65535;
 	max-width: 100%;
 	margin-top: calc(1em + 8px);
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	transition: top 0.1s ease, left 0.1s ease;
 
 	> ol {
@@ -419,8 +418,7 @@ export default defineComponent({
 			align-items: center;
 			padding: 4px 12px;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			font-size: 0.9em;
 			cursor: default;
 
@@ -429,8 +427,7 @@ export default defineComponent({
 			}
 
 			* {
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				text-overflow: ellipsis;
 			}
 

--- a/src/client/components/channel-preview.vue
+++ b/src/client/components/channel-preview.vue
@@ -66,8 +66,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 .eftoefju {
 	display: block;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	width: 100%;
 
 	&:hover {

--- a/src/client/components/drive.file.vue
+++ b/src/client/components/drive.file.vue
@@ -342,8 +342,7 @@ export default defineComponent({
 		text-align: center;
 		word-break: break-all;
 		color: var(--fg);
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 
 		> .ext {
 			opacity: 0.5;

--- a/src/client/components/form/input.vue
+++ b/src/client/components/form/input.vue
@@ -261,8 +261,7 @@ export default defineComponent({
 				display: inline-block;
 				min-width: 16px;
 				max-width: 150px;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
 			}

--- a/src/client/components/form/link.vue
+++ b/src/client/components/form/link.vue
@@ -83,8 +83,7 @@ export default defineComponent({
 		> .text {
 			white-space: nowrap;
 			text-overflow: ellipsis;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			padding-right: 12px;
 		}
 

--- a/src/client/components/global/avatar.vue
+++ b/src/client/components/global/avatar.vue
@@ -101,8 +101,7 @@ export default defineComponent({
 		top: 0;
 		border-radius: 100%;
 		z-index: 1;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		object-fit: cover;
 		width: 100%;
 		height: 100%;

--- a/src/client/components/global/misskey-flavored-markdown.vue
+++ b/src/client/components/global/misskey-flavored-markdown.vue
@@ -126,8 +126,7 @@ export default defineComponent({
 	&.nowrap {
 		white-space: pre;
 		word-wrap: normal; // https://codeday.me/jp/qa/20190424/690106.html
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 

--- a/src/client/components/instance-stats.vue
+++ b/src/client/components/instance-stats.vue
@@ -692,8 +692,7 @@ export default defineComponent({
 
 						> dd {
 							text-overflow: ellipsis;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 							white-space: nowrap;
 						}
 

--- a/src/client/components/instance-ticker.vue
+++ b/src/client/components/instance-ticker.vue
@@ -44,8 +44,7 @@ export default defineComponent({
 
 	height: $height;
 	border-radius: 4px 0 0 4px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	color: #fff;
 
 	> .icon {

--- a/src/client/components/media-banner.vue
+++ b/src/client/components/media-banner.vue
@@ -62,8 +62,7 @@ export default defineComponent({
 	width: 100%;
 	border-radius: 4px;
 	margin-top: 4px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	> .download,
 	> .sensitive {
@@ -78,8 +77,7 @@ export default defineComponent({
 		}
 
 		> b {
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 		}
 

--- a/src/client/components/media-image.vue
+++ b/src/client/components/media-image.vue
@@ -143,8 +143,7 @@ export default defineComponent({
 	> a {
 		display: block;
 		cursor: zoom-in;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		width: 100%;
 		height: 100%;
 		background-position: center;

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -105,8 +105,7 @@ export default defineComponent({
 			grid-gap: 4px;
 
 			> * {
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				border-radius: 6px;
 			}
 

--- a/src/client/components/media-video.vue
+++ b/src/client/components/media-video.vue
@@ -78,8 +78,7 @@ export default defineComponent({
 		align-items: center;
 
 		font-size: 3.5em;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		background-position: center;
 		background-size: cover;
 		width: 100%;

--- a/src/client/components/note-detailed.vue
+++ b/src/client/components/note-detailed.vue
@@ -886,8 +886,7 @@ export default defineComponent({
 .note {
 	position: relative;
 	transition: box-shadow 0.1s ease;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	contain: content;
 
 	&:focus-visible {
@@ -947,8 +946,7 @@ export default defineComponent({
 		}
 
 		> span {
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			flex-shrink: 1;
 			text-overflow: ellipsis;
 			white-space: nowrap;

--- a/src/client/components/note-header.vue
+++ b/src/client/components/note-header.vue
@@ -61,8 +61,7 @@ export default defineComponent({
 		display: block;
 		margin: 0 .5em 0 0;
 		padding: 0;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		font-size: 1em;
 		font-weight: bold;
 		text-decoration: none;
@@ -91,8 +90,7 @@ export default defineComponent({
 
 	> .username {
 		margin: 0 .5em 0 0;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 

--- a/src/client/components/note-preview.vue
+++ b/src/client/components/note-preview.vue
@@ -50,8 +50,7 @@ export default defineComponent({
 	display: flex;
 	margin: 0;
 	padding: 0;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	font-size: 0.95em;
 
 	> .avatar {

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -861,8 +861,7 @@ export default defineComponent({
 .tkcbzcuz {
 	position: relative;
 	transition: box-shadow 0.1s ease;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	contain: content;
 
 	// これらの指定はパフォーマンス向上には有効だが、ノートの高さは一定でないため、
@@ -949,8 +948,7 @@ export default defineComponent({
 		}
 
 		> span {
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			flex-shrink: 1;
 			text-overflow: ellipsis;
 			white-space: nowrap;
@@ -1022,8 +1020,7 @@ export default defineComponent({
 					&.collapsed {
 						position: relative;
 						max-height: 9em;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 
 						> .fade {
 							display: block;

--- a/src/client/components/notification.vue
+++ b/src/client/components/notification.vue
@@ -257,8 +257,7 @@ export default defineComponent({
 				text-overflow: ellipsis;
 				white-space: nowrap;
 				min-width: 0;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 			}
 
 			> .time {
@@ -269,8 +268,7 @@ export default defineComponent({
 
 		> .text {
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 
 			> [data-icon] {

--- a/src/client/components/poll.vue
+++ b/src/client/components/poll.vue
@@ -112,8 +112,7 @@ export default defineComponent({
 			padding: 4px 8px;
 			border: solid 1px var(--divider);
 			border-radius: 4px;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			cursor: pointer;
 
 			&:hover {

--- a/src/client/components/post-form-attaches.vue
+++ b/src/client/components/post-form-attaches.vue
@@ -127,8 +127,7 @@ export default defineComponent({
 			height: 64px;
 			margin-right: 4px;
 			border-radius: 4px;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			cursor: move;
 
 			&:hover > .remove {

--- a/src/client/components/sidebar.vue
+++ b/src/client/components/sidebar.vue
@@ -390,8 +390,7 @@ export default defineComponent({
 				font-size: $ui-font-size;
 				line-height: 3rem;
 				text-overflow: ellipsis;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				white-space: nowrap;
 				width: 100%;
 				text-align: left;

--- a/src/client/components/toast.vue
+++ b/src/client/components/toast.vue
@@ -67,8 +67,7 @@ export default defineComponent({
 		height: 100%;
 		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 		border-radius: 8px;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 	}
 }
 </style>

--- a/src/client/components/ui/button.vue
+++ b/src/client/components/ui/button.vue
@@ -124,8 +124,7 @@ export default defineComponent({
 	text-decoration: none;
 	background: var(--buttonBg);
 	border-radius: 999px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	&:not(:disabled):hover {
 		background: var(--buttonHoverBg);
@@ -213,8 +212,7 @@ export default defineComponent({
 		width: 100%;
 		height: 100%;
 		border-radius: 6px;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 
 		::v-deep(div) {
 			position: absolute;

--- a/src/client/components/ui/container.vue
+++ b/src/client/components/ui/container.vue
@@ -116,8 +116,7 @@ export default defineComponent({
 
 .ukygtjoj {
 	position: relative;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	&.naked {
 		background: transparent !important;

--- a/src/client/components/ui/input.vue
+++ b/src/client/components/ui/input.vue
@@ -298,8 +298,7 @@ export default defineComponent({
 			transform: scale(.75);
 			white-space: nowrap;
 			width: 133%;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 
 			> .warning {
@@ -355,8 +354,7 @@ export default defineComponent({
 				display: inline-block;
 				min-width: 16px;
 				max-width: 150px;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
 			}

--- a/src/client/components/ui/menu.vue
+++ b/src/client/components/ui/menu.vue
@@ -155,8 +155,7 @@ export default defineComponent({
 		font-size: 0.9em;
 		line-height: 20px;
 		text-align: center;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		text-overflow: ellipsis;
 
 		&.danger {

--- a/src/client/components/ui/modal-window.vue
+++ b/src/client/components/ui/modal-window.vue
@@ -89,8 +89,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .ebkgoccj {
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 	contain: content;
@@ -124,8 +123,7 @@ export default defineComponent({
 			padding-left: 32px;
 			font-weight: bold;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			pointer-events: none;
 

--- a/src/client/components/ui/range.vue
+++ b/src/client/components/ui/range.vue
@@ -89,8 +89,7 @@ export default defineComponent({
 		pointer-events: none;
 		font-size: 16px;
 		color: var(--inputLabel);
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 	}
 
 	> input {

--- a/src/client/components/ui/window.vue
+++ b/src/client/components/ui/window.vue
@@ -402,8 +402,7 @@ export default defineComponent({
 	}
 
 	> .body {
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		display: flex;
 		flex-direction: column;
 		contain: content;
@@ -438,8 +437,7 @@ export default defineComponent({
 				position: relative;
 				line-height: var(--height);
 				white-space: nowrap;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				text-overflow: ellipsis;
 				text-align: center;
 				cursor: move;

--- a/src/client/components/url-preview.vue
+++ b/src/client/components/url-preview.vue
@@ -244,8 +244,7 @@ export default defineComponent({
 		font-size: 14px;
 		box-shadow: 0 0 0 1px var(--divider);
 		border-radius: 8px;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 
 		&:hover {
 			text-decoration: none;
@@ -327,8 +326,7 @@ export default defineComponent({
 		&.compact {
 			> article {
 				> header h1, p, footer {
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					white-space: nowrap;
 					text-overflow: ellipsis;
 				}

--- a/src/client/components/user-info.vue
+++ b/src/client/components/user-info.vue
@@ -110,8 +110,7 @@ export default defineComponent({
 			display: -webkit-box;
 			-webkit-line-clamp: 3;
 			-webkit-box-orient: vertical;  
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 		}
 	}
 

--- a/src/client/components/user-preview.vue
+++ b/src/client/components/user-preview.vue
@@ -111,8 +111,7 @@ export default defineComponent({
 	position: absolute;
 	z-index: 11000;
 	width: 300px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	transform-origin: center top;
 
 	> .info {

--- a/src/client/components/users-dialog.vue
+++ b/src/client/components/users-dialog.vue
@@ -66,8 +66,7 @@ export default defineComponent({
 	height: 350px;
 	background: var(--panel);
 	border-radius: var(--radius);
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 
@@ -128,8 +127,7 @@ export default defineComponent({
 
 			> .body {
 				padding: 0 8px;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 
 				> .name {
 					display: block;

--- a/src/client/components/visibility-picker.vue
+++ b/src/client/components/visibility-picker.vue
@@ -141,8 +141,7 @@ export default defineComponent({
 		> *:nth-child(2) {
 			flex: 1 1 auto;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 
 			> span:first-child {

--- a/src/client/pages/about-misskey.vue
+++ b/src/client/pages/about-misskey.vue
@@ -1,5 +1,5 @@
 <template>
-<div style="overflow: hidden; overflow: clip;">
+<div style="overflow: hidden;">
 	<FormBase class="znqjceqz">
 		<div id="debug"></div>
 		<section class="_formItem about">

--- a/src/client/pages/follow-requests.vue
+++ b/src/client/pages/follow-requests.vue
@@ -104,8 +104,7 @@ export default defineComponent({
 					display: block;
 					white-space: nowrap;
 					text-overflow: ellipsis;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					margin: 0;
 				}
 
@@ -125,8 +124,7 @@ export default defineComponent({
 				width: 55%;
 				line-height: 42px;
 				white-space: nowrap;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				text-overflow: ellipsis;
 				opacity: 0.7;
 				font-size: 14px;

--- a/src/client/pages/instance/emojis.vue
+++ b/src/client/pages/instance/emojis.vue
@@ -178,20 +178,17 @@ export default defineComponent({
 					> .body {
 						padding: 0 0 0 8px;
 						white-space: nowrap;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 
 						> .name {
 							text-overflow: ellipsis;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 						}
 
 						> .info {
 							opacity: 0.5;
 							text-overflow: ellipsis;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 						}
 					}
 				}
@@ -222,20 +219,17 @@ export default defineComponent({
 					> .body {
 						padding: 0 0 0 8px;
 						white-space: nowrap;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 
 						> .name {
 							text-overflow: ellipsis;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 						}
 
 						> .info {
 							opacity: 0.5;
 							text-overflow: ellipsis;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 						}
 					}
 				}

--- a/src/client/pages/messaging/index.vue
+++ b/src/client/pages/messaging/index.vue
@@ -226,14 +226,12 @@ export default defineComponent({
 					align-items: center;
 					margin-bottom: 2px;
 					white-space: nowrap;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 
 					> .name {
 						margin: 0;
 						padding: 0;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						text-overflow: ellipsis;
 						font-size: 1em;
 						font-weight: bold;
@@ -264,8 +262,7 @@ export default defineComponent({
 						display: block;
 						margin: 0 0 0 0;
 						padding: 0;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						overflow-wrap: break-word;
 						font-size: 1.1em;
 						color: var(--faceText);

--- a/src/client/pages/messaging/messaging-room.message.vue
+++ b/src/client/pages/messaging/messaging-room.message.vue
@@ -154,8 +154,7 @@ export default defineComponent({
 					display: block;
 					margin: 0;
 					padding: 0;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					overflow-wrap: break-word;
 					font-size: 1em;
 					color: rgba(#000, 0.5);
@@ -165,8 +164,7 @@ export default defineComponent({
 					display: block;
 					margin: 0;
 					padding: 12px 18px;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					overflow-wrap: break-word;
 					word-break: break-word;
 					font-size: 1em;
@@ -184,8 +182,7 @@ export default defineComponent({
 						display: block;
 						max-width: 100%;
 						border-radius: 16px;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						text-decoration: none;
 
 						&:hover {

--- a/src/client/pages/page-editor/page-editor.container.vue
+++ b/src/client/pages/page-editor/page-editor.container.vue
@@ -74,8 +74,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 .cpjygsrt {
 	position: relative;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	background: var(--panel);
 	border: solid 2px var(--X12);
 	border-radius: 6px;

--- a/src/client/pages/reversi/game.board.vue
+++ b/src/client/pages/reversi/game.board.vue
@@ -434,8 +434,7 @@ export default defineComponent({
 				> div {
 					background: transparent;
 					border-radius: 6px;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 
 					* {
 						pointer-events: none;

--- a/src/client/pages/reversi/game.setting.vue
+++ b/src/client/pages/reversi/game.setting.vue
@@ -333,8 +333,7 @@ export default defineComponent({
 							background: transparent;
 							border: solid 2px var(--divider);
 							border-radius: 6px;
-							overflow: hidden; // overflow: clip; をSafariが対応したら消す
-							overflow: clip;
+							overflow: hidden;
 							cursor: pointer;
 
 							* {

--- a/src/client/pages/settings/drive.vue
+++ b/src/client/pages/settings/drive.vue
@@ -230,8 +230,7 @@ export default defineComponent({
 			$size: 12px;
 			background: rgba(0, 0, 0, 0.1);
 			border-radius: ($size / 2);
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 
 			> div {
 				height: $size;

--- a/src/client/pages/settings/security.vue
+++ b/src/client/pages/settings/security.vue
@@ -144,8 +144,7 @@ export default defineComponent({
 			flex: 1;
 			min-width: 0;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			margin-right: 12px;
 		}

--- a/src/client/pages/settings/theme.vue
+++ b/src/client/pages/settings/theme.vue
@@ -184,8 +184,7 @@ export default defineComponent({
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			padding: 0 100px;
 			transform: translate3d(-50%, -50%, 0);
 

--- a/src/client/pages/user/index.vue
+++ b/src/client/pages/user/index.vue
@@ -369,8 +369,7 @@ export default defineComponent({
 		position: relative;
 		height: 450px;
 		border-radius: 16px;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		background-size: cover;
 		background-position: center;
 
@@ -473,8 +472,7 @@ export default defineComponent({
 
 					> .name {
 						width: 30%;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						white-space: nowrap;
 						text-overflow: ellipsis;
 						font-weight: bold;
@@ -482,8 +480,7 @@ export default defineComponent({
 
 					> .value {
 						width: 70%;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						white-space: nowrap;
 						text-overflow: ellipsis;
 						margin: 0;
@@ -545,8 +542,7 @@ export default defineComponent({
 .ftskorzw.narrow {
 	max-width: 100vw;
 	box-sizing: border-box;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	> .punished {
 		font-size: 0.8em;
@@ -557,14 +553,12 @@ export default defineComponent({
 
 		> .main {
 			position: relative;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 
 			> .banner-container {
 				position: relative;
 				height: 250px;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				background-size: cover;
 				background-position: center;
 
@@ -709,8 +703,7 @@ export default defineComponent({
 
 					> .name {
 						width: 30%;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						white-space: nowrap;
 						text-overflow: ellipsis;
 						font-weight: bold;
@@ -719,8 +712,7 @@ export default defineComponent({
 
 					> .value {
 						width: 70%;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						white-space: nowrap;
 						text-overflow: ellipsis;
 						margin: 0;

--- a/src/client/pages/welcome.entrance.a.vue
+++ b/src/client/pages/welcome.entrance.a.vue
@@ -167,8 +167,7 @@ export default defineComponent({
 			margin: auto;
 			width: 500px;
 			height: calc(100% - 128px);
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			-webkit-mask-image: linear-gradient(0deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 128px, rgba(0,0,0,1) calc(100% - 128px), rgba(0,0,0,0) 100%);
 			mask-image: linear-gradient(0deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 128px, rgba(0,0,0,1) calc(100% - 128px), rgba(0,0,0,0) 100%);
 

--- a/src/client/pages/welcome.entrance.b.vue
+++ b/src/client/pages/welcome.entrance.b.vue
@@ -151,8 +151,7 @@ export default defineComponent({
 			margin: auto;
 			width: 500px;
 			height: calc(100% - 128px);
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			-webkit-mask-image: linear-gradient(0deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 128px, rgba(0,0,0,1) calc(100% - 128px), rgba(0,0,0,0) 100%);
 			mask-image: linear-gradient(0deg, rgba(0,0,0,0) 0%, rgba(0,0,0,1) 128px, rgba(0,0,0,1) calc(100% - 128px), rgba(0,0,0,0) 100%);
 		}

--- a/src/client/pages/welcome.setup.vue
+++ b/src/client/pages/welcome.setup.vue
@@ -71,8 +71,7 @@ export default defineComponent({
 .mk-setup {
 	border-radius: var(--radius);
 	box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	> h1 {
 		margin: 0;

--- a/src/client/style.scss
+++ b/src/client/style.scss
@@ -241,8 +241,7 @@ hr {
 	border-radius: var(--radius);
 	//border: var(--panelBorder);
 	box-shadow: var(--panelShadow);
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 }
 
 ._card {
@@ -456,14 +455,6 @@ hr {
 ._caption {
 	font-size: 0.8em;
 	opacity: 0.7;
-}
-
-// TODO: refactor: 全てのvueファイル中の text-overflow: ellipsis; している箇所をこのクラスを使って置き換える
-._oneline {
-	white-space: nowrap;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
-	text-overflow: ellipsis;
 }
 
 ._monospace {

--- a/src/client/ui/_common_/header.vue
+++ b/src/client/ui/_common_/header.vue
@@ -132,8 +132,7 @@ export default defineComponent({
 			display: inline-block;
 			vertical-align: bottom;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			padding: 0 16px;
 			position: relative;

--- a/src/client/ui/_common_/upload.vue
+++ b/src/client/ui/_common_/upload.vue
@@ -89,8 +89,7 @@ export default defineComponent({
   font-size: 0.8em;
   white-space: nowrap;
   text-overflow: ellipsis;
-  overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+  overflow: hidden;
   flex-shrink: 1;
 }
 .mk-uploader > ol > li > .top > .name > [data-icon] {
@@ -120,8 +119,7 @@ export default defineComponent({
   background: transparent;
   border: none;
   border-radius: 4px;
-  overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+  overflow: hidden;
   grid-column: 2/3;
   grid-row: 2/3;
   z-index: 2;

--- a/src/client/ui/chat/index.vue
+++ b/src/client/ui/chat/index.vue
@@ -427,8 +427,7 @@ export default defineComponent({
 
 					> .text {
 						white-space: nowrap;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						text-overflow: ellipsis;
 						font-size: 0.9em;
 					}
@@ -483,8 +482,7 @@ export default defineComponent({
 						padding: 6px 8px;
 						border-radius: 4px;
 						white-space: nowrap;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						text-overflow: ellipsis;
 
 						&:hover {
@@ -547,8 +545,7 @@ export default defineComponent({
 				}
 
 				> .title {
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
 					min-width: 0;
@@ -559,8 +556,7 @@ export default defineComponent({
 						font-size: 0.8em;
 						font-weight: normal;
 						white-space: nowrap;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 						text-overflow: ellipsis;
 					}
 				}

--- a/src/client/ui/chat/note-header.vue
+++ b/src/client/ui/chat/note-header.vue
@@ -62,8 +62,7 @@ export default defineComponent({
 		display: block;
 		margin: 0 .5em 0 0;
 		padding: 0;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		font-size: 1em;
 		font-weight: bold;
 		text-decoration: none;
@@ -92,8 +91,7 @@ export default defineComponent({
 
 	> .username {
 		margin: 0 .5em 0 0;
-		overflow: hidden; // overflow: clip; をSafariが対応したら消す
-		overflow: clip;
+		overflow: hidden;
 		text-overflow: ellipsis;
 	}
 

--- a/src/client/ui/chat/note-preview.vue
+++ b/src/client/ui/chat/note-preview.vue
@@ -50,8 +50,7 @@ export default defineComponent({
 	display: flex;
 	margin: 0;
 	padding: 0;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	font-size: 0.95em;
 
 	> .avatar {

--- a/src/client/ui/chat/note.vue
+++ b/src/client/ui/chat/note.vue
@@ -955,8 +955,7 @@ export default defineComponent({
 		}
 
 		> span {
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			flex-shrink: 1;
 			text-overflow: ellipsis;
 			white-space: nowrap;
@@ -1029,8 +1028,7 @@ export default defineComponent({
 					&.collapsed {
 						position: relative;
 						max-height: 9em;
-						overflow: hidden; // overflow: clip; をSafariが対応したら消す
-						overflow: clip;
+						overflow: hidden;
 
 						> .fade {
 							display: block;

--- a/src/client/ui/deck/column.vue
+++ b/src/client/ui/deck/column.vue
@@ -268,8 +268,7 @@ export default defineComponent({
 	--section-padding: 10px;
 
 	height: 100%;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 	contain: content;
 
 	&.draghover {
@@ -359,8 +358,7 @@ export default defineComponent({
 		> .header {
 			display: inline-block;
 			align-items: center;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 		}

--- a/src/client/ui/visitor/header.vue
+++ b/src/client/ui/visitor/header.vue
@@ -125,8 +125,7 @@ export default defineComponent({
 					display: inline-block;
 					vertical-align: bottom;
 					white-space: nowrap;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					text-overflow: ellipsis;
 					position: relative;
 
@@ -207,8 +206,7 @@ export default defineComponent({
 		> .title {
 			flex: 1;
 			white-space: nowrap;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 			text-overflow: ellipsis;
 			position: relative;
 			text-align: center;

--- a/src/client/widgets/calendar.vue
+++ b/src/client/widgets/calendar.vue
@@ -171,8 +171,7 @@ export default defineComponent({
 
 			> .meter {
 				width: 100%;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				background: var(--X11);
 				border-radius: 8px;
 

--- a/src/client/widgets/federation.vue
+++ b/src/client/widgets/federation.vue
@@ -89,8 +89,7 @@ export default defineComponent({
 	$bodyInfoHieght: 16px;
 
 	height: (62px + 1px) + (62px + 1px) + (62px + 1px) + (62px + 1px) + 62px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	> .instances {
 		.chart-move {
@@ -114,8 +113,7 @@ export default defineComponent({
 
 			> .body {
 				flex: 1;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				font-size: 0.9em;
 				color: var(--fg);
 
@@ -123,8 +121,7 @@ export default defineComponent({
 					display: block;
 					width: 100%;
 					white-space: nowrap;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					text-overflow: ellipsis;
 					line-height: $bodyTitleHieght;
 				}

--- a/src/client/widgets/rss.vue
+++ b/src/client/widgets/rss.vue
@@ -80,8 +80,7 @@ export default defineComponent({
 			color: var(--fg);
 			white-space: nowrap;
 			text-overflow: ellipsis;
-			overflow: hidden; // overflow: clip; をSafariが対応したら消す
-			overflow: clip;
+			overflow: hidden;
 
 			&:nth-child(even) {
 				background: rgba(#000, 0.05);

--- a/src/client/widgets/trends.vue
+++ b/src/client/widgets/trends.vue
@@ -68,8 +68,7 @@ export default defineComponent({
 <style lang="scss" scoped>
 .wbrkwala {
 	height: (62px + 1px) + (62px + 1px) + (62px + 1px) + (62px + 1px) + 62px;
-	overflow: hidden; // overflow: clip; をSafariが対応したら消す
-	overflow: clip;
+	overflow: hidden;
 
 	> .tags {
 		.chart-move {
@@ -84,8 +83,7 @@ export default defineComponent({
 
 			> .tag {
 				flex: 1;
-				overflow: hidden; // overflow: clip; をSafariが対応したら消す
-				overflow: clip;
+				overflow: hidden;
 				font-size: 0.9em;
 				color: var(--fg);
 
@@ -93,8 +91,7 @@ export default defineComponent({
 					display: block;
 					width: 100%;
 					white-space: nowrap;
-					overflow: hidden; // overflow: clip; をSafariが対応したら消す
-					overflow: clip;
+					overflow: hidden;
 					text-overflow: ellipsis;
 					line-height: 18px;
 				}


### PR DESCRIPTION
Fix #7272

This reverts commit 06e817af597e7ee621bdeb370c72d7555482d943.
