### PR TITLE
Fix `Cannot find module` issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ You should also include the user name that made the change.
 - Server: use correct order of attachments on notes @Johann150
 - Server: prevent crash when processing certain PNGs @syuilo
 - Server: Fix unable to generate video thumbnails @mei23
+- Server: Fix `Cannot find module` issue @mei23
 
 ## 12.110.1 (2022/04/23)
 

--- a/scripts/install-packages.js
+++ b/scripts/install-packages.js
@@ -3,7 +3,7 @@ const execa = require('execa');
 (async () => {
 	console.log('installing dependencies of packages/backend ...');
 
-	await execa('yarn', ['install'], {
+	await execa('yarn', ['--force', 'install'], {
 		cwd: __dirname + '/../packages/backend',
 		stdout: process.stdout,
 		stderr: process.stderr,


### PR DESCRIPTION
# What
インストールスクリプトにて、backendの `yarn` に `--force` オプションを追加しています。

# Why
Fix #6988
現状、モジュールインストールで特定の条件に当てはまると必ず `Cannot find module` で起動できないのでその修正。
https://github.com/uhop/node-re2/wiki/Problem:-unusual-errors-with-yarn

Related #6829 #6829 #7474 #8042

以前から、IssuesでもMisskey上でのリプライでも問い合わせが多く対応リソースが削がれたり、開発時にリリース間でブランチを移動すると結構発生して効率が悪かったりするので、最初から入れてしまいたい。

これを入れてもinstallが1~2秒遅くなるかならないか程度と思われるので、さほどデメリットもないかと思います。

# Additional info (optional)
パッケージマネージャーを変えたらなおる的な話は、別IssueやPull Requestがあるのでそちらで。
現状どうしても支障があるのでとにかくなおしたい。