### PR TITLE
SchemaTypeの型計算量を削減

### DIFF
--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -63,12 +63,7 @@ export const refs = {
 	Emoji: packedEmojiSchema,
 };
 
-type PackedDef<r extends { properties?: Obj; oneOf?: ReadonlyArray<Schema>; allOf?: ReadonlyArray<Schema> }> =
-	r['allOf'] extends ReadonlyArray<Schema> ? UnionToIntersection<UnionSchemaType<r['allOf']>> :
-	r['oneOf'] extends ReadonlyArray<Schema> ? UnionSchemaType<r['oneOf']> :
-	r['properties'] extends Obj ? ObjType<r['properties'], any> :
-	never;
-export type Packed<x extends keyof typeof refs> = PackedDef<typeof refs[x]>;
+export type Packed<x extends keyof typeof refs> = SchemaType<typeof refs[x]>;
 
 type TypeStringef = 'null' | 'boolean' | 'integer' | 'number' | 'string' | 'array' | 'object' | 'any';
 type StringDefToType<T extends TypeStringef> =

--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -105,10 +105,8 @@ export interface Schema extends OfSchema {
 	readonly minLength?: number;
 }
 
-type RequiredPropertyNames<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> = {
+type RequiredPropertyNames<s extends Obj> = {
 	[K in keyof s]:
-		// K is listed in RequiredProps
-		K extends RequiredProps[number] ? K :
 		// K is not optional
 		s[K]['optional'] extends false ? K :
 		// K has default value
@@ -117,9 +115,10 @@ type RequiredPropertyNames<s extends Obj, RequiredProps extends ReadonlyArray<ke
 
 export interface Obj { [key: string]: Schema; }
 
-export type ObjType<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> =
+export type ObjType<s extends Obj, RequiredProps extends keyof s> =
 	{ -readonly [P in keyof s]?: SchemaType<s[P]> } &
-	{ -readonly [P in RequiredPropertyNames<s, RequiredProps>]: SchemaType<s[P]> };
+	{ -readonly [P in RequiredProps]: SchemaType<s[P]> } &
+	{ -readonly [P in RequiredPropertyNames<s>]: SchemaType<s[P]> };
 
 type NullOrUndefined<p extends Schema, T> =
 	p['nullable'] extends true
@@ -152,7 +151,7 @@ export type SchemaTypeDef<p extends Schema> =
 	p['type'] extends 'boolean' ? boolean :
 	p['type'] extends 'object' ? (
 		p['ref'] extends keyof typeof refs ? Packed<p['ref']> :
-		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>> :
+		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>[number]> :
 		p['anyOf'] extends ReadonlyArray<Schema> ? UnionSchemaType<p['anyOf']> & Partial<UnionToIntersection<UnionSchemaType<p['anyOf']>>> :
 		p['allOf'] extends ReadonlyArray<Schema> ? UnionToIntersection<UnionSchemaType<p['allOf']>> :
 		any

--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -105,10 +105,10 @@ export interface Schema extends OfSchema {
 	readonly minLength?: number;
 }
 
-type RequiredPropertyNames<s extends Obj, RequiredProp extends keyof s> = {
+type RequiredPropertyNames<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> = {
 	[K in keyof s]:
 		// K is listed in RequiredProps
-		K extends RequiredProp ? K :
+		K extends RequiredProps[number] ? K :
 		// K is not optional
 		s[K]['optional'] extends false ? K :
 		// K has default value
@@ -117,9 +117,9 @@ type RequiredPropertyNames<s extends Obj, RequiredProp extends keyof s> = {
 
 export interface Obj { [key: string]: Schema; }
 
-export type ObjType<s extends Obj, RequiredProp extends keyof s> =
+export type ObjType<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> =
 	{ -readonly [P in keyof s]?: SchemaType<s[P]> } &
-	{ -readonly [P in RequiredPropertyNames<s, RequiredProp>]: SchemaType<s[P]> };
+	{ -readonly [P in RequiredPropertyNames<s, RequiredProps>]: SchemaType<s[P]> };
 
 type NullOrUndefined<p extends Schema, T> =
 	p['nullable'] extends true
@@ -152,7 +152,7 @@ export type SchemaTypeDef<p extends Schema> =
 	p['type'] extends 'boolean' ? boolean :
 	p['type'] extends 'object' ? (
 		p['ref'] extends keyof typeof refs ? Packed<p['ref']> :
-		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>[number]> :
+		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>> :
 		p['anyOf'] extends ReadonlyArray<Schema> ? UnionSchemaType<p['anyOf']> & Partial<UnionToIntersection<UnionSchemaType<p['anyOf']>>> :
 		p['allOf'] extends ReadonlyArray<Schema> ? UnionToIntersection<UnionSchemaType<p['allOf']>> :
 		any

--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -105,23 +105,21 @@ export interface Schema extends OfSchema {
 	readonly minLength?: number;
 }
 
-type RequiredPropertyNames<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> = {
+type RequiredPropertyNames<s extends Obj, RequiredProp extends keyof s> = {
 	[K in keyof s]:
 		// K is listed in RequiredProps
-		K extends RequiredProps[number] ? K :
+		K extends RequiredProp ? K :
 		// K is not optional
 		s[K]['optional'] extends false ? K :
 		// K has default value
-		s[K]['default'] extends null | string | number | boolean | Record<string, unknown> ? K :
-
-		never
+		s[K]['default'] extends null | string | number | boolean | Record<string, unknown> ? K : never
 }[keyof s];
 
 export interface Obj { [key: string]: Schema; }
 
-export type ObjType<s extends Obj, RequiredProps extends ReadonlyArray<keyof s>> =
+export type ObjType<s extends Obj, RequiredProp extends keyof s> =
 	{ -readonly [P in keyof s]?: SchemaType<s[P]> } &
-	{ -readonly [P in RequiredPropertyNames<s, RequiredProps>]: SchemaType<s[P]> };
+	{ -readonly [P in RequiredPropertyNames<s, RequiredProp>]: SchemaType<s[P]> };
 
 type NullOrUndefined<p extends Schema, T> =
 	p['nullable'] extends true
@@ -154,7 +152,7 @@ export type SchemaTypeDef<p extends Schema> =
 	p['type'] extends 'boolean' ? boolean :
 	p['type'] extends 'object' ? (
 		p['ref'] extends keyof typeof refs ? Packed<p['ref']> :
-		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>> :
+		p['properties'] extends NonNullable<Obj> ? ObjType<p['properties'], NonNullable<p['required']>[number]> :
 		p['anyOf'] extends ReadonlyArray<Schema> ? UnionSchemaType<p['anyOf']> & Partial<UnionToIntersection<UnionSchemaType<p['anyOf']>>> :
 		p['allOf'] extends ReadonlyArray<Schema> ? UnionToIntersection<UnionSchemaType<p['allOf']>> :
 		any

--- a/packages/backend/src/models/repositories/app.ts
+++ b/packages/backend/src/models/repositories/app.ts
@@ -28,13 +28,13 @@ export class AppRepository extends Repository<App> {
 			name: app.name,
 			callbackUrl: app.callbackUrl,
 			permission: app.permission,
-			...(opts.includeSecret ? { secret: app.secret } : { secret: undefined }),
+			...(opts.includeSecret ? { secret: app.secret } : {}),
 			...(me ? {
 				isAuthorized: await AccessTokens.count({
 					appId: app.id,
 					userId: me.id,
 				}).then(count => count > 0),
-			} : { isAuthorized: undefined }),
+			} : {}),
 		};
 	}
 }

--- a/packages/backend/src/models/repositories/app.ts
+++ b/packages/backend/src/models/repositories/app.ts
@@ -28,13 +28,13 @@ export class AppRepository extends Repository<App> {
 			name: app.name,
 			callbackUrl: app.callbackUrl,
 			permission: app.permission,
-			...(opts.includeSecret ? { secret: app.secret } : {}),
+			...(opts.includeSecret ? { secret: app.secret } : { secret: undefined }),
 			...(me ? {
 				isAuthorized: await AccessTokens.count({
 					appId: app.id,
-					userId: me,
+					userId: me.id,
 				}).then(count => count > 0),
-			} : {}),
+			} : { isAuthorized: undefined }),
 		};
 	}
 }

--- a/packages/backend/src/models/repositories/page-like.ts
+++ b/packages/backend/src/models/repositories/page-like.ts
@@ -2,6 +2,7 @@ import { EntityRepository, Repository } from 'typeorm';
 import { PageLike } from '@/models/entities/page-like';
 import { Pages } from '../index';
 import { User } from '@/models/entities/user';
+import { awaitAll } from '@/prelude/await-all';
 
 @EntityRepository(PageLike)
 export class PageLikeRepository extends Repository<PageLike> {

--- a/packages/backend/src/models/repositories/page-like.ts
+++ b/packages/backend/src/models/repositories/page-like.ts
@@ -2,7 +2,6 @@ import { EntityRepository, Repository } from 'typeorm';
 import { PageLike } from '@/models/entities/page-like';
 import { Pages } from '../index';
 import { User } from '@/models/entities/user';
-import { awaitAll } from '@/prelude/await-all';
 
 @EntityRepository(PageLike)
 export class PageLikeRepository extends Repository<PageLike> {

--- a/packages/backend/src/server/api/endpoints/admin/announcements/create.ts
+++ b/packages/backend/src/server/api/endpoints/admin/announcements/create.ts
@@ -65,5 +65,5 @@ export default define(meta, paramDef, async (ps) => {
 		imageUrl: ps.imageUrl,
 	}).then(x => Announcements.findOneOrFail(x.identifiers[0]));
 
-	return announcement;
+	return Object.assign({}, announcement, { createdAt: announcement.createdAt.toISOString(), updatedAt: null });
 });

--- a/packages/backend/src/server/api/endpoints/i/gallery/likes.ts
+++ b/packages/backend/src/server/api/endpoints/i/gallery/likes.ts
@@ -10,20 +10,24 @@ export const meta = {
 	kind: 'read:gallery-likes',
 
 	res: {
-		type: 'object',
+		type: 'array',
 		optional: false, nullable: false,
-		properties: {
-			id: {
-				type: 'string',
-				optional: false, nullable: false,
-				format: 'id',
+		items: {
+			type: 'object',
+			optional: false, nullable: false,
+			properties: {
+				id: {
+					type: 'string',
+					optional: false, nullable: false,
+					format: 'id',
+				},
+				post: {
+					type: 'object',
+					optional: false, nullable: false,
+					ref: 'GalleryPost',
+				},
 			},
-			page: {
-				type: 'object',
-				optional: false, nullable: false,
-				ref: 'GalleryPost',
-			},
-		},
+		}
 	},
 } as const;
 

--- a/packages/backend/src/server/api/endpoints/i/page-likes.ts
+++ b/packages/backend/src/server/api/endpoints/i/page-likes.ts
@@ -10,20 +10,23 @@ export const meta = {
 	kind: 'read:page-likes',
 
 	res: {
-		type: 'object',
+		type: 'array',
 		optional: false, nullable: false,
-		properties: {
-			id: {
-				type: 'string',
-				optional: false, nullable: false,
-				format: 'id',
+		items: {
+			type: 'object',
+			properties: {
+				id: {
+					type: 'string',
+					optional: false, nullable: false,
+					format: 'id',
+				},
+				page: {
+					type: 'object',
+					optional: false, nullable: false,
+					ref: 'Page',
+				},
 			},
-			page: {
-				type: 'object',
-				optional: false, nullable: false,
-				ref: 'Page',
-			},
-		},
+		}
 	},
 } as const;
 
@@ -47,5 +50,5 @@ export default define(meta, paramDef, async (ps, user) => {
 		.take(ps.limit)
 		.getMany();
 
-	return await PageLikes.packMany(likes, user);
+	return PageLikes.packMany(likes, user);
 });

--- a/packages/backend/src/server/api/endpoints/my/apps.ts
+++ b/packages/backend/src/server/api/endpoints/my/apps.ts
@@ -12,46 +12,7 @@ export const meta = {
 		items: {
 			type: 'object',
 			optional: false, nullable: false,
-			properties: {
-				id: {
-					type: 'string',
-					optional: false, nullable: false,
-				},
-				name: {
-					type: 'string',
-					optional: false, nullable: false,
-				},
-				callbackUrl: {
-					type: 'string',
-					optional: false, nullable: false,
-				},
-				permission: {
-					type: 'array',
-					optional: false, nullable: false,
-					items: {
-						type: 'string',
-						optional: false, nullable: false,
-					},
-				},
-				secret: {
-					type: 'string',
-					optional: true, nullable: false,
-				},
-				isAuthorized: {
-					type: 'object',
-					optional: true, nullable: false,
-					properties: {
-						appId: {
-							type: 'string',
-							optional: false, nullable: false,
-						},
-						userId: {
-							type: 'string',
-							optional: false, nullable: false,
-						},
-					},
-				},
-			},
+			ref: 'App',
 		},
 	},
 } as const;

--- a/packages/backend/src/server/api/endpoints/sw/register.ts
+++ b/packages/backend/src/server/api/endpoints/sw/register.ts
@@ -14,12 +14,12 @@ export const meta = {
 		properties: {
 			state: {
 				type: 'string',
-				optional: false, nullable: false,
+				optional: true, nullable: false,
 				enum: ['already-subscribed', 'subscribed'],
 			},
 			key: {
 				type: 'string',
-				optional: false, nullable: false,
+				optional: false, nullable: true,
 			},
 		},
 	},
@@ -49,7 +49,7 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	if (exist != null) {
 		return {
-			state: 'already-subscribed',
+			state: 'already-subscribed' as const,
 			key: instance.swPublicKey,
 		};
 	}
@@ -64,7 +64,7 @@ export default define(meta, paramDef, async (ps, user) => {
 	});
 
 	return {
-		state: 'subscribed',
+		state: 'subscribed' as const,
 		key: instance.swPublicKey,
 	};
 });

--- a/packages/backend/src/server/api/stream/types.ts
+++ b/packages/backend/src/server/api/stream/types.ts
@@ -84,6 +84,7 @@ export interface MainStreamTypes {
 	};
 	driveFileCreated: Packed<'DriveFile'>;
 	readAntenna: Antenna;
+	receiveFollowRequest: Packed<'User'>;
 }
 
 export interface DriveStreamTypes {

--- a/packages/backend/src/services/create-system-user.ts
+++ b/packages/backend/src/services/create-system-user.ts
@@ -4,7 +4,7 @@ import generateNativeUserToken from '../server/api/common/generate-native-user-t
 import { genRsaKeyPair } from '@/misc/gen-key-pair';
 import { User } from '@/models/entities/user';
 import { UserProfile } from '@/models/entities/user-profile';
-import { getConnection } from 'typeorm';
+import { getConnection, ObjectLiteral } from 'typeorm';
 import { genId } from '@/misc/gen-id';
 import { UserKeypair } from '@/models/entities/user-keypair';
 import { UsedUsername } from '@/models/entities/used-username';
@@ -21,7 +21,7 @@ export async function createSystemUser(username: string) {
 
 	const keyPair = await genRsaKeyPair(4096);
 
-	let account!: User;
+	let account!: User | ObjectLiteral;
 
 	// Start transaction
 	await getConnection().transaction(async transactionalEntityManager => {


### PR DESCRIPTION
# What
- SchemaTypeの型計算量を削減
- schema.tsのコメント編集

# Why
- 型計算量が多すぎて`型のインスタンス化は非常に深く、無限である可能性があります。`が出ている箇所があったため、ちょっと計算量を減らすように
- 現状に即していない記述を削除, 英語化
