### PR TITLE
perf: delete-account処理を軽くする

### DIFF
--- a/src/queue/processors/db/delete-account.ts
+++ b/src/queue/processors/db/delete-account.ts
@@ -67,7 +67,7 @@ export async function deleteAccount(job: Bull.Job<DbUserDeleteJobData>): Promise
 			cursor = files[files.length - 1].id;
 
 			for (const file of files) {
-				await deleteFileSync(file);
+				await deleteFileSync(file, false, false);
 			}
 		}
 

--- a/src/queue/processors/db/delete-account.ts
+++ b/src/queue/processors/db/delete-account.ts
@@ -67,7 +67,7 @@ export async function deleteAccount(job: Bull.Job<DbUserDeleteJobData>): Promise
 			cursor = files[files.length - 1].id;
 
 			for (const file of files) {
-				await deleteFileSync(file, false, false);
+				await deleteFileSync(file);
 			}
 		}
 

--- a/src/remote/activitypub/kernel/delete/actor.ts
+++ b/src/remote/activitypub/kernel/delete/actor.ts
@@ -15,7 +15,7 @@ export async function deleteActor(actor: IRemoteUser, uri: string): Promise<stri
 	if (actor.isDeleted) {
 		logger.info(`skip: already deleted`);
 	}
-/*
+
 	const job = await createDeleteAccountJob(actor);
 
 	await Users.update(actor.id, {
@@ -23,7 +23,4 @@ export async function deleteActor(actor: IRemoteUser, uri: string): Promise<stri
 	});
 
 	return `ok: queued ${job.name} ${job.id}`;
-*/
-
-	return `skip: account deletion temporaly disabled`;
 }


### PR DESCRIPTION
# What
pref #7892 delete-accountが重い

アカウント削除処理をする場合、削除するユーザーの drive_file を使用している note を全て削除する処理をスキップする

# Why
アカウント削除処理で遅いのは `WHERE $1 = ANY("fileIds")` を使用しているクエリで、該当するのは次の 2 箇所です。
https://github.com/misskey-dev/misskey/blob/71d9c2a53d116a61f4c9b21ff98712a0000412b8/src/services/drive/delete-file.ts#L137
https://github.com/misskey-dev/misskey/blob/71d9c2a53d116a61f4c9b21ff98712a0000412b8/src/services/drive/delete-file.ts#L109-L111

アカウント削除処理では

1.そのユーザーの note を全て削除
↓
2.そのユーザーの drive_file を全て削除
↓
3.そのユーザーの drive_file を使用している note を全て削除
↓
4.必要に応じてそのユーザーの user を削除

という流れになっていますが、1. でユーザーの note を全て削除しているので 3. で再度 note を削除する必要がないため、アカウント削除処理の場合は3.の処理をスキップして処理を軽くします。