### PR TITLE
Fix Agent type, httpでもDNSキャッシュ

### DIFF
--- a/src/misc/fetch.ts
+++ b/src/misc/fetch.ts
@@ -55,7 +55,8 @@ export async function getHtml(url: string, accept = 'text/html, */*', timeout = 
 const _http = new http.Agent({
 	keepAlive: true,
 	keepAliveMsecs: 30 * 1000,
-});
+	lookup: cache.lookup,
+} as http.AgentOptions);
 
 /**
  * Get https non-proxy agent
@@ -70,14 +71,14 @@ const _https = new https.Agent({
  * Get http proxy or non-proxy agent
  */
 export const httpAgent = config.proxy
-	? new HttpProxyAgent(config.proxy) as unknown as http.Agent
+	? new HttpProxyAgent(config.proxy)
 	: _http;
 
 /**
  * Get https proxy or non-proxy agent
  */
 export const httpsAgent = config.proxy
-	? new HttpsProxyAgent(config.proxy) as unknown as https.Agent
+	? new HttpsProxyAgent(config.proxy)
 	: _https;
 
 /**


### PR DESCRIPTION
## Summary
ちょっとした変更

angetの`as unknown as http.Agent`のような記述はdependenciesが更新されていれば出ないようなので削除
(本来は依存モジュールのdependenciesをなおしてもらった方が確実だけど)

なぜかhttp.Agentでlookupオプションを指定するとType errorになるのでhttpではDNSキャッシュ使ってなかったけど
`@types/node`がおかしいだけみたいなので使うように。