### PR TITLE
fix(#8133): hCaptcha の reCAPTCHA 互換挙動を無効化する

### DIFF
--- a/packages/client/src/components/captcha.vue
+++ b/packages/client/src/components/captcha.vue
@@ -56,7 +56,7 @@ const loaded = computed(() => !!window[variable.value]);
 
 const src = computed(() => {
 	switch (props.provider) {
-		case 'hcaptcha': return 'https://hcaptcha.com/1/api.js?render=explicit&recaptchacompat=off';
+		case 'hcaptcha': return 'https://js.hcaptcha.com/1/api.js?render=explicit&recaptchacompat=off';
 		case 'recaptcha': return 'https://www.recaptcha.net/recaptcha/api.js?render=explicit';
 	}
 });

--- a/packages/client/src/components/captcha.vue
+++ b/packages/client/src/components/captcha.vue
@@ -56,7 +56,7 @@ const loaded = computed(() => !!window[variable.value]);
 
 const src = computed(() => {
 	switch (props.provider) {
-		case 'hcaptcha': return 'https://hcaptcha.com/1/api.js?render=explicit&recaptchacompat=off'
+		case 'hcaptcha': return 'https://hcaptcha.com/1/api.js?render=explicit&recaptchacompat=off';
 		case 'recaptcha': return 'https://www.recaptcha.net/recaptcha/api.js?render=explicit';
 	}
 });

--- a/packages/client/src/components/captcha.vue
+++ b/packages/client/src/components/captcha.vue
@@ -55,12 +55,10 @@ const variable = computed(() => {
 const loaded = computed(() => !!window[variable.value]);
 
 const src = computed(() => {
-	const endpoint = ({
-		hcaptcha: 'https://hcaptcha.com/1',
-		recaptcha: 'https://www.recaptcha.net/recaptcha',
-	} as Record<CaptchaProvider, string>)[props.provider];
-
-	return `${typeof endpoint === 'string' ? endpoint : 'about:invalid'}/api.js?render=explicit`;
+	switch (props.provider) {
+		case 'hcaptcha': return 'https://hcaptcha.com/1/api.js?render=explicit&recaptchacompat=off'
+		case 'recaptcha': return 'https://www.recaptcha.net/recaptcha/api.js?render=explicit';
+	}
 });
 
 const captcha = computed<Captcha>(() => window[variable.value] || {} as unknown as Captcha);


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

hCaptcha をロードしても reCAPTCHA (v2) が死なないようにする

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Fixes #8133

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
