### PR TITLE
fix: v-sizeディレクティブの動作を修正

### DIFF
--- a/packages/client/src/directives/get-size.ts
+++ b/packages/client/src/directives/get-size.ts
@@ -13,8 +13,8 @@ function calc(src: Element) {
 
 	if (!info) return;
 
+	// アクティベート前などでsrcが描画されていない場合
 	if (!height) {
-		// アクティベート前などでsrcが描画されていない場合があるので、
 		// IntersectionObserverで表示検出する
 		if (!info.intersection) {
 			info.intersection = new IntersectionObserver(entries => {

--- a/packages/client/src/directives/size.ts
+++ b/packages/client/src/directives/size.ts
@@ -18,14 +18,17 @@ type ClassOrder = {
 const cache = new Map<string, ClassOrder>();
 
 function getClassOrder(width: number, queue: Value): ClassOrder {
+	const getMaxClass = (v: number) => `max-width_${v}px`;
+	const getMinClass = (v: number) => `min-width_${v}px`;
+
 	return {
 		add: [
-			...(queue.max ? queue.max.filter(v => width <= v).map(v => `max-width_${v}px`) : []),
-			...(queue.min ? queue.min.filter(v => width >= v).map(v => `min-width_${v}px`) : []),
+			...(queue.max ? queue.max.filter(v => width <= v).map(getMaxClass) : []),
+			...(queue.min ? queue.min.filter(v => width >= v).map(getMinClass) : []),
 		],
 		remove: [
-			...(queue.max ? queue.max.filter(v => width  > v).map(v => `max-width_${v}px`) : []),
-			...(queue.min ? queue.min.filter(v => width  < v).map(v => `min-width_${v}px`) : []),
+			...(queue.max ? queue.max.filter(v => width  > v).map(getMaxClass) : []),
+			...(queue.min ? queue.min.filter(v => width  < v).map(getMinClass) : []),
 		]
 	};
 }
@@ -49,10 +52,8 @@ function calc(el: Element) {
 
 	const cached = cache.get(getOrderName(width, info.value));
 	if (cached) {
-		console.log('cache found', cached);
 		applyClassOrder(el, cached);
 	} else {
-		console.log('cache not found', width, info.value);
 		const order = getClassOrder(width, info.value);
 		cache.set(getOrderName(width, info.value), order);
 		applyClassOrder(el, order);

--- a/packages/client/src/directives/size.ts
+++ b/packages/client/src/directives/size.ts
@@ -92,8 +92,8 @@ export default {
 	unmounted(src, binding, vn) {
 		const info = mountings.get(src);
 		if (!info) return;
-		info.resize.observe(src);
-		info.intersection.observe(src);
+		info.resize.disconnect();
+		info.intersection.disconnect();
 		mountings.delete(src);
 	}
 } as Directive<Element, Value>;

--- a/packages/client/src/directives/size.ts
+++ b/packages/client/src/directives/size.ts
@@ -48,8 +48,8 @@ function calc(el: Element) {
 
 	if (!info || info.previousWidth === width) return;
 
+	// アクティベート前などでsrcが描画されていない場合
 	if (!width) {
-		// アクティベート前などでsrcが描画されていない場合があるので、
 		// IntersectionObserverで表示検出する
 		if (!info.intersection) {
 			info.intersection = new IntersectionObserver(entries => {

--- a/packages/client/src/directives/size.ts
+++ b/packages/client/src/directives/size.ts
@@ -72,6 +72,7 @@ export default {
 
 	updated(src, binding, vn) {
 		mountings.set(src, Object.assign({}, mountings.get(src), { value: binding.value }));
+		calc(src);
 	},
 
 	unmounted(src, binding, vn) {


### PR DESCRIPTION
# What
MkTimelinePage（メインタイムライン）が非アクティブの状態でタイムラインを更新すると、DOMが描画されていないためv-sizeディレクティブがmountedで計算できず、タイムラインに戻った時に画面サイズに関わらずデスクトップのレイアウトで表示されてしまう。  
「戻った時」にはIntersectionObserverが発火するので、それを利用して修正。

ついでにResizeObserverを復活したり登録状況を管理したり型を付けたりなど。

# Why
通常の大きさ

![A941F632-952B-4C14-B4FF-855385763DD7 png](https://user-images.githubusercontent.com/7973572/152400063-21d6210d-f316-4995-8af2-685d6a36a2ee.png)

計算できなかった場合の大きさ（デスクトップ版が表示されてしまう）

![863E3D54-CED4-4352-8D78-3071434BE37A png](https://user-images.githubusercontent.com/7973572/152400070-52ee7e67-9b82-4419-b4b7-ab217681baf7.png)

# Additional info (optional)
該当Issue捜索中
