### PR TITLE
fix: validation (better #8456)

### DIFF
--- a/packages/backend/src/models/schema/emoji.ts
+++ b/packages/backend/src/models/schema/emoji.ts
@@ -27,6 +27,7 @@ export const packedEmojiSchema = {
 		host: {
 			type: 'string',
 			optional: false, nullable: true,
+			description: 'The local host is represented with `null`.',
 		},
 		url: {
 			type: 'string',

--- a/packages/backend/src/models/schema/user.ts
+++ b/packages/backend/src/models/schema/user.ts
@@ -21,6 +21,7 @@ export const packedUserLiteSchema = {
 			type: 'string',
 			nullable: true, optional: false,
 			example: 'misskey.example.com',
+			description: 'The local host is represented with `null`.',
 		},
 		avatarUrl: {
 			type: 'string',

--- a/packages/backend/src/server/api/endpoints/admin/drive/files.ts
+++ b/packages/backend/src/server/api/endpoints/admin/drive/files.ts
@@ -27,7 +27,12 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		type: { type: 'string', nullable: true, pattern: /^[a-zA-Z0-9\/\-*]+$/.toString().slice(1, -1) },
 		origin: { type: 'string', enum: ['combined', 'local', 'remote'], default: "local" },
-		hostname: { type: 'string', nullable: true, default: null },
+		hostname: {
+			type: 'string',
+			nullable: true,
+			default: null,
+			description: 'The local host is represented with `null`.',
+		},
 	},
 	required: [],
 } as const;

--- a/packages/backend/src/server/api/endpoints/admin/drive/show-file.ts
+++ b/packages/backend/src/server/api/endpoints/admin/drive/show-file.ts
@@ -40,6 +40,7 @@ export const meta = {
 			userHost: {
 				type: 'string',
 				optional: false, nullable: true,
+				description: 'The local host is represented with `null`.',
 			},
 			md5: {
 				type: 'string',
@@ -151,11 +152,20 @@ export const meta = {
 
 export const paramDef = {
 	type: 'object',
-	properties: {
-		fileId: { type: 'string', format: 'misskey:id' },
-		url: { type: 'string' },
-	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				fileId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['fileId'],
+		},
+		{
+			properties: {
+				url: { type: 'string' },
+			},
+			required: ['url'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/admin/emoji/list-remote.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/list-remote.ts
@@ -40,6 +40,7 @@ export const meta = {
 				host: {
 					type: 'string',
 					optional: false, nullable: true,
+					description: 'The local host is represented with `null`.',
 				},
 				url: {
 					type: 'string',
@@ -54,7 +55,12 @@ export const paramDef = {
 	type: 'object',
 	properties: {
 		query: { type: 'string', nullable: true, default: null },
-		host: { type: 'string', nullable: true, default: null },
+		host: {
+			type: 'string',
+			nullable: true,
+			default: null,
+			description: 'Use `null` to represent the local host.',
+		},
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },

--- a/packages/backend/src/server/api/endpoints/admin/emoji/list.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/list.ts
@@ -38,8 +38,9 @@ export const meta = {
 					optional: false, nullable: true,
 				},
 				host: {
-					type: 'string',
-					optional: false, nullable: true,
+					type: 'null',
+					optional: false,
+					description: 'The local host is represented with `null`. The field exists for compatibility with other API endpoints that return files.',
 				},
 				url: {
 					type: 'string',

--- a/packages/backend/src/server/api/endpoints/admin/emoji/set-category-bulk.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/set-category-bulk.ts
@@ -17,7 +17,11 @@ export const paramDef = {
 		ids: { type: 'array', items: {
 			type: 'string', format: 'misskey:id',
 		} },
-		category: { type: 'string', nullable: true },
+		category: {
+			type: 'string',
+			nullable: true,
+			description: 'Use `null` to reset the category.',
+		},
 	},
 	required: ['ids'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -23,7 +23,11 @@ export const paramDef = {
 	properties: {
 		id: { type: 'string', format: 'misskey:id' },
 		name: { type: 'string' },
-		category: { type: 'string', nullable: true },
+		category: {
+			type: 'string',
+			nullable: true,
+			description: 'Use `null` to reset the category.',
+		},
 		aliases: { type: 'array', items: {
 			type: 'string',
 		} },

--- a/packages/backend/src/server/api/endpoints/admin/show-users.ts
+++ b/packages/backend/src/server/api/endpoints/admin/show-users.ts
@@ -26,8 +26,13 @@ export const paramDef = {
 		sort: { type: 'string', enum: ['+follower', '-follower', '+createdAt', '-createdAt', '+updatedAt', '-updatedAt'] },
 		state: { type: 'string', enum: ['all', 'available', 'admin', 'moderator', 'adminOrModerator', 'silenced', 'suspended'], default: "all" },
 		origin: { type: 'string', enum: ['combined', 'local', 'remote'], default: "local" },
-		username: { type: 'string', default: null },
-		hostname: { type: 'string', default: null },
+		username: { type: 'string', nullable: true, default: null },
+		hostname: {
+			type: 'string',
+			nullable: true,
+			default: null,
+			description: 'The local host is represented with `null`.',
+		},
 	},
 	required: [],
 } as const;

--- a/packages/backend/src/server/api/endpoints/clips/create.ts
+++ b/packages/backend/src/server/api/endpoints/clips/create.ts
@@ -20,7 +20,7 @@ export const paramDef = {
 	type: 'object',
 	properties: {
 		name: { type: 'string', minLength: 1, maxLength: 100 },
-		isPublic: { type: 'boolean' },
+		isPublic: { type: 'boolean', default: false },
 		description: { type: 'string', nullable: true, minLength: 1, maxLength: 2048 },
 	},
 	required: ['name'],

--- a/packages/backend/src/server/api/endpoints/drive/files/show.ts
+++ b/packages/backend/src/server/api/endpoints/drive/files/show.ts
@@ -28,22 +28,25 @@ export const meta = {
 			code: 'ACCESS_DENIED',
 			id: '25b73c73-68b1-41d0-bad1-381cfdf6579f',
 		},
-
-		fileIdOrUrlRequired: {
-			message: 'fileId or url required.',
-			code: 'INVALID_PARAM',
-			id: '89674805-722c-440c-8d88-5641830dc3e4',
-		},
 	},
 } as const;
 
 export const paramDef = {
 	type: 'object',
-	properties: {
-		fileId: { type: 'string', format: 'misskey:id' },
-		url: { type: 'string' },
-	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				fileId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['fileId'],
+		},
+		{
+			properties: {
+				url: { type: 'string' },
+			},
+			required: ['url'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export
@@ -62,8 +65,6 @@ export default define(meta, paramDef, async (ps, user) => {
 				thumbnailUrl: ps.url,
 			}],
 		});
-	} else {
-		throw new ApiError(meta.errors.fileIdOrUrlRequired);
 	}
 
 	if (file == null) {

--- a/packages/backend/src/server/api/endpoints/federation/instances.ts
+++ b/packages/backend/src/server/api/endpoints/federation/instances.ts
@@ -22,7 +22,7 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		host: { type: 'string', nullable: true },
+		host: { type: 'string', nullable: true, description: 'Omit or use `null` to not filter by host.' },
 		blocked: { type: 'boolean', nullable: true },
 		notResponding: { type: 'boolean', nullable: true },
 		suspended: { type: 'boolean', nullable: true },

--- a/packages/backend/src/server/api/endpoints/messaging/messages.ts
+++ b/packages/backend/src/server/api/endpoints/messaging/messages.ts
@@ -47,14 +47,25 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		userId: { type: 'string', format: 'misskey:id' },
-		groupId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
 		markAsRead: { type: 'boolean', default: true },
 	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				userId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['userId'],
+		},
+		{
+			properties: {
+				groupId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['groupId'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export
@@ -126,7 +137,5 @@ export default define(meta, paramDef, async (ps, user) => {
 		return await Promise.all(messages.map(message => MessagingMessages.pack(message, user, {
 			populateGroup: false,
 		})));
-	} else {
-		throw new Error();
 	}
 });

--- a/packages/backend/src/server/api/endpoints/messaging/messages/create.ts
+++ b/packages/backend/src/server/api/endpoints/messaging/messages/create.ts
@@ -67,12 +67,23 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		userId: { type: 'string', format: 'misskey:id' },
-		groupId: { type: 'string', format: 'misskey:id' },
 		text: { type: 'string', nullable: true, maxLength: 3000 },
 		fileId: { type: 'string', format: 'misskey:id' },
 	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				userId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['userId'],
+		},
+		{
+			properties: {
+				groupId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['groupId'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -169,6 +169,7 @@ export const meta = {
 						host: {
 							type: 'string',
 							optional: false, nullable: true,
+							description: 'The local host is represented with `null`.',
 						},
 						url: {
 							type: 'string',

--- a/packages/backend/src/server/api/endpoints/mute/create.ts
+++ b/packages/backend/src/server/api/endpoints/mute/create.ts
@@ -38,7 +38,11 @@ export const paramDef = {
 	type: 'object',
 	properties: {
 		userId: { type: 'string', format: 'misskey:id' },
-		expiresAt: { type: 'integer', nullable: true },
+		expiresAt: {
+			type: 'integer',
+			nullable: true,
+			description: 'A Unix Epoch timestamp that must lie in the future. `null` means an indefinite mute.',
+		},
 	},
 	required: ['userId'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes.ts
+++ b/packages/backend/src/server/api/endpoints/notes.ts
@@ -19,7 +19,7 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		local: { type: 'boolean' },
+		local: { type: 'boolean', default: false },
 		reply: { type: 'boolean' },
 		renote: { type: 'boolean' },
 		withFiles: { type: 'boolean' },

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -185,7 +185,7 @@ export default define(meta, paramDef, async (ps, user) => {
 
 		if (renote == null) {
 			throw new ApiError(meta.errors.noSuchRenoteTarget);
-		} else if (renote.renoteId && !renote.text && !renote.fileIds) {
+		} else if (renote.renoteId && !renote.text && !renote.fileIds && !renote.poll) {
 			throw new ApiError(meta.errors.cannotReRenote);
 		}
 
@@ -208,10 +208,7 @@ export default define(meta, paramDef, async (ps, user) => {
 
 		if (reply == null) {
 			throw new ApiError(meta.errors.noSuchReplyTarget);
-		}
-
-		// 返信対象が引用でないRenoteだったらエラー
-		if (reply.renoteId && !reply.text && !reply.fileIds) {
+		} else if (reply.renoteId && !reply.text && !reply.fileIds && !renote.poll) {
 			throw new ApiError(meta.errors.cannotReplyToPureRenote);
 		}
 

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -152,6 +152,10 @@ export const paramDef = {
 			},
 			required: ['poll'],
 		},
+		{
+			// pure renote
+			required: ['renoteId'],
+		},
 	],
 } as const;
 

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -59,12 +59,6 @@ export const meta = {
 			id: '3ac74a84-8fd5-4bb0-870f-01804f82ce15',
 		},
 
-		contentRequired: {
-			message: 'Content required. You need to set text, fileIds, renoteId or poll.',
-			code: 'CONTENT_REQUIRED',
-			id: '6f57e42b-c348-439b-bc45-993995cc515a',
-		},
-
 		cannotCreateAlreadyExpiredPoll: {
 			message: 'Poll is already expired.',
 			code: 'CANNOT_CREATE_ALREADY_EXPIRED_POLL',
@@ -92,29 +86,41 @@ export const paramDef = {
 		visibleUserIds: { type: 'array', uniqueItems: true, items: {
 			type: 'string', format: 'misskey:id',
 		} },
-		text: { type: 'string', nullable: true, maxLength: MAX_NOTE_TEXT_LENGTH, default: null },
+		text: { type: 'string', maxLength: MAX_NOTE_TEXT_LENGTH, nullable: true },
 		cw: { type: 'string', nullable: true, maxLength: 100 },
 		localOnly: { type: 'boolean', default: false },
 		noExtractMentions: { type: 'boolean', default: false },
 		noExtractHashtags: { type: 'boolean', default: false },
 		noExtractEmojis: { type: 'boolean', default: false },
-		fileIds: { type: 'array', uniqueItems: true, minItems: 1, maxItems: 16, items: {
-			type: 'string', format: 'misskey:id',
-		} },
-		mediaIds: { type: 'array', uniqueItems: true, minItems: 1, maxItems: 16, items: {
-			type: 'string', format: 'misskey:id',
-		} },
+		fileIds: {
+			type: 'array',
+			uniqueItems: true,
+			minItems: 1,
+			maxItems: 16,
+			items: { type: 'string', format: 'misskey:id' },
+		},
+		mediaIds: {
+			deprecated: true,
+			description: 'Use `fileIds` instead. If both are specified, this property is discarded.',
+			type: 'array',
+			uniqueItems: true,
+			minItems: 1,
+			maxItems: 16,
+			items: { type: 'string', format: 'misskey:id' },
+		},
 		replyId: { type: 'string', format: 'misskey:id', nullable: true },
 		renoteId: { type: 'string', format: 'misskey:id', nullable: true },
 		channelId: { type: 'string', format: 'misskey:id', nullable: true },
 		poll: {
-			type: 'object', nullable: true,
+			type: 'object',
+			nullable: true,
 			properties: {
 				choices: {
-					type: 'array', uniqueItems: true, minItems: 2, maxItems: 10, 
-					items: {
-						type: 'string', minLength: 1, maxLength: 50,
-					},
+					type: 'array',
+					uniqueItems: true,
+					minItems: 2,
+					maxItems: 10,
+					items: { type: 'string', minLength: 1, maxLength: 50 },
 				},
 				multiple: { type: 'boolean', default: false },
 				expiresAt: { type: 'integer', nullable: true },
@@ -123,7 +129,30 @@ export const paramDef = {
 			required: ['choices'],
 		},
 	},
-	required: [],
+	anyOf: [
+		{
+			// (re)note with text, files and poll are optional
+			properties: {
+				text: { type: 'string', maxLength: MAX_NOTE_TEXT_LENGTH, nullable: false },
+			},
+			required: ['text'],
+		},
+		{
+			// (re)note with files, text and poll are optional
+			required: ['fileIds'],
+		},
+		{
+			// (re)note with files, text and poll are optional
+			required: ['mediaIds'],
+		},
+		{
+			// (re)note with poll, text and files are optional
+			properties: {
+				poll: { type: 'object', nullable: false, },
+			},
+			required: ['poll'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export
@@ -202,11 +231,6 @@ export default define(meta, paramDef, async (ps, user) => {
 		} else if (typeof ps.poll.expiredAfter === 'number') {
 			ps.poll.expiresAt = Date.now() + ps.poll.expiredAfter;
 		}
-	}
-
-	// テキストが無いかつ添付ファイルが無いかつRenoteも無いかつ投票も無かったらエラー
-	if (!(ps.text || files.length || renote || ps.poll)) {
-		throw new ApiError(meta.errors.contentRequired);
 	}
 
 	let channel: Channel | undefined;

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -35,7 +35,11 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -48,7 +48,11 @@ export const paramDef = {
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 	},
 	required: [],
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -37,7 +37,11 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 		fileType: { type: 'array', items: {
 			type: 'string',
 		} },

--- a/packages/backend/src/server/api/endpoints/notes/search-by-tag.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search-by-tag.ts
@@ -25,21 +25,44 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		tag: { type: 'string' },
-		query: { type: 'array', items: {
-			type: 'array', items: {
-				type: 'string',
-			},
-		} },
 		reply: { type: 'boolean', nullable: true, default: null },
 		renote: { type: 'boolean', nullable: true, default: null },
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 		poll: { type: 'boolean', nullable: true, default: null },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				tag: { type: 'string', minLength: 1 },
+			},
+			required: ['tag'],
+		},
+		{
+			properties: {
+				query: {
+					type: 'array',
+					description: 'The outer arrays are chained with OR, the inner arrays are chained with AND.',
+					items: {
+						type: 'array',
+						items: {
+							type: 'string',
+							minLength: 1,
+						},
+						minItems: 1,
+					},
+					minItems: 1,
+				},
+			},
+			required: ['query'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/notes/search.ts
+++ b/packages/backend/src/server/api/endpoints/notes/search.ts
@@ -35,7 +35,11 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		offset: { type: 'integer', default: 0 },
-		host: { type: 'string', nullable: true },
+		host: {
+			type: 'string',
+			nullable: true,
+			description: 'The local host is represented with `null`.',
+		},
 		userId: { type: 'string', format: 'misskey:id', nullable: true, default: null },
 		channelId: { type: 'string', format: 'misskey:id', nullable: true, default: null },
 	},

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -38,7 +38,11 @@ export const paramDef = {
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 	},
 	required: [],
 } as const;

--- a/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -42,7 +42,11 @@ export const paramDef = {
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
-		withFiles: { type: 'boolean' },
+		withFiles: {
+			type: 'boolean',
+			default: false,
+			description: 'Only show notes that have attached files.',
+		},
 	},
 	required: ['listId'],
 } as const;

--- a/packages/backend/src/server/api/endpoints/pages/show.ts
+++ b/packages/backend/src/server/api/endpoints/pages/show.ts
@@ -26,12 +26,21 @@ export const meta = {
 
 export const paramDef = {
 	type: 'object',
-	properties: {
-		pageId: { type: 'string', format: 'misskey:id' },
-		name: { type: 'string' },
-		username: { type: 'string' },
-	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				pageId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['pageId'],
+		},
+		{
+			properties: {
+				name: { type: 'string' },
+				username: { type: 'string' },
+			},
+			required: ['name', 'username'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/users/followers.ts
+++ b/packages/backend/src/server/api/endpoints/users/followers.ts
@@ -38,14 +38,29 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		userId: { type: 'string', format: 'misskey:id' },
-		username: { type: 'string' },
-		host: { type: 'string', nullable: true },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				userId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['userId'],
+		},
+		{
+			properties: {
+				username: { type: 'string' },
+				host: {
+					type: 'string',
+					nullable: true,
+					description: 'The local host is represented with `null`.',
+				},
+			},
+			required: ['username', 'host'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/users/following.ts
+++ b/packages/backend/src/server/api/endpoints/users/following.ts
@@ -38,14 +38,29 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		userId: { type: 'string', format: 'misskey:id' },
-		username: { type: 'string' },
-		host: { type: 'string', nullable: true },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				userId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['userId'],
+		},
+		{
+			properties: {
+				username: { type: 'string' },
+				host: {
+					type: 'string',
+					nullable: true,
+					description: 'The local host is represented with `null`.',
+				},
+			},
+			required: ['username', 'host'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export

--- a/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
+++ b/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
@@ -28,7 +28,10 @@ export const paramDef = {
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		detail: { type: 'boolean', default: true },
 	},
-	required: [],
+	anyOf: [
+		{ required: ['username'] },
+		{ required: ['host'] },
+	],
 } as const;
 
 // TODO: avatar,bannerをJOINしたいけどエラーになる

--- a/packages/backend/src/server/api/endpoints/users/show.ts
+++ b/packages/backend/src/server/api/endpoints/users/show.ts
@@ -46,15 +46,33 @@ export const meta = {
 
 export const paramDef = {
 	type: 'object',
-	properties: {
-		userId: { type: 'string', format: 'misskey:id' },
-		userIds: { type: 'array', uniqueItems: true, items: {
-			type: 'string', format: 'misskey:id',
-		} },
-		username: { type: 'string' },
-		host: { type: 'string', nullable: true },
-	},
-	required: [],
+	anyOf: [
+		{
+			properties: {
+				userId: { type: 'string', format: 'misskey:id' },
+			},
+			required: ['userId'],
+		},
+		{
+			properties: {
+				userIds: { type: 'array', uniqueItems: true, items: {
+					type: 'string', format: 'misskey:id',
+				} },
+			},
+			required: ['userIds'],
+		},
+		{
+			properties: {
+				username: { type: 'string' },
+				host: {
+					type: 'string',
+					nullable: true,
+					description: 'The local host is represented with `null`.',
+				},
+			},
+			required: ['username', 'host'],
+		},
+	],
 } as const;
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
- fix mistake from #8456: pure renotes are also allowed via `notes/create`
- fix pure renote checks in `notes/create`