### PR TITLE
Fix IP address rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ You should also include the user name that made the change.
   Your own theme color may be unset if it was in an invalid format.
   Admins should check their instance settings if in doubt.
 - Perform port diagnosis at startup only when Listen fails @mei23
-- Rate limiting is now also usable for non-authenticated users. @Johann150
+- Rate limiting is now also usable for non-authenticated users. @Johann150 @mei23
   Admins should make sure the reverse proxy sets the `X-Forwarded-For` header to the original address.
 
 ### Bugfixes

--- a/packages/backend/src/misc/get-ip-hash.ts
+++ b/packages/backend/src/misc/get-ip-hash.ts
@@ -1,0 +1,9 @@
+import IPCIDR from 'ip-cidr';
+
+export function getIpHash(ip: string) {
+	// because a single person may control many IPv6 addresses,
+	// only a /64 subnet prefix of any IP will be taken into account.
+	// (this means for IPv4 the entire address is used)
+	const prefix = IPCIDR.createAddress(ip).mask(64);
+	return BigInt('0b' + prefix).toString(36);
+}

--- a/packages/backend/src/misc/get-ip-hash.ts
+++ b/packages/backend/src/misc/get-ip-hash.ts
@@ -5,5 +5,5 @@ export function getIpHash(ip: string) {
 	// only a /64 subnet prefix of any IP will be taken into account.
 	// (this means for IPv4 the entire address is used)
 	const prefix = IPCIDR.createAddress(ip).mask(64);
-	return BigInt('0b' + prefix).toString(36);
+	return 'ip-' + BigInt('0b' + prefix).toString(36);
 }

--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -6,7 +6,7 @@ import endpoints, { IEndpointMeta } from './endpoints.js';
 import { ApiError } from './error.js';
 import { apiLogger } from './logger.js';
 import { AccessToken } from '@/models/entities/access-token.js';
-import IPCIDR from 'ip-cidr';
+import { getIpHash } from '@/misc/get-ip-hash.js';
 
 const accessDenied = {
 	message: 'Access denied.',
@@ -33,18 +33,13 @@ export default async (endpoint: string, user: CacheableLocalUser | null | undefi
 		throw new ApiError(accessDenied);
 	}
 
-	if (ep.meta.requireCredential && ep.meta.limit && !isModerator) {
+	if (ep.meta.limit && !isModerator) {
 		// koa will automatically load the `X-Forwarded-For` header if `proxy: true` is configured in the app.
 		let limitActor: string;
 		if (user) {
 			limitActor = user.id;
 		} else {
-			// because a single person may control many IPv6 addresses,
-			// only a /64 subnet prefix of any IP will be taken into account.
-			// (this means for IPv4 the entire address is used)
-			const ip = IPCIDR.createAddress(ctx.ip).mask(64);
-
-			limitActor = 'ip-' + parseInt(ip, 2).toString(36);
+			limitActor = 'ip-' + getIpHash(ctx!.ip);
 		}
 
 		const limit = Object.assign({}, ep.meta.limit);

--- a/packages/backend/src/server/api/call.ts
+++ b/packages/backend/src/server/api/call.ts
@@ -39,7 +39,7 @@ export default async (endpoint: string, user: CacheableLocalUser | null | undefi
 		if (user) {
 			limitActor = user.id;
 		} else {
-			limitActor = 'ip-' + getIpHash(ctx!.ip);
+			limitActor = getIpHash(ctx!.ip);
 		}
 
 		const limit = Object.assign({}, ep.meta.limit);

--- a/packages/backend/src/server/api/private/signin.ts
+++ b/packages/backend/src/server/api/private/signin.ts
@@ -10,6 +10,7 @@ import { verifyLogin, hash } from '../2fa.js';
 import { randomBytes } from 'node:crypto';
 import { IsNull } from 'typeorm';
 import { limiter } from '../limiter.js';
+import { getIpHash } from '@/misc/get-ip-hash.js';
 
 export default async (ctx: Koa.Context) => {
 	ctx.set('Access-Control-Allow-Origin', config.url);
@@ -27,7 +28,7 @@ export default async (ctx: Koa.Context) => {
 
 	try {
 		// not more than 1 attempt per second and not more than 10 attempts per hour
-		await limiter({ key: 'signin', duration: 60 * 60 * 1000, max: 10, minInterval: 1000 }, ctx.ip);
+		await limiter({ key: 'signin', duration: 60 * 60 * 1000, max: 10, minInterval: 1000 }, 'ip-' + getIpHash(ctx.ip));
 	} catch (err) {
 		ctx.status = 429;
 		ctx.body = {

--- a/packages/backend/src/server/api/private/signin.ts
+++ b/packages/backend/src/server/api/private/signin.ts
@@ -28,7 +28,7 @@ export default async (ctx: Koa.Context) => {
 
 	try {
 		// not more than 1 attempt per second and not more than 10 attempts per hour
-		await limiter({ key: 'signin', duration: 60 * 60 * 1000, max: 10, minInterval: 1000 }, 'ip-' + getIpHash(ctx.ip));
+		await limiter({ key: 'signin', duration: 60 * 60 * 1000, max: 10, minInterval: 1000 }, getIpHash(ctx.ip));
 	} catch (err) {
 		ctx.status = 429;
 		ctx.body = {


### PR DESCRIPTION
# What
#8740 の以下の問題を修正
- IPv6 /64 prefix が `signin` に適用されない。
- API endpoint に`limit`を定義しても、依然としてnon-authenticated usersには効かない。
- IPv6 64bit prefix の処理で、整数部の制度が53bit程度しかないNumberで行っているので正しく計算されない。

# Why
バグ修正

# Additional info (optional)
ちゃんとテストしました
- 認証不要APIにlimitプロパティを追加して、未認証ユーザーに制限がかかるようになること。
- 以下の64bit prefix下部の異なるIPv6アドレスが異なるhashを生成すること。
  `2001:db8:3:4:5:6:7:8`
  `2001:db8:3:5:5:6:7:8`
