### PR TITLE
ActivityPub JSON-LD @context をちゃんと付けるように

### DIFF
--- a/src/remote/activitypub/renderer/index.ts
+++ b/src/remote/activitypub/renderer/index.ts
@@ -15,7 +15,33 @@ export const renderActivity = (x: any): IActivity | null => {
 	return Object.assign({
 		'@context': [
 			'https://www.w3.org/ns/activitystreams',
-			'https://w3id.org/security/v1'
+			'https://w3id.org/security/v1',
+			{
+				// as non-standards
+				manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
+				sensitive: 'as:sensitive',
+				Hashtag: 'as:Hashtag',
+				quoteUrl: 'as:quoteUrl',
+				// Mastodon
+				toot: 'http://joinmastodon.org/ns#',
+				Emoji: 'toot:Emoji',
+				featured: 'toot:featured',
+				discoverable: 'toot:discoverable',
+				// schema
+				schema: 'http://schema.org#',
+				PropertyValue: 'schema:PropertyValue',
+				value: 'schema:value',
+				// Misskey
+				misskey: `${config.url}/ns#`,
+				'_misskey_content': 'misskey:_misskey_content',
+				'_misskey_quote': 'misskey:_misskey_quote',
+				'_misskey_reaction': 'misskey:_misskey_reaction',
+				'_misskey_votes': 'misskey:_misskey_votes',
+				'_misskey_talk': 'misskey:_misskey_talk',
+				'isCat': 'misskey:isCat',
+				// vcard
+				vcard: 'http://www.w3.org/2006/vcard/ns#',
+			}
 		]
 	}, x);
 };
@@ -24,35 +50,6 @@ export const attachLdSignature = async (activity: any, user: { id: User['id']; h
 	if (activity == null) return null;
 
 	const keypair = await getUserKeypair(user.id);
-
-	const obj = {
-		// as non-standards
-		manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
-		sensitive: 'as:sensitive',
-		Hashtag: 'as:Hashtag',
-		quoteUrl: 'as:quoteUrl',
-		// Mastodon
-		toot: 'http://joinmastodon.org/ns#',
-		Emoji: 'toot:Emoji',
-		featured: 'toot:featured',
-		discoverable: 'toot:discoverable',
-		// schema
-		schema: 'http://schema.org#',
-		PropertyValue: 'schema:PropertyValue',
-		value: 'schema:value',
-		// Misskey
-		misskey: `${config.url}/ns#`,
-		'_misskey_content': 'misskey:_misskey_content',
-		'_misskey_quote': 'misskey:_misskey_quote',
-		'_misskey_reaction': 'misskey:_misskey_reaction',
-		'_misskey_votes': 'misskey:_misskey_votes',
-		'_misskey_talk': 'misskey:_misskey_talk',
-		'isCat': 'misskey:isCat',
-		// vcard
-		vcard: 'http://www.w3.org/2006/vcard/ns#',
-	};
-
-	activity['@context'].push(obj);
 
 	const ldSignature = new LdSignature();
 	ldSignature.debug = false;


### PR DESCRIPTION
## Summary
リモートに生成するActivityの`@context`のここんところ (正式な名前を知らない)
![image](https://user-images.githubusercontent.com/30769358/118543834-c77d0e00-b78f-11eb-9074-7a8676fe3c00.png)

どうせ、JSON-LD Sinature 付けなければ使用されないだろうと思っていたので
(JSON-LD Signatureを付けたら署名検証前のJSON-LD.canonizeで使用されるはず)
リレーに送信するActivity以外では付けるのを省略していたけど、
たぶんJSON-LDとしてはInvali~~e~~dだし、
JSON-LD.compact (たぶん整形処理の一種) をかける実装 (Friendicaとか？) があるらしく
それだと付けるのをサボるのは不味そうなので、リレー向け以外でもおとなしく付けるようにしました。

※JSON-LD.(canonize|compact)などのイメージはこの辺を参照？！
https://github.com/digitalbazaar/jsonld.js