### PR TITLE
enhance(MFM): limit large MFM

### DIFF
--- a/packages/client/src/components/global/misskey-flavored-markdown.vue
+++ b/packages/client/src/components/global/misskey-flavored-markdown.vue
@@ -32,15 +32,29 @@ const props = withDefaults(defineProps<{
 }
 
 .mfm-x2 {
-	font-size: 200%;
+	--mfm-zoom-size: 200%;
 }
 
 .mfm-x3 {
-	font-size: 400%;
+	--mfm-zoom-size: 400%;
 }
 
 .mfm-x4 {
-	font-size: 600%;
+	--mfm-zoom-size: 600%;
+}
+
+.mfm-x2, .mfm-x3, .mfm-x4 {
+	font-size: var(--mfm-zoom-size);
+
+	.mfm-x2, .mfm-x3, .mfm-x4 {
+		/* only half effective */
+		font-size: calc( ( var(--mfm-zoom-size) + 100% ) / 2 );
+
+		.mfm-x2, .mfm-x3, .mfm-x4 {
+			/* disabled */
+			font-size: 100%;
+		}
+	}
 }
 
 @keyframes mfm-spin {

--- a/packages/client/src/components/global/misskey-flavored-markdown.vue
+++ b/packages/client/src/components/global/misskey-flavored-markdown.vue
@@ -31,6 +31,18 @@ const props = withDefaults(defineProps<{
 	}
 }
 
+.mfm-x2 {
+	font-size: 200%;
+}
+
+.mfm-x3 {
+	font-size: 400%;
+}
+
+.mfm-x4 {
+	font-size: 600%;
+}
+
 @keyframes mfm-spin {
 	0% { transform: rotate(0deg); }
 	100% { transform: rotate(360deg); }

--- a/packages/client/src/components/global/misskey-flavored-markdown.vue
+++ b/packages/client/src/components/global/misskey-flavored-markdown.vue
@@ -48,7 +48,7 @@ const props = withDefaults(defineProps<{
 
 	.mfm-x2, .mfm-x3, .mfm-x4 {
 		/* only half effective */
-		font-size: calc( ( var(--mfm-zoom-size) + 100% ) / 2 );
+		font-size: calc(var(--mfm-zoom-size) / 2 + 50%);
 
 		.mfm-x2, .mfm-x3, .mfm-x4 {
 			/* disabled */

--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -139,16 +139,19 @@ export default defineComponent({
 							break;
 						}
 						case 'x2': {
-							style = `font-size: 200%;`;
-							break;
+							return h('span', {
+								class: 'mfm-x2',
+							}, genEl(token.children));
 						}
 						case 'x3': {
-							style = `font-size: 400%;`;
-							break;
+							return h('span', {
+								class: 'mfm-x3',
+							}, genEl(token.children));
 						}
 						case 'x4': {
-							style = `font-size: 600%;`;
-							break;
+							return h('span', {
+								class: 'mfm-x4',
+							}, genEl(token.children));
 						}
 						case 'font': {
 							const family =


### PR DESCRIPTION
# What
1. Use classes for rendering `$[x2 ]`, `$[x3 ]` and `$[x4 ]` MFM, instead of an inline style attribute.
2. With the new selectors, limit nesting of these MFM functions:
    - applying them 1 time has no changed behaviour
    - applying them 2 times makes them only 1/2 effective
    - applying them 3 times makes them ineffective
    - This works even for something like `$[x4 $[x3 $[x2 ]]]`:
        - the `x3` will only be half as effective
        - the `x2` will be ineffective

# Why
fix #8241 
https://mk.absturztau.be/notes/8qi5s0jjez