### PR TITLE
feat: クライアントでログインするアカウントidを指定するクエリ(loginId=:userId)

### DIFF
--- a/src/client/init.ts
+++ b/src/client/init.ts
@@ -37,7 +37,7 @@ import { isMobile } from '@client/scripts/is-mobile';
 import { initializeSw } from '@client/scripts/initialize-sw';
 import { reloadChannel } from '@client/scripts/unison-reload';
 import { reactionPicker } from '@client/scripts/reaction-picker';
-import { deleteLoginId } from '@client/scripts/login-id';
+import { getUrlWithoutLoginId } from '@client/scripts/login-id';
 import { getAccountFromId } from '@client/scripts/get-account-from-id';
 
 console.info(`Misskey v${version}`);
@@ -123,7 +123,7 @@ const params = new URLSearchParams(location.search);
 const loginId = params.get('loginId');
 
 if (loginId) {
-	const target = deleteLoginId(location.href);
+	const target = getUrlWithoutLoginId(location.href);
 
 	if (!$i || $i.id !== loginId) {
 		const account = await getAccountFromId(loginId);

--- a/src/client/init.ts
+++ b/src/client/init.ts
@@ -128,7 +128,7 @@ if (loginId) {
 	if (!$i || $i.id !== loginId) {
 		const account = await getAccountFromId(loginId);
 		if (account) {
-			login(account.token, target);
+			await login(account.token, target);
 		}
 	}
 

--- a/src/client/init.ts
+++ b/src/client/init.ts
@@ -37,6 +37,8 @@ import { isMobile } from '@client/scripts/is-mobile';
 import { initializeSw } from '@client/scripts/initialize-sw';
 import { reloadChannel } from '@client/scripts/unison-reload';
 import { reactionPicker } from '@client/scripts/reaction-picker';
+import { deleteLoginId } from '@client/scripts/login-id';
+import { getAccountFromId } from '@client/scripts/get-account-from-id';
 
 console.info(`Misskey v${version}`);
 
@@ -114,6 +116,25 @@ if (isMobile || window.innerWidth <= 1024) {
 //#region Set lang attr
 const html = document.documentElement;
 html.setAttribute('lang', lang);
+//#endregion
+
+//#region loginId
+const params = new URLSearchParams(location.search);
+const loginId = params.get('loginId');
+
+if (loginId) {
+	const target = deleteLoginId(location.href);
+
+	if (!$i || $i.id !== loginId) {
+		const account = await getAccountFromId(loginId);
+		if (account) {
+			login(account.token, target);
+		}
+	}
+
+	history.replaceState({ misskey: 'loginId' }, '', target);
+}
+
 //#endregion
 
 //#region Fetch user

--- a/src/client/scripts/login-id.ts
+++ b/src/client/scripts/login-id.ts
@@ -1,10 +1,10 @@
-export function appendLoginId(url: string, loginId: string) {
+export function getUrlWithLoginId(url: string, loginId: string) {
 	const u = new URL(url, origin);
 	u.searchParams.append('loginId', loginId);
 	return u.toString();
 }
 
-export function deleteLoginId(url: string) {
+export function getUrlWithoutLoginId(url: string) {
 	const u = new URL(url);
 	u.searchParams.delete('loginId');
 	return u.toString();

--- a/src/client/scripts/login-id.ts
+++ b/src/client/scripts/login-id.ts
@@ -1,0 +1,11 @@
+export function appendLoginId(url: string, loginId: string) {
+	const u = new URL(url, origin);
+	u.searchParams.append('loginId', loginId);
+	return u.toString();
+}
+
+export function deleteLoginId(url: string) {
+	const u = new URL(url);
+	u.searchParams.delete('loginId');
+	return u.toString();
+}


### PR DESCRIPTION
# What
Spin off of #7667

`${origin}/path?loginId=:userId`にアクセスすることで指定したユーザーIDのアカウントにログインするように
