### PR TITLE
認証の修正

### DIFF
--- a/src/server/api/authenticate.ts
+++ b/src/server/api/authenticate.ts
@@ -2,11 +2,6 @@ import isNativeToken from './common/is-native-token';
 import { User } from '../../models/entities/user';
 import { Users, AccessTokens, Apps } from '../../models';
 import { AccessToken } from '../../models/entities/access-token';
-import { Cache } from '@/misc/cache';
-
-// TODO: TypeORMのカスタムキャッシュプロバイダを使っても良いかも
-// ref. https://github.com/typeorm/typeorm/blob/master/docs/caching.md
-const cache = new Cache<User>(1000 * 60 * 60);
 
 export default async (token: string): Promise<[User | null | undefined, AccessToken | null | undefined]> => {
 	if (token == null) {
@@ -14,11 +9,6 @@ export default async (token: string): Promise<[User | null | undefined, AccessTo
 	}
 
 	if (isNativeToken(token)) {
-		const cached = cache.get(token);
-		if (cached) {
-			return [cached, null];
-		}
-
 		// Fetch user
 		const user = await Users
 			.findOne({ token });
@@ -27,11 +17,8 @@ export default async (token: string): Promise<[User | null | undefined, AccessTo
 			throw new Error('user not found');
 		}
 
-		cache.set(token, user);
-
 		return [user, null];
 	} else {
-		// TODO: cache
 		const accessToken = await AccessTokens.findOne({
 			where: [{
 				hash: token.toLowerCase() // app

--- a/src/server/api/endpoints/admin/suspend-user.ts
+++ b/src/server/api/endpoints/admin/suspend-user.ts
@@ -6,6 +6,7 @@ import { Users, Followings, Notifications } from '../../../../models';
 import { User } from '../../../../models/entities/user';
 import { insertModerationLog } from '../../../../services/insert-moderation-log';
 import { doPostSuspend } from '../../../../services/suspend-user';
+import { publishUserEvent } from '@/services/stream';
 
 export const meta = {
 	tags: ['admin'],
@@ -42,6 +43,9 @@ export default define(meta, async (ps, me) => {
 	insertModerationLog(me, 'suspend', {
 		targetId: user.id,
 	});
+
+	// Terminate streaming
+	publishUserEvent(user.id, 'terminate', {});
 
 	(async () => {
 		await doPostSuspend(user).catch(e => {});

--- a/src/server/api/endpoints/admin/suspend-user.ts
+++ b/src/server/api/endpoints/admin/suspend-user.ts
@@ -45,7 +45,9 @@ export default define(meta, async (ps, me) => {
 	});
 
 	// Terminate streaming
-	publishUserEvent(user.id, 'terminate', {});
+	if (Users.isLocalUser(user)) {
+		publishUserEvent(user.id, 'terminate', {});
+	}
 
 	(async () => {
 		await doPostSuspend(user).catch(e => {});

--- a/src/server/api/endpoints/i/delete-account.ts
+++ b/src/server/api/endpoints/i/delete-account.ts
@@ -27,11 +27,11 @@ export default define(meta, async (ps, user) => {
 		throw new Error('incorrect password');
 	}
 
-	// Terminate streaming
-	publishUserEvent(user.id, 'terminate', {});
-
 	// 物理削除する前にDelete activityを送信する
 	await doPostSuspend(user).catch(e => {});
 
 	await Users.delete(user.id);
+
+	// Terminate streaming
+	publishUserEvent(user.id, 'terminate', {});
 });

--- a/src/server/api/endpoints/i/delete-account.ts
+++ b/src/server/api/endpoints/i/delete-account.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcryptjs';
 import define from '../../define';
 import { Users, UserProfiles } from '../../../../models';
 import { doPostSuspend } from '../../../../services/suspend-user';
+import { publishUserEvent } from '@/services/stream';
 
 export const meta = {
 	requireCredential: true as const,
@@ -25,6 +26,9 @@ export default define(meta, async (ps, user) => {
 	if (!same) {
 		throw new Error('incorrect password');
 	}
+
+	// Terminate streaming
+	publishUserEvent(user.id, 'terminate', {});
 
 	// 物理削除する前にDelete activityを送信する
 	await doPostSuspend(user).catch(e => {});

--- a/src/server/api/endpoints/i/regenerate-token.ts
+++ b/src/server/api/endpoints/i/regenerate-token.ts
@@ -38,5 +38,7 @@ export default define(meta, async (ps, user) => {
 	publishMainStream(user.id, 'myTokenRegenerated');
 
 	// Terminate streaming
-	publishUserEvent(user.id, 'terminate', {});
+	setTimeout(() => {
+		publishUserEvent(user.id, 'terminate', {});
+	}, 5000);
 });

--- a/src/server/api/endpoints/i/regenerate-token.ts
+++ b/src/server/api/endpoints/i/regenerate-token.ts
@@ -1,6 +1,6 @@
 import $ from 'cafy';
 import * as bcrypt from 'bcryptjs';
-import { publishMainStream } from '../../../../services/stream';
+import { publishMainStream, publishUserEvent } from '../../../../services/stream';
 import generateUserToken from '../../common/generate-native-user-token';
 import define from '../../define';
 import { Users, UserProfiles } from '../../../../models';
@@ -36,4 +36,7 @@ export default define(meta, async (ps, user) => {
 
 	// Publish event
 	publishMainStream(user.id, 'myTokenRegenerated');
+
+	// Terminate streaming
+	publishUserEvent(user.id, 'terminate', {});
 });

--- a/src/server/api/endpoints/i/revoke-token.ts
+++ b/src/server/api/endpoints/i/revoke-token.ts
@@ -2,6 +2,7 @@ import $ from 'cafy';
 import define from '../../define';
 import { AccessTokens } from '../../../../models';
 import { ID } from '@/misc/cafy-id';
+import { publishUserEvent } from '@/services/stream';
 
 export const meta = {
 	requireCredential: true as const,
@@ -23,5 +24,8 @@ export default define(meta, async (ps, user) => {
 			id: ps.tokenId,
 			userId: user.id,
 		});
+
+		// Terminate streaming
+		publishUserEvent(user.id, 'terminate');
 	}
 });

--- a/src/server/api/endpoints/i/revoke-token.ts
+++ b/src/server/api/endpoints/i/revoke-token.ts
@@ -19,6 +19,9 @@ export default define(meta, async (ps, user) => {
 	const token = await AccessTokens.findOne(ps.tokenId);
 
 	if (token) {
-		AccessTokens.delete(token.id);
+		await AccessTokens.delete({
+			id: ps.tokenId,
+			userId: user.id,
+		});
 	}
 });

--- a/src/server/api/private/signin.ts
+++ b/src/server/api/private/signin.ts
@@ -39,9 +39,16 @@ export default async (ctx: Koa.Context) => {
 		host: null
 	}) as ILocalUser;
 
-	if (user == null || user.isSuspended) {
+	if (user == null) {
 		ctx.throw(404, {
 			error: 'user not found'
+		});
+		return;
+	}
+
+	if (user.isSuspended) {
+		ctx.throw(403, {
+			error: 'user is suspended'
 		});
 		return;
 	}

--- a/src/server/api/private/signin.ts
+++ b/src/server/api/private/signin.ts
@@ -39,7 +39,7 @@ export default async (ctx: Koa.Context) => {
 		host: null
 	}) as ILocalUser;
 
-	if (user == null) {
+	if (user == null || user.isSuspended) {
 		ctx.throw(404, {
 			error: 'user not found'
 		});

--- a/src/server/api/stream/index.ts
+++ b/src/server/api/stream/index.ts
@@ -92,6 +92,11 @@ export default class Connection {
 				this.userProfile = body;
 				break;
 
+			case 'terminate':
+				this.wsConnection.close();
+				this.dispose();
+				break;
+
 			default:
 				break;
 		}

--- a/src/server/api/streaming.ts
+++ b/src/server/api/streaming.ts
@@ -17,6 +17,9 @@ module.exports = (server: http.Server) => {
 	ws.on('request', async (request) => {
 		const q = request.resourceURL.query as ParsedUrlQuery;
 
+		// TODO: トークンが間違ってるなどしてauthenticateに失敗したら
+		// コネクション切断するなりエラーメッセージ返すなりする
+		// (現状はエラーがキャッチされておらずサーバーのログに流れて邪魔なので)
 		const [user, app] = await authenticate(q.i as string);
 
 		if (user?.isSuspended) {

--- a/src/server/api/streaming.ts
+++ b/src/server/api/streaming.ts
@@ -17,10 +17,12 @@ module.exports = (server: http.Server) => {
 	ws.on('request', async (request) => {
 		const q = request.resourceURL.query as ParsedUrlQuery;
 
-		// TODO: トークンが間違ってるなどしてauthenticateに失敗したら
-		// コネクション切断するなりエラーメッセージ返すなりする
-		// (現状はエラーがキャッチされておらずサーバーのログに流れて邪魔なので)
 		const [user, app] = await authenticate(q.i as string);
+
+		if (user?.isSuspended) {
+			request.reject(400);
+			return;
+		}
 
 		const connection = request.accept();
 


### PR DESCRIPTION
## Summary
Fix #7595
Fix #7525

1. authenticateのキャッシュを廃止
  凍結やサイレンスが即時反映されないのを修正
2. 凍結ユーザーがサインイン出来てしまうのを修正
  凍結ユーザーがサインインできてアクセストークンも取得出来てしまうのを修正
3. 凍結ユーザーはストリーミング接続出来ないように
  2で最新のアクセストークンが取得できてしまうので、ストリーミング接続も出来てしまう。
4. アプリのアクセストークン無効化が他のユーザーからも出来てしまうのを修正
  デフォルトaidがキーであまり長くないので総当り出来そう
  あと、正常削除を待機するように修正
5. ユーザー/アクセストークンを無効化したらストリーミングを切断するように
  ユーザー凍結/ユーザー削除/トークン再生成/アプリ無効化 を行った後もストリーミング接続が有効なままなので、それらを行ったらストリーミング接続を切断するように修正。