### PR TITLE
chore: Fix The unauthenticated git protocol on port 9418 is no longer supported

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -75,7 +75,7 @@
 		"ms": "2.1.3",
 		"nested-property": "4.0.0",
 		"parse5": "6.0.1",
-		"photoswipe": "git://github.com/dimsemenov/photoswipe#v5-beta",
+		"photoswipe": "git+https://github.com/dimsemenov/photoswipe#v5-beta",
 		"portscanner": "2.2.0",
 		"postcss": "8.4.5",
 		"postcss-loader": "6.2.1",

--- a/packages/client/yarn.lock
+++ b/packages/client/yarn.lock
@@ -4537,9 +4537,9 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-"photoswipe@git://github.com/dimsemenov/photoswipe#v5-beta":
+"photoswipe@git+https://github.com/dimsemenov/photoswipe#v5-beta":
   version "5.1.7"
-  resolved "git://github.com/dimsemenov/photoswipe#60040164333bd257409669e715e4327afdb3aec7"
+  resolved "git+https://github.com/dimsemenov/photoswipe#60040164333bd257409669e715e4327afdb3aec7"
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# What
Fix #8140

2022/1/11 から `git://` な dependencies でエラーが出て、installが出来なくなったのを修正。(多分認証入ってるユーザーは通るけどCIとか匿名ユーザーはコケる)

> The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective
https://docs.npmjs.com/cli/v8/configuring-npm/package-json#git-urls-as-dependencies

# Why
Fix bug

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
