### PR TITLE
Fix #8535 Excessive stack ... 'SchemaTypeDef<?>'

### DIFF
--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -98,8 +98,8 @@ export interface Schema extends OfSchema {
 	readonly default?: (this['type'] extends TypeStringef ? StringDefToType<this['type']> : any) | null;
 	readonly maxLength?: number;
 	readonly minLength?: number;
-	readonly minimum?: number;
 	readonly maximum?: number;
+	readonly minimum?: number;
 	readonly pattern?: string;
 }
 
@@ -144,9 +144,9 @@ export type SchemaTypeDef<p extends Schema> =
 	p['type'] extends 'number' ? number :
 	p['type'] extends 'string' ? (
 		p['enum'] extends readonly string[] ?
-			p['enum'][number] :
-			p['format'] extends 'date-time' ? string : // Dateにする？？
-			string
+		p['enum'][number] :
+		p['format'] extends 'date-time' ? string : // Dateにする？？
+		string
 	) :
 	p['type'] extends 'boolean' ? boolean :
 	p['type'] extends 'object' ? (

--- a/packages/backend/src/misc/schema.ts
+++ b/packages/backend/src/misc/schema.ts
@@ -114,6 +114,9 @@ type RequiredPropertyNames<s extends Obj> = {
 
 export type Obj = Record<string, Schema>;
 
+// https://github.com/misskey-dev/misskey/issues/8535
+// To avoid excessive stack depth error,
+// deceive TypeScript with UnionToIntersection (or more precisely, `infer` expression within it).
 export type ObjType<s extends Obj, RequiredProps extends keyof s> =
 	UnionToIntersection<
 		{ -readonly [R in RequiredPropertyNames<s>]-?: SchemaType<s[R]> } &


### PR DESCRIPTION
Co-authored-by: acid-chicken <root@acid-chicken.com>

Fix #8535

# What
ObjTypeの型を変更し、`Excessive stack depth comparing types 'SchemaTypeDef<?>' and 'SchemaTypeDef<?>'` エラーを除去します。
Removing `Excessive stack depth comparing types 'SchemaTypeDef<?>' and 'SchemaTypeDef<?>'` error.

- NullOrUndefined 型を簡単なものに書き換えます。
- Schemaにminimum, maximum, patternの定義を追加

# Why

エラーの除去と、型チェックがちゃんとできるようにするため
