### PR TITLE
Use integrity for scripts hosted on the CDN

### DIFF
--- a/assets/redoc.html
+++ b/assets/redoc.html
@@ -19,6 +19,6 @@
 	</head>
 	<body>
 		<redoc spec-url="/api.json" expand-responses="200" expand-single-schema-field="true"></redoc>
-		<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+		<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.48/bundles/redoc.standalone.js" integrity="sha256-FI07Zo3zrSdvkLx95toZ5sXGQKn9BsM2MulFYpo+Pno=" crossorigin="anonymous"></script>
 	</body>
 </html>

--- a/assets/redoc.html
+++ b/assets/redoc.html
@@ -19,6 +19,6 @@
 	</head>
 	<body>
 		<redoc spec-url="/api.json" expand-responses="200" expand-single-schema-field="true"></redoc>
-		<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.48/bundles/redoc.standalone.js" integrity="sha256-FI07Zo3zrSdvkLx95toZ5sXGQKn9BsM2MulFYpo+Pno=" crossorigin="anonymous"></script>
+		<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.50/bundles/redoc.standalone.js" integrity="sha256-WJbngBWN9vp6vkEuzeoSj5tE5saW9Hfj6/SinkzhL2s=" crossorigin="anonymous"></script>
 	</body>
 </html>


### PR DESCRIPTION
## Summary
Fix #7333 

https://www.jsdelivr.com/package/npm/redoc?path=bundles&version=2.0.0-rc.50