### PR TITLE
fix: アップロードエラー時の処理を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Unifying Misskey-specific IRIs in JSON-LD `@context`
 
 ### Bugfixes
+- アップロードエラー時の処理を修正
 
 ## 12.101.1 (2021/12/29)
 

--- a/packages/client/src/os.ts
+++ b/packages/client/src/os.ts
@@ -570,7 +570,7 @@ export function upload(file: File, folder?: any, name?: string): Promise<Misskey
 			const xhr = new XMLHttpRequest();
 			xhr.open('POST', apiUrl + '/drive/files/create', true);
 			xhr.onload = (ev) => {
-				if (ev.target == null || ev.target.response == null) {
+				if (xhr.status !== 200 || ev.target == null || ev.target.response == null) {
 					// TODO: 消すのではなくて再送できるようにしたい
 					uploads.value = uploads.value.filter(x => x.id != id);
 


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
アップロード時にステータスコードチェックを追加

<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

# Why
アップロードで400等でエラー応答を受けると、ErrorオブジェクトをDriveFile扱いで採用してしまい
添付ファイル一覧がもう表示できなくなり 消すこともできず, 投稿もできず
localStorageにdraft扱いで入ってしまうためリロードしても回復せず詰んでしまうバグを修正。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
