### PR TITLE
fix: mention local users in replies

### DIFF
--- a/packages/client/src/components/post-form.vue
+++ b/packages/client/src/components/post-form.vue
@@ -279,8 +279,8 @@ export default defineComponent({
 			this.text += ' ';
 		}
 
-		if (this.reply && this.reply.user.host != null) {
-			this.text = `@${this.reply.user.username}@${toASCII(this.reply.user.host)} `;
+		if (this.reply && (this.reply.user.username != this.$i.username || (this.reply.user.host != null && this.reply.user.host != host))) {
+			this.text = `@${this.reply.user.username}${this.reply.user.host != null ? '@' + toASCII(this.reply.user.host) : ''} `;
 		}
 
 		if (this.reply && this.reply.text != null) {

--- a/packages/client/src/ui/chat/post-form.vue
+++ b/packages/client/src/ui/chat/post-form.vue
@@ -207,8 +207,8 @@ export default defineComponent({
 			this.text += ' ';
 		}
 
-		if (this.reply && this.reply.user.host != null) {
-			this.text = `@${this.reply.user.username}@${toASCII(this.reply.user.host)} `;
+		if (this.reply && (this.reply.user.username != this.$i.username || (this.reply.user.host != null && this.reply.user.host != host))) {
+			this.text = `@${this.reply.user.username}${this.reply.user.host != null ? '@' + toASCII(this.reply.user.host) : ''} `;
 		}
 
 		if (this.reply && this.reply.text != null) {


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Close #7870

When replying to local users, mentions will be used.
```
user1: Hello!
-->user2: How are you? (notification)
-->-->user2: I hope you are doing good. (no mention, so no notification)
```
new:
```
user1: Hello!
-->user2: @user1 How are you? (notification)
-->-->user2: @user1 I hope you are doing good. (mention, so there is notification)
```


# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
No mentions causes issues when replying in threads; the users may not get notifications because they do not get mentioned.
Also, it may confuse remote users replying, and the local users will not get notified.
# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
