### PR TITLE
fix: instance ticker

### DIFF
--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -27,7 +27,7 @@ const instance = props.instance ?? {
 const themeColor = instance.themeColor ?? '#777777';
 
 const bg = {
-	background: `linear-gradient(90deg, ${themeColor}, ${themeColor + '00'})`
+	background: `linear-gradient(90deg, ${themeColor}, ${themeColor}00)`
 };
 </script>
 

--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -7,12 +7,24 @@
 
 <script lang="ts" setup>
 import { } from 'vue';
+import { instanceName } from '@/config';
 
 const props = defineProps<{
-	instance: any; // TODO
+	instance?: {
+		faviconUrl?: string
+		name: string
+		themeColor?: string
+	}
 }>();
 
-const themeColor = props.instance.themeColor || '#777777';
+// if no instance data is given, this is for the local instance
+const instance = props.instance ?? {
+	faviconUrl: '/favicon.ico',
+	name: instanceName,
+	themeColor: (document.querySelector('meta[name="theme-color-orig"]') as HTMLMetaElement)?.content
+};
+
+const themeColor = instance.themeColor ?? '#777777';
 
 const bg = {
 	background: `linear-gradient(90deg, ${themeColor}, ${themeColor + '00'})`


### PR DESCRIPTION
# What
1. Restore behaviour as before 21c9705a0f947bf6e3900052987695c67f2d7510 by adding default values that are taken from the local instance.
2. Added a respective type definition.
3. Removed an unnecessary string concatenation (in ec32a62b90b49a044f63b93337e3b6c205411fca).

# Why
Fix #8205 and `TODO` comment.
