### PR TITLE
perf: fix caching

### DIFF
--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -48,6 +48,7 @@ export class Cache<T> {
 
 		// Cache MISS
 		const value = await fetcher();
+		this.set(key, value);
 		return value;
 	}
 


### PR DESCRIPTION
# What
Fixes the cache implementation to actually store the result when fetching a value for a cache miss.

# Why
The cache implementation did previously not store the results of the computation and was thus not a cache at all. This can cause a significant number of database queries each time someone with a large number of followers does something that causes an activity to be federated.