### PR TITLE
feat: remove file count limit for a note

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -78,11 +78,11 @@ export const meta = {
 		},
 
 		fileIds: {
-			validator: $.optional.arr($.type(ID)).unique().range(1, 4),
+			validator: $.optional.arr($.type(ID)).unique(),
 		},
 
 		mediaIds: {
-			validator: $.optional.arr($.type(ID)).unique().range(1, 4),
+			validator: $.optional.arr($.type(ID)).unique(),
 			deprecated: true,
 		},
 

--- a/packages/client/src/components/post-form-attaches.vue
+++ b/packages/client/src/components/post-form-attaches.vue
@@ -10,7 +10,7 @@
 			</div>
 		</template>
 	</XDraggable>
-	<p class="remain">{{ 4 - files.length }}/4</p>
+	<p class="count">{{ files.length }}</p>
 </div>
 </template>
 
@@ -41,7 +41,6 @@ export default defineComponent({
 	data() {
 		return {
 			menu: null as Promise<null> | null,
-
 		};
 	},
 
@@ -179,7 +178,7 @@ export default defineComponent({
 		}
 	}
 
-	> .remain {
+	> .count {
 		display: block;
 		position: absolute;
 		top: 8px;


### PR DESCRIPTION
# What & Why
Resolves #8054.

# Additional info (optional)
This also changed the class name of `.remain` for semantic reasons, please check if it creates breakages elsewhere.

Also, We probably also need some UX changes to optimize for too many images in a note.