### PR TITLE
ページエディタの表示を修正

### DIFF
--- a/src/client/pages/page-editor/page-editor.vue
+++ b/src/client/pages/page-editor/page-editor.vue
@@ -4,9 +4,9 @@
 		<MkA class="view" v-if="pageId" :to="`/@${ author.username }/pages/${ currentName }`"><Fa :icon="faExternalLinkSquareAlt"/> {{ $ts._pages.viewPage }}</MkA>
 
 		<div class="buttons" style="margin: 16px 0;">
-			<MkButton inline @click="save" primary class="save"><Fa :icon="faSave"/> {{ $ts.save }}</MkButton>
+			<MkButton inline @click="save" primary class="save" v-if="!readonly"><Fa :icon="faSave"/> {{ $ts.save }}</MkButton>
 			<MkButton inline @click="duplicate" class="duplicate" v-if="pageId"><Fa :icon="faCopy"/> {{ $ts.duplicate }}</MkButton>
-			<MkButton inline @click="del" class="delete" v-if="pageId"><Fa :icon="faTrashAlt"/> {{ $ts.delete }}</MkButton>
+			<MkButton inline @click="del" class="delete" v-if="pageId && !readonly"><Fa :icon="faTrashAlt"/> {{ $ts.delete }}</MkButton>
 		</div>
 
 		<MkContainer :body-togglable="true" :expanded="true" class="_vMargin">
@@ -134,12 +134,18 @@ export default defineComponent({
 
 	data() {
 		return {
-			INFO: computed(() => this.initPageId ? {
-				title: this.$ts._pages.editPage,
-				icon: faPencilAlt,
-			} : {
-				title: this.$ts._pages.newPage,
-				icon: faPencilAlt,
+			INFO: computed(() => {
+				let title = this.$ts._pages.newPage;
+				if (this.initPageId) {
+					title = this.$ts._pages.editPage;
+				}
+				else if (this.initPageName && this.initUser) {
+					title = this.$ts._pages.readPage;
+				}
+				return {
+					title: title,
+					icon: faPencilAlt,
+				};
 			}),
 			author: this.$i,
 			readonly: false,


### PR DESCRIPTION
## 概要
* ページエディタ: ボタンの表示状態を修正 (Resolve #7224)
* ページエディタ: タイトルを修正

## 修正後の表示
操作 | 表示
----|----
新規作成 | ![new](https://user-images.githubusercontent.com/10358431/110235748-167b1b80-7f75-11eb-922b-fa6e11debdfc.png)
編集 | ![edit](https://user-images.githubusercontent.com/10358431/110235753-1d099300-7f75-11eb-8e87-201f53f7cef3.png)
ソース表示 | ![show](https://user-images.githubusercontent.com/10358431/110235758-2135b080-7f75-11eb-9d3f-d91c04971a92.png)
