### PR TITLE
Prevent access to user pages when not logged in

### DIFF
--- a/packages/client/src/router.ts
+++ b/packages/client/src/router.ts
@@ -15,7 +15,7 @@ const page = (path: string | AsyncComponentLoader<any>, uiName?: string) => defi
 });
 
 const signinRequired = () => {
-	pleaseLogin('/', false);
+	pleaseLogin('/');
 }
 
 let indexScrollPos = 0;

--- a/packages/client/src/router.ts
+++ b/packages/client/src/router.ts
@@ -5,6 +5,7 @@ import MkError from '@/pages/_error_.vue';
 import MkTimeline from '@/pages/timeline.vue';
 import { $i, iAmModerator } from './account';
 import { ui } from '@/config';
+import { pleaseLogin } from './scripts/please-login';
 
 // pathに/が入るとrollupが解決してくれないので、() => import('*.vue')を指定すること
 const page = (path: string | AsyncComponentLoader<any>, uiName?: string) => defineAsyncComponent({
@@ -12,6 +13,10 @@ const page = (path: string | AsyncComponentLoader<any>, uiName?: string) => defi
 	loadingComponent: MkLoading,
 	errorComponent: MkError,
 });
+
+const signinRequired = () => {
+	pleaseLogin('/', false);
+}
 
 let indexScrollPos = 0;
 
@@ -21,15 +26,14 @@ const defaultRoutes = [
 	{ path: '/@:acct/:page?', name: 'user', component: page(() => import('./pages/user/index.vue')), props: route => ({ acct: route.params.acct, page: route.params.page || 'index' }) },
 	{ path: '/@:user/pages/:page', component: page('page'), props: route => ({ pageName: route.params.page, username: route.params.user }) },
 	{ path: '/@:user/pages/:pageName/view-source', component: page(() => import('./pages/page-editor/page-editor.vue')), props: route => ({ initUser: route.params.user, initPageName: route.params.pageName }) },
-	{ path: '/settings/:page(.*)?', name: 'settings', component: page(() => import('./pages/settings/index.vue')), props: route => ({ initialPage: route.params.page || null }) },
+	{ path: '/settings/:page(.*)?', name: 'settings', component: page(() => import('./pages/settings/index.vue')), props: route => ({ initialPage: route.params.page || null }), beforeEnter: signinRequired },
 	{ path: '/reset-password/:token?', component: page('reset-password'), props: route => ({ token: route.params.token }) },
 	{ path: '/signup-complete/:code', component: page('signup-complete'), props: route => ({ code: route.params.code }) },
 	{ path: '/announcements', component: page('announcements') },
 	{ path: '/about', component: page('about') },
 	{ path: '/about-misskey', component: page('about-misskey') },
 	{ path: '/featured', component: page('featured') },
-	{ path: '/theme-editor', component: page('theme-editor') },
-	{ path: '/advanced-theme-editor', component: page('advanced-theme-editor') },
+	{ path: '/theme-editor', component: page('theme-editor'), beforeEnter: signinRequired },
 	{ path: '/explore', component: page('explore') },
 	{ path: '/explore/tags/:tag', props: true, component: page('explore') },
 	{ path: '/federation', component: page('federation') },
@@ -37,36 +41,36 @@ const defaultRoutes = [
 	{ path: '/search', component: page('search'), props: route => ({ query: route.query.q, channel: route.query.channel }) },
 	{ path: '/pages', name: 'pages', component: page('pages') },
 	{ path: '/pages/new', component: page(() => import('./pages/page-editor/page-editor.vue')) },
-	{ path: '/pages/edit/:pageId', component: page(() => import('./pages/page-editor/page-editor.vue')), props: route => ({ initPageId: route.params.pageId }) },
+	{ path: '/pages/edit/:pageId', component: page(() => import('./pages/page-editor/page-editor.vue')), props: route => ({ initPageId: route.params.pageId }), beforeEnter: signinRequired },
 	{ path: '/gallery', component: page(() => import('./pages/gallery/index.vue')) },
-	{ path: '/gallery/new', component: page(() => import('./pages/gallery/edit.vue')) },
-	{ path: '/gallery/:postId/edit', component: page(() => import('./pages/gallery/edit.vue')), props: route => ({ postId: route.params.postId }) },
+	{ path: '/gallery/new', component: page(() => import('./pages/gallery/edit.vue')), beforeEnter: signinRequired },
+	{ path: '/gallery/:postId/edit', component: page(() => import('./pages/gallery/edit.vue')), props: route => ({ postId: route.params.postId }), beforeEnter: signinRequired },
 	{ path: '/gallery/:postId', component: page(() => import('./pages/gallery/edit.vue')), props: route => ({ postId: route.params.postId }) },
 	{ path: '/channels', component: page('channels') },
-	{ path: '/channels/new', component: page('channel-editor') },
-	{ path: '/channels/:channelId/edit', component: page('channel-editor'), props: true },
+	{ path: '/channels/new', component: page('channel-editor'), beforeEnter: signinRequired },
+	{ path: '/channels/:channelId/edit', component: page('channel-editor'), props: true, beforeEnter: signinRequired },
 	{ path: '/channels/:channelId', component: page('channel'), props: route => ({ channelId: route.params.channelId }) },
 	{ path: '/clips/:clipId', component: page('clip'), props: route => ({ clipId: route.params.clipId }) },
-	{ path: '/timeline/list/:listId', component: page('user-list-timeline'), props: route => ({ listId: route.params.listId }) },
-	{ path: '/timeline/antenna/:antennaId', component: page('antenna-timeline'), props: route => ({ antennaId: route.params.antennaId }) },
-	{ path: '/my/notifications', component: page('notifications') },
-	{ path: '/my/favorites', component: page('favorites') },
-	{ path: '/my/messages', component: page('messages') },
-	{ path: '/my/mentions', component: page('mentions') },
-	{ path: '/my/messaging', name: 'messaging', component: page(() => import('./pages/messaging/index.vue')) },
-	{ path: '/my/messaging/:user', component: page(() => import('./pages/messaging/messaging-room.vue')), props: route => ({ userAcct: route.params.user }) },
-	{ path: '/my/messaging/group/:group', component: page(() => import('./pages/messaging/messaging-room.vue')), props: route => ({ groupId: route.params.group }) },
-	{ path: '/my/drive', name: 'drive', component: page('drive') },
-	{ path: '/my/drive/folder/:folder', component: page('drive') },
-	{ path: '/my/follow-requests', component: page('follow-requests') },
-	{ path: '/my/lists', component: page(() => import('./pages/my-lists/index.vue')) },
-	{ path: '/my/lists/:list', component: page(() => import('./pages/my-lists/list.vue')) },
-	{ path: '/my/groups', component: page(() => import('./pages/my-groups/index.vue')) },
-	{ path: '/my/groups/:group', component: page(() => import('./pages/my-groups/group.vue')), props: route => ({ groupId: route.params.group }) },
-	{ path: '/my/antennas', component: page(() => import('./pages/my-antennas/index.vue')) },
-	{ path: '/my/antennas/create', component: page(() => import('./pages/my-antennas/create.vue')) },
-	{ path: '/my/antennas/:antennaId', component: page(() => import('./pages/my-antennas/edit.vue')), props: true },
-	{ path: '/my/clips', component: page(() => import('./pages/my-clips/index.vue')) },
+	{ path: '/timeline/list/:listId', component: page('user-list-timeline'), props: route => ({ listId: route.params.listId }), beforeEnter: signinRequired },
+	{ path: '/timeline/antenna/:antennaId', component: page('antenna-timeline'), props: route => ({ antennaId: route.params.antennaId }), beforeEnter: signinRequired },
+	{ path: '/my/notifications', component: page('notifications'), beforeEnter: signinRequired },
+	{ path: '/my/favorites', component: page('favorites'), beforeEnter: signinRequired },
+	{ path: '/my/messages', component: page('messages'), beforeEnter: signinRequired },
+	{ path: '/my/mentions', component: page('mentions'), beforeEnter: signinRequired },
+	{ path: '/my/messaging', name: 'messaging', component: page(() => import('./pages/messaging/index.vue')), beforeEnter: signinRequired },
+	{ path: '/my/messaging/:user', component: page(() => import('./pages/messaging/messaging-room.vue')), props: route => ({ userAcct: route.params.user }), beforeEnter: signinRequired },
+	{ path: '/my/messaging/group/:group', component: page(() => import('./pages/messaging/messaging-room.vue')), props: route => ({ groupId: route.params.group }), beforeEnter: signinRequired },
+	{ path: '/my/drive', name: 'drive', component: page('drive'), beforeEnter: signinRequired },
+	{ path: '/my/drive/folder/:folder', component: page('drive'), beforeEnter: signinRequired },
+	{ path: '/my/follow-requests', component: page('follow-requests'), beforeEnter: signinRequired },
+	{ path: '/my/lists', component: page(() => import('./pages/my-lists/index.vue')), beforeEnter: signinRequired },
+	{ path: '/my/lists/:list', component: page(() => import('./pages/my-lists/list.vue')), beforeEnter: signinRequired },
+	{ path: '/my/groups', component: page(() => import('./pages/my-groups/index.vue')), beforeEnter: signinRequired },
+	{ path: '/my/groups/:group', component: page(() => import('./pages/my-groups/group.vue')), props: route => ({ groupId: route.params.group }), beforeEnter: signinRequired },
+	{ path: '/my/antennas', component: page(() => import('./pages/my-antennas/index.vue')), beforeEnter: signinRequired },
+	{ path: '/my/antennas/create', component: page(() => import('./pages/my-antennas/create.vue')), beforeEnter: signinRequired },
+	{ path: '/my/antennas/:antennaId', component: page(() => import('./pages/my-antennas/edit.vue')), props: true, beforeEnter: signinRequired },
+	{ path: '/my/clips', component: page(() => import('./pages/my-clips/index.vue')), beforeEnter: signinRequired },
 	{ path: '/scratchpad', component: page('scratchpad') },
 	{ path: '/admin/:page(.*)?', component: iAmModerator ? page(() => import('./pages/admin/index.vue')) : page('not-found'), props: route => ({ initialPage: route.params.page || null }) },
 	{ path: '/admin', component: iAmModerator ? page(() => import('./pages/admin/index.vue')) : page('not-found') },
@@ -75,13 +79,12 @@ const defaultRoutes = [
 	{ path: '/user-info/:user', component: page('user-info'), props: route => ({ userId: route.params.user }) },
 	{ path: '/instance-info/:host', component: page('instance-info'), props: route => ({ host: route.params.host }) },
 	{ path: '/mfm-cheat-sheet', component: page('mfm-cheat-sheet') },
-	{ path: '/api-console', component: page('api-console') },
+	{ path: '/api-console', component: page('api-console'), beforeEnter: signinRequired },
 	{ path: '/preview', component: page('preview') },
-	{ path: '/test', component: page('test') },
 	{ path: '/auth/:token', component: page('auth') },
 	{ path: '/miauth/:session', component: page('miauth') },
-	{ path: '/authorize-follow', component: page('follow') },
-	{ path: '/share', component: page('share') },
+	{ path: '/authorize-follow', component: page('follow'), beforeEnter: signinRequired },
+	{ path: '/share', component: page('share'), beforeEnter: signinRequired },
 	{ path: '/:catchAll(.*)', component: page('not-found') }
 ];
 

--- a/packages/client/src/scripts/please-login.ts
+++ b/packages/client/src/scripts/please-login.ts
@@ -3,7 +3,7 @@ import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { popup } from '@/os';
 
-export function pleaseLogin(path?: string) {
+export function pleaseLogin(path?: string, stopExecution: boolean = true) {
 	if ($i) return;
 
 	popup(defineAsyncComponent(() => import('@/components/signin-dialog.vue')), {
@@ -17,5 +17,5 @@ export function pleaseLogin(path?: string) {
 		},
 	}, 'closed');
 
-	throw new Error('signin required');
+	if (stopExecution) throw new Error('signin required');
 }

--- a/packages/client/src/scripts/please-login.ts
+++ b/packages/client/src/scripts/please-login.ts
@@ -3,7 +3,7 @@ import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { popup } from '@/os';
 
-export function pleaseLogin(path?: string, stopExecution: boolean = true) {
+export function pleaseLogin(path?: string) {
 	if ($i) return;
 
 	popup(defineAsyncComponent(() => import('@/components/signin-dialog.vue')), {
@@ -17,5 +17,5 @@ export function pleaseLogin(path?: string, stopExecution: boolean = true) {
 		},
 	}, 'closed');
 
-	if (stopExecution) throw new Error('signin required');
+	if (!path) throw new Error('signin required');
 }


### PR DESCRIPTION
# What

This PR uses the newly refactored `pleaseLogin` script to prevent non-logged in users from accessing parts of the website that require a user object or are in general not supposed to be visible to off-site users.

It also removes two routes that point to pages that don't exist as components (`advanced-theme-editor` and `test`)

# Why

Pages that require user data are broken, and thus shouldn't be accessible in that case. Trying to close the sign-in modal then redirects to the homepage, preventing the users from seeing (partially) broken pages and thus improving the user experience.

fixes #8377

# Additional info (optional)

I extended `pleaseLogin` with another optional argument `stopExecution`. This allows to trigger the throwing of the error on demand, because if logic is followed after the prompt that should be cancelled, we need the error, but in cases like the navigation or component rendering this breaks Misskey.
