### PR TITLE
fix: thread mute also mutes notifications

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -73,15 +73,18 @@ class NotificationManager {
 
 	public async deliver() {
 		for (const x of this.queue) {
-			// ミュート情報を取得
-			const mentioneeMutes = await Mutings.find({
+			// check if the sender or thread are muted
+			const userMuted = await Mutings.findOne({
 				muterId: x.target,
+				muteeId: this.notifier.id,
 			});
 
-			const mentioneesMutedUserIds = mentioneeMutes.map(m => m.muteeId);
+			const threadMuted = await NoteThreadMutings.findOne({
+				userId: x.target,
+				threadId: this.note.threadId || this.note.id,
+			});
 
-			// 通知される側のユーザーが通知する側のユーザーをミュートしていない限りは通知する
-			if (!mentioneesMutedUserIds.includes(this.notifier.id)) {
+			if (!userMuted && !threadMuted) {
 				createNotification(x.target, x.reason, {
 					notifierId: this.notifier.id,
 					noteId: this.note.id,

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -5,7 +5,7 @@ import { renderActivity } from '@/remote/activitypub/renderer/index.js';
 import { toDbReaction, decodeReaction } from '@/misc/reaction-lib.js';
 import { User, IRemoteUser } from '@/models/entities/user.js';
 import { Note } from '@/models/entities/note.js';
-import { NoteReactions, Users, NoteWatchings, Notes, Emojis, Blockings } from '@/models/index.js';
+import { NoteReactions, Users, NoteWatchings, Notes, Emojis, Blockings, NoteThreadMutings } from '@/models/index.js';
 import { Not } from 'typeorm';
 import { perUserReactionsChart } from '@/services/chart/index.js';
 import { genId } from '@/misc/gen-id.js';
@@ -93,8 +93,13 @@ export default async (user: { id: User['id']; host: User['host']; }, note: Note,
 		userId: user.id,
 	});
 
+	// check if this thread is muted
+	const threadMuted = await NoteThreadMutings.findOne({
+		userId: note.userId,
+		threadId: note.threadId || note.id,
+	});
 	// リアクションされたユーザーがローカルユーザーなら通知を作成
-	if (note.userHost === null) {
+	if (note.userHost === null && !threadMuted) {
 		createNotification(note.userId, 'reaction', {
 			notifierId: user.id,
 			noteId: note.id,


### PR DESCRIPTION
# What
If a notification is in relation to a note, first check if the respective thread is muted. Do not create notifications if the thread of the note is muted.

I also changed the implementation of muted users in `packages/backend/src/services/note/create.ts`, because it seemed inefficient for doing the checking and filtering by `muteeId` in JavaScript instead of letting the database server do it.

# Why
fix #2144
fix #2227
fix #8102

# Additional info
> 一律にオフでもいいがリプライ、Renote、リアクションで分けて制限できると便利かもしれない

This request from #2144 is **not** implemented, all types of notifications will be disabled. (see also https://github.com/misskey-dev/misskey/issues/2144#issuecomment-412100756)