### PR TITLE
fix: ユーザー情報のhasUnreadChannelが常にfalseになってしまっているのを修正

### DIFF
--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -112,7 +112,7 @@ export class UserRepository extends Repository<User> {
 
 		const unread = channels.length > 0 ? await NoteUnreads.findOne({
 			userId: userId,
-			noteChannelId: In(channels.map(x => x.id)),
+			noteChannelId: In(channels.map(x => x.followeeId)),
 		}) : null;
 
 		return unread != null;


### PR DESCRIPTION
# What
ユーザー情報のhasUnreadChannelが常にfalseになってしまっているのを修正

# Why
バグ修正

# Additional info (optional)
noteChannelId には channelId を指定するのが正しいが channelFollowingId が指定されてしまっているため NoteUnreads.findOne の結果が常に undefined になっている