### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ COPY --from=builder /misskey/built ./built
 COPY --from=builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
 COPY --from=builder /misskey/packages/backend/built ./packages/backend/built
 COPY --from=builder /misskey/packages/client/node_modules ./packages/client/node_modules
-COPY --from=builder /misskey/packages/client/built ./packages/client/built
 COPY . ./
 
 CMD ["npm", "run", "migrateandstart"]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"gulp-cssnano": "2.1.3",
 		"gulp-rename": "2.0.0",
 		"gulp-replace": "1.1.3",
-		"gulp-terser": "2.1.0"
+		"gulp-terser": "2.1.0",
+		"js-yaml": "4.1.0"
 	},
 	"devDependencies": {
 		"@redocly/openapi-core": "1.0.0-beta.54",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -106,6 +106,7 @@
 		"punycode": "2.1.1",
 		"pureimage": "0.3.5",
 		"qrcode": "1.4.4",
+		"querystring": "0.2.1",
 		"random-seed": "0.3.0",
 		"ratelimiter": "3.4.1",
 		"reflect-metadata": "0.1.13",

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -5237,6 +5237,11 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+querystring@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
+  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
+
 quick-lru@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"

--- a/yarn.lock
+++ b/yarn.lock
@@ -323,6 +323,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2299,6 +2304,13 @@ js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
   integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
+js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 js-yaml@^3.14.1:
   version "3.14.1"


### PR DESCRIPTION
# What
Dokcerのビルドが出来ないのを修正
Related #7981

- `<root package>/locales` に `js-yaml` が必要 https://github.com/misskey-dev/misskey/blob/7042933b3bece2ac13983bf1bb7b25f37b91b5d6/locales/index.js#L6
- `<client packege>` => `misskey.js`が存在しないはずの `querystring` に依存してしまっているため追加
  本来は [misskey.js](https://github.com/misskey-dev/misskey.js) のバグ https://github.com/misskey-dev/misskey.js/issues/31
- `packages/client/built` のコピーはいらない

# Why
バグ修正

# Additional info (optional)
Docker build, publish, pull, up, 投稿 & 画像投稿 が出来るまで確認

![image](https://user-images.githubusercontent.com/30769358/141653119-2d6ca56e-07ce-4f1c-aa08-5d214ab98053.png)
