### PR TITLE
chore(deps): Update github actions to use the same version as defined in .node-version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         cache: 'yarn'
         cache-dependency-path: |
           packages/backend/yarn.lock
@@ -31,7 +31,7 @@ jobs:
         submodules: true
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 18.x
         cache: 'yarn'
         cache-dependency-path: |
           packages/client/yarn.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
 
     services:
       postgres:
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         browser: [chrome]
 
     services:


### PR DESCRIPTION
# What
Update GitHub Actions to use the same version as defined in the .node-version file.

# Why

The [.node_version file](https://github.com/misskey-dev/misskey/blob/develop/.node-version) has `v18.x`, and with [this PR](https://github.com/misskey-dev/misskey/pull/8388) it will complain if the version is outdated. The CI can use `v17.x`, but it makes more sense to just use the same.

# Additional info (optional)
Right now all CI jobs are failing. I don't know if it fixes it, but potentially it can (will not fix lint that's for sure). I remember I had to update once from v16.x while updated my server, but I don't remember which version (and I couldn't find mention in the release notes)
