### PR TITLE
fix(client): reaction viewer layout

### DIFF
--- a/packages/client/src/components/reactions-viewer.details.vue
+++ b/packages/client/src/components/reactions-viewer.details.vue
@@ -9,12 +9,14 @@
 			<template v-if="users.length <= 10">
 				<b v-for="u in users" :key="u.id" style="margin-right: 12px;">
 					<MkAvatar :user="u" style="width: 24px; height: 24px; margin-right: 2px;"/>
+					<br/>
 					<MkUserName :user="u" :nowrap="false" style="line-height: 24px;"/>
 				</b>
 			</template>
 			<template v-if="10 < users.length">
 				<b v-for="u in users" :key="u.id" style="margin-right: 12px;">
 					<MkAvatar :user="u" style="width: 24px; height: 24px; margin-right: 2px;"/>
+					<br/>
 					<MkUserName :user="u" :nowrap="false" style="line-height: 24px;"/>
 				</b>
 				<span slot="omitted">+{{ count - 10 }}</span>
@@ -64,7 +66,6 @@ export default defineComponent({
 	display: flex;
 
 	> .reaction {
-		flex: 1;
 		max-width: 100px;
 		text-align: center;
 
@@ -80,12 +81,13 @@ export default defineComponent({
 	}
 
 	> .users {
+		display: flex;
 		flex: 1;
 		min-width: 0;
 		font-size: 0.9em;
 		border-left: solid 0.5px var(--divider);
 		padding-left: 10px;
-    margin-left: 10px;
+		margin-left: 10px;
 	}
 }
 </style>


### PR DESCRIPTION
# What
The design of the reaction viewer is changed so that the situation like in the picture can not occur:
![image](https://user-images.githubusercontent.com/20990607/139597326-b384bde2-a251-43c7-95c7-56c5101182b3.png)
Note how the profile picture of the 2nd person is on the 1st line, but the name is on the 2nd line.

Instead the design now looks like this: (sorry the background was different, the square/round profile pictures are different because i took the picture on another misskey instance)
![image](https://user-images.githubusercontent.com/20990607/139597362-ade5b2dc-9da4-46ef-92e3-61d8d5bf9ca1.png)
The profile picture is always above the name, and different users are separated vertically.

# Why
The profile picture and name should be grouped together as they belong, and it should be clear which picture belongs to which name.

# Additional info
What seemed to be the error in the old code is that `display: flex` is not inherited by `.users`.

The intendation of one line was also fixed.