### PR TITLE
enhance: send-drive-file(/files)でsvgをpngに変換するように

### DIFF
--- a/packages/backend/src/server/file/send-drive-file.ts
+++ b/packages/backend/src/server/file/send-drive-file.ts
@@ -11,7 +11,7 @@ import { DriveFiles } from '@/models/index';
 import { InternalStorage } from '@/services/drive/internal-storage';
 import { downloadUrl } from '@/misc/download-url';
 import { detectType } from '@/misc/get-file-info';
-import { convertToJpeg, convertToPngOrJpeg } from '@/services/drive/image-processor';
+import { convertToJpeg, convertToPng, convertToPngOrJpeg } from '@/services/drive/image-processor';
 import { GenerateVideoThumbnail } from '@/services/drive/generate-video-thumbnail';
 import { StatusError } from '@/misc/fetch';
 import { FILE_TYPE_BROWSERSAFE } from '@/const';
@@ -67,10 +67,16 @@ export default async function(ctx: Koa.Context) {
 					if (isThumbnail) {
 						if (['image/jpeg', 'image/webp'].includes(mime)) {
 							return await convertToJpeg(path, 498, 280);
-						} else if (['image/png'].includes(mime)) {
+						} else if (['image/png', 'image/svg+xml'].includes(mime)) {
 							return await convertToPngOrJpeg(path, 498, 280);
 						} else if (mime.startsWith('video/')) {
 							return await GenerateVideoThumbnail(path);
+						}
+					}
+
+					if (isWebpublic) {
+						if (['image/svg+xml'].includes(mime)) {
+							return await convertToPng(path, 2048, 2048);
 						}
 					}
 


### PR DESCRIPTION
Related to #8101

# What
send-drive-file(/files)でsvgをpng(サムネイルの場合はjpegになるかも)に変換するようにします。
