### PR TITLE
Fix unexpected token breaking builds

### DIFF
--- a/packages/client/src/pages/admin/bot-protection.vue
+++ b/packages/client/src/pages/admin/bot-protection.vue
@@ -56,7 +56,7 @@ import { fetchInstance } from '@/instance';
 
 const MkCaptcha = defineAsyncComponent(() => import('@/components/captcha.vue'));
 
-let provider: = $ref(null);
+let provider = $ref(null);
 let hcaptchaSiteKey: string | null = $ref(null);
 let hcaptchaSecretKey: string | null = $ref(null);
 let recaptchaSiteKey: string | null = $ref(null);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

A typo while refactoring broke builds, this PR fixes it.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

From a recent `Build` action step output:
```
/home/runner/work/misskey/misskey/packages/client/src/pages/admin/bot-protection.vue
57 |  const MkCaptcha = defineAsyncComponent(() => import('@/components/captcha.vue'));
58 |  
59 |  let provider: = $ref(null);
   |                ^
```