### PR TITLE
fix: ノートのインスタンス情報の文字に縁を付けて見やすくする

### DIFF
--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -40,6 +40,7 @@ const bg = {
 	border-radius: 4px 0 0 4px;
 	overflow: hidden;
 	color: #fff;
+	text-shadow: 0 -1px 1px #000, -1px 0 1px #000, 0 1px 1px #000, 1px 0 1px #000;
 
 	> .icon {
 		height: 100%;

--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -39,7 +39,19 @@ const bg = {
 	border-radius: 4px 0 0 4px;
 	overflow: hidden;
 	color: #fff;
-	text-shadow: 0 -1px 1px #000, -1px 0 1px #000, 0 1px 1px #000, 1px 0 1px #000;
+	text-shadow: /* .866 ≈ sin(60deg) */
+		1px 0 1px #000,
+		.866px .5px 1px #000,
+		.5px .866px 1px #000,
+		0 1px 1px #000,
+		-.5px .866px 1px #000,
+		-.866px .5px 1px #000,
+		-1px 0 1px #000,
+		-.866px -.5px 1px #000,
+		-.5px -.866px 1px #000,
+		0 -1px 1px #000,
+		.5px -.866px 1px #000,
+		.866px -.5px 1px #000;
 
 	> .icon {
 		height: 100%;

--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -7,7 +7,6 @@
 
 <script lang="ts" setup>
 import { } from 'vue';
-import tinycolor from 'tinycolor2';
 import { instanceName } from '@/config';
 
 const props = defineProps<{
@@ -25,10 +24,10 @@ const instance = props.instance ?? {
 	themeColor: (document.querySelector('meta[name="theme-color-orig"]') as HTMLMetaElement)?.content
 };
 
-const themeColor = tinycolor(instance.themeColor ?? '#777777');
+const themeColor = instance.themeColor ?? '#777777';
 
 const bg = {
-	background: `linear-gradient(90deg, ${themeColor}, ${themeColor.clone().setAlpha(0)})`
+	background: `linear-gradient(90deg, ${themeColor}, ${themeColor}00)`
 };
 </script>
 

--- a/packages/client/src/components/instance-ticker.vue
+++ b/packages/client/src/components/instance-ticker.vue
@@ -7,6 +7,7 @@
 
 <script lang="ts" setup>
 import { } from 'vue';
+import tinycolor from 'tinycolor2';
 import { instanceName } from '@/config';
 
 const props = defineProps<{
@@ -24,10 +25,10 @@ const instance = props.instance ?? {
 	themeColor: (document.querySelector('meta[name="theme-color-orig"]') as HTMLMetaElement)?.content
 };
 
-const themeColor = instance.themeColor ?? '#777777';
+const themeColor = tinycolor(instance.themeColor ?? '#777777');
 
 const bg = {
-	background: `linear-gradient(90deg, ${themeColor}, ${themeColor}00)`
+	background: `linear-gradient(90deg, ${themeColor}, ${themeColor.clone().setAlpha(0)})`
 };
 </script>
 


### PR DESCRIPTION
# What
ノートのインスタンス情報の文字に縁を付けて見やすくする。
~~ノートのインスタンス情報でテーマカラーが HEX 6 桁以外の場合(例えば `#fff` など)に背景色が反映されていないのを修正する。~~

# Why
Fix #8079

# Additional info (optional)
影付き文字を少し調整した。
`text-shadow: 0 -1px 1px #000, -1px 0 1px #000, 0 1px 1px #000, 1px 0 1px #000;`

![いい感じの影文字](https://user-images.githubusercontent.com/91555638/168894479-b5e3879f-2723-4759-9abd-6ad28e268b46.png)
