### PR TITLE
fix: integration links

### DIFF
--- a/packages/client/src/pages/admin/integrations-discord.vue
+++ b/packages/client/src/pages/admin/integrations-discord.vue
@@ -6,7 +6,7 @@
 		</FormSwitch>
 
 		<template v-if="enableDiscordIntegration">
-			<FormInfo>Callback URL: {{ `${url}/api/dc/cb` }}</FormInfo>
+			<FormInfo>Callback URL: {{ `${uri}/api/dc/cb` }}</FormInfo>
 		
 			<FormInput v-model="discordClientId">
 				<template #prefix><i class="fas fa-key"></i></template>
@@ -67,6 +67,7 @@ export default defineComponent({
 	methods: {
 		async init() {
 			const meta = await os.api('meta', { detail: true });
+			this.uri = meta.uri;
 			this.enableDiscordIntegration = meta.enableDiscordIntegration;
 			this.discordClientId = meta.discordClientId;
 			this.discordClientSecret = meta.discordClientSecret;

--- a/packages/client/src/pages/admin/integrations-github.vue
+++ b/packages/client/src/pages/admin/integrations-github.vue
@@ -6,7 +6,7 @@
 		</FormSwitch>
 
 		<template v-if="enableGithubIntegration">
-			<FormInfo>Callback URL: {{ `${url}/api/gh/cb` }}</FormInfo>
+			<FormInfo>Callback URL: {{ `${uri}/api/gh/cb` }}</FormInfo>
 		
 			<FormInput v-model="githubClientId">
 				<template #prefix><i class="fas fa-key"></i></template>
@@ -67,6 +67,7 @@ export default defineComponent({
 	methods: {
 		async init() {
 			const meta = await os.api('meta', { detail: true });
+			this.uri = meta.uri;
 			this.enableGithubIntegration = meta.enableGithubIntegration;
 			this.githubClientId = meta.githubClientId;
 			this.githubClientSecret = meta.githubClientSecret;

--- a/packages/client/src/pages/admin/integrations-twitter.vue
+++ b/packages/client/src/pages/admin/integrations-twitter.vue
@@ -6,7 +6,7 @@
 		</FormSwitch>
 
 		<template v-if="enableTwitterIntegration">
-			<FormInfo>Callback URL: {{ `${url}/api/tw/cb` }}</FormInfo>
+			<FormInfo>Callback URL: {{ `${uri}/api/tw/cb` }}</FormInfo>
 		
 			<FormInput v-model="twitterConsumerKey">
 				<template #prefix><i class="fas fa-key"></i></template>
@@ -67,6 +67,7 @@ export default defineComponent({
 	methods: {
 		async init() {
 			const meta = await os.api('meta', { detail: true });
+			this.uri = meta.uri;
 			this.enableTwitterIntegration = meta.enableTwitterIntegration;
 			this.twitterConsumerKey = meta.twitterConsumerKey;
 			this.twitterConsumerSecret = meta.twitterConsumerSecret;


### PR DESCRIPTION
# What

Pick the `meta.uri` out and put it in the right places.

# Why

This will fix the callback URL display in:
* `/admin/integrations/discord`
* `/admin/integrations/github`
* `/admin/integrations/twitter`

Instead of:

![Callback URL: undefined/api/gh/cb](https://user-images.githubusercontent.com/19144373/144718096-eb67376e-7dec-4ac6-9cb4-eb63eafdd8b9.png)
