### PR TITLE
fix missing i18n string

### DIFF
--- a/src/client/pages/explore.vue
+++ b/src/client/pages/explore.vue
@@ -70,7 +70,7 @@
 					<MkRadios v-model="searchOrigin">
 						<option value="local">{{ $ts.local }}</option>
 						<option value="remote">{{ $ts.remote }}</option>
-						<option value="both">{{ $ts.both }}</option>
+						<option value="both">{{ $ts.all }}</option>
 					</MkRadios>
 				</div>
 


### PR DESCRIPTION
# What
Use the existing `all` string instead of missing `both` string.

# Why
fix #7931 