### PR TITLE
Fix: show login dialog on settings page if not logged in

### DIFF
--- a/packages/client/src/components/signin-dialog.vue
+++ b/packages/client/src/components/signin-dialog.vue
@@ -24,7 +24,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
 	(e: 'done'): void;
-	(e: 'close'): void;
+	(e: 'cancelled'): void;
 	(e: 'closed'): void;
 }>();
 
@@ -36,7 +36,7 @@ function onLogin(res) {
 }
 
 function onClose() {
-	emit('close');
+	emit('cancelled');
 	dialog.close();
 }
 </script>

--- a/packages/client/src/components/signin-dialog.vue
+++ b/packages/client/src/components/signin-dialog.vue
@@ -2,7 +2,7 @@
 <XModalWindow ref="dialog"
 	:width="370"
 	:height="400"
-	@close="dialog.close()"
+	@close="onClose"
 	@closed="emit('closed')"
 >
 	<template #header>{{ $ts.login }}</template>
@@ -24,6 +24,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
 	(e: 'done'): void;
+	(e: 'close'): void;
 	(e: 'closed'): void;
 }>();
 
@@ -31,6 +32,11 @@ const dialog = $ref<InstanceType<typeof XModalWindow>>();
 
 function onLogin(res) {
 	emit('done', res);
+	dialog.close();
+}
+
+function onClose() {
+	emit('close');
 	dialog.close();
 }
 </script>

--- a/packages/client/src/pages/settings/index.vue
+++ b/packages/client/src/pages/settings/index.vue
@@ -33,6 +33,7 @@ import { unisonReload } from '@/scripts/unison-reload';
 import * as symbols from '@/symbols';
 import { instance } from '@/instance';
 import { $i } from '@/account';
+import { popup } from '@/os';
 
 const props = defineProps<{
   initialPage?: string
@@ -211,6 +212,17 @@ const component = computed(() => {
 	}
 	return null;
 });
+
+if (!$i) {
+	popup(import('@/components/signin-dialog.vue'), {}, {
+		done: () => {
+			unisonReload();
+		},
+		close: () => {
+			window.location.href = '/';
+		},
+	}, 'closed');
+}
 
 watch(component, () => {
 	pageProps.value = {};

--- a/packages/client/src/pages/settings/index.vue
+++ b/packages/client/src/pages/settings/index.vue
@@ -33,7 +33,7 @@ import { unisonReload } from '@/scripts/unison-reload';
 import * as symbols from '@/symbols';
 import { instance } from '@/instance';
 import { $i } from '@/account';
-import { popup } from '@/os';
+import { promptLoginOrRedirect } from '@/scripts/prompt-login';
 
 const props = defineProps<{
   initialPage?: string
@@ -213,16 +213,7 @@ const component = computed(() => {
 	return null;
 });
 
-if (!$i) {
-	popup(import('@/components/signin-dialog.vue'), {}, {
-		done: () => {
-			unisonReload();
-		},
-		close: () => {
-			window.location.href = '/';
-		},
-	}, 'closed');
-}
+promptLoginOrRedirect();
 
 watch(component, () => {
 	pageProps.value = {};

--- a/packages/client/src/scripts/prompt-login.ts
+++ b/packages/client/src/scripts/prompt-login.ts
@@ -6,7 +6,7 @@ export function promptLoginOrRedirect(path: string = '/') {
         popup(import('@/components/signin-dialog.vue'), {
             autoSet: true
         }, {
-            close: () => {
+            cancelled: () => {
                 window.location.href = path;
             },
         }, 'closed');

--- a/packages/client/src/scripts/prompt-login.ts
+++ b/packages/client/src/scripts/prompt-login.ts
@@ -1,0 +1,14 @@
+import { $i } from '@/account';
+import { popup } from '@/os';
+
+export function promptLoginOrRedirect(path: string = '/') {
+    if (!$i) {
+        popup(import('@/components/signin-dialog.vue'), {
+            autoSet: true
+        }, {
+            close: () => {
+                window.location.href = path;
+            },
+        }, 'closed');
+    }
+}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR adds a login dialog to the settings page if a visitor is not logged in, and if they try to dismiss it, they will be redirected to the root page instead.

Fixes #8377

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Generally, there is no kind of data leak on settings, because a user is required to even see anything, it still isn't a nice practise to possibly encounter an empty page if you don't need to, showing a dialog to log (back) in is way better.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

As mentioned in my issue, I adjusted `XSigninDialog` to also emit the `close` event, which is required to handle what happens on manual closing of the dialog.

Also, I extracted the logic for this into a method `promptLoginOrRedirect(path: string = '/')` to easily reuse this in any other view that requires authentication!
