### PR TITLE
enhance: Add NOTE related to Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You should also include the user name that made the change.
 
 ## 12.x.x (unreleased)
 ### NOTE
-- From this version, Node 18.0.0 or later is required.
+- From this version, Node.js v18.0.0 or later is required.
 
 ### Improvements
 - enhance: ドライブに画像ファイルをアップロードするときオリジナル画像を破棄してwebpublicのみ保持するオプション @tamaina
@@ -27,6 +27,8 @@ You should also include the user name that made the change.
 - Federation: Add rel attribute to host-meta @mei23
 
 ## 12.110.1 (2022/04/23)
+**ℹ️ Important**<br>
+This version doesn't require Node.js v18.0.0 or later.
 
 ### Bugfixes
 - Fix GOP rendering @syuilo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ You should also include the user name that made the change.
 - Federation: Add rel attribute to host-meta @mei23
 
 ## 12.110.1 (2022/04/23)
-**ℹ️ Important**<br>
-This version doesn't require Node.js v18.0.0 or later.
+### NOTE<br>
+Node.js v16.14.0 is recommended for building Misskey v12.110.1<br>
+This version doesn't require Node.js v16.15.0 or later.<br>
+See: https://github.com/misskey-dev/misskey/blob/master/.node-version
 
 ### Bugfixes
 - Fix GOP rendering @syuilo


### PR DESCRIPTION
日本語圏だけでなく英語圏のMisskeyインスタンス管理者やユーザーからも、最新バージョンのMisskey v12.110.1をビルドする際にNode.js v18が必要なのか必要でないのか、という疑問や質問が最近散見されます。インスタンス管理者やユーザーの誤解や混乱を避けるためにfediverse上でアナウンスすることも大事ですが、CHANGELOGに「v12.110.1ではNode.js v18またはそれ以降のバージョンについては必要ない」と明記することも大事なように考えます。

※その他、細かいですが文言の微修正を行いました。