### PR TITLE
fix: 投稿フォームでファイルをアップロードできない問題を修正

### DIFF
--- a/packages/client/src/components/post-form.vue
+++ b/packages/client/src/components/post-form.vue
@@ -350,8 +350,8 @@ function detachFile(id) {
 	files = files.filter(x => x.id != id);
 }
 
-function updateFiles(files) {
-	files = files;
+function updateFiles(_files) {
+	files = _files;
 }
 
 function updateFileSensitive(file, sensitive) {


### PR DESCRIPTION
Related to #8158

# What
投稿フォームでファイルをアップロードできない問題を修正

# Why
ルートの変数名とmethodの引数名が被ってしまっていたのを修正

# Additional info (optional)
他のファイルざっと見たけど多分これ以外は大丈夫っぽい
