### PR TITLE
Fix japanese instanceMuteDescription string

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1023,7 +1023,7 @@ _wordMute:
   mutedNotes: "ミュートされたノート"
 
 _instanceMute:
-  instanceMuteDescription: "ミュートしたインスタンスのユーザーからの返信を含めて、設定したインスタンスの全てのノートとRenoteをミュートします。"
+  instanceMuteDescription: "ミュートしたインスタンスのユーザーへの返信を含めて、設定したインスタンスの全てのノートとRenoteをミュートします。"
   instanceMuteDescription2: "改行で区切って設定します"
   title: "設定したインスタンスのノートを隠します。"
   heading: "ミュートするインスタンス"


### PR DESCRIPTION
# What
今日マージされたの #7712 にja-jp.ymlのinstanceMuteDescriptionに不具合がありました。元の英語には "including users replying to a user _**from**_ a muted instance" があったけど翻訳時に「ミュートしたインスタンスのユーザー _**から**_ の返信を含めて」をja-jp.ymlに入れました。このPRで「から」を「へ」に正しました。

# Why
元ja-jp.ymlにある日本語は間違っているです。

# Additional info (optional)
ありません
