### PR TITLE
fix: correctly render empty note text

### DIFF
--- a/packages/backend/src/remote/activitypub/misc/get-note-html.ts
+++ b/packages/backend/src/remote/activitypub/misc/get-note-html.ts
@@ -3,8 +3,6 @@ import { Note } from '@/models/entities/note.js';
 import { toHtml } from '../../../mfm/to-html.js';
 
 export default function(note: Note) {
-	let html = note.text ? toHtml(mfm.parse(note.text), JSON.parse(note.mentionedRemoteUsers)) : null;
-	if (html == null) html = '<p>.</p>';
-
-	return html;
+	if (!note.text) return '';
+	return toHtml(mfm.parse(note.text), JSON.parse(note.mentionedRemoteUsers));
 }

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -82,15 +82,15 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 
 	const files = await getPromisedFiles(note.fileIds);
 
-	const text = note.text;
+	// text should never be undefined
+	const text = note.text ?? null;
 	let poll: Poll | null = null;
 
 	if (note.hasPoll) {
 		poll = await Polls.findOneBy({ noteId: note.id });
 	}
 
-	let apText = text;
-	if (apText == null) apText = '';
+	let apText = text ?? '';
 
 	if (quote) {
 		apText += `\n\nRE: ${quote}`;


### PR DESCRIPTION
# What
Ensure that the `_misskey_content` attribute will always be set. Because the API endpoint does not require the existence of the `text` field, that field may be `undefined` when rendering the ActivityPub representation. If it does not exist it will now be set to `null` instead.

The code was made a bit more succinct by using the null coercion operator for initializing `apText`.

# Why
fix #8745

# Additional info
While this is not strictly necessary to fix the issue at hand, the rendered HTML of a note with empty text will now also be rendered correctly. From git blame it seems that the previous behaviour was added because of a Mastodon bug that might have previously existed. However, this seems to be no longer the case, as I can find Mastodon posts that have empty content.