### PR TITLE
fix: Fix API cast

### DIFF
--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -79,11 +79,21 @@ export default async (endpoint: string, user: User | null | undefined, token: Ac
 
 	// Cast non JSON input
 	if (ep.meta.requireFile && ep.meta.params) {
-		const body = (ctx!.request as any).body;
 		for (const k of Object.keys(ep.meta.params)) {
 			const param = ep.meta.params[k];
-			if (['Boolean', 'Number'].includes(param.validator.name) && typeof body[k] === 'string') {
-				body[k] = JSON.parse(body[k]);
+			if (['Boolean', 'Number'].includes(param.validator.name) && typeof data[k] === 'string') {
+				try {
+					data[k] = JSON.parse(data[k]);
+				} catch (e) {
+					throw	new ApiError({
+						message: 'Invalid param.',
+						code: 'INVALID_PARAM',
+						id: '0b5f1631-7c1a-41a6-b399-cce335f34d85',
+					}, {
+						param: k,
+						reason: `cannot cast to ${param.validator.name}`,
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
# What
Fix
https://github.com/misskey-dev/misskey/pull/8229#pullrequestreview-873768779
https://github.com/misskey-dev/misskey/pull/8229#pullrequestreview-873775064

APIで非JSON入力の型変換はendpointに渡す前に行うように #8229 で
書き換える場所が間違っている (同じobjectを参照しているから偶然動いてるけど) のを修正。
不正な入力がJSON parse errorで500になってしまうのでちゃんとinvalid paramを返すように修正。

# Why
バグ修正

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
