### PR TITLE
test: テストコード内でまだ`__dirname`が使われていたので置き換えた

### DIFF
--- a/packages/backend/.eslintrc.cjs
+++ b/packages/backend/.eslintrc.cjs
@@ -16,6 +16,17 @@ module.exports = {
 					'position': 'after'
 				}
 			],
-		}]
+		}],
+		'no-restricted-globals': [
+			'error',
+			{
+				'name': '__dirname',
+				'message': 'Not in ESModule. Use `import.meta.url` instead.'
+			},
+			{
+				'name': '__filename',
+				'message': 'Not in ESModule. Use `import.meta.url` instead.'
+			}
+	]
 	},
 };

--- a/packages/backend/test/.eslintrc
+++ b/packages/backend/test/.eslintrc
@@ -1,7 +1,0 @@
-{
-	"env": {
-		"node": true,
-		"mocha": true,
-		"commonjs": true
-	}
-}

--- a/packages/backend/test/.eslintrc.cjs
+++ b/packages/backend/test/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+	parserOptions: {
+		tsconfigRootDir: __dirname,
+		project: ['./tsconfig.json'],
+	},
+	extends: ['../.eslintrc.cjs'],
+	env: {
+		node: true,
+		mocha: true,
+	},
+};

--- a/packages/backend/test/get-file-info.ts
+++ b/packages/backend/test/get-file-info.ts
@@ -1,10 +1,15 @@
 import * as assert from 'assert';
-import { async } from './utils.js';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { getFileInfo } from '../src/misc/get-file-info.js';
+import { async } from './utils.js';
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = dirname(_filename);
 
 describe('Get file info', () => {
 	it('Empty file', async (async () => {
-		const path = `${__dirname}/resources/emptyfile`;
+		const path = `${_dirname}/resources/emptyfile`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -22,7 +27,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Generic JPEG', async (async () => {
-		const path = `${__dirname}/resources/Lenna.jpg`;
+		const path = `${_dirname}/resources/Lenna.jpg`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -40,7 +45,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Generic APNG', async (async () => {
-		const path = `${__dirname}/resources/anime.png`;
+		const path = `${_dirname}/resources/anime.png`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -58,7 +63,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Generic AGIF', async (async () => {
-		const path = `${__dirname}/resources/anime.gif`;
+		const path = `${_dirname}/resources/anime.gif`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -76,7 +81,7 @@ describe('Get file info', () => {
 	}));
 
 	it('PNG with alpha', async (async () => {
-		const path = `${__dirname}/resources/with-alpha.png`;
+		const path = `${_dirname}/resources/with-alpha.png`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -94,7 +99,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Generic SVG', async (async () => {
-		const path = `${__dirname}/resources/image.svg`;
+		const path = `${_dirname}/resources/image.svg`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -113,7 +118,7 @@ describe('Get file info', () => {
 
 	it('SVG with XML definition', async (async () => {
 		// https://github.com/misskey-dev/misskey/issues/4413
-		const path = `${__dirname}/resources/with-xml-def.svg`;
+		const path = `${_dirname}/resources/with-xml-def.svg`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -131,7 +136,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Dimension limit', async (async () => {
-		const path = `${__dirname}/resources/25000x25000.png`;
+		const path = `${_dirname}/resources/25000x25000.png`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;
@@ -149,7 +154,7 @@ describe('Get file info', () => {
 	}));
 
 	it('Rotate JPEG', async (async () => {
-		const path = `${__dirname}/resources/rotate.jpg`;
+		const path = `${_dirname}/resources/rotate.jpg`;
 		const info = await getFileInfo(path) as any;
 		delete info.warnings;
 		delete info.blurhash;

--- a/packages/backend/test/user-notes.ts
+++ b/packages/backend/test/user-notes.ts
@@ -2,7 +2,12 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { async, signup, request, post, uploadFile, startServer, shutdownServer } from './utils.js';
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = dirname(_filename);
 
 describe('users/notes', () => {
 	let p: childProcess.ChildProcess;
@@ -15,8 +20,8 @@ describe('users/notes', () => {
 	before(async () => {
 		p = await startServer();
 		alice = await signup({ username: 'alice' });
-		const jpg = await uploadFile(alice, __dirname + '/resources/Lenna.jpg');
-		const png = await uploadFile(alice, __dirname + '/resources/Lenna.png');
+		const jpg = await uploadFile(alice, _dirname + '/resources/Lenna.jpg');
+		const png = await uploadFile(alice, _dirname + '/resources/Lenna.png');
 		jpgNote = await post(alice, {
 			fileIds: [jpg.id]
 		});

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -1,4 +1,6 @@
 import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import * as WebSocket from 'ws';
 import * as misskey from 'misskey-js';
 import fetch from 'node-fetch';
@@ -8,6 +10,9 @@ import * as http from 'node:http';
 import loadConfig from '../src/config/load.js';
 import { SIGKILL } from 'constants';
 import { entities } from '../src/db/postgre.js';
+
+const _filename = fileURLToPath(import.meta.url);
+const _dirname = dirname(_filename);
 
 const config = loadConfig();
 export const port = config.port;
@@ -72,7 +77,7 @@ export const react = async (user: any, note: any, reaction: string): Promise<any
 export const uploadFile = (user: any, path?: string): Promise<any> => {
 		const formData = new FormData();
 		formData.append('i', user.token);
-		formData.append('file', fs.createReadStream(path || __dirname + '/resources/Lenna.png'));
+		formData.append('file', fs.createReadStream(path || _dirname + '/resources/Lenna.png'));
 
 		return fetch(`http://localhost:${port}/api/drive/files/create`, {
 			method: 'post',
@@ -139,7 +144,7 @@ export const simpleGet = async (path: string, accept = '*/*'): Promise<{ status?
 
 export function launchServer(callbackSpawnedProcess: (p: childProcess.ChildProcess) => void, moreProcess: () => Promise<void> = async () => {}) {
 	return (done: (err?: Error) => any) => {
-		const p = childProcess.spawn('node', [__dirname + '/../index.js'], {
+		const p = childProcess.spawn('node', [_dirname + '/../index.js'], {
 			stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
 			env: { NODE_ENV: 'test', PATH: process.env.PATH }
 		});
@@ -178,7 +183,7 @@ export function startServer(timeout = 30 * 1000): Promise<childProcess.ChildProc
 			rej('timeout to start');
 		}, timeout);
 
-		const p = childProcess.spawn('node', [__dirname + '/../built/index.js'], {
+		const p = childProcess.spawn('node', [_dirname + '/../built/index.js'], {
 			stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
 			env: { NODE_ENV: 'test', PATH: process.env.PATH }
 		});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- https://github.com/misskey-dev/misskey/issues/7658 でテストコード内の`__dirname`が置き換えられておらず、テストが死んでいたため、置き換えた。
- コード内に`__dirname`があったら、もう使えないのでESLintがエラーを出すようにした。
- テスト用のeslintrcが動くようにした。（tsconfigが読み込めておらずエラーが出ていたので親を継承して設定を上書きした）

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
