### PR TITLE
chore, perf: Reduce redis memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 -->
 
 ## 12.x.x (unreleased)
+- ActivityPub: deliverキューのメモリ使用量を削減
 
 ### Improvements
 - ActivityPub: リモートユーザーのDeleteアクティビティに対応

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.90.1-20210919175827",
+	"version": "12.90.1",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "misskey",
 	"author": "syuilo <syuilotan@yahoo.co.jp>",
-	"version": "12.90.1",
+	"version": "12.90.1-20210919175827",
 	"codename": "indigo",
 	"repository": {
 		"type": "git",

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -64,7 +64,9 @@ export function deliver(user: ThinUser, content: unknown, to: string | null) {
 	if (to == null) return null;
 
 	const data = {
-		user,
+		user: {
+			id: user.id
+		},
 		content,
 		to
 	};


### PR DESCRIPTION
# What
Redisに入れるdeliverキューのサイズを削減
enqueueする前にuserオブジェクトをパージ

# Why
deliverキューのペイロードの`user`は、型定義上は
```ts
export type ThinUser = {
	id: User['id'];
};
```
になってるけど、実際はフルの`User`オブジェクトが来たりするので
Redisにenqueueする前にパージしないと、無駄にでかいオブジェクトがRedisに入ってしまう。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
