### PR TITLE
chore: yarn.lockがおかしかったらCIでコケるように

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,6 +35,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
       run: yarn install
+    - name: Check yarn.lock
+      run: git diff --exit-code yarn.lock
     - name: Copy Configure
       run: cp .circleci/misskey/*.yml .config
     - name: Build


### PR DESCRIPTION
# What
開発時にyarn.lockの更新を忘れたり、dependabot (今使ってないけど) とかが稀に不整合のあるyarn.lockを生成した場合に
CIで検出できるようにします。

# Why
めんどいから

# Additional info (optional)
`yarn install --frozen-lockfile` というマニュアル的にはそれをやってくれそうなオプションはあるものの
バグってて効かないみたいです。