### PR TITLE
Add additional background for acrylic popups if backdrop-filter is unsupported

### DIFF
--- a/packages/client/src/style.scss
+++ b/packages/client/src/style.scss
@@ -385,6 +385,20 @@ hr {
 	background: var(--acrylicPanel);
 	-webkit-backdrop-filter: var(--blur, blur(15px));
 	backdrop-filter: var(--blur, blur(15px));
+
+	@supports not (backdrop-filter: var(--blur, blur(15px))) {
+		&:after {
+			content: "";
+			position: absolute;
+			top: 0;
+			right: 0;
+			left: 0;
+			bottom: 0;
+			z-index: -1;
+			background: var(--bg);
+			opacity: .75;
+		}
+	}
 }
 
 ._formBlock {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR adds an additional background layer if the `backdrop-filter` is not supported.

This fixes  #7996

**Screenshot:**

Firefox 100.0 on Windows 11, no `backdrop-filter` support:
![image](https://user-images.githubusercontent.com/1774242/168427013-20a940fa-ef46-4412-921a-5921df027753.png)

Microsoft Edge 101.0.1210.39 on Windows 11, `backdrop-filter` support
![image](https://user-images.githubusercontent.com/1774242/168427046-237e182a-e39f-4069-b788-9979a5aaa1f7.png)




# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Reaction or chart popups are hardly readable on Firefox.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

This implementation is somewhat of a "hack". The clean solution would be introducing an additional theme color variable that generates a less transparent background color variant, but I'm not sure what the effects of adding/changing theme colors would be for...all the created themes, basically.

So, for clarity, this implementation just adds an `:after` element via CSS *only* if `backdrop-filter` is not supported. It takes up the height/width of the element, places itself behind it and uses `var(--bg)` at 75% transparency.
