### PR TITLE
feat: ARM64 Docker Imageのサポート

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -27,6 +31,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Resolve #8555

<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

リリース時にARM64(aarch64)のDocker ImageがビルドされてDockerhubにpushされます

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

aarch64 on Docker環境でmisskeyをホスティングしている場合、ビルドする必要が無くpullすることが可能になります
自分は独自にregistryにpushしているので、取り込んでもらえると楽になります

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

ビルド時間が増える(5分前後 -> 40分前後)という問題があります