### PR TITLE
refactor: awaitAllの型定義を変えてみる

### DIFF
--- a/packages/backend/src/prelude/await-all.ts
+++ b/packages/backend/src/prelude/await-all.ts
@@ -1,9 +1,11 @@
-export type Promiseable<T extends Record<string, unknown>> = { [K in keyof T]: Promise<T[K]> | T[K] };
+export type Promiseable<T> = {
+	[K in keyof T]: Promise<T[K]> | T[K];
+};
 
-export async function awaitAll<T extends Record<string, unknown>, U = Promiseable<T>>(obj: U): Promise<T> {
+export async function awaitAll<T>(obj: Promiseable<T>): Promise<T> {
 	const target = {} as T;
 	const keys = Object.keys(obj) as unknown as (keyof T)[];
-	const values = Object.values(obj);
+	const values = Object.values(obj) as any[];
 
 	const resolvedValues = await Promise.all(values.map(value =>
 		(!value || !value.constructor || value.constructor.name !== 'Object')

--- a/packages/backend/src/prelude/await-all.ts
+++ b/packages/backend/src/prelude/await-all.ts
@@ -1,8 +1,8 @@
 export type Promiseable<T extends Record<string, unknown>> = { [K in keyof T]: Promise<T[K]> | T[K] };
 
 export async function awaitAll<T extends Record<string, unknown>, U extends Promiseable<T>>(obj: U): Promise<T> {
-	const target = {} as any;
-	const keys = Object.keys(obj);
+	const target = {} as T;
+	const keys = Object.keys(obj) as unknown as (keyof T)[];
 	const values = Object.values(obj);
 
 	const resolvedValues = await Promise.all(values.map(value =>

--- a/packages/backend/src/prelude/await-all.ts
+++ b/packages/backend/src/prelude/await-all.ts
@@ -1,6 +1,6 @@
-export type Promiseable<T extends any> = { [K in keyof T]: Promise<T[K]> | T[K] };
+export type Promiseable<T extends Record<string, unknown>> = { [K in keyof T]: Promise<T[K]> | T[K] };
 
-export async function awaitAll<T extends Record<string, any>, U extends Promiseable<T>>(obj: U): Promise<T> {
+export async function awaitAll<T extends Record<string, unknown>, U extends Promiseable<T>>(obj: U): Promise<T> {
 	const target = {} as any;
 	const keys = Object.keys(obj);
 	const values = Object.values(obj);

--- a/packages/backend/src/prelude/await-all.ts
+++ b/packages/backend/src/prelude/await-all.ts
@@ -1,10 +1,6 @@
-type Await<T> = T extends Promise<infer U> ? U : T;
+export type Promiseable<T extends any> = { [K in keyof T]: Promise<T[K]> | T[K] };
 
-type AwaitAll<T> = {
-	[P in keyof T]: Await<T[P]>;
-};
-
-export async function awaitAll<T>(obj: T): Promise<AwaitAll<T>> {
+export async function awaitAll<T extends Record<string, any>, U extends Promiseable<T>>(obj: U): Promise<T> {
 	const target = {} as any;
 	const keys = Object.keys(obj);
 	const values = Object.values(obj);

--- a/packages/backend/src/prelude/await-all.ts
+++ b/packages/backend/src/prelude/await-all.ts
@@ -1,6 +1,6 @@
 export type Promiseable<T extends Record<string, unknown>> = { [K in keyof T]: Promise<T[K]> | T[K] };
 
-export async function awaitAll<T extends Record<string, unknown>, U extends Promiseable<T>>(obj: U): Promise<T> {
+export async function awaitAll<T extends Record<string, unknown>, U = Promiseable<T>>(obj: U): Promise<T> {
 	const target = {} as T;
 	const keys = Object.keys(obj) as unknown as (keyof T)[];
 	const values = Object.values(obj);


### PR DESCRIPTION
# What
出力する型につけるAwait, AwaitAll型を廃止し、入力する型を定義するPromiseable型を追加し利用する。

# Why
- Promiseable型を提供することで、入力する値の型を予め指定できるようになる
- 出力型が単純になるため、出力後の値で型を比較するのが単純になる
