### PR TITLE
use assets submodule instead of discord twemoji

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -15,7 +15,6 @@
 	},
 	"dependencies": {
 		"@bull-board/koa": "3.10.4",
-		"@discordapp/twemoji": "13.1.1",
 		"@elastic/elasticsearch": "7.11.0",
 		"@koa/cors": "3.1.0",
 		"@koa/multer": "3.0.0",

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -120,9 +120,7 @@ router.get('/apple-touch-icon.png', async ctx => {
 });
 
 router.get('/twemoji/(.*)', async ctx => {
-	const path = ctx.path.replace('/twemoji/', '');
-
-	if (!path.match(/^[0-9a-f-]+\.svg$/)) {
+	if (!path.match(/^\/twemoji\/[0-9a-f-]+\.svg$/)) {
 		ctx.status = 404;
 		return;
 	}
@@ -130,7 +128,7 @@ router.get('/twemoji/(.*)', async ctx => {
 	ctx.set('Content-Security-Policy', 'default-src \'none\'; style-src \'unsafe-inline\'');
 
 	await send(ctx as any, path, {
-		root: `${_dirname}/../../../node_modules/@discordapp/twemoji/dist/svg/`,
+		root: staticAssets,
 		maxage: ms('30 days'),
 	});
 });


### PR DESCRIPTION
# What
Adjust paths for using Twemoji from assets repository instead of `@discord/twemoji`.

# Why
- part of #8505
- counterpart of https://github.com/misskey-dev/assets/pull/2
- `@discord/twemoji` also contains the PNG versions of twemoji leading to unnecessary files. When including twemoji as separate assets, these unnecessary files can be left out.

# Additional info
Waiting for https://github.com/misskey-dev/assets/pull/2 to be merged first, because the git submodule has to be updated then.