### PR TITLE
Update reactions-viewer.reaction.vue

### DIFF
--- a/src/client/components/reactions-viewer.reaction.vue
+++ b/src/client/components/reactions-viewer.reaction.vue
@@ -177,6 +177,7 @@ export default defineComponent({
 	> span {
 		font-size: 0.9em;
 		line-height: 32px;
+		margin: 0 0 0 8px;
 	}
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/misskey-dev/misskey/issues/7908

Give same spacing as renote button. See screenshot

![misskeyreactionbeforeafter](https://user-images.githubusercontent.com/1679025/138580699-b4d55501-95cd-44cd-9cca-504576e42c25.png)

