### PR TITLE
enhance(federation): limit federation of reactions on direct notes

### DIFF
--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -124,7 +124,16 @@ export default async (user: { id: User['id']; host: User['host']; }, note: Note,
 			const reactee = await Users.findOneBy({ id: note.userId });
 			dm.addDirectRecipe(reactee as IRemoteUser);
 		}
-		dm.addFollowersRecipe();
+
+		if (['public', 'home', 'followers'].includes(note.visibility)) {
+			dm.addFollowersRecipe();
+		} else if (note.visibility === 'specified') {
+			const visibleUsers = await Promise.all(note.visibleUserIds.map(id => Users.findOneBy({ id })));
+			for (const u of visibleUsers.filter(u => u && Users.isRemoteUser(u))) {
+				dm.addDirectRecipe(u as IRemoteUser);
+			}
+		}
+
 		dm.execute();
 	}
 	//#endregion


### PR DESCRIPTION
# What
Reactions to notes that have `specified` visibility are only federated to the people that the note is visible to, instead of delivering it to all followers.

# Why
Related to #8317, but does not yet fix it.

Without this, remote instances may be able to gather information about a private note.