### PR TITLE
Unifying Misskey-specific IRIs in JSON-LD `@context` Resolve #8116 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - カスタム絵文字一括編集機能
 - カスタム絵文字一括インポート
 - 投稿フォームで一時的に投稿するアカウントを切り替えられるように
+- Unifying Misskey-specific IRIs in JSON-LD `@context`
 
 ### Bugfixes
 

--- a/packages/backend/src/remote/activitypub/renderer/index.ts
+++ b/packages/backend/src/remote/activitypub/renderer/index.ts
@@ -32,7 +32,7 @@ export const renderActivity = (x: any): IActivity | null => {
 				PropertyValue: 'schema:PropertyValue',
 				value: 'schema:value',
 				// Misskey
-				misskey: `${config.url}/ns#`,
+				misskey: 'https://misskey-hub.net/ns#',
 				'_misskey_content': 'misskey:_misskey_content',
 				'_misskey_quote': 'misskey:_misskey_quote',
 				'_misskey_reaction': 'misskey:_misskey_reaction',


### PR DESCRIPTION
# What
Unifying Misskey-specific IRIs in JSON-LD `@context`

# Why
Resolve #8116 

# Additional info (optional)
![image](https://user-images.githubusercontent.com/30769358/150647008-5c147e55-5661-4e9c-82d8-1c9cd717e5c8.png)

