### PR TITLE
fix(federation): recognize null in _misskey_content for notes

### DIFF
--- a/packages/backend/src/remote/activitypub/models/note.ts
+++ b/packages/backend/src/remote/activitypub/models/note.ts
@@ -197,7 +197,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	const cw = note.summary === '' ? null : note.summary;
 
 	// テキストのパース
-	const text = note._misskey_content || (note.content ? htmlToMfm(note.content, note.tag) : null);
+	const text = typeof note._misskey_content !== 'undefined' ? note._misskey_content : (note.content ? htmlToMfm(note.content, note.tag) : null);
 
 	// vote
 	if (reply && reply.hasPoll) {


### PR DESCRIPTION
# What
Correctly recognize `null` (and also empty string) in `_misskey_content` on incoming notes.

# Why
fix #8439