### PR TITLE
enhance: ユーザーをミュートしている間に作成された通知などは常に既読にするように

### DIFF
--- a/src/models/repositories/muting.ts
+++ b/src/models/repositories/muting.ts
@@ -31,6 +31,17 @@ export class MutingRepository extends Repository<Muting> {
 	) {
 		return Promise.all(mutings.map(x => this.pack(x, me)));
 	}
+
+	public async isMuting(
+		muterId: User['id'],
+		muteeId: User['id']
+	): Promise<boolean> {
+		return this.findOne({
+			muterId,
+			muteeId
+		})
+		.then(muting => muting !== undefined);
+	}
 }
 
 export const packedMutingSchema = {

--- a/src/services/add-note-to-antenna.ts
+++ b/src/services/add-note-to-antenna.ts
@@ -34,7 +34,7 @@ export async function addNoteToAntenna(antenna: Antenna, note: Note, noteUser: {
 			return;
 		}
 	}
-	
+
 	AntennaNotes.insert({
 		id: genId(),
 		antennaId: antenna.id,

--- a/src/services/note/unread.ts
+++ b/src/services/note/unread.ts
@@ -9,13 +9,9 @@ export default async function(userId: User['id'], note: Note, params: {
 	isSpecified: boolean;
 	isMentioned: boolean;
 }) {
-	//#region ミュートしているなら無視
+	// ミュートしているなら無視
 	// TODO: 現在の仕様ではChannelにミュートは適用されないのでよしなにケアする
-	const mute = await Mutings.find({
-		muterId: userId
-	});
-	if (mute.map(m => m.muteeId).includes(note.userId)) return;
-	//#endregion
+	if (await Mutings.isMuting(userId, note.userId)) return;
 
 	const unread = {
 		id: genId(),


### PR DESCRIPTION
Resolve #7759

# What
- [-] リポジトリにisMuting関数を追加
- [-] 通知を既読に
- [-] ノート未読に登録しないように
- [-] アンテナに登録しないように
- [ ] グループの既読をよしなにする
- [ ] テストを書く

# Why
ミュート解除後に未読になる必要性はないので、既読をつけてしまう。  
判定を単純化できるはず。
