### PR TITLE
Add `img-src` and `media-src` to `Content-Security-Policy` header for files and media proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### Bugfixes
 - アップロードエラー時の処理を修正
+- Add `img-src` and `media-src` directives to `Content-Security-Policy` for
+  files and media proxy
 
 ## 12.101.1 (2021/12/29)
 

--- a/packages/backend/src/server/file/index.ts
+++ b/packages/backend/src/server/file/index.ts
@@ -18,7 +18,7 @@ const _dirname = dirname(_filename);
 const app = new Koa();
 app.use(cors());
 app.use(async (ctx, next) => {
-	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'`);
+	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; media-src 'self';`);
 	await next();
 });
 

--- a/packages/backend/src/server/file/index.ts
+++ b/packages/backend/src/server/file/index.ts
@@ -18,7 +18,7 @@ const _dirname = dirname(_filename);
 const app = new Koa();
 app.use(cors());
 app.use(async (ctx, next) => {
-	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; media-src 'self';`);
+	ctx.set('Content-Security-Policy', `default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'`);
 	await next();
 });
 

--- a/packages/backend/src/server/proxy/index.ts
+++ b/packages/backend/src/server/proxy/index.ts
@@ -11,7 +11,7 @@ import { proxyMedia } from './proxy-media';
 const app = new Koa();
 app.use(cors());
 app.use(async (ctx, next) => {
-	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'`);
+	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; media-src 'self';`);
 	await next();
 });
 

--- a/packages/backend/src/server/proxy/index.ts
+++ b/packages/backend/src/server/proxy/index.ts
@@ -11,7 +11,7 @@ import { proxyMedia } from './proxy-media';
 const app = new Koa();
 app.use(cors());
 app.use(async (ctx, next) => {
-	ctx.set('Content-Security-Policy', `default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; media-src 'self';`);
+	ctx.set('Content-Security-Policy', `default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'`);
 	await next();
 });
 


### PR DESCRIPTION
# What
This PR adds `img-src` and `media-src` to the `Content-Security-Policy` header for the files drive and media proxy.
Please let me know if there are any other changes needed to this PR!

# Why
This fixes an invalid CSP error in Chrome and other browsers that can cause images or videos to not load if embedded in HTML viewers.

# Issues
Closes #8187 