### PR TITLE
enhance: replace signin CAPTCHA with rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ You should also include the user name that made the change.
   Your own theme color may be unset if it was in an invalid format.
   Admins should check their instance settings if in doubt.
 - Perform port diagnosis at startup only when Listen fails @mei23
+- Rate limiting is now also usable for non-authenticated users. @Johann150
+  Admins should make sure the reverse proxy sets the `X-Forwarded-For` header to the original address.
 
 ### Bugfixes
 - Client: fix settings page @tamaina

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -842,6 +842,7 @@ oneDay: "1日"
 oneWeek: "1週間"
 reflectMayTakeTime: "反映されるまで時間がかかる場合があります。"
 failedToFetchAccountInformation: "アカウント情報の取得に失敗しました"
+rateLimitExceeded: "レート制限を超えました"
 
 _emailUnavailable:
   used: "既に使用されています"

--- a/packages/backend/src/server/api/endpoints.ts
+++ b/packages/backend/src/server/api/endpoints.ts
@@ -654,7 +654,6 @@ export interface IEndpointMeta {
 	/**
 	 * エンドポイントのリミテーションに関するやつ
 	 * 省略した場合はリミテーションは無いものとして解釈されます。
-	 * また、withCredential が false の場合はリミテーションを行うことはできません。
 	 */
 	readonly limit?: {
 

--- a/packages/backend/src/server/api/limiter.ts
+++ b/packages/backend/src/server/api/limiter.ts
@@ -1,24 +1,17 @@
 import Limiter from 'ratelimiter';
 import { redisClient } from '../../db/redis.js';
-import { IEndpoint } from './endpoints.js';
+import { IEndpointMeta } from './endpoints.js';
 import { CacheableLocalUser, User } from '@/models/entities/user.js';
 import Logger from '@/services/logger.js';
 
 const logger = new Logger('limiter');
 
-export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndpoint['meta']['limit']> } }, actor: string) => new Promise<void>((ok, reject) => {
-	const limitation = endpoint.meta.limit;
-
-	const key = Object.prototype.hasOwnProperty.call(limitation, 'key')
-		? limitation.key
-		: endpoint.name;
-
-	const hasShortTermLimit =
-		Object.prototype.hasOwnProperty.call(limitation, 'minInterval');
+export const limiter = (limitation: IEndpointMeta['limit'] & { key: NonNullable<string> }, actor: string) => new Promise<void>((ok, reject) => {
+	const hasShortTermLimit = typeof limitation.minInterval === 'number';
 
 	const hasLongTermLimit =
-		Object.prototype.hasOwnProperty.call(limitation, 'duration') &&
-		Object.prototype.hasOwnProperty.call(limitation, 'max');
+		typeof limitation.duration === 'number' &&
+		typeof limitation.max === 'number';
 
 	if (hasShortTermLimit) {
 		min();
@@ -31,7 +24,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 	// Short-term limit
 	function min(): void {
 		const minIntervalLimiter = new Limiter({
-			id: `${actor}:${key}:min`,
+			id: `${actor}:${limitation.key}:min`,
 			duration: limitation.minInterval,
 			max: 1,
 			db: redisClient,
@@ -59,7 +52,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 	// Long term limit
 	function max(): void {
 		const limiter = new Limiter({
-			id: `${actor}:${key}`,
+			id: `${actor}:${limitation.key}`,
 			duration: limitation.duration,
 			max: limitation.max,
 			db: redisClient,

--- a/packages/backend/src/server/api/limiter.ts
+++ b/packages/backend/src/server/api/limiter.ts
@@ -35,7 +35,7 @@ export const limiter = (limitation: IEndpointMeta['limit'] & { key: NonNullable<
 				return reject('ERR');
 			}
 
-			logger.debug(`${actor} ${endpoint.name} min remaining: ${info.remaining}`);
+			logger.debug(`${actor} ${limitation.key} min remaining: ${info.remaining}`);
 
 			if (info.remaining === 0) {
 				reject('BRIEF_REQUEST_INTERVAL');
@@ -63,7 +63,7 @@ export const limiter = (limitation: IEndpointMeta['limit'] & { key: NonNullable<
 				return reject('ERR');
 			}
 
-			logger.debug(`${actor} ${endpoint.name} max remaining: ${info.remaining}`);
+			logger.debug(`${actor} ${limitation.key} max remaining: ${info.remaining}`);
 
 			if (info.remaining === 0) {
 				reject('RATE_LIMIT_EXCEEDED');

--- a/packages/backend/src/server/api/limiter.ts
+++ b/packages/backend/src/server/api/limiter.ts
@@ -1,13 +1,12 @@
 import Limiter from 'ratelimiter';
 import { redisClient } from '../../db/redis.js';
 import { IEndpoint } from './endpoints.js';
-import * as Acct from '@/misc/acct.js';
 import { CacheableLocalUser, User } from '@/models/entities/user.js';
 import Logger from '@/services/logger.js';
 
 const logger = new Logger('limiter');
 
-export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndpoint['meta']['limit']> } }, user: CacheableLocalUser) => new Promise<void>((ok, reject) => {
+export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndpoint['meta']['limit']> } }, actor: string) => new Promise<void>((ok, reject) => {
 	const limitation = endpoint.meta.limit;
 
 	const key = Object.prototype.hasOwnProperty.call(limitation, 'key')
@@ -32,7 +31,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 	// Short-term limit
 	function min(): void {
 		const minIntervalLimiter = new Limiter({
-			id: `${user.id}:${key}:min`,
+			id: `${actor}:${key}:min`,
 			duration: limitation.minInterval,
 			max: 1,
 			db: redisClient,
@@ -43,7 +42,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 				return reject('ERR');
 			}
 
-			logger.debug(`@${Acct.toString(user)} ${endpoint.name} min remaining: ${info.remaining}`);
+			logger.debug(`${actor} ${endpoint.name} min remaining: ${info.remaining}`);
 
 			if (info.remaining === 0) {
 				reject('BRIEF_REQUEST_INTERVAL');
@@ -60,7 +59,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 	// Long term limit
 	function max(): void {
 		const limiter = new Limiter({
-			id: `${user.id}:${key}`,
+			id: `${actor}:${key}`,
 			duration: limitation.duration,
 			max: limitation.max,
 			db: redisClient,
@@ -71,7 +70,7 @@ export const limiter = (endpoint: IEndpoint & { meta: { limit: NonNullable<IEndp
 				return reject('ERR');
 			}
 
-			logger.debug(`@${Acct.toString(user)} ${endpoint.name} max remaining: ${info.remaining}`);
+			logger.debug(`${actor} ${endpoint.name} max remaining: ${info.remaining}`);
 
 			if (info.remaining === 0) {
 				reject('RATE_LIMIT_EXCEEDED');

--- a/packages/backend/src/server/api/private/signin.ts
+++ b/packages/backend/src/server/api/private/signin.ts
@@ -1,38 +1,21 @@
-import { randomBytes } from 'node:crypto';
 import Koa from 'koa';
 import bcrypt from 'bcryptjs';
 import * as speakeasy from 'speakeasy';
-import { IsNull } from 'typeorm';
+import signin from '../common/signin.js';
 import config from '@/config/index.js';
 import { Users, Signins, UserProfiles, UserSecurityKeys, AttestationChallenges } from '@/models/index.js';
 import { ILocalUser } from '@/models/entities/user.js';
 import { genId } from '@/misc/gen-id.js';
-import { fetchMeta } from '@/misc/fetch-meta.js';
-import { verifyHcaptcha, verifyRecaptcha } from '@/misc/captcha.js';
 import { verifyLogin, hash } from '../2fa.js';
+import { randomBytes } from 'node:crypto';
+import { IsNull } from 'typeorm';
 import { limiter } from '../limiter.js';
-import signin from '../common/signin.js';
 
 export default async (ctx: Koa.Context) => {
 	ctx.set('Access-Control-Allow-Origin', config.url);
 	ctx.set('Access-Control-Allow-Credentials', 'true');
 
 	const body = ctx.request.body as any;
-
-	const instance = await fetchMeta(true);
-
-	if (instance.enableHcaptcha && instance.hcaptchaSecretKey) {
-		await verifyHcaptcha(instance.hcaptchaSecretKey, body['hcaptcha-response']).catch(e => {
-			ctx.throw(400, e);
-		});
-	}
-
-	if (instance.enableRecaptcha && instance.recaptchaSecretKey) {
-		await verifyRecaptcha(instance.recaptchaSecretKey, body['g-recaptcha-response']).catch(e => {
-			ctx.throw(400, e);
-		});
-	}
-
 	const username = body['username'];
 	const password = body['password'];
 	const token = body['token'];
@@ -188,7 +171,7 @@ export default async (ctx: Koa.Context) => {
 				body.credentialId
 					.replace(/-/g, '+')
 					.replace(/_/g, '/'),
-				'base64',
+					'base64'
 			).toString('hex'),
 		});
 

--- a/packages/backend/src/server/api/private/signin.ts
+++ b/packages/backend/src/server/api/private/signin.ts
@@ -21,6 +21,18 @@ export default async (ctx: Koa.Context) => {
 
 	const instance = await fetchMeta(true);
 
+	if (instance.enableHcaptcha && instance.hcaptchaSecretKey) {
+		await verifyHcaptcha(instance.hcaptchaSecretKey, body['hcaptcha-response']).catch(e => {
+			ctx.throw(400, e);
+		});
+	}
+
+	if (instance.enableRecaptcha && instance.recaptchaSecretKey) {
+		await verifyRecaptcha(instance.recaptchaSecretKey, body['g-recaptcha-response']).catch(e => {
+			ctx.throw(400, e);
+		});
+	}
+
 	const username = body['username'];
 	const password = body['password'];
 	const token = body['token'];
@@ -100,18 +112,6 @@ export default async (ctx: Koa.Context) => {
 	}
 
 	if (!profile.twoFactorEnabled) {
-		if (instance.enableHcaptcha && instance.hcaptchaSecretKey) {
-			await verifyHcaptcha(instance.hcaptchaSecretKey, body['hcaptcha-response']).catch(e => {
-				ctx.throw(400, e);
-			});
-		}
-	
-		if (instance.enableRecaptcha && instance.recaptchaSecretKey) {
-			await verifyRecaptcha(instance.recaptchaSecretKey, body['g-recaptcha-response']).catch(e => {
-				ctx.throw(400, e);
-			});
-		}
-	
 		if (same) {
 			signin(ctx, user);
 			return;

--- a/packages/client/src/components/signin.vue
+++ b/packages/client/src/components/signin.vue
@@ -213,6 +213,14 @@ function loginFailed(err) {
 			showSuspendedDialog();
 			break;
 		}
+		case '22d05606-fbcf-421a-a2db-b32610dcfd1b': {
+			os.alert({
+				type: 'error',
+				title: i18n.ts.loginFailed,
+				text: i18n.ts.rateLimitExceeded,
+			});
+			break;
+		}
 		default: {
 			console.log(err)
 			os.alert({

--- a/packages/client/src/components/signin.vue
+++ b/packages/client/src/components/signin.vue
@@ -14,8 +14,6 @@
 				<template #prefix><i class="fas fa-lock"></i></template>
 				<template #caption><button class="_textButton" type="button" @click="resetPassword">{{ i18n.ts.forgotPassword }}</button></template>
 			</MkInput>
-			<MkCaptcha v-if="meta.enableHcaptcha" ref="hcaptcha" v-model="hCaptchaResponse" class="_formBlock captcha" provider="hcaptcha" :sitekey="meta.hcaptchaSiteKey"/>
-			<MkCaptcha v-if="meta.enableRecaptcha" ref="recaptcha" v-model="reCaptchaResponse" class="_formBlock captcha" provider="recaptcha" :sitekey="meta.recaptchaSiteKey"/>
 			<MkButton class="_formBlock" type="submit" primary :disabled="signing" style="margin: 0 auto;">{{ signing ? i18n.ts.loggingIn : i18n.ts.login }}</MkButton>
 		</div>
 		<div v-if="totpLogin" class="2fa-signin" :class="{ securityKeys: user && user.securityKeys }">

--- a/packages/client/src/components/signin.vue
+++ b/packages/client/src/components/signin.vue
@@ -62,8 +62,6 @@ import { showSuspendedDialog } from '../scripts/show-suspended-dialog';
 import { instance } from '@/instance';
 import { i18n } from '@/i18n';
 
-const MkCaptcha = defineAsyncComponent(() => import('./captcha.vue'));
-
 let signing = $ref(false);
 let user = $ref(null);
 let username = $ref('');


### PR DESCRIPTION
# What
Instead of solving a CAPTCHA, the signin endpoint uses a rate limit. For this to work the rate limiter code had to be slightly adjusted to also work with IP addresses if no user has yet signed in. With this adjustment it might be possible to rate limit other API endpoints in the future as well, without requiring signing in.

# Why
- fix #8739
- undo breaking change to signin process

# Additional info
Applications which are using this endpoint should be aware that it is not strictly a part of the API. The native login token that gets returned from this endpoint gives special privileges due to the `secure` flag on some endpoints. This includes for example: 2FA setup, data import & export, app authentication, miauth, account deletion.

But these capabilities may be desired for alternative front ends.