### PR TITLE
fix: always remove completed tasks

### DIFF
--- a/packages/backend/src/queue/index.ts
+++ b/packages/backend/src/queue/index.ts
@@ -305,11 +305,13 @@ export default function() {
 	systemQueue.add('resyncCharts', {
 	}, {
 		repeat: { cron: '0 0 * * *' },
+		removeOnComplete: true,
 	});
 
 	systemQueue.add('cleanCharts', {
 	}, {
 		repeat: { cron: '0 0 * * *' },
+		removeOnComplete: true,
 	});
 
 	systemQueue.add('checkExpiredMutings', {

--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -312,7 +312,8 @@ export default async (user: { id: User['id']; username: User['username']; host: 
 		endedPollNotificationQueue.add({
 			noteId: note.id,
 		}, {
-			delay
+			delay,
+			removeOnComplete: true,
 		});
 	}
 


### PR DESCRIPTION
# What
Always remove completed items from the task queues.

# Why
Do not take up unnecessary resources in Redis.

All other cases of adding tasks to a queue that I could find also used `removeOnComplete: true` so I assume leaving them out in these cases was not intended.

