### PR TITLE
[Fix] Resolve pop-out bug

### DIFF
--- a/packages/client/src/scripts/popout.ts
+++ b/packages/client/src/scripts/popout.ts
@@ -1,8 +1,8 @@
 import * as config from '@/config';
 
 export function popout(path: string, w?: HTMLElement) {
-	let url = path.startsWith('http://') || path.startsWith('https://') ? path : config.url + path;
-	url += '?zen'; // TODO: ちゃんとURLパースしてクエリ付ける
+	let url = path.startsWith('http://') || path.startsWith('https://') ? path : config.url + "/" + path;
+	url += '?zen';
 	if (w) {
 		const position = w.getBoundingClientRect();
 		const width = parseInt(getComputedStyle(w, '').width, 10);


### PR DESCRIPTION


# What

Fix pop-out bug where URL wouldn't have slash.

# Why

Before: clicking pop-out in theme-editor would give `https://stop.voring.mepreview/?zen` (Invalid)

After: clicking pop-out in theme-editor would give `https://stop.voring.me/preview/?zen` (Valid)