### PR TITLE
fix: アンテナで「特定の日付にジャンプ」が機能していないのを修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/antennas/notes.ts
+++ b/packages/backend/src/server/api/endpoints/antennas/notes.ts
@@ -33,6 +33,14 @@ export const meta = {
 		untilId: {
 			validator: $.optional.type(ID),
 		},
+
+		sinceDate: {
+			validator: $.optional.num,
+		},
+
+		untilDate: {
+			validator: $.optional.num,
+		},
 	},
 
 	errors: {
@@ -68,7 +76,8 @@ export default define(meta, async (ps, user) => {
 		.select('joining.noteId')
 		.where('joining.antennaId = :antennaId', { antennaId: antenna.id });
 
-	const query = makePaginationQuery(Notes.createQueryBuilder('note'), ps.sinceId, ps.untilId)
+	const query = makePaginationQuery(Notes.createQueryBuilder('note'),
+			ps.sinceId, ps.untilId, ps.sinceDate, ps.untilDate)
 		.andWhere(`note.id IN (${ antennaQuery.getQuery() })`)
 		.innerJoinAndSelect('note.user', 'user')
 		.leftJoinAndSelect('note.reply', 'reply')


### PR DESCRIPTION
# What
/antennas/notes API で日付による絞り込みができるようにすることでアンテナの「特定の日付にジャンプ」が機能するようになる
fix #7978

# Why
「特定の日付にジャンプ」の機能は API のリクエストパラメーターに untilDate がないと機能しないが /antennas/notes API にはそのパラメーターが含まれていなかったため。