### PR TITLE
Fix duplicate token request dialog in plugin install

### DIFF
--- a/packages/client/src/pages/settings/plugin.install.vue
+++ b/packages/client/src/pages/settings/plugin.install.vue
@@ -79,37 +79,6 @@ async function install() {
 	}
 
 	const token = permissions == null || permissions.length === 0 ? null : await new Promise((res, rej) => {
-		os.popup(import('@/components/token-generate-window.vue'), {
-			title: i18n.ts.tokenRequested,
-			information: i18n.ts.pluginTokenRequestedDescription,
-			initialName: name,
-			initialPermissions: permissions
-		}, {
-			done: async result => {
-				const { name, permissions } = result;
-				const { token } = await os.api('miauth/gen-token', {
-					session: null,
-					name: name,
-					permission: permissions,
-				});
-
-				res(token);
-			}
-		}, 'closed');
-	});
-
-	installPlugin({
-		id: uuid(),
-		meta: {
-			name, version, author, description, permissions, config
-		},
-		token,
-		ast: serialize(ast)
-	});
-
-	os.success();
-
-	const token = permissions == null || permissions.length === 0 ? null : await new Promise((res, rej) => {
 		os.popup(defineAsyncComponent(() => import('@/components/token-generate-window.vue')), {
 			title: i18n.ts.tokenRequested,
 			information: i18n.ts.pluginTokenRequestedDescription,
@@ -127,6 +96,17 @@ async function install() {
 			}
 		}, 'closed');
 	});
+
+	installPlugin({
+		id: uuid(),
+		meta: {
+			name, version, author, description, permissions, config
+		},
+		token,
+		ast: serialize(ast)
+	});
+
+	os.success();
 
 	nextTick(() => {
 		unisonReload();


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Fixes a `token has already been declared` error preventing builds from working.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

This completely breaks building the Misskey frontend. 

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

This probably came about from trying to resolve the merge conflict of the Vite branch with mine, and GitHubs conflict resolution duplicated the entire dialog, causing this oversight. 🙏 