### PR TITLE
search uses misskey note search

### DIFF
--- a/packages/backend/src/mfm/to-html.ts
+++ b/packages/backend/src/mfm/to-html.ts
@@ -140,10 +140,9 @@ export function toHtml(nodes: mfm.MfmNode[] | null, mentionedRemoteUsers: IMenti
 		},
 
 		search(node) {
-			const a = doc.createElement('a');
-			a.href = `https://www.google.com/search?q=${node.props.query}`;
-			a.textContent = node.props.content;
-			return a;
+			const el = doc.createElement('span');
+			el.innerText = `${node.props.content} [\ud83d\udd0d]';
+			return el;
 		},
 	};
 

--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -7,7 +7,7 @@ import MkEmoji from '@/components/global/emoji.vue';
 import { concat } from '@/scripts/array';
 import MkFormula from '@/components/formula.vue';
 import MkCode from '@/components/code.vue';
-import MkGoogle from '@/components/google.vue';
+import MkSearch from '@/components/search.vue';
 import MkSparkle from '@/components/sparkle.vue';
 import MkA from '@/components/global/a.vue';
 import { host } from '@/config';
@@ -299,7 +299,7 @@ export default defineComponent({
 				}
 
 				case 'search': {
-					return [h(MkGoogle, {
+					return [h(MkSearch, {
 						key: Math.random(),
 						q: token.props.query
 					})];

--- a/packages/client/src/components/search.vue
+++ b/packages/client/src/components/search.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="mk-google">
+<div class="mk-search">
 	<input v-model="query" type="search" :placeholder="q">
 	<button @click="search"><i class="fas fa-search"></i> {{ $ts.search }}</button>
 </div>
@@ -7,6 +7,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { router } from '@/router';
 
 const props = defineProps<{
 	q: string;
@@ -15,12 +16,12 @@ const props = defineProps<{
 const query = ref(props.q);
 
 const search = () => {
-	window.open(`https://www.google.com/search?q=${query.value}`, '_blank');
+	router.push(`/search?q=${query.value}`);
 };
 </script>
 
 <style lang="scss" scoped>
-.mk-google {
+.mk-search {
 	display: flex;
 	margin: 8px 0;
 


### PR DESCRIPTION
# What
The note search button leads to misskey's own note search feature instead of Google.

It is federated in HTML like this:
```html
<span>honi [🔍]</span>
```

# Why
With this the privacy problem can be resolved, and no discussion about which search engine should be used will occur again.

fix #8266 (see https://github.com/misskey-dev/misskey/issues/8266#issuecomment-1036406095)
close #8283
close #2479