### PR TITLE
Remove require captcha from signin from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ You should also include the user name that made the change.
 - replaced webpack with Vite @tamaina
 - update dependencies @syuilo
 - enhance: display URL of QR code for TOTP registration @syuilo
-- make CAPTCHA required for signin to improve security @syuilo
 - enhance: Supports Unicode Emoji 14.0 @mei23
 - The theme color is now better validated. @Johann150
   Your own theme color may be unset if it was in an invalid format.


### PR DESCRIPTION
#8740 removed making CAPTCHA required for signin, so it should be removed from the changelog.