### PR TITLE
Refactor emoji-edit-dialog to use Composition API

### DIFF
--- a/packages/client/src/components/ui/pagination.vue
+++ b/packages/client/src/components/ui/pagination.vue
@@ -244,6 +244,11 @@ const append = (item: Item): void => {
 	items.value.push(item);
 };
 
+const removeItem = (finder: (item: Item) => boolean) => {
+	const i = items.value.findIndex(finder);
+	items.value.splice(i, 1);
+};
+
 const updateItem = (id: Item['id'], replacer: (old: Item) => Item): void => {
 	const i = items.value.findIndex(item => item.id === id);
 	items.value[i] = replacer(items.value[i]);
@@ -276,6 +281,7 @@ defineExpose({
 	fetchMoreAhead,
 	prepend,
 	append,
+	removeItem,
 	updateItem,
 });
 </script>

--- a/packages/client/src/pages/admin/emoji-edit-dialog.vue
+++ b/packages/client/src/pages/admin/emoji-edit-dialog.vue
@@ -35,6 +35,7 @@ import MkInput from '@/components/form/input.vue';
 import * as os from '@/os';
 import { unique } from '@/scripts/array';
 import { i18n } from '@/i18n';
+import { emojiCategories } from '@/instance';
 
 const props = defineProps<{
 	emoji: any,
@@ -44,11 +45,7 @@ let dialog = $ref(null);
 let name: string = $ref(props.emoji.name);
 let category: string = $ref(props.emoji.category);
 let aliases: string = $ref(props.emoji.aliases.join(' '));
-let categories: string[] = $ref([]);
-
-os.api('meta', { detail: false }).then(({ emojis }) => {
-	categories = unique(emojis.map((x: any) => x.category || '').filter((x: string) => x !== ''));
-});
+let categories: unknown[] = $ref(emojiCategories);
 
 const emit = defineEmits<{
 	(ev: 'done', v: { deleted?: boolean, updated?: any }): void,

--- a/packages/client/src/pages/admin/emoji-edit-dialog.vue
+++ b/packages/client/src/pages/admin/emoji-edit-dialog.vue
@@ -27,85 +27,75 @@
 </XModalWindow>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script lang="ts" setup>
+import { } from 'vue';
 import XModalWindow from '@/components/ui/modal-window.vue';
 import MkButton from '@/components/ui/button.vue';
 import MkInput from '@/components/form/input.vue';
 import * as os from '@/os';
 import { unique } from '@/scripts/array';
+import { i18n } from '@/i18n';
 
-export default defineComponent({
-	components: {
-		XModalWindow,
-		MkButton,
-		MkInput,
-	},
-
-	props: {
-		emoji: {
-			required: true,
-		}
-	},
-
-	emits: ['done', 'closed'],
-
-	data() {
-		return {
-			name: this.emoji.name,
-			category: this.emoji.category,
-			aliases: this.emoji.aliases?.join(' '),
-			categories: [],
-		}
-	},
-
-	created() {
-		os.api('meta', { detail: false }).then(({ emojis }) => {
-			this.categories = unique(emojis.map((x: any) => x.category || '').filter((x: string) => x !== ''));
-		});
-	},
-
-	methods: {
-		ok() {
-			this.update();
-		},
-
-		async update() {
-			await os.apiWithDialog('admin/emoji/update', {
-				id: this.emoji.id,
-				name: this.name,
-				category: this.category,
-				aliases: this.aliases.split(' '),
-			});
-
-			this.$emit('done', {
-				updated: {
-					name: this.name,
-					category: this.category,
-					aliases: this.aliases.split(' '),
-				}
-			});
-			this.$refs.dialog.close();
-		},
-
-		async del() {
-			const { canceled } = await os.confirm({
-				type: 'warning',
-				text: this.$t('removeAreYouSure', { x: this.emoji.name }),
-			});
-			if (canceled) return;
-
-			os.api('admin/emoji/delete', {
-				id: this.emoji.id
-			}).then(() => {
-				this.$emit('done', {
-					deleted: true
-				});
-				this.$refs.dialog.close();
-			});
-		},
+const props = defineProps({
+	emoji: {
+		required: true,
 	}
 });
+
+let dialog = $ref(null);
+let name: string = $ref(props.emoji.name);
+let category: string = $ref(props.emoji.category);
+let aliases: string = $ref(props.emoji.aliases?.join(' '));
+let categories: string[] = $ref([]);
+
+os.api('meta', { detail: false }).then(({ emojis }) => {
+	categories = unique(emojis.map((x: any) => x.category || '').filter((x: string) => x !== ''));
+});
+
+const emit = defineEmits<{
+	(ev: 'done', v: { deleted?: boolean, updated?: any }): void,
+	(ev: 'closed'): void
+}>();
+
+function ok() {
+	update();
+}
+
+async function update() {
+	await os.apiWithDialog('admin/emoji/update', {
+		id: props.emoji.id,
+		name: name,
+		category: category,
+		aliases: aliases.split(' '),
+	});
+
+	emit('done', {
+		updated: {
+			name: name,
+			category: category,
+			aliases: aliases.split(' '),
+		}
+	});
+
+	dialog.close();
+}
+
+async function del() {
+	const { canceled } = await os.confirm({
+		type: 'warning',
+		text: i18n.t('removeAreYouSure', { x: name }),
+	});
+	if (canceled) return;
+
+	os.api('admin/emoji/delete', {
+		id: props.emoji.id
+	}).then(() => {
+		emit('done', {
+			deleted: true
+		});
+		dialog.close();
+	});
+}
 </script>
 
 <style lang="scss" scoped>

--- a/packages/client/src/pages/admin/emoji-edit-dialog.vue
+++ b/packages/client/src/pages/admin/emoji-edit-dialog.vue
@@ -45,7 +45,7 @@ let dialog = $ref(null);
 let name: string = $ref(props.emoji.name);
 let category: string = $ref(props.emoji.category);
 let aliases: string = $ref(props.emoji.aliases.join(' '));
-let categories: unknown[] = $ref(emojiCategories);
+let categories: string[] = $ref(emojiCategories);
 
 const emit = defineEmits<{
 	(ev: 'done', v: { deleted?: boolean, updated?: any }): void,

--- a/packages/client/src/pages/admin/emoji-edit-dialog.vue
+++ b/packages/client/src/pages/admin/emoji-edit-dialog.vue
@@ -66,6 +66,7 @@ async function update() {
 
 	emit('done', {
 		updated: {
+			id: props.emoji.id,
 			name,
 			category,
 			aliases: aliases.split(' '),

--- a/packages/client/src/pages/admin/emoji-edit-dialog.vue
+++ b/packages/client/src/pages/admin/emoji-edit-dialog.vue
@@ -36,16 +36,14 @@ import * as os from '@/os';
 import { unique } from '@/scripts/array';
 import { i18n } from '@/i18n';
 
-const props = defineProps({
-	emoji: {
-		required: true,
-	}
-});
+const props = defineProps<{
+	emoji: any,
+}>();
 
 let dialog = $ref(null);
 let name: string = $ref(props.emoji.name);
 let category: string = $ref(props.emoji.category);
-let aliases: string = $ref(props.emoji.aliases?.join(' '));
+let aliases: string = $ref(props.emoji.aliases.join(' '));
 let categories: string[] = $ref([]);
 
 os.api('meta', { detail: false }).then(({ emojis }) => {
@@ -64,15 +62,15 @@ function ok() {
 async function update() {
 	await os.apiWithDialog('admin/emoji/update', {
 		id: props.emoji.id,
-		name: name,
-		category: category,
+		name,
+		category,
 		aliases: aliases.split(' '),
 	});
 
 	emit('done', {
 		updated: {
-			name: name,
-			category: category,
+			name,
+			category,
 			aliases: aliases.split(' '),
 		}
 	});

--- a/packages/client/src/pages/admin/emojis.vue
+++ b/packages/client/src/pages/admin/emojis.vue
@@ -134,7 +134,12 @@ const edit = (emoji) => {
 		emoji: emoji
 	}, {
 		done: result => {
-			if (result.updated || result.deleted) {
+			if (result.updated) {
+				emojisPaginationComponent.value.updateItem(result.updated.id, (oldEmoji: any) => ({
+					...oldEmoji,
+					...result.updated
+				}));
+			} else if (result.deleted) {
 				emojisPaginationComponent.value.reload();
 			}
 		},

--- a/packages/client/src/pages/admin/emojis.vue
+++ b/packages/client/src/pages/admin/emojis.vue
@@ -134,13 +134,8 @@ const edit = (emoji) => {
 		emoji: emoji
 	}, {
 		done: result => {
-			if (result.updated) {
-				emojisPaginationComponent.value.replaceItem(item => item.id === emoji.id, {
-					...emoji,
-					...result.updated
-				});
-			} else if (result.deleted) {
-				emojisPaginationComponent.value.removeItem(item => item.id === emoji.id);
+			if (result.updated || result.deleted) {
+				emojisPaginationComponent.value.reload();
 			}
 		},
 	}, 'closed');

--- a/packages/client/src/pages/admin/emojis.vue
+++ b/packages/client/src/pages/admin/emojis.vue
@@ -140,7 +140,7 @@ const edit = (emoji) => {
 					...result.updated
 				}));
 			} else if (result.deleted) {
-				emojisPaginationComponent.value.reload();
+				emojisPaginationComponent.value.removeItem((item) => item.id === emoji.id);
 			}
 		},
 	}, 'closed');


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Use Composition API for emoji edit dialog component in the admin settings

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Refactor to Composition API (per contribution guide)

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

After submitting edit changes with the dialog I noticed that nothing happened. `MkPagination` lost the `replaceItem` and `removeItem` methods while it was refactored to the Composition API. Was this intentional?

To "quick-fix" this problem I mitigated the issue with just opting to `reload()` the entire pagination instead. If we should bring back the missing methods tell me so and I'll add them back to the component!
