### PR TITLE
Add `.yarn` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Node.js
 node_modules
 report.*.json
+.yarn
 
 # Cypress
 cypress/screenshots


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
Adds `.yarn` to `.gitignore`

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
When building with `yarn` > 2.x, it creates the `.yarn` folder which should be ignored.

# Additional info (optional)
<!-- テスト観点など -->
Without `.yarn` in `.gitignore`, git shows over 2k changes.
![image](https://user-images.githubusercontent.com/44733677/161824608-07eb942b-caab-4a09-b6c0-8bbc06d4c079.png)

