### PR TITLE
fix: proxyでsvgをpngに変換するように

### DIFF
--- a/packages/backend/src/server/file/send-drive-file.ts
+++ b/packages/backend/src/server/file/send-drive-file.ts
@@ -67,7 +67,7 @@ export default async function(ctx: Koa.Context) {
 					if (isThumbnail) {
 						if (['image/jpeg', 'image/webp'].includes(mime)) {
 							return await convertToJpeg(path, 498, 280);
-						} else if (['image/png'].includes(mime)) {
+						} else if (['image/png', 'image/svg+xml'].includes(mime)) {
 							return await convertToPngOrJpeg(path, 498, 280);
 						} else if (mime.startsWith('video/')) {
 							return await GenerateVideoThumbnail(path);

--- a/packages/backend/src/server/file/send-drive-file.ts
+++ b/packages/backend/src/server/file/send-drive-file.ts
@@ -67,7 +67,7 @@ export default async function(ctx: Koa.Context) {
 					if (isThumbnail) {
 						if (['image/jpeg', 'image/webp'].includes(mime)) {
 							return await convertToJpeg(path, 498, 280);
-						} else if (['image/png', 'image/svg+xml'].includes(mime)) {
+						} else if (['image/png'].includes(mime)) {
 							return await convertToPngOrJpeg(path, 498, 280);
 						} else if (mime.startsWith('video/')) {
 							return await GenerateVideoThumbnail(path);

--- a/packages/backend/src/server/proxy/proxy-media.ts
+++ b/packages/backend/src/server/proxy/proxy-media.ts
@@ -25,6 +25,8 @@ export async function proxyMedia(ctx: Koa.Context) {
 			image = await convertToPng(path, 498, 280);
 		} else if ('preview' in ctx.query && ['image/jpeg', 'image/png', 'image/gif', 'image/apng', 'image/vnd.mozilla.apng', 'image/svg+xml'].includes(mime)) {
 			image = await convertToJpeg(path, 200, 200);
+		}	else if (['image/svg+xml'].includes(mime)) {
+			image = await convertToPng(path, 2048, 2048);
 		} else if (!mime.startsWith('image/') || !FILE_TYPE_BROWSERSAFE.includes(mime)) {
 			throw 403;
 		} else {

--- a/packages/backend/src/server/proxy/proxy-media.ts
+++ b/packages/backend/src/server/proxy/proxy-media.ts
@@ -28,7 +28,7 @@ export async function proxyMedia(ctx: Koa.Context) {
 		}	else if (['image/svg+xml'].includes(mime)) {
 			image = await convertToPng(path, 2048, 2048);
 		} else if (!mime.startsWith('image/') || !FILE_TYPE_BROWSERSAFE.includes(mime)) {
-			throw 403;
+			throw new StatusError('Rejected type', 403, 'Rejected type');
 		} else {
 			image = {
 				data: fs.readFileSync(path),

--- a/packages/backend/src/server/proxy/proxy-media.ts
+++ b/packages/backend/src/server/proxy/proxy-media.ts
@@ -19,15 +19,14 @@ export async function proxyMedia(ctx: Koa.Context) {
 
 		const { mime, ext } = await detectType(path);
 
-		if (!mime.startsWith('image/')) throw 403;
-		if (!FILE_TYPE_BROWSERSAFE.includes(mime)) throw 403;
-
 		let image: IImage;
 
-		if ('static' in ctx.query && ['image/png', 'image/gif', 'image/apng', 'image/vnd.mozilla.apng', 'image/webp'].includes(mime)) {
+		if ('static' in ctx.query && ['image/png', 'image/gif', 'image/apng', 'image/vnd.mozilla.apng', 'image/webp', 'image/svg+xml'].includes(mime)) {
 			image = await convertToPng(path, 498, 280);
-		} else if ('preview' in ctx.query && ['image/jpeg', 'image/png', 'image/gif', 'image/apng', 'image/vnd.mozilla.apng'].includes(mime)) {
+		} else if ('preview' in ctx.query && ['image/jpeg', 'image/png', 'image/gif', 'image/apng', 'image/vnd.mozilla.apng', 'image/svg+xml'].includes(mime)) {
 			image = await convertToJpeg(path, 200, 200);
+		} else if (!mime.startsWith('image/') || !FILE_TYPE_BROWSERSAFE.includes(mime)) {
+			throw 403;
 		} else {
 			image = {
 				data: fs.readFileSync(path),


### PR DESCRIPTION
Related to #8101

# What
proxyでsvgをpngに変換するようにします。  

リモートがカスタム絵文字としてsvgを送ってきた場合に表示できるようにします。
