### PR TITLE
enhance: Improve poll-editor UI + composition port

### DIFF
--- a/packages/client/src/components/poll-editor.vue
+++ b/packages/client/src/components/poll-editor.vue
@@ -14,8 +14,8 @@
 	</ul>
 	<MkButton v-if="choices.length < 10" class="add" @click="add">{{ $ts.add }}</MkButton>
 	<MkButton v-else class="add" disabled>{{ $ts._poll.noMore }}</MkButton>
+	<MkSwitch v-model="multiple">{{ $ts._poll.canMultipleVote }}</MkSwitch>
 	<section>
-		<MkSwitch v-model="multiple">{{ $ts._poll.canMultipleVote }}</MkSwitch>
 		<div>
 			<MkSelect v-model="expiration">
 				<template #label>{{ $ts._poll.expiration }}</template>
@@ -216,7 +216,7 @@ export default defineComponent({
 	}
 
 	> .add {
-		margin: 8px 0 0 0;
+		margin: 8px 0;
 		z-index: 1;
 	}
 
@@ -225,21 +225,27 @@ export default defineComponent({
 
 		> div {
 			margin: 0 8px;
+			display: flex;
+			flex-direction: row;
+			flex-wrap: wrap;
+			gap: 12px;
 
 			&:last-child {
 				flex: 1 0 auto;
 
-				> section {
-					align-items: center;
-					display: flex;
-					margin: -32px 0 0;
+				> div {
+					flex-grow: 1;
+				}
 
-					> &:first-child {
-						margin-right: 16px;
-					}
+				> section {
+					// MAGIC: Prevent div above from growing unless wrapped to its own line
+					flex-grow: 9999;
+					align-items: end;
+					display: flex;
+					gap: 4px;
 
 					> .input {
-						flex: 1 0 auto;
+						flex: 1 1 auto;
 					}
 				}
 			}

--- a/packages/client/src/components/poll-editor.vue
+++ b/packages/client/src/components/poll-editor.vue
@@ -97,12 +97,12 @@ function remove(i) {
 }
 
 function get() {
-	const at = () => {
-		return new Date(`${atDate} ${atTime}`).getTime();
+	const calcAt = () => {
+		return new Date(`${atDate.value} ${atTime.value}`).getTime();
 	};
 
 	const calcAfter = () => {
-		let base = parseInt(after);
+		let base = parseInt(after.value);
 		switch (unit) {
 			case 'day': base *= 24;
 			case 'hour': base *= 60;
@@ -116,7 +116,7 @@ function get() {
 		choices: poll.choices,
 		multiple: poll.multiple,
 		...(
-			expiration.value === 'at' ? { expiresAt: at() } :
+			expiration.value === 'at' ? { expiresAt: calcAt() } :
 			expiration.value === 'after' ? { expiredAfter: calcAfter() } : {}
 		)
 	};

--- a/packages/client/src/components/post-form.vue
+++ b/packages/client/src/components/post-form.vue
@@ -43,7 +43,7 @@
 		<textarea ref="textareaEl" v-model="text" class="text" :class="{ withCw: useCw }" :disabled="posting" :placeholder="placeholder" data-cy-post-form-text @keydown="onKeydown" @paste="onPaste" @compositionupdate="onCompositionUpdate" @compositionend="onCompositionEnd"/>
 		<input v-show="withHashtags" ref="hashtagsInputEl" v-model="hashtags" class="hashtags" :placeholder="i18n.locale.hashtags" list="hashtags">
 		<XPostFormAttaches class="attaches" :files="files" @updated="updateFiles" @detach="detachFile" @changeSensitive="updateFileSensitive" @changeName="updateFileName"/>
-		<XPollEditor v-if="poll" :poll="poll" @destroyed="poll = null" @updated="onPollUpdate"/>
+		<XPollEditor v-if="poll" v-model="poll" @destroyed="poll = null"/>
 		<XNotePreview v-if="showPreview" class="preview" :text="text"/>
 		<footer>
 			<button v-tooltip="i18n.locale.attachFile" class="_button" @click="chooseFileFrom"><i class="fas fa-photo-video"></i></button>
@@ -111,9 +111,9 @@ const props = withDefaults(defineProps<{
 });
 
 const emit = defineEmits<{
-	(e: 'posted'): void;
-	(e: 'cancel'): void;
-	(e: 'esc'): void;
+	(ev: 'posted'): void;
+	(ev: 'cancel'): void;
+	(ev: 'esc'): void;
 }>();
 
 const textareaEl = $ref<HTMLTextAreaElement | null>(null);
@@ -127,8 +127,8 @@ let files = $ref(props.initialFiles ?? []);
 let poll = $ref<{
 	choices: string[];
 	multiple: boolean;
-	expiresAt: string;
-	expiredAfter: string;
+	expiresAt: string | null;
+	expiredAfter: string | null;
 } | null>(null);
 let useCw = $ref(false);
 let showPreview = $ref(false);
@@ -369,11 +369,6 @@ function upload(file: File, name?: string) {
 	os.upload(file, defaultStore.state.uploadFolder, name).then(res => {
 		files.push(res);
 	});
-}
-
-function onPollUpdate(poll) {
-	poll = poll;
-	saveDraft();
 }
 
 function setVisibility() {


### PR DESCRIPTION
# What
Adds some (imo, much needed) whitespace to the poll creation UI, and takes better advantage of screen width when available by making expiration options one line. In addition, this ports the component to the composition API (setup sugar)

![image](https://user-images.githubusercontent.com/5824729/150904811-cfcf80be-50c0-4064-b755-e389bb24319a.png)
![image](https://user-images.githubusercontent.com/5824729/150904862-0c66d0ec-5711-4ff4-ab50-072ce17a4b8c.png)

# Why
The current design feels a bit cramped, especially on mobile, and has some alignment issues.

# Additional info (optional)
Feel free to cherry-pick just the composition API port if you don't like the design (last 2 commits). praise syulio~
