### PR TITLE
fix: ユーザー検索で、クエリがusernameの条件を満たす場合はusernameもLIKE検索するように

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/search.ts
+++ b/packages/backend/src/server/api/endpoints/users/search.ts
@@ -61,7 +61,14 @@ export default define(meta, paramDef, async (ps, me) => {
 			.getMany();
 	} else {
 		const nameQuery = Users.createQueryBuilder('user')
-			.where('user.name ILIKE :query', { query: '%' + ps.query + '%' })
+			.where(new Brackets(qb => { 
+				qb.where('user.name ILIKE :query', { query: '%' + ps.query + '%' });
+
+				// Also search username if it qualifies as username
+				if (Users.validateLocalUsername(ps.query)) {
+					qb.orWhere('user.usernameLower LIKE :username', { username: ps.query.toLowerCase() + '%' });
+				}
+			}))
 			.andWhere(new Brackets(qb => { qb
 				.where('user.updatedAt IS NULL')
 				.orWhere('user.updatedAt > :activeThreshold', { activeThreshold: activeThreshold });

--- a/packages/backend/src/server/api/endpoints/users/search.ts
+++ b/packages/backend/src/server/api/endpoints/users/search.ts
@@ -66,7 +66,7 @@ export default define(meta, paramDef, async (ps, me) => {
 
 				// Also search username if it qualifies as username
 				if (Users.validateLocalUsername(ps.query)) {
-					qb.orWhere('user.usernameLower LIKE :username', { username: ps.query.toLowerCase() + '%' });
+					qb.orWhere('user.usernameLower LIKE :username', { username: '%' + ps.query.toLowerCase() + '%' });
 				}
 			}))
 			.andWhere(new Brackets(qb => { qb


### PR DESCRIPTION
fix: In user search, if the query meets the username condition, then username is also searched LIKE.

Fix #8643

