### PR TITLE
fix: replace `keypress` with `keydown`

### DIFF
--- a/packages/client/src/pages/messaging/messaging-room.form.vue
+++ b/packages/client/src/pages/messaging/messaging-room.form.vue
@@ -7,7 +7,7 @@
 		ref="text"
 		v-model="text"
 		:placeholder="$ts.inputMessageHere"
-		@keypress="onKeypress"
+		@keydown="onKeydown"
 		@compositionupdate="onCompositionUpdate"
 		@paste="onPaste"
 	></textarea>
@@ -141,7 +141,7 @@ export default defineComponent({
 			//#endregion
 		},
 
-		onKeypress(e) {
+		onKeydown(e) {
 			this.typing();
 			if ((e.which == 10 || e.which == 13) && (e.ctrlKey || e.metaKey) && this.canSend) {
 				this.send();


### PR DESCRIPTION
# What

Replace `keypress` in textarea with `keydown`.

# Why

`keypress` event is no longer fired for non-printable keys (except <kbd>Enter</kbd>, <kbd>Shift</kbd>+<kbd>Enter</kbd>, <kbd>Ctrl</kbd>+<kbd>Enter</kbd>).

Also, `keypress` event and `onkeypress` event handler are deprecated. Instead `onkeydown` is recommended. See https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onkeypress

# Additional info

Closes #8191.
