### PR TITLE
サインアップ・ログアウト周りの怪しい挙動を修正

### DIFF
--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -1,4 +1,4 @@
-import { get, set } from '@client/scripts/idb-proxy';
+import { del, get, set } from '@client/scripts/idb-proxy';
 import { reactive } from 'vue';
 import { apiUrl } from '@client/config';
 import { waiting } from '@client/os';
@@ -26,7 +26,9 @@ export async function signout() {
 	//#region Remove account
 	const accounts = await getAccounts();
 	accounts.splice(accounts.findIndex(x => x.id === $i.id), 1);
-	set('accounts', accounts);
+
+	if (accounts.length > 0) await set('accounts', accounts);
+	else await del('accounts');
 	//#endregion
 
 	//#region Remove push notification registration

--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -33,16 +33,18 @@ export async function signout() {
 
 	//#region Remove push notification registration
 	try {
-		const registration = await navigator.serviceWorker.ready;
-		const push = await registration.pushManager.getSubscription();
-		if (push) {
-			await fetch(`${apiUrl}/sw/unregister`, {
-				method: 'POST',
-				body: JSON.stringify({
-					i: $i.token,
-					endpoint: push.endpoint,
-				}),
-			});
+		if (navigator.serviceWorker.controller) {
+			const registration = await navigator.serviceWorker.ready;
+			const push = await registration.pushManager.getSubscription();
+			if (push) {
+				await fetch(`${apiUrl}/sw/unregister`, {
+					method: 'POST',
+					body: JSON.stringify({
+						i: $i.token,
+						endpoint: push.endpoint,
+					}),
+				});
+			}
 		}
 	} catch (e) {}
 	//#endregion

--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -31,7 +31,7 @@ export async function signout() {
 	else await del('accounts');
 	//#endregion
 
-	//#region Remove push notification registration
+	//#region Remove service worker registration
 	try {
 		if (navigator.serviceWorker.controller) {
 			const registration = await navigator.serviceWorker.ready;
@@ -45,6 +45,13 @@ export async function signout() {
 					}),
 				});
 			}
+		}
+
+		if (accounts.length === 0) {
+			await navigator.serviceWorker.getRegistrations()
+				.then(registrations => {
+					return Promise.all(registrations.map(registration => registration.unregister()));
+				})
 		}
 	} catch (e) {}
 	//#endregion

--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -51,7 +51,7 @@ export async function signout() {
 			await navigator.serviceWorker.getRegistrations()
 				.then(registrations => {
 					return Promise.all(registrations.map(registration => registration.unregister()));
-				})
+				});
 		}
 	} catch (e) {}
 	//#endregion

--- a/src/client/account.ts
+++ b/src/client/account.ts
@@ -35,14 +35,15 @@ export async function signout() {
 	try {
 		const registration = await navigator.serviceWorker.ready;
 		const push = await registration.pushManager.getSubscription();
-		if (!push) return;
-		await fetch(`${apiUrl}/sw/unregister`, {
-			method: 'POST',
-			body: JSON.stringify({
-				i: $i.token,
-				endpoint: push.endpoint,
-			}),
-		});
+		if (push) {
+			await fetch(`${apiUrl}/sw/unregister`, {
+				method: 'POST',
+				body: JSON.stringify({
+					i: $i.token,
+					endpoint: push.endpoint,
+				}),
+			});
+		}
 	} catch (e) {}
 	//#endregion
 

--- a/src/client/components/signin.vue
+++ b/src/client/components/signin.vue
@@ -111,7 +111,9 @@ export default defineComponent({
 
 		onLogin(res) {
 			if (this.autoSet) {
-				login(res.i);
+				return login(res.i);
+			} else {
+				return;
 			}
 		},
 
@@ -144,7 +146,7 @@ export default defineComponent({
 				});
 			}).then(res => {
 				this.$emit('login', res);
-				this.onLogin(res);
+				return this.onLogin(res);
 			}).catch(err => {
 				if (err === null) return;
 				os.dialog({

--- a/src/client/components/signup.vue
+++ b/src/client/components/signup.vue
@@ -185,7 +185,7 @@ export default defineComponent({
 					this.$emit('signup', res);
 
 					if (this.autoSet) {
-						return login(res.token);
+						return login(res.i);
 					}
 				});
 			}).catch(() => {

--- a/src/client/components/signup.vue
+++ b/src/client/components/signup.vue
@@ -178,14 +178,14 @@ export default defineComponent({
 				'hcaptcha-response': this.hCaptchaResponse,
 				'g-recaptcha-response': this.reCaptchaResponse,
 			}).then(() => {
-				os.api('signin', {
+				return os.api('signin', {
 					username: this.username,
 					password: this.password
 				}).then(res => {
 					this.$emit('signup', res);
 
 					if (this.autoSet) {
-						login(res.i);
+						return login(res.token);
 					}
 				});
 			}).catch(() => {

--- a/src/client/pages/welcome.setup.vue
+++ b/src/client/pages/welcome.setup.vue
@@ -53,7 +53,7 @@ export default defineComponent({
 				username: this.username,
 				password: this.password,
 			}).then(res => {
-				login(res.i);
+				return login(res.token);
 			}).catch(() => {
 				this.submitting = false;
 


### PR DESCRIPTION
Fix #7749

# What
- fix: welcome.setup（管理者が最初にサインアップするページ）でログインされないのを修正
- fix: #7611 で仕込んだクライアントのsw/unregisterのコードのせいで、プッシュ通知を登録していない環境でログアウトが完了しないのを修正
- enhance: 完全ログアウト時にIndexedDBのaccountsを削除するように
- enhance: 完全ログアウト時にService Workerを削除するように
- refactor: 関数内で可能なところはlogin()をreturnするようにしてエラーハンドリングしやすく

# Why
- 細かい挙動の改善
