### PR TITLE
fix(mfm): <br> tag + newline

### DIFF
--- a/packages/backend/src/mfm/from-html.ts
+++ b/packages/backend/src/mfm/from-html.ts
@@ -6,6 +6,9 @@ const urlRegex     = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+/;
 const urlRegexFull = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+$/;
 
 export function fromHtml(html: string, hashtagNames?: string[]): string {
+	// some AP servers like Pixelfed use br tags as well as newlines
+	html = html.replace(/<br\s?\/?>\r?\n/gi, '\n');
+
 	const dom = parse5.parseFragment(html);
 
 	let text = '';


### PR DESCRIPTION
# What
Before processing incoming HTML to MFM, `<br>` tags that are followed by the end of a line (`\n` or `\r\n`) are replaced with just a newline (`\n`) to remove the duplicate meaning of a `<br>` tag and a newline. Because this would be quite hard to do with the already parsed HTML this is done before parsing the HTML.

# Why
fix misskey-dev/misskey#8617