### PR TITLE
fix: 続・pizzaxのPRの修正

### DIFF
--- a/packages/client/src/pizzax.ts
+++ b/packages/client/src/pizzax.ts
@@ -74,7 +74,7 @@ export class Storage<T extends StateDef> {
 			}, 1);
 			// streamingのuser storage updateイベントを監視して更新
 			connection?.on('registryUpdated', ({ scope, key, value }: { scope: string[], key: keyof T, value: T[typeof key]['default'] }) => {
-				if (scope[1] !== this.key || this.state[key] === value) return;
+				if (scope.length !== 2 || scope[0] !== 'client' || scope[1] !== this.key || this.state[key] === value) return;
 
 				this.state[key] = value;
 				this.reactiveState[key].value = value;


### PR DESCRIPTION
# What
#8095 の修正

スコープを厳密に比較するように（レジストリはpizzax以外でも使われるので、いつも長さが2とは限らないし、0個目がclientであるとも限らない）