### PR TITLE
fix: mentions to remote local user

### DIFF
--- a/packages/client/src/components/post-form.vue
+++ b/packages/client/src/components/post-form.vue
@@ -289,9 +289,14 @@ export default defineComponent({
 
 		if (this.reply && this.reply.text != null) {
 			const ast = mfm.parse(this.reply.text);
+			const otherHost = this.reply.user.host;
 
 			for (const x of extractMentions(ast)) {
-				const mention = x.host ? `@${x.username}@${toASCII(x.host)}` : `@${x.username}`;
+				const mention = x.host ?
+													`@${x.username}@${toASCII(x.host)}` :
+													(otherHost == null || otherHost == host) ?
+														`@${x.username}` :
+														`@${x.username}@${toASCII(otherHost)}`;
 
 				// 自分は除外
 				if (this.$i.username == x.username && x.host == null) continue;


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
when replying to a mention to another instance's local user, the host part is added.

![20211130_09h33m26s_grim](https://user-images.githubusercontent.com/22283693/144098539-3f9e9a64-8c18-4a34-bbce-22fa12a4d318.png)

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
![20211130_09h29m54s_grim](https://user-images.githubusercontent.com/22283693/144098415-1219c649-26bd-4cb8-9490-e3e2e3b8fd6c.png)

before the fix, replying to another user's post with a local mention breaks and tries to mention a potentially nonexistent local user. this is jarring and not proper behavior
# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
