### PR TITLE
fix: hide metadata of private notes

### DIFF
--- a/packages/backend/src/misc/get-note-summary.ts
+++ b/packages/backend/src/misc/get-note-summary.ts
@@ -9,10 +9,6 @@ export const getNoteSummary = (note: Packed<'Note'>): string => {
 		return `(❌⛔)`;
 	}
 
-	if (note.isHidden) {
-		return `(⛔)`;
-	}
-
 	let summary = '';
 
 	// 本文

--- a/packages/backend/src/models/repositories/note-favorite.ts
+++ b/packages/backend/src/models/repositories/note-favorite.ts
@@ -24,6 +24,6 @@ export const NoteFavoriteRepository = db.getRepository(NoteFavorite).extend({
 		me: { id: User['id'] }
 	) {
 		return Promise.allSettled(favorites.map(x => this.pack(x, me)))
-		.then(promises => promises.flatMap(result => result.status === 'fulfilled' ? [result.value] : []);
+		.then(promises => promises.flatMap(result => result.status === 'fulfilled' ? [result.value] : []));
 	},
 });

--- a/packages/backend/src/models/repositories/note-favorite.ts
+++ b/packages/backend/src/models/repositories/note-favorite.ts
@@ -14,6 +14,7 @@ export const NoteFavoriteRepository = db.getRepository(NoteFavorite).extend({
 			id: favorite.id,
 			createdAt: favorite.createdAt.toISOString(),
 			noteId: favorite.noteId,
+			// may throw error
 			note: await Notes.pack(favorite.note || favorite.noteId, me),
 		};
 	},
@@ -22,6 +23,7 @@ export const NoteFavoriteRepository = db.getRepository(NoteFavorite).extend({
 		favorites: any[],
 		me: { id: User['id'] }
 	) {
-		return Promise.all(favorites.map(x => this.pack(x, me)));
+		return Promise.allSettled(favorites.map(x => this.pack(x, me)))
+		.then(promises => promises.flatMap(result => result.status === 'fulfilled' ? [result.value] : []);
 	},
 });

--- a/packages/backend/src/models/repositories/note-reaction.ts
+++ b/packages/backend/src/models/repositories/note-reaction.ts
@@ -25,8 +25,22 @@ export const NoteReactionRepository = db.getRepository(NoteReaction).extend({
 			user: await Users.pack(reaction.user ?? reaction.userId, me),
 			type: convertLegacyReaction(reaction.reaction),
 			...(opts.withNote ? {
+				// may throw error
 				note: await Notes.pack(reaction.note ?? reaction.noteId, me),
 			} : {}),
 		};
 	},
+
+	async packMany(
+		src: NoteReaction[],
+		me?: { id: User['id'] } | null | undefined,
+		options?: {
+			withNote: booleam;
+		},
+	): Promise<Packed<'NoteReaction'>[]> {
+		const reactions = await Promise.allSettled(src.map(reaction => this.pack(reaction, me, options)));
+
+		// filter out rejected promises, only keep fulfilled values
+		return reactions.flatMap(result => result.status === 'fulfilled' ? [result.value] : []);
+	}
 });

--- a/packages/backend/src/models/schema/note.ts
+++ b/packages/backend/src/models/schema/note.ts
@@ -52,10 +52,6 @@ export const packedNoteSchema = {
 			optional: true, nullable: true,
 			ref: 'Note',
 		},
-		isHidden: {
-			type: 'boolean',
-			optional: true, nullable: false,
-		},
 		visibility: {
 			type: 'string',
 			optional: false, nullable: false,

--- a/packages/backend/src/server/api/common/getters.ts
+++ b/packages/backend/src/server/api/common/getters.ts
@@ -2,12 +2,20 @@ import { IdentifiableError } from '@/misc/identifiable-error.js';
 import { User } from '@/models/entities/user.js';
 import { Note } from '@/models/entities/note.js';
 import { Notes, Users } from '@/models/index.js';
+import { generateVisibilityQuery } from './generate-visibility-query.js';
 
 /**
- * Get note for API processing
+ * Get note for API processing, taking into account visibility.
  */
-export async function getNote(noteId: Note['id']) {
-	const note = await Notes.findOneBy({ id: noteId });
+export async function getNote(noteId: Note['id'], me: { id: User['id'] } | null) {
+	const query = Notes.createQueryBuilder('note')
+		.where("note.id = :id", {
+			id: noteId,
+		});
+
+	generateVisibilityQuery(query, me);
+
+	const note = await query.getOne();
 
 	if (note == null) {
 		throw new IdentifiableError('9725d0ce-ba28-4dde-95a7-2cbb2c15de24', 'No such note.');

--- a/packages/backend/src/server/api/endpoints/admin/promo/create.ts
+++ b/packages/backend/src/server/api/endpoints/admin/promo/create.ts
@@ -35,7 +35,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/clips/add-note.ts
+++ b/packages/backend/src/server/api/endpoints/clips/add-note.ts
@@ -52,7 +52,7 @@ export default define(meta, paramDef, async (ps, user) => {
 		throw new ApiError(meta.errors.noSuchClip);
 	}
 
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/clips.ts
+++ b/packages/backend/src/server/api/endpoints/notes/clips.ts
@@ -38,7 +38,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, me) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, me).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/conversation.ts
+++ b/packages/backend/src/server/api/endpoints/notes/conversation.ts
@@ -50,7 +50,11 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	async function get(id: any) {
 		i++;
-		const p = await Notes.findOneBy({ id });
+		const p = await getNote(id, user).catch(e => {
+			if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') return null;
+			throw e;
+		});
+
 		if (p == null) return;
 
 		if (i > ps.offset!) {

--- a/packages/backend/src/server/api/endpoints/notes/conversation.ts
+++ b/packages/backend/src/server/api/endpoints/notes/conversation.ts
@@ -40,7 +40,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -7,9 +7,9 @@ import { DriveFile } from '@/models/entities/drive-file.js';
 import { Note } from '@/models/entities/note.js';
 import { Channel } from '@/models/entities/channel.js';
 import { MAX_NOTE_TEXT_LENGTH } from '@/const.js';
-import { noteVisibilities } from '../../../../types.js';
 import { ApiError } from '../../error.js';
 import define from '../../define.js';
+import { getNote } from '../../common/getters.js';
 
 export const meta = {
 	tags: ['notes'],
@@ -185,11 +185,12 @@ export default define(meta, paramDef, async (ps, user) => {
 	let renote: Note | null = null;
 	if (ps.renoteId != null) {
 		// Fetch renote to note
-		renote = await Notes.findOneBy({ id: ps.renoteId });
+		renote = await getNote(ps.renoteId, user).catch(e => {
+			if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchRenoteTarget);
+			throw e;
+		});
 
-		if (renote == null) {
-			throw new ApiError(meta.errors.noSuchRenoteTarget);
-		} else if (renote.renoteId && !renote.text && !renote.fileIds && !renote.hasPoll) {
+		if (renote.renoteId && !renote.text && !renote.fileIds && !renote.hasPoll) {
 			throw new ApiError(meta.errors.cannotReRenote);
 		}
 
@@ -208,11 +209,12 @@ export default define(meta, paramDef, async (ps, user) => {
 	let reply: Note | null = null;
 	if (ps.replyId != null) {
 		// Fetch reply
-		reply = await Notes.findOneBy({ id: ps.replyId });
+		reply = await getNote(ps.replyId, user).catch(e => {
+			if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchReplyTarget);
+			throw e;
+		});
 
-		if (reply == null) {
-			throw new ApiError(meta.errors.noSuchReplyTarget);
-		} else if (reply.renoteId && !reply.text && !reply.fileIds && !reply.hasPoll) {
+		if (reply.renoteId && !reply.text && !reply.fileIds && !reply.hasPoll) {
 			throw new ApiError(meta.errors.cannotReplyToPureRenote);
 		}
 

--- a/packages/backend/src/server/api/endpoints/notes/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/delete.ts
@@ -43,7 +43,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/favorites/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/favorites/create.ts
@@ -37,7 +37,7 @@ export const paramDef = {
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
 	// Get favoritee
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/favorites/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/favorites/delete.ts
@@ -36,7 +36,7 @@ export const paramDef = {
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
 	// Get favoritee
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/polls/vote.ts
+++ b/packages/backend/src/server/api/endpoints/notes/polls/vote.ts
@@ -72,7 +72,7 @@ export default define(meta, paramDef, async (ps, user) => {
 	const createdAt = new Date();
 
 	// Get votee
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/reactions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions.ts
@@ -3,6 +3,7 @@ import { NoteReactions } from '@/models/index.js';
 import { NoteReaction } from '@/models/entities/note-reaction.js';
 import define from '../../define.js';
 import { ApiError } from '../../error.js';
+import { getNote } from '../../common/getters.js';
 
 export const meta = {
 	tags: ['notes', 'reactions'],

--- a/packages/backend/src/server/api/endpoints/notes/reactions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions.ts
@@ -72,5 +72,5 @@ export default define(meta, paramDef, async (ps, user) => {
 		relations: ['user', 'user.avatar', 'user.banner', 'note'],
 	});
 
-	return await Promise.all(reactions.map(reaction => NoteReactions.pack(reaction, user)));
+	return await NoteReactions.packMany(reactions, user);
 });

--- a/packages/backend/src/server/api/endpoints/notes/reactions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions.ts
@@ -43,6 +43,12 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
+	// check note visibility
+	const note = await getNote(ps.noteId, user).catch(e => {
+		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
+		throw e;
+	});
+
 	const query = {
 		noteId: ps.noteId,
 	} as FindOptionsWhere<NoteReaction>;

--- a/packages/backend/src/server/api/endpoints/notes/reactions/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions/create.ts
@@ -42,7 +42,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/reactions/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/reactions/delete.ts
@@ -42,7 +42,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/renotes.ts
+++ b/packages/backend/src/server/api/endpoints/notes/renotes.ts
@@ -44,7 +44,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/show.ts
+++ b/packages/backend/src/server/api/endpoints/notes/show.ts
@@ -39,6 +39,10 @@ export default define(meta, paramDef, async (ps, user) => {
 	});
 
 	return await Notes.pack(note, user, {
+		// FIXME: packing with detail may throw an error if the reply or renote is not visible (#8774)
 		detail: true,
+	}).catch(err => {
+		if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
+		throw err;
 	});
 });

--- a/packages/backend/src/server/api/endpoints/notes/show.ts
+++ b/packages/backend/src/server/api/endpoints/notes/show.ts
@@ -33,7 +33,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/show.ts
+++ b/packages/backend/src/server/api/endpoints/notes/show.ts
@@ -33,9 +33,9 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId, user).catch(e => {
-		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
-		throw e;
+	const note = await getNote(ps.noteId, user).catch(err => {
+		if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
+		throw err;
 	});
 
 	return await Notes.pack(note, user, {

--- a/packages/backend/src/server/api/endpoints/notes/state.ts
+++ b/packages/backend/src/server/api/endpoints/notes/state.ts
@@ -1,4 +1,5 @@
 import { NoteFavorites, Notes, NoteThreadMutings, NoteWatchings } from '@/models/index.js';
+import { getNote } from '../../common/getters.js';
 import define from '../../define.js';
 
 export const meta = {
@@ -36,7 +37,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await Notes.findOneByOrFail({ id: ps.noteId });
+	const note = await getNote(ps.noteId, user);
 
 	const [favorite, watching, threadMuting] = await Promise.all([
 		NoteFavorites.count({

--- a/packages/backend/src/server/api/endpoints/notes/thread-muting/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/thread-muting/create.ts
@@ -31,7 +31,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/thread-muting/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/thread-muting/delete.ts
@@ -29,7 +29,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/translate.ts
+++ b/packages/backend/src/server/api/endpoints/notes/translate.ts
@@ -38,14 +38,10 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});
-
-	if (!(await Notes.isVisibleForMe(note, user ? user.id : null))) {
-		return 204; // TODO: 良い感じのエラー返す
-	}
 
 	if (note.text == null) {
 		return 204;

--- a/packages/backend/src/server/api/endpoints/notes/unrenote.ts
+++ b/packages/backend/src/server/api/endpoints/notes/unrenote.ts
@@ -37,7 +37,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/watching/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/watching/create.ts
@@ -29,7 +29,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/notes/watching/delete.ts
+++ b/packages/backend/src/server/api/endpoints/notes/watching/delete.ts
@@ -29,7 +29,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/promo/read.ts
+++ b/packages/backend/src/server/api/endpoints/promo/read.ts
@@ -28,7 +28,7 @@ export const paramDef = {
 
 // eslint-disable-next-line import/no-default-export
 export default define(meta, paramDef, async (ps, user) => {
-	const note = await getNote(ps.noteId).catch(e => {
+	const note = await getNote(ps.noteId, user).catch(e => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});

--- a/packages/backend/src/server/api/endpoints/users/reactions.ts
+++ b/packages/backend/src/server/api/endpoints/users/reactions.ts
@@ -62,5 +62,5 @@ export default define(meta, paramDef, async (ps, me) => {
 		.take(ps.limit)
 		.getMany();
 
-	return await Promise.all(reactions.map(reaction => NoteReactions.pack(reaction, me, { withNote: true })));
+	return await NoteReactions.packMany(reactions, me, { withNote: true });
 });

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -1,4 +1,8 @@
 import Connection from '.';
+import { Note } from '@/models/entities/note.js';
+import { Notes } from '@/models/index.js';
+import { Packed } from '@/misc/schema.js';
+import { IdentifiableError } from '@/misc/identifiable-error.js';
 
 /**
  * Stream channel
@@ -52,6 +56,23 @@ export default abstract class Channel {
 			type: type,
 			body: body,
 		});
+	}
+
+	protected withPackedNote(callback: (Packed<'Note'>) => void): (Note) => void {
+		return async (note: Note) => {
+			try {
+				const packed = await Notes.pack(note, this.user.id, { detail: true });
+
+				callback(packed);
+			} catch (e) {
+				if (e instanceof IdentifiableError && e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') {
+					// skip: note not visible to user
+					return;
+				} else {
+					throw e;
+				}
+			}
+		};
 	}
 
 	public abstract init(params: any): void;

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -58,7 +58,7 @@ export default abstract class Channel {
 		});
 	}
 
-	protected withPackedNote(callback: (Packed<'Note'>) => void): (Note) => void {
+	protected withPackedNote(callback: (note: Packed<'Note'>) => void): (Note) => void {
 		return async (note: Note) => {
 			try {
 				const packed = await Notes.pack(note, this.user.id, { detail: true });

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -61,6 +61,15 @@ export default abstract class Channel {
 	protected withPackedNote(callback: (note: Packed<'Note'>) => void): (Note) => void {
 		return async (note: Note) => {
 			try {
+				// because `note` was previously JSON.stringify'ed, the fields that
+				// were objects before are now strings and have to be restored or
+				// removed from the object
+				note.createdAt = new Date(note.createdAt);
+				delete note.reply;
+				delete note.renote;
+				delete note.user;
+				delete note.channel;
+
 				const packed = await Notes.pack(note, this.user.id, { detail: true });
 
 				callback(packed);

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -70,7 +70,7 @@ export default abstract class Channel {
 				delete note.user;
 				delete note.channel;
 
-				const packed = await Notes.pack(note, this.user.id, { detail: true });
+				const packed = await Notes.pack(note, this.user, { detail: true });
 
 				callback(packed);
 			} catch (e) {

--- a/packages/backend/src/server/api/stream/channels/antenna.ts
+++ b/packages/backend/src/server/api/stream/channels/antenna.ts
@@ -35,12 +35,12 @@ export default class extends Channel {
 				this.connection.cacheNote(note);
 
 				this.send('note', note);
-			} catch (e) {
-				if (e instanceof IdentifiableError && e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') {
+			} catch (err) {
+				if (err instanceof IdentifiableError && err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') {
 					// skip: note not visible to user
 					return;
 				} else {
-					throw e;
+					throw err;
 				}
 			}
 		} else {

--- a/packages/backend/src/server/api/stream/channels/channel.ts
+++ b/packages/backend/src/server/api/stream/channels/channel.ts
@@ -1,5 +1,5 @@
 import Channel from '../channel.js';
-import { Notes, Users } from '@/models/index.js';
+import { Users } from '@/models/index.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { User } from '@/models/entities/user.js';
 import { StreamMessages } from '../types.js';
@@ -15,7 +15,7 @@ export default class extends Channel {
 
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -29,19 +29,6 @@ export default class extends Channel {
 
 	private async onNote(note: Packed<'Note'>) {
 		if (note.channelId !== this.channelId) return;
-
-		// リプライなら再pack
-		if (note.replyId != null) {
-			note.reply = await Notes.pack(note.replyId, this.user, {
-				detail: true,
-			});
-		}
-		// Renoteなら再pack
-		if (note.renoteId != null) {
-			note.renote = await Notes.pack(note.renoteId, this.user, {
-				detail: true,
-			});
-		}
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.muting)) return;

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -1,6 +1,5 @@
 import Channel from '../channel.js';
 import { fetchMeta } from '@/misc/fetch-meta.js';
-import { Notes } from '@/models/index.js';
 import { checkWordMute } from '@/misc/check-word-mute.js';
 import { isInstanceMuted } from '@/misc/is-instance-muted.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
@@ -13,7 +12,7 @@ export default class extends Channel {
 
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -29,19 +28,6 @@ export default class extends Channel {
 	private async onNote(note: Packed<'Note'>) {
 		if (note.visibility !== 'public') return;
 		if (note.channelId != null) return;
-
-		// リプライなら再pack
-		if (note.replyId != null) {
-			note.reply = await Notes.pack(note.replyId, this.user, {
-				detail: true,
-			});
-		}
-		// Renoteなら再pack
-		if (note.renoteId != null) {
-			note.renote = await Notes.pack(note.renoteId, this.user, {
-				detail: true,
-			});
-		}
 
 		// 関係ない返信は除外
 		if (note.reply && !this.user!.showTimelineReplies) {

--- a/packages/backend/src/server/api/stream/channels/hashtag.ts
+++ b/packages/backend/src/server/api/stream/channels/hashtag.ts
@@ -1,5 +1,4 @@
 import Channel from '../channel.js';
-import { Notes } from '@/models/index.js';
 import { normalizeForSearch } from '@/misc/normalize-for-search.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { Packed } from '@/misc/schema.js';
@@ -12,7 +11,7 @@ export default class extends Channel {
 
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -28,13 +27,6 @@ export default class extends Channel {
 		const noteTags = note.tags ? note.tags.map((t: string) => t.toLowerCase()) : [];
 		const matched = this.q.some(tags => tags.every(tag => noteTags.includes(normalizeForSearch(tag))));
 		if (!matched) return;
-
-		// Renoteなら再pack
-		if (note.renoteId != null) {
-			note.renote = await Notes.pack(note.renoteId, this.user, {
-				detail: true,
-			});
-		}
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.muting)) return;

--- a/packages/backend/src/server/api/stream/channels/home-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/home-timeline.ts
@@ -1,5 +1,4 @@
 import Channel from '../channel.js';
-import { Notes } from '@/models/index.js';
 import { checkWordMute } from '@/misc/check-word-mute.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { isInstanceMuted } from '@/misc/is-instance-muted.js';
@@ -12,7 +11,7 @@ export default class extends Channel {
 
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -30,29 +29,6 @@ export default class extends Channel {
 
 		// Ignore notes from instances the user has muted
 		if (isInstanceMuted(note, new Set<string>(this.userProfile?.mutedInstances ?? []))) return;
-
-		if (['followers', 'specified'].includes(note.visibility)) {
-			note = await Notes.pack(note.id, this.user!, {
-				detail: true,
-			});
-
-			if (note.isHidden) {
-				return;
-			}
-		} else {
-			// リプライなら再pack
-			if (note.replyId != null) {
-				note.reply = await Notes.pack(note.replyId, this.user!, {
-					detail: true,
-				});
-			}
-			// Renoteなら再pack
-			if (note.renoteId != null) {
-				note.renote = await Notes.pack(note.renoteId, this.user!, {
-					detail: true,
-				});
-			}
-		}
 
 		// 関係ない返信は除外
 		if (note.reply && !this.user!.showTimelineReplies) {

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -1,6 +1,5 @@
 import Channel from '../channel.js';
 import { fetchMeta } from '@/misc/fetch-meta.js';
-import { Notes } from '@/models/index.js';
 import { checkWordMute } from '@/misc/check-word-mute.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { Packed } from '@/misc/schema.js';
@@ -12,7 +11,7 @@ export default class extends Channel {
 
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -29,19 +28,6 @@ export default class extends Channel {
 		if (note.user.host !== null) return;
 		if (note.visibility !== 'public') return;
 		if (note.channelId != null && !this.followingChannels.has(note.channelId)) return;
-
-		// リプライなら再pack
-		if (note.replyId != null) {
-			note.reply = await Notes.pack(note.replyId, this.user, {
-				detail: true,
-			});
-		}
-		// Renoteなら再pack
-		if (note.renoteId != null) {
-			note.renote = await Notes.pack(note.renoteId, this.user, {
-				detail: true,
-			});
-		}
 
 		// 関係ない返信は除外
 		if (note.reply && !this.user!.showTimelineReplies) {

--- a/packages/backend/src/server/api/stream/channels/main.ts
+++ b/packages/backend/src/server/api/stream/channels/main.ts
@@ -1,5 +1,4 @@
 import Channel from '../channel.js';
-import { Notes } from '@/models/index.js';
 import { isInstanceMuted, isUserFromMutedInstance } from '@/misc/is-instance-muted.js';
 
 export default class extends Channel {
@@ -16,26 +15,12 @@ export default class extends Channel {
 					if (isUserFromMutedInstance(data.body, new Set<string>(this.userProfile?.mutedInstances ?? []))) return;
 					if (data.body.userId && this.muting.has(data.body.userId)) return;
 
-					if (data.body.note && data.body.note.isHidden) {
-						const note = await Notes.pack(data.body.note.id, this.user, {
-							detail: true,
-						});
-						this.connection.cacheNote(note);
-						data.body.note = note;
-					}
 					break;
 				}
 				case 'mention': {
 					if (isInstanceMuted(data.body, new Set<string>(this.userProfile?.mutedInstances ?? []))) return;
 
 					if (this.muting.has(data.body.userId)) return;
-					if (data.body.isHidden) {
-						const note = await Notes.pack(data.body.id, this.user, {
-							detail: true,
-						});
-						this.connection.cacheNote(note);
-						data.body = note;
-					}
 					break;
 				}
 			}

--- a/packages/backend/src/server/api/stream/channels/user-list.ts
+++ b/packages/backend/src/server/api/stream/channels/user-list.ts
@@ -1,5 +1,5 @@
 import Channel from '../channel.js';
-import { Notes, UserListJoinings, UserLists } from '@/models/index.js';
+import { UserListJoinings, UserLists } from '@/models/index.js';
 import { User } from '@/models/entities/user.js';
 import { isUserRelated } from '@/misc/is-user-related.js';
 import { Packed } from '@/misc/schema.js';
@@ -15,7 +15,7 @@ export default class extends Channel {
 	constructor(id: string, connection: Channel['connection']) {
 		super(id, connection);
 		this.updateListUsers = this.updateListUsers.bind(this);
-		this.onNote = this.onNote.bind(this);
+		this.onNote = this.withPackedNote(this.onNote.bind(this));
 	}
 
 	public async init(params: any) {
@@ -50,29 +50,6 @@ export default class extends Channel {
 
 	private async onNote(note: Packed<'Note'>) {
 		if (!this.listUsers.includes(note.userId)) return;
-
-		if (['followers', 'specified'].includes(note.visibility)) {
-			note = await Notes.pack(note.id, this.user, {
-				detail: true,
-			});
-
-			if (note.isHidden) {
-				return;
-			}
-		} else {
-			// リプライなら再pack
-			if (note.replyId != null) {
-				note.reply = await Notes.pack(note.replyId, this.user, {
-					detail: true,
-				});
-			}
-			// Renoteなら再pack
-			if (note.renoteId != null) {
-				note.renote = await Notes.pack(note.renoteId, this.user, {
-					detail: true,
-				});
-			}
-		}
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.muting)) return;

--- a/packages/backend/src/server/api/stream/types.ts
+++ b/packages/backend/src/server/api/stream/types.ts
@@ -243,7 +243,7 @@ export type StreamMessages = {
 	};
 	notes: {
 		name: 'notesStream';
-		payload: Packed<'Note'>;
+		payload: Note;
 	};
 };
 

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -322,23 +322,32 @@ router.get('/notes/:note', async (ctx, next) => {
 	});
 
 	if (note) {
-		const _note = await Notes.pack(note);
-		const profile = await UserProfiles.findOneByOrFail({ userId: note.userId });
-		const meta = await fetchMeta();
-		await ctx.render('note', {
-			note: _note,
-			profile,
-			avatarUrl: await Users.getAvatarUrl(await Users.findOneByOrFail({ id: note.userId })),
-			// TODO: Let locale changeable by instance setting
-			summary: getNoteSummary(_note),
-			instanceName: meta.name || 'Misskey',
-			icon: meta.iconUrl,
-			themeColor: meta.themeColor,
-		});
+		try {
+			// FIXME: packing with detail may throw an error if the reply or renote is not visible (#8774)
+			const _note = await Notes.pack(note);
+			const profile = await UserProfiles.findOneByOrFail({ userId: note.userId });
+			const meta = await fetchMeta();
+			await ctx.render('note', {
+				note: _note,
+				profile,
+				avatarUrl: await Users.getAvatarUrl(await Users.findOneByOrFail({ id: note.userId })),
+				// TODO: Let locale changeable by instance setting
+				summary: getNoteSummary(_note),
+				instanceName: meta.name || 'Misskey',
+				icon: meta.iconUrl,
+				themeColor: meta.themeColor,
+			});
 
-		ctx.set('Cache-Control', 'public, max-age=15');
+			ctx.set('Cache-Control', 'public, max-age=15');
 
-		return;
+			return;
+		} catch (err) {
+			if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') {
+				// note not visible to user
+			} else {
+				throw err;
+			}
+		}
 	}
 
 	await next();

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -641,9 +641,15 @@ async function createMentionedEvents(mentionedUsers: MinimumUser[], note: Note, 
 			continue;
 		}
 
-		const detailPackedNote = await Notes.pack(note, u, {
-			detail: true,
-		});
+		// note with "specified" visibility might not be visible to mentioned users
+		try {
+			const detailPackedNote = await Notes.pack(note, u, {
+				detail: true,
+			});
+		} catch (err) {
+			if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') continue;
+			throw err;
+		}
 
 		publishMainStream(u.id, 'mention', detailPackedNote);
 

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -351,7 +351,7 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 		for (const webhook of webhooks) {
 			webhookDeliver(webhook, 'note', {
-				note: await Notes.pack(note, user.id),
+				note: await Notes.pack(note, user),
 			});
 		}
 
@@ -375,7 +375,7 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 				if (!threadMuted) {
 					nm.push(data.reply.userId, 'reply');
 
-					const packedReply = await Notes.pack(note, data.reply.userId);
+					const packedReply = await Notes.pack(note, { id: data.reply.userId });
 					publishMainStream(data.reply.userId, 'reply', packedReply);
 
 					const webhooks = (await getActiveWebhooks()).filter(x => x.userId === data.reply!.userId && x.on.includes('reply'));
@@ -402,7 +402,7 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 			// Publish event
 			if ((user.id !== data.renote.userId) && data.renote.userHost === null) {
-				const packedRenote = await Notes.pack(note, data.renote.userId);
+				const packedRenote = await Notes.pack(note, { id: data.renote.userId });
 				publishMainStream(data.renote.userId, 'renote', packedRenote);
 
 				const webhooks = (await getActiveWebhooks()).filter(x => x.userId === data.renote!.userId && x.on.includes('renote'));

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -347,9 +347,7 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 		publishNotesStream(note);
 
-		const webhooks = await getActiveWebhooks().then(webhooks => {
-			webhooks.filter(x => x.userId === user.id && x.on.includes('note'))
-		});
+		const webhooks = await getActiveWebhooks().then(webhooks => webhooks.filter(x => x.userId === user.id && x.on.includes('note')));
 
 		for (const webhook of webhooks) {
 			webhookDeliver(webhook, 'note', {

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -646,18 +646,18 @@ async function createMentionedEvents(mentionedUsers: MinimumUser[], note: Note, 
 			const detailPackedNote = await Notes.pack(note, u, {
 				detail: true,
 			});
+
+			publishMainStream(u.id, 'mention', detailPackedNote);
+
+			const webhooks = (await getActiveWebhooks()).filter(x => x.userId === u.id && x.on.includes('mention'));
+			for (const webhook of webhooks) {
+				webhookDeliver(webhook, 'mention', {
+					note: detailPackedNote,
+				});
+			}
 		} catch (err) {
 			if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') continue;
 			throw err;
-		}
-
-		publishMainStream(u.id, 'mention', detailPackedNote);
-
-		const webhooks = (await getActiveWebhooks()).filter(x => x.userId === u.id && x.on.includes('mention'));
-		for (const webhook of webhooks) {
-			webhookDeliver(webhook, 'mention', {
-				note: detailPackedNote,
-			});
 		}
 
 		// Create notification

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -345,16 +345,13 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 			}
 		}
 
-		// Pack the note
-		const noteObj = await Notes.pack(note);
-
-		publishNotesStream(noteObj);
+		publishNotesStream(note);
 
 		getActiveWebhooks().then(webhooks => {
 			webhooks = webhooks.filter(x => x.userId === user.id && x.on.includes('note'));
 			for (const webhook of webhooks) {
 				webhookDeliver(webhook, 'note', {
-					note: noteObj,
+					note: await Notes.pack(note, user.id),
 				});
 			}
 		});
@@ -378,12 +375,14 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 				if (!threadMuted) {
 					nm.push(data.reply.userId, 'reply');
-					publishMainStream(data.reply.userId, 'reply', noteObj);
+
+					const packedReply = await Notes.pack(note, data.reply.userId);
+					publishMainStream(data.reply.userId, 'reply', packedReply);
 
 					const webhooks = (await getActiveWebhooks()).filter(x => x.userId === data.reply!.userId && x.on.includes('reply'));
 					for (const webhook of webhooks) {
 						webhookDeliver(webhook, 'reply', {
-							note: noteObj,
+							note: packedReply,
 						});
 					}
 				}
@@ -404,12 +403,13 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 			// Publish event
 			if ((user.id !== data.renote.userId) && data.renote.userHost === null) {
-				publishMainStream(data.renote.userId, 'renote', noteObj);
+				const packedRenote = await Notes.pack(note, data.renote.userId);
+				publishMainStream(data.renote.userId, 'renote', packedRenote);
 
 				const webhooks = (await getActiveWebhooks()).filter(x => x.userId === data.renote!.userId && x.on.includes('renote'));
 				for (const webhook of webhooks) {
 					webhookDeliver(webhook, 'renote', {
-						note: noteObj,
+						note: packedRenote,
 					});
 				}
 			}

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -347,14 +347,15 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 
 		publishNotesStream(note);
 
-		getActiveWebhooks().then(webhooks => {
-			webhooks = webhooks.filter(x => x.userId === user.id && x.on.includes('note'));
-			for (const webhook of webhooks) {
-				webhookDeliver(webhook, 'note', {
-					note: await Notes.pack(note, user.id),
-				});
-			}
+		const webhooks = await getActiveWebhooks().then(webhooks => {
+			webhooks.filter(x => x.userId === user.id && x.on.includes('note'))
 		});
+
+		for (const webhook of webhooks) {
+			webhookDeliver(webhook, 'note', {
+				note: await Notes.pack(note, user.id),
+			});
+		}
 
 		const nm = new NotificationManager(user, note);
 		const nmRelatedPromises = [];

--- a/packages/backend/src/services/stream.ts
+++ b/packages/backend/src/services/stream.ts
@@ -22,7 +22,6 @@ import {
 	UserListStreamTypes,
 	UserStreamTypes,
 } from '@/server/api/stream/types.js';
-import { Packed } from '@/misc/schema.js';
 
 class Publisher {
 	private publish = (channel: StreamChannels, type: string | null, value?: any): void => {
@@ -87,7 +86,7 @@ class Publisher {
 		this.publish(`messagingIndexStream:${userId}`, type, typeof value === 'undefined' ? null : value);
 	};
 
-	public publishNotesStream = (note: Packed<'Note'>): void => {
+	public publishNotesStream = (note: Note): void => {
 		this.publish('notesStream', null, note);
 	};
 

--- a/packages/backend/test/api-visibility.ts
+++ b/packages/backend/test/api-visibility.ts
@@ -154,18 +154,18 @@ describe('API visibility', () => {
 
 		it('[show] followers-postを非フォロワーが見れない', async(async () => {
 			const res = await show(fol.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] followers-postを未認証が見れない', async(async () => {
 			const res = await show(fol.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		// specified
 		it('[show] specified-postを自分が見れる', async(async () => {
 			const res = await show(spe.id, alice);
-			assert.strictEqual(res.body.text, 'x');
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-postを指定ユーザーが見れる', async(async () => {
@@ -175,17 +175,17 @@ describe('API visibility', () => {
 
 		it('[show] specified-postをフォロワーが見れない', async(async () => {
 			const res = await show(spe.id, follower);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-postを非フォロワーが見れない', async(async () => {
 			const res = await show(spe.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-postを未認証が見れない', async(async () => {
 			const res = await show(spe.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 		//#endregion
 
@@ -260,12 +260,12 @@ describe('API visibility', () => {
 
 		it('[show] followers-replyを非フォロワーが見れない', async(async () => {
 			const res = await show(folR.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] followers-replyを未認証が見れない', async(async () => {
 			const res = await show(folR.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		// specified
@@ -286,17 +286,17 @@ describe('API visibility', () => {
 
 		it('[show] specified-replyをフォロワーが見れない', async(async () => {
 			const res = await show(speR.id, follower);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-replyを非フォロワーが見れない', async(async () => {
 			const res = await show(speR.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-replyを未認証が見れない', async(async () => {
 			const res = await show(speR.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 		//#endregion
 
@@ -371,12 +371,12 @@ describe('API visibility', () => {
 
 		it('[show] followers-mentionを非フォロワーが見れない', async(async () => {
 			const res = await show(folM.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] followers-mentionを未認証が見れない', async(async () => {
 			const res = await show(folM.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		// specified
@@ -392,22 +392,22 @@ describe('API visibility', () => {
 
 		it('[show] specified-mentionをされた人が指定されてなかったら見れない', async(async () => {
 			const res = await show(speM.id, target2);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-mentionをフォロワーが見れない', async(async () => {
 			const res = await show(speM.id, follower);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-mentionを非フォロワーが見れない', async(async () => {
 			const res = await show(speM.id, other);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 
 		it('[show] specified-mentionを未認証が見れない', async(async () => {
 			const res = await show(speM.id, null);
-			assert.strictEqual(res.body.isHidden, true);
+			assert.strictEqual(res.status, 404);
 		}));
 		//#endregion
 

--- a/packages/client/src/components/note-detailed.vue
+++ b/packages/client/src/components/note-detailed.vue
@@ -62,7 +62,6 @@
 				</p>
 				<div v-show="appearNote.cw == null || showContent" class="content">
 					<div class="text">
-						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ $ts.private }})</span>
 						<MkA v-if="appearNote.replyId" class="reply" :to="`/notes/${appearNote.replyId}`"><i class="fas fa-reply"></i></MkA>
 						<Mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$i" :custom-emojis="appearNote.emojis"/>
 						<a v-if="appearNote.renote != null" class="rp">RN:</a>

--- a/packages/client/src/components/note.vue
+++ b/packages/client/src/components/note.vue
@@ -48,7 +48,6 @@
 				</p>
 				<div v-show="appearNote.cw == null || showContent" class="content" :class="{ collapsed }">
 					<div class="text">
-						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" class="reply" :to="`/notes/${appearNote.replyId}`"><i class="fas fa-reply"></i></MkA>
 						<Mfm v-if="appearNote.text" :text="appearNote.text" :author="appearNote.user" :i="$i" :custom-emojis="appearNote.emojis"/>
 						<a v-if="appearNote.renote != null" class="rp">RN:</a>

--- a/packages/client/src/components/sub-note-content.vue
+++ b/packages/client/src/components/sub-note-content.vue
@@ -1,7 +1,6 @@
 <template>
 <div class="wrmlmaau" :class="{ collapsed }">
 	<div class="body">
-		<span v-if="note.isHidden" style="opacity: 0.5">({{ $ts.private }})</span>
 		<span v-if="note.deletedAt" style="opacity: 0.5">({{ $ts.deleted }})</span>
 		<MkA v-if="note.replyId" class="reply" :to="`/notes/${note.replyId}`"><i class="fas fa-reply"></i></MkA>
 		<Mfm v-if="note.text" :text="note.text" :author="note.user" :i="$i" :custom-emojis="note.emojis"/>

--- a/packages/client/src/scripts/get-note-summary.ts
+++ b/packages/client/src/scripts/get-note-summary.ts
@@ -10,10 +10,6 @@ export const getNoteSummary = (note: misskey.entities.Note): string => {
 		return `(${i18n.ts.deletedNote})`;
 	}
 
-	if (note.isHidden) {
-		return `(${i18n.ts.invisibleNote})`;
-	}
-
 	let summary = '';
 
 	// 本文


### PR DESCRIPTION
# What
- [x] the `getNote` getter is expanded to also check visibility as this is a common task across all API endpoints
- [x] some uses of `Notes.find` or similar are replaced by uses of `getNote` so the visibility is checked properly
- [x] `Notes.pack` will return an error if the note is not visible to the specified user instead of only hiding metadata
- [x] `Notes.packMany` is modified to not throw an error, but only filters out notes that would have raised an error
- [x] all uses of `Notes.pack` properly handle the new error
- [x] adjust tests

# Why
fix #8317

# Additional Info
The `hideNote` function has been removed. This has the additional advantage that it removes duplicated code for checking the visibility of a note already in `isVisibleForMe`.

Users will no longer be able to see notes that are not visible to them. The previous behaviour was to show the note just with the text replaced by a message that the note is not visible to the user. The new behaviour is that the server claims that the note does not exist at all if it is not visible to the user.

Users will no longer be able to reply to or renote notes that are not visible to them.