### PR TITLE
fix: downloadUrl ignores proxyBypassHosts

### DIFF
--- a/packages/backend/src/misc/download-url.ts
+++ b/packages/backend/src/misc/download-url.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as stream from 'node:stream';
 import * as util from 'node:util';
 import got, * as Got from 'got';
-import { httpAgent, httpsAgent, StatusError } from './fetch.js';
+import { getAgentByUrl, httpAgent, httpsAgent, StatusError } from './fetch.js';
 import config from '@/config/index.js';
 import chalk from 'chalk';
 import Logger from '@/services/logger.js';
@@ -34,8 +34,8 @@ export async function downloadUrl(url: string, path: string): Promise<void> {
 			request: operationTimeout,	// whole operation timeout
 		},
 		agent: {
-			http: httpAgent,
-			https: httpsAgent,
+			http: getAgentByUrl(new URL(url)),
+			https: getAgentByUrl(new URL(url)) as any,
 		},
 		http2: false,	// default
 		retry: {


### PR DESCRIPTION
# What
fix: downloadUrl ignores proxyBypassHosts

# Why
fix #8766

# Additional info (optional)
