### PR TITLE
Update preloaded JSON-LD

### DIFF
--- a/src/remote/activitypub/misc/contexts.ts
+++ b/src/remote/activitypub/misc/contexts.ts
@@ -511,6 +511,10 @@ const activitystreams = {
     "shares": {
       "@id": "as:shares",
       "@type": "@id"
+    },
+    "alsoKnownAs": {
+      "@id": "as:alsoKnownAs",
+      "@type": "@id"
     }
   }
 };


### PR DESCRIPTION
## Summary
ActivityPubでLinked Data Signatureの検証 (主にリレーから飛んできたときに発生) のために
`@context`の`https://www.w3.org/ns/activitystreams`をローカルキャッシュしてるけど
その内容を最新のSPECで更新。

これを行うとMastodonなんかから送られてくるやつで
`alsoKnownAs`が被る感じになるけど…
```json5

  '@context': [
    'https://www.w3.org/ns/activitystreams', ← ここでalsoKnownAsが展開されるようになる
    'https://w3id.org/security/v1',
    {
        (略)
      alsoKnownAs: { '@id': 'as:alsoKnownAs', '@type': '@id' }, ← ここにもalsoKnownAsあるじゃん
        (略) 
    }
```
内容は同じだし、検証したところ別に問題なく解析できるみたい。