### PR TITLE
fix(meta): Adjust path to contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,7 @@
-<!-- ℹ お読みください
+<!-- ℹ お読みください / README
 PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
-https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
--->
-<!-- ℹ README
 Thank you for your PR! Before creating a PR, please check the contribution guide:
-https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
+https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
 -->
 
 # What


### PR DESCRIPTION
<!-- ℹ お読みください
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
<!-- ℹ README
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/docs/CONTRIBUTING.en.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Adjusts the link to the contribution guidelines in the Pull Request template to work again.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

If the link to contribution guidelines doesn't work, this might confuse some developers. Even if the GitHub UI links to the proper one, the one mentioned in the Pull Request template doesn't resolve.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

I did a bit more than changing just the link, I decided to concatenate both comments into a single group (like it is done with the other headings as well) since there is no distinction required as there are no language-specific contribution guidelines anymore.