### PR TITLE
Import shared ESLint config in client package

### DIFF
--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -1,68 +1,79 @@
 module.exports = {
 	root: true,
 	env: {
-		"node": false
+		'node': false,
 	},
-	parser: "vue-eslint-parser",
+	parser: 'vue-eslint-parser',
 	parserOptions: {
-		"parser": "@typescript-eslint/parser",
+		'parser': '@typescript-eslint/parser',
 		tsconfigRootDir: __dirname,
-		//project: ['./tsconfig.json'],
+		project: ['./tsconfig.json'],
+		extraFileExtensions: ['.vue'],
 	},
 	extends: [
-		//"../shared/.eslintrc.js",
-		"plugin:vue/vue3-recommended"
+		'../shared/.eslintrc.js',
+		'plugin:vue/vue3-recommended',
 	],
 	rules: {
 		// window の禁止理由: グローバルスコープと衝突し、予期せぬ結果を招くため
 		// data の禁止理由: 抽象的すぎるため
 		// e の禁止理由: error や event など、複数のキーワードの頭文字であり分かりにくいため
-		"id-denylist": ["error", "window", "data", "e"],
+		'id-denylist': ['error', 'window', 'data', 'e'],
 		'eqeqeq': ['error', 'always', { 'null': 'ignore' }],
-		"no-shadow": ["warn"],
-		"vue/attributes-order": ["error", {
-			"alphabetical": false
+		'no-shadow': ['warn'],
+		'vue/attributes-order': ['error', {
+			'alphabetical': false,
 		}],
-		"vue/no-use-v-if-with-v-for": ["error", {
-			"allowUsingIterationVar": false
+		'vue/no-use-v-if-with-v-for': ['error', {
+			'allowUsingIterationVar': false,
 		}],
-		"vue/no-ref-as-operand": "error",
-		"vue/no-multi-spaces": ["error", {
-			"ignoreProperties": false
+		'vue/no-ref-as-operand': 'error',
+		'vue/no-multi-spaces': ['error', {
+			'ignoreProperties': false,
 		}],
-		"vue/no-v-html": "error",
-		"vue/order-in-components": "error",
-		"vue/html-indent": ["warn", "tab", {
-			"attribute": 1,
-			"baseIndent": 0,
-			"closeBracket": 0,
-			"alignAttributesVertically": true,
-			"ignores": []
+		'vue/no-v-html': 'error',
+		'vue/order-in-components': 'error',
+		'vue/html-indent': ['warn', 'tab', {
+			'attribute': 1,
+			'baseIndent': 0,
+			'closeBracket': 0,
+			'alignAttributesVertically': true,
+			'ignores': [],
 		}],
-		"vue/html-closing-bracket-spacing": ["warn", {
-			"startTag": "never",
-			"endTag": "never",
-			"selfClosingTag": "never"
+		'vue/html-closing-bracket-spacing': ['warn', {
+			'startTag': 'never',
+			'endTag': 'never',
+			'selfClosingTag': 'never',
 		}],
-		"vue/multi-word-component-names": "warn",
-		"vue/require-v-for-key": "warn",
-		"vue/no-unused-components": "warn",
-		"vue/valid-v-for": "warn",
-		"vue/return-in-computed-property": "warn",
-		"vue/no-setup-props-destructure": "warn",
-		"vue/max-attributes-per-line": "off",
-		"vue/html-self-closing": "off",
-		"vue/singleline-html-element-content-newline": "off",
+		'vue/multi-word-component-names': 'warn',
+		'vue/require-v-for-key': 'warn',
+		'vue/no-unused-components': 'warn',
+		'vue/valid-v-for': 'warn',
+		'vue/return-in-computed-property': 'warn',
+		'vue/no-setup-props-destructure': 'warn',
+		'vue/max-attributes-per-line': 'off',
+		'vue/html-self-closing': 'off',
+		'vue/singleline-html-element-content-newline': 'off',
 	},
 	globals: {
-		"require": false,
-		"_DEV_": false,
-		"_LANGS_": false,
-		"_VERSION_": false,
-		"_ENV_": false,
-		"_PERF_PREFIX_": false,
-		"_DATA_TRANSFER_DRIVE_FILE_": false,
-		"_DATA_TRANSFER_DRIVE_FOLDER_": false,
-		"_DATA_TRANSFER_DECK_COLUMN_": false
-	}
-}
+		// Node.js
+		'module': false,
+		'require': false,
+		'__dirname': false,
+
+		// Vue
+		'$$': false,
+		'$ref': false,
+		'$computed': false,
+
+		// Misskey
+		'_DEV_': false,
+		'_LANGS_': false,
+		'_VERSION_': false,
+		'_ENV_': false,
+		'_PERF_PREFIX_': false,
+		'_DATA_TRANSFER_DRIVE_FILE_': false,
+		'_DATA_TRANSFER_DRIVE_FOLDER_': false,
+		'_DATA_TRANSFER_DECK_COLUMN_': false,
+	},
+};

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -39,6 +39,7 @@
 	},
 	"compileOnSave": false,
 	"include": [
+		".eslintrc.js",
 		"./**/*.ts",
 		"./**/*.vue"
 	]


### PR DESCRIPTION
# What

Because of errors with ESLint and TypeScript/Vue setups the shared configuration was never imported, causing us to miss out on a few project-specific code style guidelines (like semicolons, spacing, etc.)

# Why

This is done to ensure a consistent code style between all parts of Misskey.

# Additional info (optional)

The errors from before are fixed like so:
* typescript-eslint has an option `extraFileExtensions` to specify for non-TS files
* `parserOptions.project` is set again (also was commented out)
* in `tsconfig.json` we add `.eslintrc.js` to the project so IDEs/ESLint does not complain about non-project files
