### PR TITLE
fix: limit menu list size

### DIFF
--- a/src/client/components/ui/menu.vue
+++ b/src/client/components/ui/menu.vue
@@ -147,6 +147,8 @@ export default defineComponent({
 .rrevdjwt {
 	padding: 8px 0;
 	min-width: 200px;
+	max-height: 90vh;
+	overflow: auto;
 
 	&.center {
 		> .item {


### PR DESCRIPTION
# What
Limit the size of a selection menu. This can be an issue for example when adding an object to the room.
Also use `overflow: auto` to make sure a scroll bar appears if necessary.

# Why
fix #7946