### PR TITLE
fix: アンテナが既読になってもアンテナ既読フラグがtrueにならないのを修正

### DIFF
--- a/src/services/note/read.ts
+++ b/src/services/note/read.ts
@@ -52,7 +52,7 @@ export default async function(
 
 		if (note.user != null) { // たぶんnullになることは無いはずだけど一応
 			for (const antenna of myAntennas) {
-				if (checkHitAntenna(antenna, note, note.user as any, undefined, Array.from(following))) {
+				if (await checkHitAntenna(antenna, note, note.user as any, undefined, Array.from(following))) {
 					readAntennaNotes.push(note);
 				}
 			}


### PR DESCRIPTION
Spin off of #7792

# What
アンテナが既読になってもアンテナ既読フラグがtrueにならないのを修正

# Why
コードをブラウジングしていたらエラーを見つけた
