### PR TITLE
DB上で壊れたドライブファイルを無視するように

### DIFF
--- a/src/models/repositories/drive-file.ts
+++ b/src/models/repositories/drive-file.ts
@@ -12,6 +12,12 @@ import { fetchMeta } from '../../misc/fetch-meta';
 
 export type PackedDriveFile = SchemaType<typeof packedDriveFileSchema>;
 
+type PackOptions = {
+	detail?: boolean,
+	self?: boolean,
+	withUser?: boolean,
+};
+
 @EntityRepository(DriveFile)
 export class DriveFileRepository extends Repository<DriveFile> {
 	public validateFileName(name: string): boolean {
@@ -89,20 +95,19 @@ export class DriveFileRepository extends Repository<DriveFile> {
 		return parseInt(sum, 10) || 0;
 	}
 
+	public async pack(src: DriveFile['id'], options?: PackOptions): Promise<PackedDriveFile | null>;
+	public async pack(src: DriveFile, options?: PackOptions): Promise<PackedDriveFile>;
 	public async pack(
 		src: DriveFile['id'] | DriveFile,
-		options?: {
-			detail?: boolean,
-			self?: boolean,
-			withUser?: boolean,
-		}
-	): Promise<PackedDriveFile> {
+		options?: PackOptions
+	): Promise<PackedDriveFile | null> {
 		const opts = Object.assign({
 			detail: false,
 			self: false
 		}, options);
 
-		const file = typeof src === 'object' ? src : await this.findOneOrFail(src);
+		const file = typeof src === 'object' ? src : await this.findOne(src);
+		if (file == null) return null;
 
 		const meta = await fetchMeta();
 
@@ -128,15 +133,12 @@ export class DriveFileRepository extends Repository<DriveFile> {
 		});
 	}
 
-	public packMany(
+	public async packMany(
 		files: any[],
-		options?: {
-			detail?: boolean
-			self?: boolean,
-			withUser?: boolean,
-		}
+		options?: PackOptions
 	) {
-		return Promise.all(files.map(f => this.pack(f, options)));
+		const items = await Promise.all(files.map(f => this.pack(f, options)));
+		return items.filter(x => x != null);
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix #7244
Fix #4724
e265b538cc96b10b2ffc98c15227ab097cf4744b の修正だと、過去分が壊れたままなのとトランザクションしてないのでまた起きる可能性がある。

過去分はともかく、ちゃんとトランザクションするようにする方法もあるけど #7346 あたりに書いてある理由で結構大変。