### PR TITLE
fix _misskey_content of quote renotes

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -187,6 +187,8 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 	if (data.text) {
 		data.text = data.text.trim();
+	} else {
+		data.text = null;
 	}
 
 	let tags = data.apHashtags;


### PR DESCRIPTION
# What
`_misskey_content` is defaulted to `null` to ensure it is not `undefined`. If the value is undefined, the `_misskey_content` does not arrive on remote instances and rendering of quote renotes will be wrong. Setting it to `null` results in the correct behaviour thanks to #8440.

# Why
fix #8439