### PR TITLE
fix: keep file order

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -172,10 +172,14 @@ export default define(meta, paramDef, async (ps, user) => {
 	let files: DriveFile[] = [];
 	const fileIds = ps.fileIds != null ? ps.fileIds : ps.mediaIds != null ? ps.mediaIds : null;
 	if (fileIds != null) {
-		files = await DriveFiles.findBy({
-			userId: user.id,
-			id: In(fileIds),
-		});
+		files = await DriveFiles.createQueryBuilder('file')
+			.where('file.userId = :userId AND file.id IN (:...fileIds)', {
+				userId: user.id,
+				fileIds,
+			})
+			.orderBy('array_position(ARRAY[:...fileIds], "id")')
+			.setParameters({ fileIds })
+			.getMany();
 	}
 
 	let renote: Note | null = null;


### PR DESCRIPTION
# What
The file IDs are used in the order they are sent.

When using the `IN` operator, the database will return the files in the order they are stored on disk, which is usually the order they were inserted in. That explains why attachments were always ordered by file ID as noted in the issue.

To keep the advantage of having a single database query, I modified the query to add an order by clause instead of partly reverting 9f7cdb4bc734e02be0acc03bfae5abe94ac7466c which would have meant multiple queries. This should keep any improved performance.

# Why
fix #8647