### PR TITLE
ソフトミュートですべてがマッチしてしまうのを修正

### DIFF
--- a/packages/client/src/scripts/check-word-mute.ts
+++ b/packages/client/src/scripts/check-word-mute.ts
@@ -8,7 +8,7 @@ export function checkWordMute(note: Record<string, any>, me: Record<string, any>
 		const matched = mutedWords.some(filter => {
 			if (Array.isArray(filter)) {
 				// Clean up
-				const filteredFilter = filter.filter(keyword => keyword !== '')
+				const filteredFilter = filter.filter(keyword => keyword !== '');
 				if (filteredFilter.length === 0) return false;
 
 				return filter.every(keyword => note.text!.includes(keyword));

--- a/packages/client/src/scripts/check-word-mute.ts
+++ b/packages/client/src/scripts/check-word-mute.ts
@@ -11,7 +11,7 @@ export function checkWordMute(note: Record<string, any>, me: Record<string, any>
 				const filteredFilter = filter.filter(keyword => keyword !== '')
 				if (filteredFilter.length === 0) return false;
 
-				return filter.every(keyword => note.text!.includes(keyword));
+				return filteredFilter.every(keyword => note.text!.includes(keyword));
 			} else {
 				// represents RegExp
 				const regexp = filter.match(/^\/(.+)\/(.*)$/);

--- a/packages/client/src/scripts/check-word-mute.ts
+++ b/packages/client/src/scripts/check-word-mute.ts
@@ -7,8 +7,9 @@ export function checkWordMute(note: Record<string, any>, me: Record<string, any>
 
 		const matched = mutedWords.some(filter => {
 			if (Array.isArray(filter)) {
-				// 後方互換のため
-				if (filter.every(keyword => keyword === '')) return false;
+				// Clean up
+				const filteredFilter = filter.filter(keyword => keyword !== '')
+				if (filteredFilter.length === 0) return false;
 
 				return filter.every(keyword => note.text!.includes(keyword));
 			} else {

--- a/packages/client/src/scripts/check-word-mute.ts
+++ b/packages/client/src/scripts/check-word-mute.ts
@@ -7,6 +7,9 @@ export function checkWordMute(note: Record<string, any>, me: Record<string, any>
 
 		const matched = mutedWords.some(filter => {
 			if (Array.isArray(filter)) {
+				// 後方互換のため
+				if (filter.every(keyword => keyword === '')) return false;
+
 				return filter.every(keyword => note.text!.includes(keyword));
 			} else {
 				// represents RegExp


### PR DESCRIPTION
前のバージョンでソフトワードミュートで`[['']]`が指定されているとすべてマッチしてしまうのを修正

前のバージョンで先頭に書いていたフィルターが外れてしまったのを修正した

https://github.com/misskey-dev/misskey/pull/8254#issuecomment-1036166714
