### PR TITLE
fix(client): fix #6811 - Fix image height when uses CW to hide it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - UIの改善
 
 ### Bugfixes
+- fix image height when uses CW to hide it (#6811)
 - アカウントデータのエクスポート/インポート処理ができない問題を修正
 - popupで設定ページを表示すると、アカウントの削除ページにアクセスすることができない問題を修正
 

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 				if (this.$refs.gridOuter) {
 					let height = 287;
-					const parent = this.$parent.getElementsByClassName('main');
+					const parent = this.$parent?.$el.getElementsByClassName('main')[0];
 
 					if (this.$refs.gridOuter.clientHeight) {
 						height = this.$refs.gridOuter.clientHeight;

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 				if (this.$refs.gridOuter) {
 					let height = 287;
-					const parent = this.$parent?.$el.getElementsByClassName('main')[0];
+					const parent = this.$parent.getElementsByClassName('main')[0];
 
 					if (this.$refs.gridOuter.clientHeight) {
 						height = this.$refs.gridOuter.clientHeight;

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 				if (this.$refs.gridOuter) {
 					let height = 287;
-					const parent = this.$parent.getElementsByClassName('main')[0];
+					const parent = this.$parent?.$el.getElementsByClassName('main')[0];
 
 					if (this.$refs.gridOuter.clientHeight) {
 						height = this.$refs.gridOuter.clientHeight;

--- a/src/client/components/media-list.vue
+++ b/src/client/components/media-list.vue
@@ -64,7 +64,7 @@ export default defineComponent({
 
 				if (this.$refs.gridOuter) {
 					let height = 287;
-					const parent = this.$parent.$el;
+					const parent = this.$parent.getElementsByClassName('main');
 
 					if (this.$refs.gridOuter.clientHeight) {
 						height = this.$refs.gridOuter.clientHeight;


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Replace `const parent = this.$parent.$el;` by `const parent = this.$parent.getElementsByClassName('main');`
Will use div (class main) as reference to calculate the image height instead of whole note box (this.$parent.$el).

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Try to fix UI glitch that affects default, deck and pope when uses CW (#6811).
So, this fix an annoying UI glitch when CW is used to hide images, because those images stay behind of polls and footer bar (overlapping the image).

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
The easiest way to reproduce the problem are using deck UI and resizing the timeline box.

- Before apply this:

![before](https://user-images.githubusercontent.com/13387251/133873453-03cb7826-5747-44f8-a0f6-4f5f09a5e8d4.png)


- After apply this:

![after](https://user-images.githubusercontent.com/13387251/133894059-8676b03f-0289-4c0a-a248-6494feebf558.png)


