### PR TITLE
API AuthenticateでDB接続エラーなどが発生するとログアウトさせられてしまうのを修正 Fix #7603

### DIFF
--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -47,7 +47,7 @@ function fetchAccount(token): Promise<Account> {
 		})
 		.then(res => {
 			// When failed to authenticate user
-			if (res.status !== 200 && res.status < 500) {
+			if (res.status >= 400 && res.status < 500) {
 				return signout();
 			}
 

--- a/src/server/api/api-handler.ts
+++ b/src/server/api/api-handler.ts
@@ -1,7 +1,7 @@
 import * as Koa from 'koa';
 
 import { IEndpoint } from './endpoints';
-import authenticate from './authenticate';
+import authenticate, { AuthenticationError } from './authenticate';
 import call from './call';
 import { ApiError } from './error';
 
@@ -37,11 +37,15 @@ export default (endpoint: IEndpoint, ctx: Koa.Context) => new Promise((res) => {
 		}).catch((e: ApiError) => {
 			reply(e.httpStatusCode ? e.httpStatusCode : e.kind === 'client' ? 400 : 500, e);
 		});
-	}).catch(() => {
-		reply(403, new ApiError({
-			message: 'Authentication failed. Please ensure your token is correct.',
-			code: 'AUTHENTICATION_FAILED',
-			id: 'b0a7f5f8-dc2f-4171-b91f-de88ad238e14'
-		}));
+	}).catch(e => {
+		if (e instanceof AuthenticationError) {
+			reply(403, new ApiError({
+				message: 'Authentication failed. Please ensure your token is correct.',
+				code: 'AUTHENTICATION_FAILED',
+				id: 'b0a7f5f8-dc2f-4171-b91f-de88ad238e14'
+			}));
+		} else {
+			reply(500, new ApiError());
+		}
 	});
 });

--- a/src/server/api/authenticate.ts
+++ b/src/server/api/authenticate.ts
@@ -8,7 +8,14 @@ import { Cache } from '@/misc/cache';
 // ref. https://github.com/typeorm/typeorm/blob/master/docs/caching.md
 const cache = new Cache<User>(1000 * 60 * 60);
 
-export default async (token: string): Promise<[User | null | undefined, AccessToken | null | undefined]> => {
+export class AuthenticationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'AuthenticationError';
+	}
+}
+
+export default async (token: string): Promise<[User | null | undefined, App | null | undefined]> => {
 	if (token == null) {
 		return [null, null];
 	}
@@ -24,7 +31,7 @@ export default async (token: string): Promise<[User | null | undefined, AccessTo
 			.findOne({ token });
 
 		if (user == null) {
-			throw new Error('user not found');
+			throw new AuthenticationError('user not found');
 		}
 
 		cache.set(token, user);
@@ -41,7 +48,7 @@ export default async (token: string): Promise<[User | null | undefined, AccessTo
 		});
 
 		if (accessToken == null) {
-			throw new Error('invalid signature');
+			throw new AuthenticationError('invalid signature');
 		}
 
 		AccessTokens.update(accessToken.id, {


### PR DESCRIPTION
## Summary
API AuthenticateでDB接続エラーなどが発生するとログアウトさせられてしまうのを修正 Fix #7603
<!--
  -
  - * Please describe your changes here *
  -
  - If you are going to resolve some issue, please add this context.
  - Resolve #ISSUE_NUMBER
  -
  - If you are going to fix some bug issue, please add this context.
  - Fix #ISSUE_NUMBER
  -
  -->
