### PR TITLE
chore: remove ms-vscode.typescript-javascript-grammar

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
 	"recommendations": [
 		"editorconfig.editorconfig",
 		"eg2.vscode-npm-script",
-		"ms-vscode.typescript-javascript-grammar",
 		"dbaeumer.vscode-eslint",
 		"johnsoncodehk.volar",
 		"sysoev.language-stylus"


### PR DESCRIPTION
# What
Remove `ms-vscode.typescript-javascript-grammar` from VSC extension suggestions.

# Why
[The extension's gone for long](https://marketplace.visualstudio.com/items?itemName=ms-vscode.typescript-javascript-grammar) and VSCode has already [bundled with TypeScript support](https://code.visualstudio.com/docs/languages/typescript).
