### PR TITLE
fix: モバイル画面で表示更新直後にヘッダーメニューをタップしてもポップアップにならないようにする

### DIFF
--- a/packages/client/src/scripts/touch.ts
+++ b/packages/client/src/scripts/touch.ts
@@ -14,6 +14,10 @@ if (isTouchSupported) {
 	}, { passive: true });
 	
 	window.addEventListener('touchend', () => {
+		// 子要素のtouchstartイベントでstopPropagation()が呼ばれると親要素に伝搬されずタッチされたと判定されないため、
+		// touchendイベントでもtouchstartイベントと同様にtrueにする
+		isTouchUsing = true;
+
 		isScreenTouching = false;
 	}, { passive: true });
 }


### PR DESCRIPTION
# What
モバイル画面のヘッダーをタップして出てくるメニューがドロワーではなくポップアップになることがあるのを修正する
fix #8070

# Why
バグ修正

# Additional info (optional)
モバイル画面で表示更新直後にヘッダーメニューをタップしてドロワー表示ではなくポップアップ表示になってしまうのは、起動してから初っ端でメニューを出すような操作でタッチ操作の有無の取得が間に合わないためではなく、touchstart イベントで stopPropagation() が呼ばれているのでタッチ操作の有無の取得がされていないためだった

touchend イベントでタッチ操作の有無を取得しても間に合うので、touchend イベントでもタッチ操作の有無の取得をするようにした