### PR TITLE
fix: NodeInfo のユーザー数と投稿数の内容を見直す

### DIFF
--- a/packages/backend/src/server/nodeinfo.ts
+++ b/packages/backend/src/server/nodeinfo.ts
@@ -29,8 +29,8 @@ const nodeinfo2 = async () => {
 	] = await Promise.all([
 		fetchMeta(true),
 		Users.count({ where: { host: null } }),
-		Users.count({ where: { host: null, updatedAt: MoreThan(new Date(now - 15552000000)) } }),
-		Users.count({ where: { host: null, updatedAt: MoreThan(new Date(now - 2592000000)) } }),
+		Users.count({ where: { host: null, lastActiveDate: MoreThan(new Date(now - 15552000000)) } }),
+		Users.count({ where: { host: null, lastActiveDate: MoreThan(new Date(now - 2592000000)) } }),
 		Notes.count({ where: { userHost: null, replyId: null } }),
 		Notes.count({ where: { userHost: null, replyId: Not(IsNull()) } }),
 	]);

--- a/packages/backend/src/server/nodeinfo.ts
+++ b/packages/backend/src/server/nodeinfo.ts
@@ -2,7 +2,7 @@ import * as Router from '@koa/router';
 import config from '@/config/index';
 import { fetchMeta } from '@/misc/fetch-meta';
 import { Users, Notes } from '@/models/index';
-import { Not, IsNull, MoreThan } from 'typeorm';
+import { MoreThan } from 'typeorm';
 
 const router = new Router();
 
@@ -25,14 +25,12 @@ const nodeinfo2 = async () => {
 		activeHalfyear,
 		activeMonth,
 		localPosts,
-		localComments,
 	] = await Promise.all([
 		fetchMeta(true),
 		Users.count({ where: { host: null } }),
 		Users.count({ where: { host: null, lastActiveDate: MoreThan(new Date(now - 15552000000)) } }),
 		Users.count({ where: { host: null, lastActiveDate: MoreThan(new Date(now - 2592000000)) } }),
-		Notes.count({ where: { userHost: null, replyId: null } }),
-		Notes.count({ where: { userHost: null, replyId: Not(IsNull()) } }),
+		Notes.count({ where: { userHost: null } }),
 	]);
 
 	const proxyAccount = meta.proxyAccountId ? await Users.pack(meta.proxyAccountId).catch(() => null) : null;
@@ -52,7 +50,7 @@ const nodeinfo2 = async () => {
 		usage: {
 			users: { total, activeHalfyear, activeMonth },
 			localPosts,
-			localComments,
+			localComments: 0,
 		},
 		metadata: {
 			nodeName: meta.name,


### PR DESCRIPTION
# What
#8123 の続き
投稿数の内容の見直し

https://github.com/misskey-dev/misskey/pull/8126#pullrequestreview-872557259
アクティブユーザー数の取得方法の修正


# Why
リプライはコメントではないということで `localComments` は 0 とし `localPosts` をローカルの投稿数にする。
それによりクエリが 1 つ減るので負荷も減る。

アクティブユーザーを取得する条件は今なら `lastActiveDate` の方がよさそうとのことで変更する。