### PR TITLE
Use asset/resource and remove url loader; Resolve #7395

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,6 @@
 		"typeorm": "0.2.31",
 		"typescript": "4.2.3",
 		"ulid": "2.3.0",
-		"url-loader": "4.1.1",
 		"uuid": "8.3.2",
 		"v-debounce": "0.1.2",
 		"vanilla-tilt": "1.7.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -105,7 +105,7 @@ module.exports = {
 			}, postcss]
 		}, {
 			test: /\.(eot|woff|woff2|svg|ttf)([?]?.*)$/,
-			loader: 'url-loader'
+			type: 'asset/resource'
 		}, {
 			test: /\.json5$/,
 			loader: 'json5-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -10730,15 +10730,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
-
 url@0.10.3:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"


### PR DESCRIPTION
## Summary
Resolve #7395

フォントの読み込みにurl-loaderを使っていたのをやめて、asset/resourceを使うように

c2鯖に適用してるけど、ちゃんと表示されていそう  
https://c2.a9z.dev/notes/8jnl3e1cvd

KaTeXのチャンクファイルもだいぶ軽くなった
https://c2.a9z.dev/assets/849.12.75.0-c2.2.js

![image](https://user-images.githubusercontent.com/7973572/112199114-2bcc9700-8c51-11eb-9409-a9d366526689.png)
