### PR TITLE
chore: Remove vips from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ RUN apk add --no-cache \
     nasm \
     pkgconfig \
     python3 \
-    zlib-dev \
-    vips-dev \
-    vips
+    zlib-dev
 
 COPY package.json yarn.lock .yarnrc ./
 RUN yarn install
@@ -31,8 +29,7 @@ FROM base AS runner
 
 RUN apk add --no-cache \
     ffmpeg \
-    tini \
-    vips
+    tini
 
 ENTRYPOINT ["/sbin/tini", "--"]
 


### PR DESCRIPTION
# What
Dockerfileからlibvipsを削除

# Why
Dockerfileのvipsは、Linux on ARM64 (Raspberry Piとか) 上でsharpをビルドするために入れていたが
sharp v0.28 あたりからLinux on ARM64にもprebuild binaryが追加されているためもう不要なため。

https://github.com/lovell/sharp/commit/984a9e653e4105cbb77fdd4cb17a8bbb5afe05eb#diff-162b45a313f5f057a233411edbe31e72a13185f4df0ae0e1af2c13521bc05d5a

※ Dockerfileで使われている alpine3.13 は musl v1.2.2 なので条件を満たす
https://pkgs.alpinelinux.org/packages?name=musl&branch=v3.13

# Additional info (optional)
Linux on ARM64 の Dockerで動いたからたぶん大丈夫。