### PR TITLE
enhance: page image component with alt text

### DIFF
--- a/packages/client/src/components/page/page.image.vue
+++ b/packages/client/src/components/page/page.image.vue
@@ -1,11 +1,12 @@
 <template>
 <div class="lzyxtsnt">
-	<img v-if="image" :src="image.url"/>
+	<ImgWithBlurhash v-if="image" :hash="image.blurhash" :src="url" :alt="image.comment" :title="image.comment" :cover="false"/>
 </div>
 </template>
 
 <script lang="ts" setup>
 import { defineComponent, PropType } from 'vue';
+import ImgWithBlurhash from '@/components/img-with-blurhash.vue';
 import * as os from '@/os';
 import { ImageBlock } from '@/scripts/hpml/block';
 import { Hpml } from '@/scripts/hpml/evaluator';

--- a/packages/client/src/components/page/page.image.vue
+++ b/packages/client/src/components/page/page.image.vue
@@ -4,31 +4,24 @@
 </div>
 </template>
 
-<script lang="ts">
+<script lang="ts" setup>
 import { defineComponent, PropType } from 'vue';
 import * as os from '@/os';
 import { ImageBlock } from '@/scripts/hpml/block';
 import { Hpml } from '@/scripts/hpml/evaluator';
 
-export default defineComponent({
-	props: {
-		block: {
-			type: Object as PropType<ImageBlock>,
-			required: true
-		},
-		hpml: {
-			type: Object as PropType<Hpml>,
-			required: true
-		}
+const props = defineProps({
+	block: {
+		type: Object as PropType<ImageBlock>,
+		required: true
 	},
-	setup(props, ctx) {
-		const image = props.hpml.page.attachedFiles.find(x => x.id === props.block.fileId);
-
-		return {
-			image
-		};
+	hpml: {
+		type: Object as PropType<Hpml>,
+		required: true
 	}
 });
+
+const image = props.hpml.page.attachedFiles.find(x => x.id === props.block.fileId);
 </script>
 
 <style lang="scss" scoped>

--- a/packages/client/src/components/page/page.image.vue
+++ b/packages/client/src/components/page/page.image.vue
@@ -12,15 +12,9 @@ import { ImageBlock } from '@/scripts/hpml/block';
 import { Hpml } from '@/scripts/hpml/evaluator';
 
 const props = defineProps({
-	block: {
-		type: Object as PropType<ImageBlock>,
-		required: true
-	},
-	hpml: {
-		type: Object as PropType<Hpml>,
-		required: true
-	}
-});
+	block: PropType<ImageBlock>,
+	hpml: PropType<Hpml>,
+}>();
 
 const image = props.hpml.page.attachedFiles.find(x => x.id === props.block.fileId);
 </script>

--- a/packages/client/src/components/page/page.image.vue
+++ b/packages/client/src/components/page/page.image.vue
@@ -11,7 +11,7 @@ import * as os from '@/os';
 import { ImageBlock } from '@/scripts/hpml/block';
 import { Hpml } from '@/scripts/hpml/evaluator';
 
-const props = defineProps({
+const props = defineProps<{
 	block: PropType<ImageBlock>,
 	hpml: PropType<Hpml>,
 }>();

--- a/packages/client/src/components/page/page.image.vue
+++ b/packages/client/src/components/page/page.image.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="lzyxtsnt">
-	<ImgWithBlurhash v-if="image" :hash="image.blurhash" :src="url" :alt="image.comment" :title="image.comment" :cover="false"/>
+	<ImgWithBlurhash v-if="image" :hash="image.blurhash" :src="image.url" :alt="image.comment" :title="image.comment" :cover="false"/>
 </div>
 </template>
 


### PR DESCRIPTION
# What
- refactor page image component to composition API
- image uses the existing image component to display the image, so blurhash and alt text work

# Why
succeeds #6601