### PR TITLE
fix: first user gets admin

### DIFF
--- a/packages/backend/src/server/api/common/signup.ts
+++ b/packages/backend/src/server/api/common/signup.ts
@@ -87,6 +87,7 @@ export async function signup(opts: {
 			token: secret,
 			isAdmin: (await Users.countBy({
 				host: IsNull(),
+				isAdmin: true,
 			})) === 0,
 		}));
 

--- a/packages/backend/src/server/api/endpoints/admin/accounts/create.ts
+++ b/packages/backend/src/server/api/endpoints/admin/accounts/create.ts
@@ -33,6 +33,7 @@ export default define(meta, paramDef, async (ps, _me) => {
 	const me = _me ? await Users.findOneByOrFail({ id: _me.id }) : null;
 	const noUsers = (await Users.countBy({
 		host: IsNull(),
+		isAdmin: true,
 	})) === 0;
 	if (!noUsers && !me?.isAdmin) throw new Error('access denied');
 

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -385,6 +385,7 @@ export default define(meta, paramDef, async (ps, me) => {
 			cacheRemoteFiles: instance.cacheRemoteFiles,
 			requireSetup: (await Users.countBy({
 				host: IsNull(),
+				isAdmin: true,
 			})) === 0,
 		} : {}),
 	};


### PR DESCRIPTION
# What
Some of the system users may be created before the admin signs up. Because the system users do not get admin rights, adding a check for `isAdmin` will ignore system users in this check.

# Why
fix #8685