### PR TITLE
fix(doc): correct information for drive upload

### DIFF
--- a/packages/backend/src/server/api/openapi/gen-spec.ts
+++ b/packages/backend/src/server/api/openapi/gen-spec.ts
@@ -59,6 +59,18 @@ export function genOpenapiSpec(lang = 'ja-JP') {
 			desc += ` / **Permission**: *${kind}*`;
 		}
 
+		const requestType = endpoint.meta.requireFile ? 'multipart/form-data' : 'application/json';
+		const schema = endpoint.params;
+
+		if (endpoint.meta.requireFile) {
+			schema.properties.file = {
+				type: 'string',
+				format: 'binary',
+				description: 'The file contents.',
+			};
+			schema.required.push('file');
+		}
+
 		const info = {
 			operationId: endpoint.name,
 			summary: endpoint.name,
@@ -78,8 +90,8 @@ export function genOpenapiSpec(lang = 'ja-JP') {
 			requestBody: {
 				required: true,
 				content: {
-					'application/json': {
-						schema: endpoint.params,
+					[requestType]: {
+						schema,
 					},
 				},
 			},


### PR DESCRIPTION
# What
Fixes the OpenAPI documentation regarding endpoints that require file upload. This mainly means `/drive/file/upload` but the fix is written in a general way that could be applied to other endpoints as well.

This documents the existing behaviour, the client already uses `FormData` for uploading files: https://github.com/misskey-dev/misskey/blob/9c80403072d2f49103f77af54dffbd21325806db/packages/client/src/scripts/upload.ts#L72-L76

# Why
Improve the documentation.

# Additional Information
https://swagger.io/docs/specification/describing-request-body/multipart-requests/

deployed on https://genau.qwertqwefsday.eu/api-doc#operation/drive/files/create
<details>
<summary>screenshot</summary>

<img src="https://user-images.githubusercontent.com/20990607/170476632-ebcf4ff5-1472-4db9-a5dc-3a37bf12ee5d.png" height="500"/>
</details>