### PR TITLE
fix(federation): avoid duplicate activity delivery

### DIFF
--- a/packages/backend/src/remote/activitypub/deliver-manager.ts
+++ b/packages/backend/src/remote/activitypub/deliver-manager.ts
@@ -109,7 +109,7 @@ export default class DeliverManager {
 			}
 		}
 
-		this.recipes.filter(recipe => {
+		this.recipes.filter((recipe): recipe is IDirectRecipe => {
 			// followers recipes have already been processed
 			isDirect(recipe)
 			// check that shared inbox has not been added yet

--- a/packages/backend/src/remote/activitypub/deliver-manager.ts
+++ b/packages/backend/src/remote/activitypub/deliver-manager.ts
@@ -79,7 +79,13 @@ export default class DeliverManager {
 
 		const inboxes = new Set<string>();
 
-		// build inbox list
+		/*
+		build inbox list
+
+		Always prefer shared inbox over individual inbox to avoid duplication.
+		For example if a direct recipe is combined with a followers recipe,
+		or multiple directs from the same instance are present.
+		*/
 		for (const recipe of this.recipes) {
 			if (isFollowers(recipe)) {
 				// followers deliver
@@ -105,7 +111,7 @@ export default class DeliverManager {
 				}
 			} else if (isDirect(recipe)) {
 				// direct deliver
-				const inbox = recipe.to.inbox;
+				const inbox = recipe.to.sharedInbox || recipe.to.inbox;
 				if (inbox) inboxes.add(inbox);
 			}
 		}

--- a/packages/backend/src/remote/activitypub/deliver-manager.ts
+++ b/packages/backend/src/remote/activitypub/deliver-manager.ts
@@ -82,39 +82,42 @@ export default class DeliverManager {
 		/*
 		build inbox list
 
-		Always prefer shared inbox over individual inbox to avoid duplication.
-		For example if a direct recipe is combined with a followers recipe,
-		or multiple directs from the same instance are present.
+		Process follower recipes first to avoid duplication when processing
+		direct recipes later.
 		*/
-		for (const recipe of this.recipes) {
-			if (isFollowers(recipe)) {
-				// followers deliver
-				// TODO: SELECT DISTINCT ON ("followerSharedInbox") "followerSharedInbox" みたいな問い合わせにすればよりパフォーマンス向上できそう
-				// ただ、sharedInboxがnullなリモートユーザーも稀におり、その対応ができなさそう？
-				const followers = await Followings.find({
-					where: {
-						followeeId: this.actor.id,
-						followerHost: Not(IsNull()),
-					},
-					select: {
-						followerSharedInbox: true,
-						followerInbox: true,
-					},
-				}) as {
-					followerSharedInbox: string | null;
-					followerInbox: string;
-				}[];
+		if (this.recipes.some(r => isFollowers(r)) {
+			// followers deliver
+			// TODO: SELECT DISTINCT ON ("followerSharedInbox") "followerSharedInbox" みたいな問い合わせにすればよりパフォーマンス向上できそう
+			// ただ、sharedInboxがnullなリモートユーザーも稀におり、その対応ができなさそう？
+			const followers = await Followings.find({
+				where: {
+					followeeId: this.actor.id,
+					followerHost: Not(IsNull()),
+				},
+				select: {
+					followerSharedInbox: true,
+					followerInbox: true,
+				},
+			}) as {
+				followerSharedInbox: string | null;
+				followerInbox: string;
+			}[];
 
-				for (const following of followers) {
-					const inbox = following.followerSharedInbox || following.followerInbox;
-					inboxes.add(inbox);
-				}
-			} else if (isDirect(recipe)) {
-				// direct deliver
-				const inbox = recipe.to.sharedInbox || recipe.to.inbox;
-				if (inbox) inboxes.add(inbox);
+			for (const following of followers) {
+				const inbox = following.followerSharedInbox || following.followerInbox;
+				inboxes.add(inbox);
 			}
 		}
+
+		this.recipes.filter(recipe => {
+			// followers recipes have already been processed
+			isDirect(recipe)
+			// check that shared inbox has not been added yet
+			&& !(recipe.to.sharedInbox && inboxes.has(recipe.to.sharedInbox))
+			// check that they actually have an inbox
+			&& recipe.to.inbox
+		})
+		.forEach(recipe => inboxes.add(recipe.to.inbox));
 
 		// deliver
 		for (const inbox of inboxes) {


### PR DESCRIPTION
# What
Always prefer shared inboxes over individual inboxes to avoid sending an activity twice to the same instance.

# Why
fix #8428