### PR TITLE
remove HTTPS handling

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -15,10 +15,7 @@ url: https://example.tld/
 #───┘ Port and TLS settings └───────────────────────────────────
 
 #
-# Misskey supports two deployment options for public.
-#
-
-# Option 1: With Reverse Proxy
+# Misskey requires a reverse proxy to support HTTPS connections.
 #
 #                 +----- https://example.tld/ ------------+
 #   +------+      |+-------------+      +----------------+|
@@ -26,30 +23,12 @@ url: https://example.tld/
 #   +------+      |+-------------+      +----------------+|
 #                 +---------------------------------------+
 #
-#   You need to setup reverse proxy. (eg. nginx)
-#   You do not define 'https' section.
+#   You need to set up a reverse proxy. (e.g. nginx)
+#   An encrypted connection with HTTPS is highly recommended
+#   because tokens may be transferred in GET requests.
 
-# Option 2: Standalone
-#
-#                 +- https://example.tld/ -+
-#   +------+      |   +---------------+    |
-#   | User | ---> |   | Misskey (443) |    |
-#   +------+      |   +---------------+    |
-#                 +------------------------+
-#
-#   You need to run Misskey as root.
-#   You need to set Certificate in 'https' section.
-
-# To use option 1, uncomment below line.
-#port: 3000    # A port that your Misskey server should listen.
-
-# To use option 2, uncomment below lines.
-#port: 443
-
-#https:
-#  # path for certification
-#  key: /etc/letsencrypt/live/example.tld/privkey.pem
-#  cert: /etc/letsencrypt/live/example.tld/fullchain.pem
+# The port that your Misskey server should listen on.
+port: 3000
 
 #   ┌──────────────────────────┐
 #───┘ PostgreSQL configuration └────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ You should also include the user name that made the change.
 
 ### Changes
 - ノートの最大文字数を設定できる機能が廃止され、デフォルトで一律3000文字になりました @syuilo
+- Misskey can no longer terminate HTTPS connections. @Johann150
+  If you did not use a reverse proxy (e.g. nginx) before, you will probably need to adjust
+  your configuration file and set up a reverse proxy. The `https` configuration key is no
+  longer recognized!
 
 ### Improvements
 - インスタンスデフォルトテーマを設定できるように @syuilo

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -6,7 +6,6 @@ export type Source = {
 	feedback_url?: string;
 	url: string;
 	port: number;
-	https?: { [x: string]: string };
 	disableHsts?: boolean;
 	db: {
 		host: string;

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -64,11 +64,6 @@ export const meta = {
 				optional: false, nullable: false,
 				default: 'https://github.com/misskey-dev/misskey/issues/new',
 			},
-			secure: {
-				type: 'boolean',
-				optional: false, nullable: false,
-				default: false,
-			},
 			defaultDarkTheme: {
 				type: 'string',
 				optional: false, nullable: true,
@@ -489,9 +484,6 @@ export default define(meta, paramDef, async (ps, me) => {
 		tosUrl: instance.ToSUrl,
 		repositoryUrl: instance.repositoryUrl,
 		feedbackUrl: instance.feedbackUrl,
-
-		secure: config.https != null,
-
 		disableRegistration: instance.disableRegistration,
 		disableLocalTimeline: instance.disableLocalTimeline,
 		disableGlobalTimeline: instance.disableGlobalTimeline,

--- a/packages/backend/src/server/index.ts
+++ b/packages/backend/src/server/index.ts
@@ -4,8 +4,6 @@
 
 import * as fs from 'node:fs';
 import * as http from 'http';
-import * as http2 from 'http2';
-import * as https from 'https';
 import Koa from 'koa';
 import Router from '@koa/router';
 import mount from 'koa-mount';
@@ -123,16 +121,7 @@ app.use(router.routes());
 app.use(mount(webServer));
 
 function createServer() {
-	if (config.https) {
-		const certs: any = {};
-		for (const k of Object.keys(config.https)) {
-			certs[k] = fs.readFileSync(config.https[k]);
-		}
-		certs['allowHTTP1'] = true;
-		return http2.createSecureServer(certs, app.callback()) as https.Server;
-	} else {
-		return http.createServer(app.callback());
-	}
+	return http.createServer(app.callback());
 }
 
 // For testing


### PR DESCRIPTION
# What
Remove HTTPS server capabilities.

The `secure` attribute is removed from the `api/meta` endpoint. It seems it was not read anywhere.

# Why
fix #8379