### PR TITLE
Extract commonly used test logic to commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - develop
+      - feature/test-commands
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - feature/test-commands
   pull_request:
 
 jobs:

--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -1,11 +1,6 @@
 describe('Before setup instance', () => {
 	beforeEach(() => {
-		cy.window(win => {
-			win.indexedDB.deleteDatabase('keyval-store');
-		});
-		cy.request('POST', '/api/reset-db').as('reset');
-		cy.get('@reset').its('status').should('equal', 204);
-		cy.reload(true);
+		cy.resetState();
 	});
 
 	afterEach(() => {
@@ -35,12 +30,7 @@ describe('Before setup instance', () => {
 
 describe('After setup instance', () => {
 	beforeEach(() => {
-		cy.window(win => {
-			win.indexedDB.deleteDatabase('keyval-store');
-		});
-		cy.request('POST', '/api/reset-db').as('reset');
-		cy.get('@reset').its('status').should('equal', 204);
-		cy.reload(true);
+		cy.resetState();
 
 		// インスタンス初期セットアップ
 		cy.request('POST', '/api/admin/accounts/create', {
@@ -76,12 +66,7 @@ describe('After setup instance', () => {
 
 describe('After user signup', () => {
 	beforeEach(() => {
-		cy.window(win => {
-			win.indexedDB.deleteDatabase('keyval-store');
-		});
-		cy.request('POST', '/api/reset-db').as('reset');
-		cy.get('@reset').its('status').should('equal', 204);
-		cy.reload(true);
+		cy.resetState();
 
 		// インスタンス初期セットアップ
 		cy.request('POST', '/api/admin/accounts/create', {
@@ -138,34 +123,15 @@ describe('After user signup', () => {
 
 describe('After user singed in', () => {
 	beforeEach(() => {
-		cy.window(win => {
-			win.indexedDB.deleteDatabase('keyval-store');
-		});
-		cy.request('POST', '/api/reset-db').as('reset');
-		cy.get('@reset').its('status').should('equal', 204);
-		cy.reload(true);
+		cy.resetState();
 
 		// インスタンス初期セットアップ
-		cy.request('POST', '/api/admin/accounts/create', {
-			username: 'admin',
-			password: 'pass',
-		}).its('body').as('admin');
+		cy.registerUser('admin', 'pass', true);
 
 		// ユーザー作成
-		cy.request('POST', '/api/signup', {
-			username: 'alice',
-			password: 'alice1234',
-		}).its('body').as('alice');
+		cy.registerUser('alice', 'alice1234');
 
-		cy.visit('/');
-
-		cy.intercept('POST', '/api/signin').as('signin');
-
-		cy.get('[data-cy-signin]').click();
-		cy.get('[data-cy-signin-username] input').type('alice');
-		cy.get('[data-cy-signin-password] input').type('alice1234{enter}');
-
-		cy.wait('@signin').as('signedIn');
+		cy.login('alice', 'alice1234');
 	});
 
 	afterEach(() => {

--- a/cypress/integration/basic.js
+++ b/cypress/integration/basic.js
@@ -33,10 +33,7 @@ describe('After setup instance', () => {
 		cy.resetState();
 
 		// インスタンス初期セットアップ
-		cy.request('POST', '/api/admin/accounts/create', {
-			username: 'admin',
-			password: 'pass',
-		}).its('body').as('admin');
+		cy.registerUser('admin', 'pass', true);
 	});
 
 	afterEach(() => {
@@ -69,16 +66,10 @@ describe('After user signup', () => {
 		cy.resetState();
 
 		// インスタンス初期セットアップ
-		cy.request('POST', '/api/admin/accounts/create', {
-			username: 'admin',
-			password: 'pass',
-		}).its('body').as('admin');
+		cy.registerUser('admin', 'pass', true);
 
 		// ユーザー作成
-		cy.request('POST', '/api/signup', {
-			username: 'alice',
-			password: 'alice1234',
-		}).its('body').as('alice');
+		cy.registerUser('alice', 'alice1234');
 	});
 
 	afterEach(() => {

--- a/cypress/integration/widgets.js
+++ b/cypress/integration/widgets.js
@@ -1,34 +1,15 @@
 describe('After user signed in', () => {
 	beforeEach(() => {
-		cy.window(win => {
-			win.indexedDB.deleteDatabase('keyval-store');
-		});
+		cy.resetState();
 		cy.viewport('macbook-16');
-		cy.request('POST', '/api/reset-db').as('reset');
-		cy.get('@reset').its('status').should('equal', 204);
-		cy.reload(true);
 
 		// インスタンス初期セットアップ
-		cy.request('POST', '/api/admin/accounts/create', {
-			username: 'admin',
-			password: 'pass',
-		}).its('body').as('admin');
+		cy.registerUser('admin', 'pass', true);
 
 		// ユーザー作成
-		cy.request('POST', '/api/signup', {
-			username: 'alice',
-			password: 'alice1234',
-		}).its('body').as('alice');
+		cy.registerUser('alice', 'alice1234');
 
-		cy.visit('/');
-
-		cy.intercept('POST', '/api/signin').as('signin');
-
-		cy.get('[data-cy-signin]').click();
-		cy.get('[data-cy-signin-username] input').type('alice');
-		cy.get('[data-cy-signin-password] input').type('alice1234{enter}');
-
-		cy.wait('@signin').as('signedIn');
+		cy.login('alice', 'alice1234');
 	});
 
 	afterEach(() => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,33 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('resetState', () => {
+	cy.window(win => {
+		win.indexedDB.deleteDatabase('keyval-store');
+	});
+	cy.request('POST', '/api/reset-db').as('reset');
+	cy.get('@reset').its('status').should('equal', 204);
+	cy.reload(true);
+});
+
+Cypress.Commands.add('registerUser', (username, password, isAdmin = false) => {
+	const route = isAdmin ? '/api/admin/accounts/create' : '/api/signup';
+
+	cy.request('POST', route, {
+		username: username,
+		password: password,
+	}).its('body').as(username);
+});
+
+Cypress.Commands.add('login', (username, password) => {
+	cy.visit('/');
+
+	cy.intercept('POST', '/api/signin').as('signin');
+
+	cy.get('[data-cy-signin]').click();
+	cy.get('[data-cy-signin-username] input').type(username);
+	cy.get('[data-cy-signin-password] input').type(`${password}{enter}`);
+
+	cy.wait('@signin').as('signedIn');
+});


### PR DESCRIPTION
# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR extracts a lot of the commonly used logic into [Cypress commands](https://docs.cypress.io/api/cypress-api/custom-commands).

* `cy.resetState()` to reset the instance database and IndexedDB
* `cy.registerUser(username, password, isAdmin)` to create a (admin) user
* `cy.login(username, password)` to log in a user

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

This reduces code duplication, especially considering we want to write more tests in the future, which require a lot of the same setup code in the beginning.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

Not every instance of logging in users or registering them has been replaced. I only replace them in `before/after{Each}` hooks because if we specifically test if registering/logging in works, that should not be hidden behind an abstraction.

Tests currently fail after a fixed point because the sign-in limiter kicks in, this is already being discussed in #7986.
