### PR TITLE
fix: stop context menu handling for videos

### DIFF
--- a/src/client/components/media-video.vue
+++ b/src/client/components/media-video.vue
@@ -11,6 +11,7 @@
 		:title="video.name"
 		preload="none"
 		controls
+		@contextmenu.stop
 	>
 		<source 
 			:src="video.url" 


### PR DESCRIPTION
# What
The context menu handler is set to stop. The native context menu will be displayed instead of the Misskey custom context menu.

# Why
fix #7926 