### PR TITLE
enhance: add setting to keep content warning

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -779,6 +779,7 @@ translate: "Translate"
 translatedFrom: "Translated from {x}"
 accountDeletionInProgress: "Account deletion is currently in progress"
 usernameInfo: "A name that identifies your account from others on this server.  You can use the alphabet (a~z, A~Z), digits (0~9) or underscores (_). Usernames can not be changed later."
+keepCw: "Keep Content Warning"
 _accountDelete:
   accountDelete: "Delete Account"
   mayTakeTime: "As account deletion is a resource-heavy process, it may take some time to complete depending on how much content you have created and how many files you have uploaded."

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -779,6 +779,7 @@ translate: "翻訳"
 translatedFrom: "{x}から翻訳"
 accountDeletionInProgress: "アカウントの削除が進行中です"
 usernameInfo: "サーバー上であなたのアカウントを一意に識別するための名前。アルファベット(a~z, A~Z)、数字(0~9)、およびアンダーバー(_)が使用できます。ユーザー名は後から変更することは出来ません。"
+keepCw: "CWを維持する"
 
 _accountDelete:
   accountDelete: "アカウントの削除"

--- a/src/client/pages/settings/privacy.vue
+++ b/src/client/pages/settings/privacy.vue
@@ -28,6 +28,7 @@
 		</FormSelect>
 		<FormSwitch v-model:value="defaultNoteLocalOnly">{{ $ts._visibility.localOnly }}</FormSwitch>
 	</FormGroup>
+	<FormSwitch v-model:value="keepCw" @update:value="save()">{{ $ts.keepCw }}</FormSwitch>
 </FormBase>
 </template>
 
@@ -69,6 +70,7 @@ export default defineComponent({
 		defaultNoteVisibility: defaultStore.makeGetterSetter('defaultNoteVisibility'),
 		defaultNoteLocalOnly: defaultStore.makeGetterSetter('defaultNoteLocalOnly'),
 		rememberNoteVisibility: defaultStore.makeGetterSetter('rememberNoteVisibility'),
+		keepCw: defaultStore.makeGetterSetter('keepCw'),
 	},
 
 	created() {


### PR DESCRIPTION
# What

Add a setting to use `keepCw` when replying to a post.

# Why

Keeping the content warning was already implemented and working, but there was no setting to enable it.
fix #6605