### PR TITLE
enhance(MFM): add parameters to rotate

### DIFF
--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -178,8 +178,12 @@ export default defineComponent({
 							return h(MkSparkle, {}, genEl(token.children));
 						}
 						case 'rotate': {
+							const rotateDir =
+								token.props.args.x ? 'X' :
+								token.props.args.y ? 'Y' :
+								'';
 							const degrees = parseInt(token.props.args.deg) || '90';
-							style = `transform: rotate(${degrees}deg); transform-origin: center center;`;
+							style = `transform: rotate${rotateDir}(${degrees}deg); transform-origin: center center;`;
 							break;
 						}
 					}

--- a/packages/client/src/components/mfm.ts
+++ b/packages/client/src/components/mfm.ts
@@ -178,12 +178,12 @@ export default defineComponent({
 							return h(MkSparkle, {}, genEl(token.children));
 						}
 						case 'rotate': {
-							const rotateDir =
-								token.props.args.x ? 'X' :
-								token.props.args.y ? 'Y' :
-								'';
+							const rotate =
+								token.props.args.x ? 'perspective(128px) rotateX' :
+								token.props.args.y ? 'perspective(128px) rotateY' :
+								'rotate';
 							const degrees = parseInt(token.props.args.deg) || '90';
-							style = `transform: rotate${rotateDir}(${degrees}deg); transform-origin: center center;`;
+							style = `transform: ${rotate}(${degrees}deg); transform-origin: center center;`;
 							break;
 						}
 					}


### PR DESCRIPTION
# What
The `x` and `y` parameters are added to the `$[rotate ]` MFM function rendering, analogous to the `$[spin ]` function.

# Why
fix #8523 