### PR TITLE
use high resolution asset for splash screen

### DIFF
--- a/packages/backend/src/server/web/views/base.pug
+++ b/packages/backend/src/server/web/views/base.pug
@@ -56,5 +56,5 @@ html
 			br
 			| Please turn on your JavaScript
 		div#splash
-			img(src='/favicon.ico')
+			img(src='/static-assets/icons/512.png')
 		block content


### PR DESCRIPTION
# What
Use the 512px size icon asset for the splash screen instead of the favicon.

# Why
fix #7873