### PR TITLE
enhance: タッチパッド・タッチスクリーンでのデッキの操作性を向上

### DIFF
--- a/packages/client/src/ui/deck.vue
+++ b/packages/client/src/ui/deck.vue
@@ -129,7 +129,7 @@ document.documentElement.style.overflowY = 'hidden';
 document.documentElement.style.scrollBehavior = 'auto';
 window.addEventListener('wheel', (ev) => {
 	if (getScrollContainer(ev.target as HTMLElement) == null && ev.deltaX === 0) {
-		document.documentElement.scrollLeft += ev.deltaY > 0 ? 96 : -96;
+		document.documentElement.scrollLeft += ev.deltaY;
 	}
 });
 loadDeck();

--- a/packages/client/src/ui/deck.vue
+++ b/packages/client/src/ui/deck.vue
@@ -128,7 +128,7 @@ if (deckStore.state.navWindow) {
 document.documentElement.style.overflowY = 'hidden';
 document.documentElement.style.scrollBehavior = 'auto';
 window.addEventListener('wheel', (ev) => {
-	if (getScrollContainer(ev.target as HTMLElement) == null) {
+	if (getScrollContainer(ev.target as HTMLElement) == null && ev.deltaX === 0) {
 		document.documentElement.scrollLeft += ev.deltaY > 0 ? 96 : -96;
 	}
 });

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -372,8 +372,7 @@ function onDrop(e) {
 
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
-		overflow: auto;
-		overflow-x: clip;
+		overflow: clip auto;
 		-webkit-overflow-scrolling: touch;
 		box-sizing: border-box;
 	}

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -372,7 +372,7 @@ function onDrop(e) {
 
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
-		overflow: auto;
+		overflow-y: auto;
 		overflow-x: hidden;
 		overflow-x: clip;
 		-webkit-overflow-scrolling: touch;

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -373,6 +373,7 @@ function onDrop(e) {
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
 		overflow: clip auto;
+		overscroll-behavior: auto contain;
 		-webkit-overflow-scrolling: touch;
 		box-sizing: border-box;
 	}

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -373,8 +373,7 @@ function onDrop(e) {
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
 		overflow: auto;
-		overflow-x: hidden;
-		overscroll-behavior: contain;
+		overflow-x: clip;
 		-webkit-overflow-scrolling: touch;
 		box-sizing: border-box;
 	}

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -373,7 +373,7 @@ function onDrop(e) {
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
 		overflow-y: auto;
-		overflow-x: hidden;
+		overflow-x: hidden; // Safari does not supports clip
 		overflow-x: clip;
 		-webkit-overflow-scrolling: touch;
 		box-sizing: border-box;

--- a/packages/client/src/ui/deck/column.vue
+++ b/packages/client/src/ui/deck/column.vue
@@ -372,8 +372,9 @@ function onDrop(e) {
 
 	> div {
 		height: calc(100% - var(--deckColumnHeaderHeight));
-		overflow: clip auto;
-		overscroll-behavior: auto contain;
+		overflow: auto;
+		overflow-x: hidden;
+		overflow-x: clip;
 		-webkit-overflow-scrolling: touch;
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
Fix #8449

# What
enhance experience of deck with touchpad

1. タッチパッドで横スクロールするとスクロールが開始地点に戻ろうとするのを修正
   * 原因: タッチパッドでスクロール→onwheel→指の上下でdeltaYがマイナスになると戻ろうとしてしまう
   * deltaXが0の場合のみ縦スクロールを横スクロールに変換するように
   * ついでに1回のonwheelで96px移動するのをdeltaYぶんだけ横スクロールするように
2. カラムのoverscroll-behavior: contain;を削除し、カラムで横スクロール操作をしてもデッキUIが横スクロールしなかったのを横スクロールするように
3. カラムのoverflow-xをhiddenからclipに

# Why
1. Fix #8449
   * なぜ96px移動してたのか知らないけど、deltaYぶんだけ横スクロールしても多分問題なさそう
2. 操作性の向上
3. パフォーマンス向上(?)

# Additional info (optional)
p1.a9z.devで動作中