### PR TITLE
fix: add instance favicon where it's missing

### DIFF
--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -276,6 +276,7 @@ router.get('/@:user/pages/:page', async (ctx, next) => {
 			page: _page,
 			profile,
 			instanceName: meta.name || 'Misskey',
+			icon: meta.iconUrl,
 		});
 
 		if (['public'].includes(page.visibility)) {
@@ -305,6 +306,7 @@ router.get('/clips/:clip', async (ctx, next) => {
 			clip: _clip,
 			profile,
 			instanceName: meta.name || 'Misskey',
+			icon: meta.iconUrl,
 		});
 
 		ctx.set('Cache-Control', 'public, max-age=180');
@@ -350,6 +352,7 @@ router.get('/channels/:channel', async (ctx, next) => {
 		await ctx.render('channel', {
 			channel: _channel,
 			instanceName: meta.name || 'Misskey',
+			icon: meta.iconUrl,
 		});
 
 		ctx.set('Cache-Control', 'public, max-age=180');


### PR DESCRIPTION
# What
add the instance favicon in pages where it's missing

# Why
fix #8265

# Additional info (optional)
as mentioned in #8265, this does not only affect clip pages. I added the favicon to all pages where it didn't appear, namely userpages and channels.