### PR TITLE
テストがうごかないのを修正

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -2,6 +2,6 @@
 	"extension": ["ts","js","cjs","mjs"],
 	"require": ["ts-node/register", "tsconfig-paths/register"],
 	"slow": 1000,
-	"timeout": 30000,
+	"timeout": 35000,
 	"exit": true
 }

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
 		"tslint": "6.1.3",
 		"tslint-sonarts": "1.9.0",
 		"twemoji-parser": "13.1.0",
-		"typeorm": "0.2.34",
+		"typeorm": "0.2.32",
 		"typescript": "4.3.2",
 		"ulid": "2.3.0",
 		"uuid": "8.3.2",

--- a/test/api-visibility.ts
+++ b/test/api-visibility.ts
@@ -12,12 +12,14 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, launchServer, shutdownServer } from './utils';
+import { async, signup, request, post, startServer, shutdownServer } from './utils';
 
 describe('API visibility', () => {
 	let p: childProcess.ChildProcess;
 
-	before(launchServer(g => p = g));
+	before(async () => {
+		p = await startServer();
+	});
 
 	after(async () => {
 		await shutdownServer(p);

--- a/test/chart.ts
+++ b/test/chart.ts
@@ -24,13 +24,13 @@ import config from '../src/config';
 import Chart from '../src/services/chart/core';
 import { initDb } from '../src/db/postgre';
 
-function initChartDb() {
+async function initChartDb() {
 	try {
-		const conn = getConnection();
-		return Promise.resolve(conn);
+		const conn = await getConnection();
+		await conn.close();
 	} catch (e) {}
 
-	return createConnection({
+	return await createConnection({
 		type: 'postgres',
 		host: config.db.host,
 		port: config.db.port,

--- a/test/fetch-resource.ts
+++ b/test/fetch-resource.ts
@@ -12,7 +12,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, launchServer, signup, post, request, simpleGet, port, shutdownServer } from './utils';
+import { async, startServer, signup, post, request, simpleGet, port, shutdownServer } from './utils';
 import * as openapi from '@redocly/openapi-core';
 
 // Request Accept
@@ -32,12 +32,13 @@ describe('Fetch resource', () => {
 	let alice: any;
 	let alicesPost: any;
 
-	before(launchServer(g => p = g, async () => {
+	before(async () => {
+		p = await startServer();
 		alice = await signup({ username: 'alice' });
 		alicesPost = await post(alice, {
 			text: 'test'
 		});
-	}));
+	});
 
 	after(async () => {
 		await shutdownServer(p);

--- a/test/mute.ts
+++ b/test/mute.ts
@@ -12,7 +12,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, react, connectStream, launchServer, shutdownServer } from './utils';
+import { async, signup, request, post, react, connectStream, startServer, shutdownServer } from './utils';
 
 describe('Mute', () => {
 	let p: childProcess.ChildProcess;
@@ -22,11 +22,12 @@ describe('Mute', () => {
 	let bob: any;
 	let carol: any;
 
-	before(launchServer(g => p = g, async () => {
+	before(async () => {
+		p = await startServer();
 		alice = await signup({ username: 'alice' });
 		bob = await signup({ username: 'bob' });
 		carol = await signup({ username: 'carol' });
-	}));
+	});
 
 	after(async () => {
 		await shutdownServer(p);

--- a/test/note.ts
+++ b/test/note.ts
@@ -12,7 +12,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, uploadFile, launchServer, shutdownServer } from './utils';
+import { async, signup, request, post, uploadFile, startServer, shutdownServer } from './utils';
 import { Note } from '../src/models/entities/note';
 import { initDb } from '../src/db/postgre';
 
@@ -23,12 +23,13 @@ describe('Note', () => {
 	let alice: any;
 	let bob: any;
 
-	before(launchServer(g => p = g, async () => {
+	before(async () => {
+		p = await startServer();
 		const connection = await initDb(true);
 		Notes = connection.getRepository(Note);
 		alice = await signup({ username: 'alice' });
 		bob = await signup({ username: 'bob' });
-	}));
+	});
 
 	after(async () => {
 		await shutdownServer(p);

--- a/test/note.ts
+++ b/test/note.ts
@@ -12,9 +12,8 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, uploadFile, startServer, shutdownServer } from './utils';
+import { async, signup, request, post, uploadFile, startServer, shutdownServer, initTestDb } from './utils';
 import { Note } from '../src/models/entities/note';
-import { initDb } from '../src/db/postgre';
 
 describe('Note', () => {
 	let p: childProcess.ChildProcess;
@@ -25,7 +24,7 @@ describe('Note', () => {
 
 	before(async () => {
 		p = await startServer();
-		const connection = await initDb(true);
+		const connection = await initTestDb(true);
 		Notes = connection.getRepository(Note);
 		alice = await signup({ username: 'alice' });
 		bob = await signup({ username: 'bob' });

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -12,9 +12,8 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { connectStream, signup, request, post, startServer, shutdownServer } from './utils';
+import { connectStream, signup, request, post, startServer, shutdownServer, initTestDb } from './utils';
 import { Following } from '../src/models/entities/following';
-import { initDb } from '../src/db/postgre';
 
 describe('Streaming', () => {
 	let p: childProcess.ChildProcess;
@@ -22,7 +21,7 @@ describe('Streaming', () => {
 
 	beforeEach(async () => {
 		p = await startServer();
-		const connection = await initDb(true);
+		const connection = await initTestDb(true);
 		Followings = connection.getRepository(Following);
 	});
 

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -12,7 +12,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { connectStream, signup, request, post, launchServer } from './utils';
+import { connectStream, signup, request, post, startServer, shutdownServer } from './utils';
 import { Following } from '../src/models/entities/following';
 import { initDb } from '../src/db/postgre';
 
@@ -20,13 +20,14 @@ describe('Streaming', () => {
 	let p: childProcess.ChildProcess;
 	let Followings: any;
 
-	beforeEach(launchServer(g => p = g, async () => {
+	beforeEach(async () => {
+		p = await startServer();
 		const connection = await initDb(true);
 		Followings = connection.getRepository(Following);
-	}));
+	});
 
-	afterEach(() => {
-		p.kill();
+	afterEach(async () => {
+		await shutdownServer(p);
 	});
 
 	const follow = async (follower: any, followee: any) => {

--- a/test/user-notes.ts
+++ b/test/user-notes.ts
@@ -12,7 +12,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, uploadFile, launchServer, shutdownServer } from './utils';
+import { async, signup, request, post, uploadFile, startServer, shutdownServer } from './utils';
 
 describe('users/notes', () => {
 	let p: childProcess.ChildProcess;
@@ -22,7 +22,8 @@ describe('users/notes', () => {
 	let pngNote: any;
 	let jpgPngNote: any;
 
-	before(launchServer(g => p = g, async () => {
+	before(async () => {
+		p = await startServer();
 		alice = await signup({ username: 'alice' });
 		const jpg = await uploadFile(alice, __dirname + '/resources/Lenna.jpg');
 		const png = await uploadFile(alice, __dirname + '/resources/Lenna.png');
@@ -35,7 +36,7 @@ describe('users/notes', () => {
 		jpgPngNote = await post(alice, {
 			fileIds: [jpg.id, png.id]
 		});
-	}));
+	});
 
 	after(async() => {
 		await shutdownServer(p);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -147,6 +147,29 @@ export function launchServer(callbackSpawnedProcess: (p: childProcess.ChildProce
 	};
 }
 
+export function startServer(timeout = 30 * 1000): Promise<childProcess.ChildProcess> {
+	return new Promise((res, rej) => {
+		const t = setTimeout(() => {
+			p.kill(SIGKILL);
+			rej('timeout to start');
+		}, timeout);
+
+		const p = childProcess.spawn('node', [__dirname + '/../index.js'], {
+			stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+			env: { NODE_ENV: 'test', PATH: process.env.PATH }
+		});
+
+		p.on('error', e => rej(e));
+
+		p.on('message', message => {
+			if (message === 'ok') {
+				clearTimeout(t);
+				res(p);
+			}
+		});
+	});
+}
+
 export function shutdownServer(p: childProcess.ChildProcess, timeout = 20 * 1000) {
 	return new Promise((res, rej) => {
 		const t = setTimeout(() => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,8 +6,11 @@ import * as childProcess from 'child_process';
 import * as http from 'http';
 import loadConfig from '../src/config/load';
 import { SIGKILL } from 'constants';
+import { createConnection, getConnection } from 'typeorm';
+import { entities } from '../src/db/postgre';
 
-export const port = loadConfig().port;
+const config = loadConfig();
+export const port = config.port;
 
 export const async = (fn: Function) => (done: Function) => {
 	fn().then(() => {
@@ -145,6 +148,27 @@ export function launchServer(callbackSpawnedProcess: (p: childProcess.ChildProce
 			if (message === 'ok') moreProcess().then(() => done()).catch(e => done(e));
 		});
 	};
+}
+
+export async function initTestDb(justBorrow = false, initEntities?: any[]) {
+	if (process.env.NODE_ENV !== 'test') throw 'NODE_ENV is not a test';
+
+	try {
+		const conn = await getConnection();
+		await conn.close();
+	} catch (e) {}
+
+	return await createConnection({
+		type: 'postgres',
+		host: config.db.host,
+		port: config.db.port,
+		username: config.db.user,
+		password: config.db.pass,
+		database: config.db.db,
+		synchronize: true && !justBorrow,
+		dropSchema: true && !justBorrow,
+		entities: initEntities || entities
+	});
 }
 
 export function startServer(timeout = 30 * 1000): Promise<childProcess.ChildProcess> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10978,10 +10978,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typeorm@0.2.34:
-  version "0.2.34"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.34.tgz#637b3cec2de54ee7f423012b813a2022c0aacc8b"
-  integrity sha512-FZAeEGGdSGq7uTH3FWRQq67JjKu0mgANsSZ04j3kvDYNgy9KwBl/6RFgMVgiSgjf7Rqd7NrhC2KxVT7I80qf7w==
+typeorm@0.2.32:
+  version "0.2.32"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.2.32.tgz#544dbfdfe0cd0887548d9bcbd28527ea4f4b3c9b"
+  integrity sha512-LOBZKZ9As3f8KRMPCUT2H0JZbZfWfkcUnO3w/1BFAbL/X9+cADTF6bczDGGaKVENJ3P8SaKheKmBgpt5h1x+EQ==
   dependencies:
     "@sqltools/formatter" "^1.2.2"
     app-root-path "^3.0.0"


### PR DESCRIPTION
## Summary
テストがうごかないのを修正 Fix #7547
- プロセスの起動に失敗したら、before ~ timeout まで固まるんじゃなくてちゃんとrejectするように。
- プロセスの起動がタイムアウトしたら、ちゃんとそのプロセスを終了するように。
  (残ってると次のテストがおかしくなることがある？)
- テストがうごかないので typeorm を 0.2.32 に戻す。 Fix #7565
- chartのテストがテストの並び順によっては正しく初期化されないのを修正。 Fix #7568
- DB接続のライフサイクルをリファクタ＆最適化 Fix #7568

