### PR TITLE
ci(docker): push arm64 images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,19 +5,33 @@ on:
     types: [published]
   workflow_dispatch:
 
+env:
+  DOCKER_IMAGE: misskey/misskey
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker Image
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+
+      # Setup QEMU to support arm64 image building
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Use buildx for multi-arch docker builds and for gh actions
+      # caching.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: misskey/misskey
+          images: ${{ env.DOCKER_IMAGE }}
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -27,6 +41,36 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: "linux/amd64,linux/arm64"
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      ## Push the built image to GHCR
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+      - name: Docker meta
+        id: meta_ghcr
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+
+      # While this builds, it's a no-op because we just built it
+      # before. We're just using build again to push from the buildkit
+      # builder setup earlier.
+      - name: Push to GHCR
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: "linux/amd64,linux/arm64"
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: ${{ steps.meta_ghcr.outputs.tags }}
+          labels: ${{ steps.meta_ghcr.outputs.labels }}


### PR DESCRIPTION
Resolve  #8555

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR adds multi-arch image building to the Github actions workflow docker release. This also publishes to GHCR, while keeping the current docker hub. I recognize that GHCR is technically an unnecessary change, so I'm happy to remove it if it's contentious. Also included is caching via Github actions cache API. This should marginally speed up docker image builds.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

I'd like to be able to run misskey in Docker on ARM64 devices and provide the ability to easily add more platforms in the future.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

I've tested this on my own fork, the results can be viewed here:

* Docker Image: https://hub.docker.com/r/jaredallard/misskey/tags
* GHCR Image: https://github.com/jaredallard/misskey/pkgs/container/misskey
* Github Actions Run: https://github.com/jaredallard/misskey/runs/6186949480?check_suite_focus=true
