### PR TITLE
fix: iPhone X以降(?)でページの内容が全て表示しきれないのを修正

### DIFF
--- a/packages/client/src/components/notification-toast.vue
+++ b/packages/client/src/components/notification-toast.vue
@@ -53,7 +53,7 @@ onMounted(() => {
 	}
 
 	@media (max-width: 500px) {
-		bottom: calc(env(safe-area-inset-bottom, 0px) + 96px);
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 92px);
 		padding: 0 8px;
 	}
 

--- a/packages/client/src/components/notification-toast.vue
+++ b/packages/client/src/components/notification-toast.vue
@@ -53,7 +53,7 @@ onMounted(() => {
 	}
 
 	@media (max-width: 500px) {
-		bottom: 92px;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 96px);
 		padding: 0 8px;
 	}
 

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -239,8 +239,6 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 }
 
 .dkgtipfy {
-	--buttons-height: calc(env(safe-area-inset-bottom, 0px) + 96px);
-
 	$ui-font-size: 1em; // TODO: どこかに集約したい
 	$widgets-hide-threshold: 1090px;
 
@@ -267,7 +265,7 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 			min-width: 0;
 
 			> .spacer {
-				height: var(--buttons-height);
+				height: calc(env(safe-area-inset-bottom, 0px) + 96px);
 
 				@media (min-width: ($widgets-hide-threshold + 1px)) {
 					display: none;

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -239,6 +239,8 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 }
 
 .dkgtipfy {
+	--buttons-height: calc(env(safe-area-inset-bottom, 0px) + 96px);
+
 	$ui-font-size: 1em; // TODO: どこかに集約したい
 	$widgets-hide-threshold: 1090px;
 
@@ -265,7 +267,7 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 			min-width: 0;
 
 			> .spacer {
-				height: calc(env(safe-area-inset-bottom, 0px) + 82px);
+				height: var(--buttons-height);
 
 				@media (min-width: ($widgets-hide-threshold + 1px)) {
 					display: none;

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -265,7 +265,7 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 			min-width: 0;
 
 			> .spacer {
-				height: 82px;
+				height: calc(env(safe-area-inset-bottom, 0px) + 82px);
 
 				@media (min-width: ($widgets-hide-threshold + 1px)) {
 					display: none;


### PR DESCRIPTION
# What
.spacerでもsafe-area-inset-bottomを考慮するように

# Why
safe-area-inset-bottomがあるiPhone X以降ではページの内容がbuttonsの背後に隠れてしまうため
