### PR TITLE
enhance: 許可されていないファイルタイプでは、オブジェクトストレージのファイル名に拡張子を付与しないように

### DIFF
--- a/packages/backend/src/services/drive/add-file.ts
+++ b/packages/backend/src/services/drive/add-file.ts
@@ -49,6 +49,9 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 			if (type === 'image/apng') ext = '.apng';
 			if (type === 'image/vnd.mozilla.apng') ext = '.apng';
 		}
+
+		// 拡張子からContent-Typeを設定してそうな挙動を示すオブジェクトストレージ (upcloud?) も存在するので、
+		// 許可されているファイル形式でしか拡張子をつけない
 		if (!FILE_TYPE_BROWSERSAFE.includes(type)) {
 			ext = '';
 		}

--- a/packages/backend/src/services/drive/add-file.ts
+++ b/packages/backend/src/services/drive/add-file.ts
@@ -49,6 +49,9 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 			if (type === 'image/apng') ext = '.apng';
 			if (type === 'image/vnd.mozilla.apng') ext = '.apng';
 		}
+		if (!FILE_TYPE_BROWSERSAFE.includes(type)) {
+			ext = '';
+		}
 
 		const baseUrl = meta.objectStorageBaseUrl
 			|| `${ meta.objectStorageUseSSL ? 'https' : 'http' }://${ meta.objectStorageEndpoint }${ meta.objectStoragePort ? `:${meta.objectStoragePort}` : '' }/${ meta.objectStorageBucket }`;


### PR DESCRIPTION
# Why
拡張子を付けることで、オブジェクトストレージなどが勝手にContent-Typeを書き換えることのないようにするため