### PR TITLE
Fix Announce/Delete AP deliver

### DIFF
--- a/src/remote/activitypub/renderer/announce.ts
+++ b/src/remote/activitypub/renderer/announce.ts
@@ -13,8 +13,8 @@ export default (object: any, note: Note) => {
 	} else if (note.visibility === 'home') {
 		to = [`${attributedTo}/followers`];
 		cc = ['https://www.w3.org/ns/activitystreams#Public'];
-	} else if (note.visibility === 'followers') {
-		to = [`${attributedTo}/followers`];
+	} else {
+		return null;
 	}
 
 	return {

--- a/src/remote/activitypub/renderer/announce.ts
+++ b/src/remote/activitypub/renderer/announce.ts
@@ -13,8 +13,8 @@ export default (object: any, note: Note) => {
 	} else if (note.visibility === 'home') {
 		to = [`${attributedTo}/followers`];
 		cc = ['https://www.w3.org/ns/activitystreams#Public'];
-	} else {
-		return null;
+	} else if (note.visibility === 'followers') {
+		to = [`${attributedTo}/followers`];
 	}
 
 	return {

--- a/src/remote/activitypub/renderer/undo.ts
+++ b/src/remote/activitypub/renderer/undo.ts
@@ -1,8 +1,12 @@
 import config from '@/config';
 import { ILocalUser, User } from '../../../models/entities/user';
 
-export default (object: any, user: { id: User['id'] }) => ({
-	type: 'Undo',
-	actor: `${config.url}/users/${user.id}`,
-	object
-});
+export default (object: any, user: { id: User['id'] }) => {
+	if (object == null) return null;
+
+	return {
+		type: 'Undo',
+		actor: `${config.url}/users/${user.id}`,
+		object
+	};
+};

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -35,7 +35,7 @@ export default async function(user: User, note: Note, quiet = false) {
 		});
 
 		//#region ローカルの投稿なら削除アクティビティを配送
-		if (Users.isLocalUser(user)) {
+		if (Users.isLocalUser(user) && !note.localOnly) {
 			let renote: Note | undefined;
 
 			// if deletd note is renote

--- a/src/services/note/delete.ts
+++ b/src/services/note/delete.ts
@@ -35,7 +35,7 @@ export default async function(user: User, note: Note, quiet = false) {
 		});
 
 		//#region ローカルの投稿なら削除アクティビティを配送
-		if (Users.isLocalUser(user) && !note.localOnly) {
+		if (Users.isLocalUser(user)) {
 			let renote: Note | undefined;
 
 			// if deletd note is renote


### PR DESCRIPTION
## Summary
Fix #7516
1. objectがnullのUndoが飛ぶのを修正
2. ローカルのみ公開範囲のNote/Renoteの解除でもAP deliverされるのを修正

1について
フォロワー限定Renoteはdeliverしないんだけんど、一旦nullでActivityを作ってdeliver時にフィルタするということをやってる。
だけんど、Undoでこれが上手くフィルタされずにそのままnullを添付して送ってしまうみたい。
「フォロワー限定Renoteはdeliverしない」とか「一旦nullで作る」みたいな仕様や実装はどうなん？てのがあるけど
とりあえず、null Activityに呼応するUndoもフィルタして送らないようにした。

「フォロワー限定Renoteはdeliverしない」とか「一旦nullで作る」仕様や実装が気に入らなかったら別Issueで…