### PR TITLE
feat(tests): add e2e tests for widgets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - feature/widget-tests
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - feature/widget-tests
   pull_request:
 
 jobs:

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -49,8 +49,7 @@ describe('After user signed in', () => {
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select('memo', { force: true });
-		// Force-close select popup with clicking elsewhere
-		cy.get('.msky-widget-select .label').click();
+		cy.get('.bg ._modalBg .transparent').click();
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -1,4 +1,4 @@
-describe('After user singed in', () => {
+describe('After user signed in', () => {
 	beforeEach(() => {
 		cy.window(win => {
 			win.indexedDB.deleteDatabase('keyval-store');
@@ -42,8 +42,15 @@ describe('After user singed in', () => {
 		cy.get('.msky-widget-edit').should('be.visible');
   });
 
-	it('select should be visible in edit mode', () => {
+	it('widget select should be visible in edit mode', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select').should('be.visible');
+  });
+
+	it('memo widget should get added', () => {
+		cy.get('.msky-widget-edit').click();
+		cy.get('.msky-widget-select select').select('memo');
+		cy.get('.msky-widget-add').click();
+		cy.get('.mkw-memo').should('be.visible');
   });
 });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -4,7 +4,7 @@ function buildWidgetTest(widgetName) {
 		cy.get('.msky-widget-select select').select(widgetName, { force: true });
 		cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
 		cy.get('.msky-widget-add').click({ force: true });
-		cy.get(`.mkw-${widgetName}`, { timeout: 6000 }).should('be.visible');
+		cy.get(`.mkw-${widgetName}`).should('be.visible');
   });
 }
 

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -58,7 +58,7 @@ describe('After user signed in', () => {
 			cy.get('.mk-widget-select select').select(widgetName, { force: true });
 			cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
 			cy.get('.mk-widget-add').click({ force: true });
-			cy.get(`.mkw-${widgetName}`).should('be.visible');
+			cy.get(`.mkw-${widgetName}`).should('exist');
 		});
 	}
 

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -53,4 +53,12 @@ describe('After user signed in', () => {
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });
+
+	it('timeline widget should get added', () => {
+		cy.get('.msky-widget-edit').click();
+		cy.get('.msky-widget-select select').select('timeline', { force: true });
+		cy.get('.bg._modalBg.transparent').click({ multiple: true });
+		cy.get('.msky-widget-add').click();
+		cy.get('.mkw-timeline', { timeout: 6000 }).should('be.visible');
+  });
 });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -38,26 +38,26 @@ describe('After user signed in', () => {
 	});
 
   it('widget edit toggle is visible', () => {
-		cy.get('.msky-widget-edit').should('be.visible');
+		cy.get('.mk-widget-edit').should('be.visible');
   });
 
 	it('widget select should be visible in edit mode', () => {
-		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select').should('be.visible');
+		cy.get('.mk-widget-edit').click();
+		cy.get('.mk-widget-select').should('be.visible');
   });
 
 	it('first widget should be removed', () => {
-		cy.get('.msky-widget-edit').click();
+		cy.get('.mk-widget-edit').click();
 		cy.get('.customize-container:first-child .remove._button').click();
 		cy.get('.customize-container').should('have.length', 2);
 	});
 
 	function buildWidgetTest(widgetName) {
 		it(`${widgetName} widget should get added`, () => {
-			cy.get('.msky-widget-edit').click();
-			cy.get('.msky-widget-select select').select(widgetName, { force: true });
+			cy.get('.mk-widget-edit').click();
+			cy.get('.mk-widget-select select').select(widgetName, { force: true });
 			cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
-			cy.get('.msky-widget-add').click({ force: true });
+			cy.get('.mk-widget-add').click({ force: true });
 			cy.get(`.mkw-${widgetName}`).should('be.visible');
 		});
 	}

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -1,13 +1,3 @@
-function buildWidgetTest(widgetName) {
-	it(`${widgetName} widget should get added`, () => {
-		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').select(widgetName, { force: true });
-		cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
-		cy.get('.msky-widget-add').click({ force: true });
-		cy.get(`.mkw-${widgetName}`).should('be.visible');
-  });
-}
-
 describe('After user signed in', () => {
 	beforeEach(() => {
 		cy.window(win => {
@@ -55,6 +45,22 @@ describe('After user signed in', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select').should('be.visible');
   });
+
+	it('first widget should be removed', () => {
+		cy.get('.msky-widget-edit').click();
+		cy.get('.customize-container:first-child .remove._button').click();
+		cy.get('.customize-container').should('have.length', 2);
+	});
+
+	function buildWidgetTest(widgetName) {
+		it(`${widgetName} widget should get added`, () => {
+			cy.get('.msky-widget-edit').click();
+			cy.get('.msky-widget-select select').select(widgetName, { force: true });
+			cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
+			cy.get('.msky-widget-add').click({ force: true });
+			cy.get(`.mkw-${widgetName}`).should('be.visible');
+		});
+	}
 
 	buildWidgetTest('memo');
 	buildWidgetTest('notifications');

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -49,7 +49,7 @@ describe('After user signed in', () => {
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select('memo', { force: true });
-		cy.get('.bg ._modalBg .transparent').click();
+		cy.get('.bg._modalBg.transparent').click();
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -50,7 +50,7 @@ describe('After user signed in', () => {
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').invoke('attr', 'value', 'memo');
-		cy.get('.msky-widget-add').click({ force: true });
-		cy.get('.mkw-memo').should('be.visible');
+		cy.get('.msky-widget-add').click();
+		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });
 });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -38,7 +38,6 @@ describe('After user signed in', () => {
 	});
 
   it('widget edit toggle is visible', () => {
-		cy.visit('/');
 		cy.get('.msky-widget-edit').should('be.visible');
   });
 

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -1,3 +1,13 @@
+function buildWidgetTest(widgetName) {
+	it(`${widgetName} widget should get added`, () => {
+		cy.get('.msky-widget-edit').click();
+		cy.get('.msky-widget-select select').select(widgetName, { force: true });
+		cy.get('.bg._modalBg.transparent').click({ multiple: true });
+		cy.get('.msky-widget-add').click();
+		cy.get(`.mkw-${widgetName}`, { timeout: 6000 }).should('be.visible');
+  });
+}
+
 describe('After user signed in', () => {
 	beforeEach(() => {
 		cy.window(win => {
@@ -46,19 +56,23 @@ describe('After user signed in', () => {
 		cy.get('.msky-widget-select').should('be.visible');
   });
 
-	it('memo widget should get added', () => {
-		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').select('memo', { force: true });
-		cy.get('.bg._modalBg.transparent').click({ multiple: true });
-		cy.get('.msky-widget-add').click();
-		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
-  });
-
-	it('timeline widget should get added', () => {
-		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').select('timeline', { force: true });
-		cy.get('.bg._modalBg.transparent').click({ multiple: true });
-		cy.get('.msky-widget-add').click();
-		cy.get('.mkw-timeline', { timeout: 6000 }).should('be.visible');
-  });
+	buildWidgetTest('memo');
+	buildWidgetTest('notifications');
+	buildWidgetTest('timeline');
+	buildWidgetTest('calendar');
+	buildWidgetTest('rss');
+	buildWidgetTest('trends');
+	buildWidgetTest('clock');
+	buildWidgetTest('activity');
+	buildWidgetTest('photos');
+	buildWidgetTest('digitalClock');
+	buildWidgetTest('federation');
+	buildWidgetTest('postForm');
+	buildWidgetTest('slideshow');
+	buildWidgetTest('serverMetric');
+	buildWidgetTest('onlineUsers');
+	buildWidgetTest('jobQueue');
+	buildWidgetTest('button');
+	buildWidgetTest('aiscript');
+	buildWidgetTest('aichan');
 });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -50,7 +50,7 @@ describe('After user signed in', () => {
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select('memo', { force: true });
-		cy.get('.msky-widget-add').click();
+		cy.get('.msky-widget-add').click({ force: true });
 		cy.get('.mkw-memo').should('be.visible');
   });
 });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -2,7 +2,7 @@ function buildWidgetTest(widgetName) {
 	it(`${widgetName} widget should get added`, () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select(widgetName, { force: true });
-		cy.get('.bg._modalBg.transparent').click({ multiple: true });
+		cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
 		cy.get('.msky-widget-add').click();
 		cy.get(`.mkw-${widgetName}`, { timeout: 6000 }).should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -48,7 +48,9 @@ describe('After user signed in', () => {
 
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').invoke('attr', 'value', 'memo');
+		cy.get('.msky-widget-select select').select('memo', { force: true });
+		// Force-close select popup with clicking elsewhere
+		cy.get('.msky-widget-select .label').click();
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -49,7 +49,7 @@ describe('After user signed in', () => {
 
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').select('memo');
+		cy.get('.msky-widget-select select').select('memo', { force: true });
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo').should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -1,0 +1,47 @@
+describe('After user singed in', () => {
+	beforeEach(() => {
+		cy.window(win => {
+			win.indexedDB.deleteDatabase('keyval-store');
+		});
+		cy.request('POST', '/api/reset-db').as('reset');
+		cy.get('@reset').its('status').should('equal', 204);
+		cy.reload(true);
+
+		// インスタンス初期セットアップ
+		cy.request('POST', '/api/admin/accounts/create', {
+			username: 'admin',
+			password: 'pass',
+		}).its('body').as('admin');
+
+		// ユーザー作成
+		cy.request('POST', '/api/signup', {
+			username: 'alice',
+			password: 'alice1234',
+		}).its('body').as('alice');
+
+		cy.visit('/');
+
+		cy.intercept('POST', '/api/signin').as('signin');
+
+		cy.get('[data-cy-signin]').click();
+		cy.get('[data-cy-signin-username] input').type('alice');
+		cy.get('[data-cy-signin-password] input').type('alice1234{enter}');
+
+		cy.wait('@signin').as('signedIn');
+	});
+
+	afterEach(() => {
+		// テスト終了直前にページ遷移するようなテストケース(例えばアカウント作成)だと、たぶんCypressのバグでブラウザの内容が次のテストケースに引き継がれてしまう(例えばアカウントが作成し終わった段階からテストが始まる)。
+		// waitを入れることでそれを防止できる
+		cy.wait(1000);
+	});
+
+  it('widget edit toggle is visible', () => {
+		cy.get('.msky-widget-edit').should('be.visible');
+  });
+
+	it('select should be visible in edit mode', () => {
+		cy.get('.msky-widget-edit').click();
+		cy.get('.msky-widget-select').should('be.visible');
+  });
+});

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -3,7 +3,7 @@ function buildWidgetTest(widgetName) {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select(widgetName, { force: true });
 		cy.get('.bg._modalBg.transparent').click({ multiple: true, force: true });
-		cy.get('.msky-widget-add').click();
+		cy.get('.msky-widget-add').click({ force: true });
 		cy.get(`.mkw-${widgetName}`, { timeout: 6000 }).should('be.visible');
   });
 }

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -49,7 +49,7 @@ describe('After user signed in', () => {
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
 		cy.get('.msky-widget-select select').select('memo', { force: true });
-		cy.get('.bg._modalBg.transparent').click();
+		cy.get('.bg._modalBg.transparent').click({ multiple: true });
 		cy.get('.msky-widget-add').click();
 		cy.get('.mkw-memo', { timeout: 6000 }).should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -49,7 +49,7 @@ describe('After user signed in', () => {
 
 	it('memo widget should get added', () => {
 		cy.get('.msky-widget-edit').click();
-		cy.get('.msky-widget-select select').select('memo', { force: true });
+		cy.get('.msky-widget-select select').invoke('attr', 'value', 'memo');
 		cy.get('.msky-widget-add').click({ force: true });
 		cy.get('.mkw-memo').should('be.visible');
   });

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -3,6 +3,7 @@ describe('After user singed in', () => {
 		cy.window(win => {
 			win.indexedDB.deleteDatabase('keyval-store');
 		});
+		cy.viewport('macbook-16');
 		cy.request('POST', '/api/reset-db').as('reset');
 		cy.get('@reset').its('status').should('equal', 204);
 		cy.reload(true);
@@ -37,6 +38,7 @@ describe('After user singed in', () => {
 	});
 
   it('widget edit toggle is visible', () => {
+		cy.visit('/');
 		cy.get('.msky-widget-edit').should('be.visible');
   });
 

--- a/packages/client/src/components/widgets.vue
+++ b/packages/client/src/components/widgets.vue
@@ -2,11 +2,11 @@
 <div class="vjoppmmu">
 	<template v-if="edit">
 		<header>
-			<MkSelect v-model="widgetAdderSelected" style="margin-bottom: var(--margin)">
+			<MkSelect v-model="widgetAdderSelected" style="margin-bottom: var(--margin)" class="msky-widget-select">
 				<template #label>{{ $ts.selectWidget }}</template>
 				<option v-for="widget in widgetDefs" :key="widget" :value="widget">{{ $t(`_widgets.${widget}`) }}</option>
 			</MkSelect>
-			<MkButton inline primary @click="addWidget"><i class="fas fa-plus"></i> {{ $ts.add }}</MkButton>
+			<MkButton inline primary class="msky-widget-add" @click="addWidget"><i class="fas fa-plus"></i> {{ $ts.add }}</MkButton>
 			<MkButton inline @click="$emit('exit')">{{ $ts.close }}</MkButton>
 		</header>
 		<XDraggable

--- a/packages/client/src/components/widgets.vue
+++ b/packages/client/src/components/widgets.vue
@@ -2,11 +2,11 @@
 <div class="vjoppmmu">
 	<template v-if="edit">
 		<header>
-			<MkSelect v-model="widgetAdderSelected" style="margin-bottom: var(--margin)" class="msky-widget-select">
+			<MkSelect v-model="widgetAdderSelected" style="margin-bottom: var(--margin)" class="mk-widget-select">
 				<template #label>{{ $ts.selectWidget }}</template>
 				<option v-for="widget in widgetDefs" :key="widget" :value="widget">{{ $t(`_widgets.${widget}`) }}</option>
 			</MkSelect>
-			<MkButton inline primary class="msky-widget-add" @click="addWidget"><i class="fas fa-plus"></i> {{ $ts.add }}</MkButton>
+			<MkButton inline primary class="mk-widget-add" @click="addWidget"><i class="fas fa-plus"></i> {{ $ts.add }}</MkButton>
 			<MkButton inline @click="$emit('exit')">{{ $ts.close }}</MkButton>
 		</header>
 		<XDraggable

--- a/packages/client/src/ui/universal.widgets.vue
+++ b/packages/client/src/ui/universal.widgets.vue
@@ -3,7 +3,7 @@
 	<XWidgets :edit="editMode" :widgets="defaultStore.reactiveState.widgets.value" @add-widget="addWidget" @remove-widget="removeWidget" @update-widget="updateWidget" @update-widgets="updateWidgets" @exit="editMode = false"/>
 
 	<button v-if="editMode" class="_textButton" style="font-size: 0.9em;" @click="editMode = false"><i class="fas fa-check"></i> {{ i18n.ts.editWidgetsExit }}</button>
-	<button v-else class="_textButton" style="font-size: 0.9em;" @click="editMode = true"><i class="fas fa-pencil-alt"></i> {{ i18n.ts.editWidgets }}</button>
+	<button v-else class="_textButton msky-widget-edit" style="font-size: 0.9em;" @click="editMode = true"><i class="fas fa-pencil-alt"></i> {{ i18n.ts.editWidgets }}</button>
 </div>
 </template>
 

--- a/packages/client/src/ui/universal.widgets.vue
+++ b/packages/client/src/ui/universal.widgets.vue
@@ -3,7 +3,7 @@
 	<XWidgets :edit="editMode" :widgets="defaultStore.reactiveState.widgets.value" @add-widget="addWidget" @remove-widget="removeWidget" @update-widget="updateWidget" @update-widgets="updateWidgets" @exit="editMode = false"/>
 
 	<button v-if="editMode" class="_textButton" style="font-size: 0.9em;" @click="editMode = false"><i class="fas fa-check"></i> {{ i18n.ts.editWidgetsExit }}</button>
-	<button v-else class="_textButton msky-widget-edit" style="font-size: 0.9em;" @click="editMode = true"><i class="fas fa-pencil-alt"></i> {{ i18n.ts.editWidgets }}</button>
+	<button v-else class="_textButton mk-widget-edit" style="font-size: 0.9em;" @click="editMode = true"><i class="fas fa-pencil-alt"></i> {{ i18n.ts.editWidgets }}</button>
 </div>
 </template>
 

--- a/packages/client/src/widgets/activity.vue
+++ b/packages/client/src/widgets/activity.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader" :naked="widgetProps.transparent">
+<MkContainer :show-header="widgetProps.showHeader" :naked="widgetProps.transparent" class="mkw-activity">
 	<template #header><i class="fas fa-chart-bar"></i>{{ $ts._widgets.activity }}</template>
 	<template #func><button class="_button" @click="toggleView()"><i class="fas fa-sort"></i></button></template>
 

--- a/packages/client/src/widgets/aichan.vue
+++ b/packages/client/src/widgets/aichan.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :naked="widgetProps.transparent" :show-header="false">
+<MkContainer :naked="widgetProps.transparent" :show-header="false" class="mkw-aichan">
 	<iframe ref="live2d" class="dedjhjmo" src="https://misskey-dev.github.io/mascot-web/?scale=1.5&y=1.1&eyeY=100" @click="touched"></iframe>
 </MkContainer>
 </template>

--- a/packages/client/src/widgets/aiscript.vue
+++ b/packages/client/src/widgets/aiscript.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader">
+<MkContainer :show-header="widgetProps.showHeader" class="mkw-aiscript">
 	<template #header><i class="fas fa-terminal"></i>{{ $ts._widgets.aiscript }}</template>
 
 	<div class="uylguesu _monospace">

--- a/packages/client/src/widgets/clock.vue
+++ b/packages/client/src/widgets/clock.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :naked="widgetProps.transparent" :show-header="false">
+<MkContainer :naked="widgetProps.transparent" :show-header="false" class="mkw-clock">
 	<div class="vubelbmv">
 		<MkAnalogClock class="clock" :thickness="widgetProps.thickness"/>
 	</div>

--- a/packages/client/src/widgets/federation.vue
+++ b/packages/client/src/widgets/federation.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader" :foldable="foldable" :scrollable="scrollable">
+<MkContainer :show-header="widgetProps.showHeader" :foldable="foldable" :scrollable="scrollable" class="mkw-federation">
 	<template #header><i class="fas fa-globe"></i>{{ $ts._widgets.federation }}</template>
 
 	<div class="wbrkwalb">

--- a/packages/client/src/widgets/memo.vue
+++ b/packages/client/src/widgets/memo.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader">
+<MkContainer :show-header="widgetProps.showHeader" class="mkw-memo">
 	<template #header><i class="fas fa-sticky-note"></i>{{ $ts._widgets.memo }}</template>
 
 	<div class="otgbylcu">

--- a/packages/client/src/widgets/notifications.vue
+++ b/packages/client/src/widgets/notifications.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :style="`height: ${widgetProps.height}px;`" :show-header="widgetProps.showHeader" :scrollable="true">
+<MkContainer :style="`height: ${widgetProps.height}px;`" :show-header="widgetProps.showHeader" :scrollable="true" class="mkw-notifications">
 	<template #header><i class="fas fa-bell"></i>{{ $ts.notifications }}</template>
 	<template #func><button class="_button" @click="configureNotification()"><i class="fas fa-cog"></i></button></template>
 

--- a/packages/client/src/widgets/photos.vue
+++ b/packages/client/src/widgets/photos.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader" :naked="widgetProps.transparent" :class="$style.root" :data-transparent="widgetProps.transparent ? true : null">
+<MkContainer :show-header="widgetProps.showHeader" :naked="widgetProps.transparent" :class="$style.root" :data-transparent="widgetProps.transparent ? true : null" class="mkw-photos">
 	<template #header><i class="fas fa-camera"></i>{{ $ts._widgets.photos }}</template>
 
 	<div class="">

--- a/packages/client/src/widgets/post-form.vue
+++ b/packages/client/src/widgets/post-form.vue
@@ -1,5 +1,5 @@
 <template>
-<XPostForm class="_panel" :fixed="true" :autofocus="false"/>
+<XPostForm class="_panel mkw-postForm" :fixed="true" :autofocus="false"/>
 </template>
 
 <script lang="ts" setup>

--- a/packages/client/src/widgets/rss.vue
+++ b/packages/client/src/widgets/rss.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader">
+<MkContainer :show-header="widgetProps.showHeader" class="mkw-rss">
 	<template #header><i class="fas fa-rss-square"></i>RSS</template>
 	<template #func><button class="_button" @click="configure"><i class="fas fa-cog"></i></button></template>
 

--- a/packages/client/src/widgets/slideshow.vue
+++ b/packages/client/src/widgets/slideshow.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="kvausudm _panel" :style="{ height: widgetProps.height + 'px' }">
+<div class="kvausudm _panel mkw-slideshow" :style="{ height: widgetProps.height + 'px' }">
 	<div @click="choose">
 		<p v-if="widgetProps.folderId == null">
 			{{ $ts.folder }}

--- a/packages/client/src/widgets/timeline.vue
+++ b/packages/client/src/widgets/timeline.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader" :style="`height: ${widgetProps.height}px;`" :scrollable="true">
+<MkContainer :show-header="widgetProps.showHeader" :style="`height: ${widgetProps.height}px;`" :scrollable="true" class="mkw-timeline">
 	<template #header>
 		<button class="_button" @click="choose">
 			<i v-if="widgetProps.src === 'home'" class="fas fa-home"></i>

--- a/packages/client/src/widgets/trends.vue
+++ b/packages/client/src/widgets/trends.vue
@@ -1,5 +1,5 @@
 <template>
-<MkContainer :show-header="widgetProps.showHeader">
+<MkContainer :show-header="widgetProps.showHeader" class="mkw-trends">
 	<template #header><i class="fas fa-hashtag"></i>{{ $ts._widgets.trends }}</template>
 
 	<div class="wbrkwala">


### PR DESCRIPTION
# What

This PR adds 22 end-to-end test cases for adding all widgets to the widget sidebar.

3 basic tests:
* checking if the `Edit widgets` button is present
* checking if the select is visible after `Edit widgets` has been pressed (Edit mode)
* checking if removing widgets works

19 tests for all current widgets

# Why

After the recent merge of the widget refactoring/lint issues a lot of regressions happened. Testing if widgets are present after being added at least makes sure that they are not breaking the application completely.

# Additional info (optional)

* I added `mk-widget-edit/select/add` classes to mark up the elements that are used to add widgets
* I added more `mkw-*` classes to the widgets that had them missing
* The test cases do not check for specific widget functionality, they only check that the wrapped `mkw-{widgetName}` is present after being added
