### PR TITLE
refactor: APIで非JSON入力の型変換はendpointに渡す前に行うように

### DIFF
--- a/packages/backend/src/server/api/api-handler.ts
+++ b/packages/backend/src/server/api/api-handler.ts
@@ -32,7 +32,7 @@ export default (endpoint: IEndpoint, ctx: Koa.Context) => new Promise((res) => {
 	// Authentication
 	authenticate(body['i']).then(([user, app]) => {
 		// API invoking
-		call(endpoint.name, user, app, body, (ctx as any).file).then((res: any) => {
+		call(endpoint.name, user, app, body, ctx).then((res: any) => {
 			reply(res);
 		}).catch((e: ApiError) => {
 			reply(e.httpStatusCode ? e.httpStatusCode : e.kind === 'client' ? 400 : 500, e);

--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -13,7 +13,7 @@ const accessDenied = {
 	id: '56f35758-7dd5-468b-8439-5d6fb8ec9b8e',
 };
 
-export default async (endpoint: string, user: User | null | undefined, token: AccessToken | null | undefined, data: any, ctx: Koa.Context) => {
+export default async (endpoint: string, user: User | null | undefined, token: AccessToken | null | undefined, data: any, ctx?: Koa.Context) => {
 	const isSecure = user != null && token == null;
 
 	const ep = endpoints.find(e => e.name === endpoint);
@@ -79,7 +79,7 @@ export default async (endpoint: string, user: User | null | undefined, token: Ac
 
 	// Cast non JSON input
 	if (ep.meta.requireFile && ep.meta.params) {
-		const body = (ctx.request as any).body;
+		const body = (ctx!.request as any).body;
 		for (const k of Object.keys(ep.meta.params)) {
 			const param = ep.meta.params[k];
 			if (['Boolean', 'Number'].includes(param.validator.name) && typeof body[k] === 'string') {
@@ -90,7 +90,7 @@ export default async (endpoint: string, user: User | null | undefined, token: Ac
 
 	// API invoking
 	const before = performance.now();
-	return await ep.exec(data, user, token, ctx.file).catch((e: Error) => {
+	return await ep.exec(data, user, token, ctx!.file).catch((e: Error) => {
 		if (e instanceof ApiError) {
 			throw e;
 		} else {

--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -1,3 +1,4 @@
+import * as Koa from 'koa';
 import { performance } from 'perf_hooks';
 import { limiter } from './limiter';
 import { User } from '@/models/entities/user';
@@ -12,7 +13,7 @@ const accessDenied = {
 	id: '56f35758-7dd5-468b-8439-5d6fb8ec9b8e',
 };
 
-export default async (endpoint: string, user: User | null | undefined, token: AccessToken | null | undefined, data: any, file?: any) => {
+export default async (endpoint: string, user: User | null | undefined, token: AccessToken | null | undefined, data: any, ctx: Koa.Context) => {
 	const isSecure = user != null && token == null;
 
 	const ep = endpoints.find(e => e.name === endpoint);
@@ -76,9 +77,20 @@ export default async (endpoint: string, user: User | null | undefined, token: Ac
 		});
 	}
 
+	// Cast non JSON input
+	if (ep.meta.requireFile && ep.meta.params) {
+		const body = (ctx.request as any).body;
+		for (const k of Object.keys(ep.meta.params)) {
+			const param = ep.meta.params[k];
+			if (['Boolean', 'Number'].includes(param.validator.name) && typeof body[k] === 'string') {
+				body[k] = JSON.parse(body[k]);
+			}
+		}
+	}
+
 	// API invoking
 	const before = performance.now();
-	return await ep.exec(data, user, token, file).catch((e: Error) => {
+	return await ep.exec(data, user, token, ctx.file).catch((e: Error) => {
 		if (e instanceof ApiError) {
 			throw e;
 		} else {

--- a/packages/backend/src/server/api/endpoints/drive/files/create.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files/create.ts
@@ -39,15 +39,13 @@ export const meta = {
 		},
 
 		isSensitive: {
-			validator: $.optional.either($.bool, $.str),
+			validator: $.optional.bool,
 			default: false,
-			transform: (v: any): boolean => v === true || v === 'true',
 		},
 
 		force: {
-			validator: $.optional.either($.bool, $.str),
+			validator: $.optional.bool,
 			default: false,
-			transform: (v: any): boolean => v === true || v === 'true',
 		},
 	},
 


### PR DESCRIPTION
# What
APIで、型を持たないmultipart経由の入力の型変換を各endpointではなくその手前で行うように変更。

# Why
Resolve #8228

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
