### PR TITLE
Label Pull Requests containing tests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,5 +4,9 @@
 '🖥️Client':
 - packages/client/**/*
 
+'🧪Test':
+- cypress/**/*
+- packages/backend/test/**/*
+
 '‼️ wrong locales':
 - any: ['locales/*.yml', '!locales/ja-JP.yml']


### PR DESCRIPTION
# What

Extends the PR labeler configuration to add the "Tests" label if changes have been made in locations of Unit/E2E tests.

# Why

Easier shows which PRs contain test-related changes
