### PR TITLE
fix(activitypub): add authorization checks

### DIFF
--- a/packages/backend/src/remote/activitypub/kernel/announce/note.ts
+++ b/packages/backend/src/remote/activitypub/kernel/announce/note.ts
@@ -9,6 +9,7 @@ import { fetchMeta } from '@/misc/fetch-meta.js';
 import { getApLock } from '@/misc/app-lock.js';
 import { parseAudience } from '../../audience.js';
 import { StatusError } from '@/misc/fetch.js';
+import { Notes } from '@/models/index.js';
 
 const logger = apLogger;
 
@@ -51,6 +52,8 @@ export default async function(resolver: Resolver, actor: CacheableRemoteUser, ac
 			}
 			throw e;
 		}
+
+		if (!await Notes.isVisibleForMe(renote, actor)) return 'skip: invalid actor for this activity';
 
 		logger.info(`Creating the (Re)Note: ${uri}`);
 

--- a/packages/backend/src/remote/activitypub/kernel/delete/index.ts
+++ b/packages/backend/src/remote/activitypub/kernel/delete/index.ts
@@ -13,37 +13,37 @@ export default async (actor: CacheableRemoteUser, activity: IDelete): Promise<st
 	}
 
 	// 削除対象objectのtype
-	let formarType: string | undefined;
+	let formerType: string | undefined;
 
 	if (typeof activity.object === 'string') {
 		// typeが不明だけど、どうせ消えてるのでremote resolveしない
-		formarType = undefined;
+		formerType = undefined;
 	} else {
 		const object = activity.object as IObject;
 		if (isTombstone(object)) {
-			formarType = toSingle(object.formerType);
+			formerType = toSingle(object.formerType);
 		} else {
-			formarType = toSingle(object.type);
+			formerType = toSingle(object.type);
 		}
 	}
 
 	const uri = getApId(activity.object);
 
 	// type不明でもactorとobjectが同じならばそれはPersonに違いない
-	if (!formarType && actor.uri === uri) {
-		formarType = 'Person';
+	if (!formerType && actor.uri === uri) {
+		formerType = 'Person';
 	}
 
 	// それでもなかったらおそらくNote
-	if (!formarType) {
-		formarType = 'Note';
+	if (!formerType) {
+		formerType = 'Note';
 	}
 
-	if (validPost.includes(formarType)) {
+	if (validPost.includes(formerType)) {
 		return await deleteNote(actor, uri);
-	} else if (validActor.includes(formarType)) {
+	} else if (validActor.includes(formerType)) {
 		return await deleteActor(actor, uri);
 	} else {
-		return `Unknown type ${formarType}`;
+		return `Unknown type ${formerType}`;
 	}
 };

--- a/packages/backend/src/remote/activitypub/kernel/undo/announce.ts
+++ b/packages/backend/src/remote/activitypub/kernel/undo/announce.ts
@@ -8,6 +8,7 @@ export const undoAnnounce = async (actor: CacheableRemoteUser, activity: IAnnoun
 
 	const note = await Notes.findOneBy({
 		uri,
+		userId: actor.id,
 	});
 
 	if (!note) return 'skip: no such Announce';

--- a/packages/backend/src/services/note/reaction/create.ts
+++ b/packages/backend/src/services/note/reaction/create.ts
@@ -27,6 +27,11 @@ export default async (user: { id: User['id']; host: User['host']; }, note: Note,
 		}
 	}
 
+	// check visibility
+	if (!await Notes.isVisibleForMe(note, user)) {
+		throw new IdentifiableError('68e9d2d1-48bf-42c2-b90a-b20e09fd3d48', 'Note not accessible for you.');
+	}
+
 	// TODO: cache
 	reaction = await toDbReaction(reaction, user.host);
 


### PR DESCRIPTION
# What
- Fixed spelling of `formerType`.
- Add missing authorization checks when performing ActivityPub actions, so the following are **rejected**:
    - pure renote deletion if actor !== renoter
        - ℹ️ This was already impossible before because the user ID is checked [later in `deleteNote`](https://github.com/misskey-dev/misskey/blob/f23d5a75f4cb64328a99e25f8a17150fe5b8a4d3/packages/backend/src/services/note/delete.ts#L81-L84) and is not a security issue. But since this is checked last, it may still mess up renote counts etc. so it is better to check it earlier too.
    - renotes where the renoter should not be able to see the original note
    - reactions where the reacter should not be able to see the original note

# Why
fix #8529
fix #6127