### PR TITLE
fix: truncate image descriptions

### DIFF
--- a/src/client/components/media-caption.vue
+++ b/src/client/components/media-caption.vue
@@ -3,10 +3,13 @@
 		<div class="container">
 			<div class="fullwidth top-caption">
 				<div class="mk-dialog">
-					<header v-if="title"><Mfm :text="title"/></header>
+					<header>
+						<Mfm v-if="title" class="title" :text="title"/>
+						<span class="text-count" :class="{ over: remainingLength < 0 }">{{ remainingLength }}</span>
+					</header>
 					<textarea autofocus v-model="inputValue" :placeholder="input.placeholder" @keydown="onInputKeydown"></textarea>
 					<div class="buttons" v-if="(showOkButton || showCancelButton)">
-						<MkButton inline @click="ok" primary>{{ $ts.ok }}</MkButton>
+						<MkButton inline @click="ok" primary :disabled="remainingLength < 0">{{ $ts.ok }}</MkButton>
 						<MkButton inline @click="cancel" >{{ $ts.cancel }}</MkButton>
 					</div>
 				</div>
@@ -26,10 +29,12 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { length } from 'stringz';
 import MkModal from '@client/components/ui/modal.vue';
 import MkButton from '@client/components/ui/button.vue';
 import bytes from '@client/filters/bytes';
 import number from '@client/filters/number';
+import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 export default defineComponent({
 	components: {
@@ -77,6 +82,12 @@ export default defineComponent({
 
 	beforeUnmount() {
 		document.removeEventListener('keydown', this.onKeydown);
+	},
+
+	computed: {
+		remainingLength(): number {
+			return DB_MAX_IMAGE_COMMENT_LENGTH - length(this.inputValue);
+		}
 	},
 
 	methods: {
@@ -156,8 +167,18 @@ export default defineComponent({
 
 	> header {
 		margin: 0 0 8px 0;
-		font-weight: bold;
-		font-size: 20px;
+		position: relative;
+
+		> .title {
+			font-weight: bold;
+			font-size: 20px;
+		}
+
+		> .text-count {
+			opacity: 0.7;
+			position: absolute;
+			right: 0;
+		}
 	}
 
 	> .buttons {

--- a/src/client/components/media-caption.vue
+++ b/src/client/components/media-caption.vue
@@ -86,6 +86,7 @@ export default defineComponent({
 
 	computed: {
 		remainingLength(): number {
+			if (typeof this.inputValue != "string") return DB_MAX_IMAGE_COMMENT_LENGTH;
 			return DB_MAX_IMAGE_COMMENT_LENGTH - length(this.inputValue);
 		}
 	},

--- a/src/misc/hard-limits.ts
+++ b/src/misc/hard-limits.ts
@@ -6,3 +6,9 @@
  * Surrogate pairs count as one
  */
 export const DB_MAX_NOTE_TEXT_LENGTH = 8192;
+
+/**
+ * Maximum image description length that can be stored in DB.
+ * Surrogate pairs count as one
+ */
+export const DB_MAX_IMAGE_COMMENT_LENGTH = 512;

--- a/src/misc/truncate.ts
+++ b/src/misc/truncate.ts
@@ -1,0 +1,9 @@
+export function truncate(input: string, size: number): string;
+export function truncate(input: string | undefined, size: number): string | undefined;
+export function truncate(input: string | undefined, size: number): string | undefined {
+	if (!input || input.length <= size) {
+		return input;
+	} else {
+		return input.substring(0, size);
+	}
+}

--- a/src/misc/truncate.ts
+++ b/src/misc/truncate.ts
@@ -1,9 +1,11 @@
+import { substring } from 'stringz';
+
 export function truncate(input: string, size: number): string;
 export function truncate(input: string | undefined, size: number): string | undefined;
 export function truncate(input: string | undefined, size: number): string | undefined {
-	if (!input || input.length <= size) {
+	if (!input) {
 		return input;
 	} else {
-		return input.substring(0, size);
+		return substring(input, 0, size);
 	}
 }

--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -5,6 +5,8 @@ import { fetchMeta } from '@/misc/fetch-meta';
 import { apLogger } from '../logger';
 import { DriveFile } from '@/models/entities/drive-file';
 import { DriveFiles } from '@/models/index';
+import { truncate } from '@/misc/truncate';
+import { DM_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 const logger = apLogger;
 
@@ -27,6 +29,8 @@ export async function createImage(actor: IRemoteUser, value: any): Promise<Drive
 
 	const instance = await fetchMeta();
 	const cache = instance.cacheRemoteFiles;
+
+	image.name = truncate(image.name, DB_MAX_IMAGE_COMMENT_LENGTH);
 
 	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache, image.name);
 

--- a/src/remote/activitypub/models/image.ts
+++ b/src/remote/activitypub/models/image.ts
@@ -30,9 +30,7 @@ export async function createImage(actor: IRemoteUser, value: any): Promise<Drive
 	const instance = await fetchMeta();
 	const cache = instance.cacheRemoteFiles;
 
-	image.name = truncate(image.name, DB_MAX_IMAGE_COMMENT_LENGTH);
-
-	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache, image.name);
+	let file = await uploadFromUrl(image.url, actor, null, image.url, image.sensitive, false, !cache, truncate(image.name, DB_MAX_IMAGE_COMMENT_LENGTH));
 
 	if (file.isLink) {
 		// URLが異なっている場合、同じ画像が以前に異なるURLで登録されていたということなので、

--- a/src/remote/activitypub/models/person.ts
+++ b/src/remote/activitypub/models/person.ts
@@ -28,21 +28,12 @@ import { getConnection } from 'typeorm';
 import { toArray } from '@/prelude/array';
 import { fetchInstanceMetadata } from '@/services/fetch-instance-metadata';
 import { normalizeForSearch } from '@/misc/normalize-for-search';
+import { truncate } from '@/misc/truncate';
 
 const logger = apLogger;
 
 const nameLength = 128;
 const summaryLength = 2048;
-
-function truncate(input: string, size: number): string;
-function truncate(input: string | undefined, size: number): string | undefined;
-function truncate(input: string | undefined, size: number): string | undefined {
-	if (!input || input.length <= size) {
-		return input;
-	} else {
-		return input.substring(0, size);
-	}
-}
 
 /**
  * Validate and convert to actor object

--- a/src/server/api/endpoints/drive/files/update.ts
+++ b/src/server/api/endpoints/drive/files/update.ts
@@ -4,6 +4,8 @@ import { publishDriveStream } from '@/services/stream';
 import define from '../../../define';
 import { ApiError } from '../../../error';
 import { DriveFiles, DriveFolders } from '@/models/index';
+import { truncate } from '@/misc/truncate';
+import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 export const meta = {
 	tags: ['drive'],
@@ -78,7 +80,7 @@ export default define(meta, async (ps, user) => {
 
 	if (ps.name) file.name = ps.name;
 
-	if (ps.comment !== undefined) file.comment = ps.comment;
+	if (ps.comment !== undefined) file.comment = truncate(ps.comment, DB_MAX_IMAGE_COMMENT_LENGTH);
 
 	if (ps.isSensitive !== undefined) file.isSensitive = ps.isSensitive;
 

--- a/src/server/api/endpoints/drive/files/update.ts
+++ b/src/server/api/endpoints/drive/files/update.ts
@@ -4,7 +4,6 @@ import { publishDriveStream } from '@/services/stream';
 import define from '../../../define';
 import { ApiError } from '../../../error';
 import { DriveFiles, DriveFolders } from '@/models/index';
-import { truncate } from '@/misc/truncate';
 import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 export const meta = {
@@ -35,7 +34,7 @@ export const meta = {
 		},
 
 		comment: {
-			validator: $.optional.nullable.str,
+			validator: $.optional.nullable.str.max(DB_MAX_IMAGE_COMMENT_LENGTH),
 			default: undefined as any,
 		}
 	},
@@ -80,7 +79,7 @@ export default define(meta, async (ps, user) => {
 
 	if (ps.name) file.name = ps.name;
 
-	if (ps.comment !== undefined) file.comment = truncate(ps.comment, DB_MAX_IMAGE_COMMENT_LENGTH);
+	if (ps.comment !== undefined) file.comment = ps.comment;
 
 	if (ps.isSensitive !== undefined) file.isSensitive = ps.isSensitive;
 

--- a/src/server/api/endpoints/drive/files/upload-from-url.ts
+++ b/src/server/api/endpoints/drive/files/upload-from-url.ts
@@ -5,6 +5,8 @@ import uploadFromUrl from '@/services/drive/upload-from-url';
 import define from '../../../define';
 import { DriveFiles } from '@/models/index';
 import { publishMainStream } from '@/services/stream';
+import { truncate } from '@/misc/truncate';
+import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 export const meta = {
 	tags: ['drive'],
@@ -52,6 +54,8 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
+	ps.comment = truncate(ps.comment, DM_MAX_IMAGE_COMMENT_LENGTH);
+
 	uploadFromUrl(ps.url, user, ps.folderId, null, ps.isSensitive, ps.force, false, ps.comment).then(file => {
 		DriveFiles.pack(file, { self: true }).then(packedFile => {
 			publishMainStream(user.id, 'urlUploadFinished', {

--- a/src/server/api/endpoints/drive/files/upload-from-url.ts
+++ b/src/server/api/endpoints/drive/files/upload-from-url.ts
@@ -5,7 +5,6 @@ import uploadFromUrl from '@/services/drive/upload-from-url';
 import define from '../../../define';
 import { DriveFiles } from '@/models/index';
 import { publishMainStream } from '@/services/stream';
-import { truncate } from '@/misc/truncate';
 import { DB_MAX_IMAGE_COMMENT_LENGTH } from '@/misc/hard-limits';
 
 export const meta = {
@@ -37,7 +36,7 @@ export const meta = {
 		},
 
 		comment: {
-			validator: $.optional.nullable.str,
+			validator: $.optional.nullable.str.max(DB_MAX_IMAGE_COMMENT_LENGTH),
 			default: null,
 		},
 
@@ -54,8 +53,6 @@ export const meta = {
 };
 
 export default define(meta, async (ps, user) => {
-	ps.comment = truncate(ps.comment, DM_MAX_IMAGE_COMMENT_LENGTH);
-
 	uploadFromUrl(ps.url, user, ps.folderId, null, ps.isSensitive, ps.force, false, ps.comment).then(file => {
 		DriveFiles.pack(file, { self: true }).then(packedFile => {
 			publishMainStream(user.id, 'urlUploadFinished', {


### PR DESCRIPTION
# What
Properly handle the length restriction on `drive_file.comment` (絵のキャプション) which is a `VARCHAR(512)`.
- Description longer than 512 chars is truncated by the API. (like #7629)
- Show the limited length in the UI, when writing the image description: <details><summary>screenshot: new dialog for editing the image caption</summary><img src="https://user-images.githubusercontent.com/20990607/130678569-60588860-265a-4d35-a9d6-ce2a057c411a.png"/></details>

# Why
Long descriptions lead to a fatal error. The file, the note and any replies to that note can not be saved correctly. This means that these notes can not be received.

This is necessary because Mastodon for example allows **1500 chars** in image descriptions (see https://github.com/mastodon/mastodon/issues/11658). In my opinion, the current limit of 512 is okay and does not have to be changed. If the limit gets larger, it can be difficult for people using screen readers (see also https://github.com/mastodon/mastodon/issues/12268).