### PR TITLE
make emoji stand out more on reaction button

### DIFF
--- a/packages/client/src/components/reactions-viewer.reaction.vue
+++ b/packages/client/src/components/reactions-viewer.reaction.vue
@@ -144,6 +144,10 @@ export default defineComponent({
 		> span {
 			color: var(--fgOnAccent);
 		}
+
+		> .mk-emoji {
+			filter: drop-shadow(0 0 3px var(--bg));
+		}
 	}
 
 	> span {


### PR DESCRIPTION
a slight shadow makes them easier to see

# What
Added a slight shadow to a persons own reaction emoji as described in the issue.

![⛳ with a slight shadow](https://user-images.githubusercontent.com/20990607/164082110-03f759c5-6e5a-446f-9c90-80c6290f26b7.png)

# Why
fix #8520
