### PR TITLE
fix: コントロールパネルのジョブキューに個々のジョブが表示されないのを修正

### DIFF
--- a/src/client/pages/admin/queue.chart.vue
+++ b/src/client/pages/admin/queue.chart.vue
@@ -55,8 +55,8 @@ export default defineComponent({
 		const jobs = ref([]);
 
 		onMounted(() => {
-			os.api(props.domain === 'inbox' ? 'admin/queue/inbox-delayed' : props.domain === 'deliver' ? 'admin/queue/deliver-delayed' : null, {}).then(jobs => {
-				jobs.value = jobs;
+			os.api(props.domain === 'inbox' ? 'admin/queue/inbox-delayed' : props.domain === 'deliver' ? 'admin/queue/deliver-delayed' : null, {}).then(result => {
+				jobs.value = result;
 			});
 
 			const onStats = (stats) => {


### PR DESCRIPTION
# What
コントロールパネルのジョブキューに個々のジョブが表示されないのを修正

# Why
バグ修正

# Additional info (optional)
jobs の変数名が重複しているため意図した代入になっていない