### PR TITLE
enhance: added the webSearchEngine setting again

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -800,6 +800,8 @@ manageAccounts: "アカウントを管理"
 makeReactionsPublic: "リアクション一覧を公開する"
 makeReactionsPublicDescription: "あなたがしたリアクション一覧を誰でも見れるようにします。"
 classic: "クラシック"
+webSearchEngine: "ウェブ検索エンジン"
+webSearchEngineDesc: "例: https://www.duckduckgo.com/?#q={{query}}"
 
 _signup:
   almostThere: "ほとんど完了です"

--- a/src/client/pages/settings/general.vue
+++ b/src/client/pages/settings/general.vue
@@ -14,6 +14,11 @@
 		</template>
 	</FormSelect>
 
+	<FormInput v-model="webSearchEngine"  manual-save>
+		<span>{{ $ts.webSearchEngine }}</span>
+		<template #caption>{{ $ts.webSearchEngineDesc }}</template>
+	</FormInput>
+
 	<FormGroup>
 		<template #label>{{ $ts.behavior }}</template>
 		<FormSwitch v-model="imageNewTab">{{ $ts.openImageInNewTab }}</FormSwitch>
@@ -91,6 +96,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import FormInput from '@client/components/debobigego/input.vue';
 import FormSwitch from '@client/components/debobigego/switch.vue';
 import FormSelect from '@client/components/debobigego/select.vue';
 import FormRadios from '@client/components/debobigego/radios.vue';
@@ -109,6 +115,7 @@ import * as symbols from '@client/symbols';
 export default defineComponent({
 	components: {
 		MkLink,
+		FormInput,
 		FormSwitch,
 		FormSelect,
 		FormRadios,
@@ -155,6 +162,7 @@ export default defineComponent({
 		useReactionPickerForContextMenu: defaultStore.makeGetterSetter('useReactionPickerForContextMenu'),
 		squareAvatars: defaultStore.makeGetterSetter('squareAvatars'),
 		aiChanMode: defaultStore.makeGetterSetter('aiChanMode'),
+		webSearchEngine: defaultStore.makeGetterSetter('webSearchEngine'),
 	},
 
 	watch: {

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -214,6 +214,10 @@ export const defaultStore = markRaw(new Storage('base', {
 		where: 'device',
 		default: false
 	},
+	webSearchEngine: {
+		where: 'device',
+		default: 'https://duckduckgo.com/?q={{query}}',
+	}
 }));
 
 // TODO: 他のタブと永続化されたstateを同期


### PR DESCRIPTION
# What
The `webSearchEngine` setting has been added to Client Settings > General. The setting is stored on the device like other client settings.
The default search engine is DuckDuckGo instead of Google. I think it is much better for privacy. If you think it should be another search engine, please let me know and I will change it!

# Why
Fix #7917

# Additional Info
The Japanese Text is from Misskey 11, so I hope it is correct.
https://github.com/misskey-dev/misskey/blob/e6b93c1dbbe5e623dbae679487094d4e34b6248b/locales/ja-JP.yml#L222-L223