### PR TITLE
ServiceWorker から locale を取得する際に localStorage にアクセスしないようにする

### DIFF
--- a/packages/client/src/components/notification.vue
+++ b/packages/client/src/components/notification.vue
@@ -157,7 +157,7 @@ export default defineComponent({
 		});
 
 		return {
-			getNoteSummary: (note: misskey.entities.Note) => getNoteSummary(note),
+			getNoteSummary: (note: misskey.entities.Note) => getNoteSummary(note, i18n.locale),
 			followRequestDone,
 			groupInviteDone,
 			notePage,

--- a/packages/client/src/scripts/get-note-summary.ts
+++ b/packages/client/src/scripts/get-note-summary.ts
@@ -1,17 +1,16 @@
 import * as misskey from 'misskey-js';
-import { i18n } from '@/i18n';
 
 /**
  * 投稿を表す文字列を取得します。
  * @param {*} note (packされた)投稿
  */
-export const getNoteSummary = (note: misskey.entities.Note): string => {
+export const getNoteSummary = (note: misskey.entities.Note, locale: any): string => {
 	if (note.deletedAt) {
-		return `(${i18n.locale.deletedNote})`;
+		return `(${locale['deletedNote']})`;
 	}
 
 	if (note.isHidden) {
-		return `(${i18n.locale.invisibleNote})`;
+		return `(${locale['invisibleNote']})`;
 	}
 
 	let summary = '';
@@ -25,18 +24,18 @@ export const getNoteSummary = (note: misskey.entities.Note): string => {
 
 	// ファイルが添付されているとき
 	if ((note.files || []).length != 0) {
-		summary += ` (${i18n.t('withNFiles', { n: note.files.length })})`;
+		summary += ` (${locale['withNFiles'].replace('{n}', note.files.length)})`;
 	}
 
 	// 投票が添付されているとき
 	if (note.poll) {
-		summary += ` (${i18n.locale.poll})`;
+		summary += ` (${locale['poll']})`;
 	}
 
 	// 返信のとき
 	if (note.replyId) {
 		if (note.reply) {
-			summary += `\n\nRE: ${getNoteSummary(note.reply)}`;
+			summary += `\n\nRE: ${getNoteSummary(note.reply, locale)}`;
 		} else {
 			summary += '\n\nRE: ...';
 		}
@@ -45,7 +44,7 @@ export const getNoteSummary = (note: misskey.entities.Note): string => {
 	// Renoteのとき
 	if (note.renoteId) {
 		if (note.renote) {
-			summary += `\n\nRN: ${getNoteSummary(note.renote)}`;
+			summary += `\n\nRN: ${getNoteSummary(note.renote, locale)}`;
 		} else {
 			summary += '\n\nRN: ...';
 		}


### PR DESCRIPTION
Fix #8068

# What
ServiceWorker から i18n.locale を取得する際に localStorage にアクセスしないようにする

# Why
ServiceWorkerが正常に動作しないため、PWAアプリとしてモバイルデバイスにインストールすることができない #8068 を修正します。

[このリファクタリング](https://github.com/misskey-dev/misskey/commit/0e4a111f81cceed275d9bec2695f6e401fb654d8)によって /packages/client/src/scripts/get-note-summary.ts で i18n を取得するのに [/packages/client/src/i18n.ts が使用されるように変更](https://github.com/misskey-dev/misskey/blob/0e4a111f81cceed275d9bec2695f6e401fb654d8/packages/client/src/scripts/get-note-summary.ts#L2)され、/packages/client/src/components/notification.vue ので取得方法と共通化されました。

この i18n.ts では [/packages/client/src/config.ts](https://github.com/misskey-dev/misskey/blob/0e4a111f81cceed275d9bec2695f6e401fb654d8/packages/client/src/config.ts) の locale が使用されており、この locale は localStorage から取得されていますが ServiceWorker から localStorage にアクセスすることはできないためエラーとなっています。
(ServiceWorker から document にもアクセスできないのでそれもエラーになっている。)

リファクタリングが行なわれる前は ServiceWorker での locale の取得は [CacheStorage が使われて](https://github.com/misskey-dev/misskey/blob/0e4a111f81cceed275d9bec2695f6e401fb654d8/packages/client/src/sw/sw.ts#L100)いて、これを変更する理由はなさそうなので locale を取得する部分をリファクタリングする前に戻すことで ServiceWorker が正常に動作するようにします。