### PR TITLE
fix: /notes API に i を指定しても認証ありの追加プロパティが取得できないのを修正

### DIFF
--- a/src/server/api/endpoints/notes.ts
+++ b/src/server/api/endpoints/notes.ts
@@ -53,7 +53,7 @@ export const meta = {
 	},
 };
 
-export default define(meta, async (ps) => {
+export default define(meta, async (ps, user) => {
 	const query = makePaginationQuery(Notes.createQueryBuilder('note'), ps.sinceId, ps.untilId)
 		.andWhere(`note.visibility = 'public'`)
 		.andWhere(`note.localOnly = FALSE`)
@@ -90,5 +90,5 @@ export default define(meta, async (ps) => {
 
 	const notes = await query.take(ps.limit!).getMany();
 
-	return await Notes.packMany(notes);
+	return await Notes.packMany(notes, user);
 });


### PR DESCRIPTION
# What
/notes API に i を指定しても認証ありの追加プロパティの myReaction が取得できないのを修正

# Why
バグ修正

# Additional info (optional)
/notes API でノートを取得する際、Notes.packMany の引数に me が指定されていない