### PR TITLE
refactor: configurable error images

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -146,3 +146,9 @@ id: 'aid'
 
 # Upload or download file size limits (bytes)
 #maxFileSize: 262144000
+
+# Images that will be shown by the web client, for example for error pages.
+#images:
+#  error: 'https://xn--931a.moe/assets/error.jpg'
+#  not_found: 'https://xn--931a.moe/assets/not_found.jpg'
+#  info: 'https://xn--931a.moe/assets/info.jpg'

--- a/packages/backend/migration/1654124623992-remove-unused-image-urls.js
+++ b/packages/backend/migration/1654124623992-remove-unused-image-urls.js
@@ -1,0 +1,14 @@
+export class removeUnusedImageUrls1654124623992 {
+	name = 'removeUnusedImageUrls1654124623992'
+
+	async up(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "mascotImageUrl"`);
+		await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "errorImageUrl"`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "meta" ADD "mascotImageUrl" character varying(512) DEFAULT '/assets/ai.png'`);
+		await queryRunner.query(`ALTER TABLE "meta" ADD "errorImageUrl" character varying(512) DEFAULT 'https://xn--931a.moe/aiart/yubitun.png'`);
+	}
+
+}

--- a/packages/backend/src/config/load.ts
+++ b/packages/backend/src/config/load.ts
@@ -50,6 +50,11 @@ export default function load() {
 
 	if (!config.redis.prefix) config.redis.prefix = mixin.host;
 
+	config.images = config.images ?? {};
+	config.images.error = config.images.error ?? 'https://xn--931a.moe/assets/error.jpg';
+	config.images.not_found = config.images.not_found ?? 'https://xn--931a.moe/assets/not-found.jpg';
+	config.images.info = config.images.info ?? 'https://xn--931a.moe/assets/info.jpg';
+
 	return Object.assign(config, mixin);
 }
 

--- a/packages/backend/src/config/types.ts
+++ b/packages/backend/src/config/types.ts
@@ -64,6 +64,12 @@ export type Source = {
 	proxyRemoteFiles?: boolean;
 
 	signToActivityPubGet?: boolean;
+
+	images?: {
+		error?: string;
+		not_found?: string;
+		info?: string;
+	};
 };
 
 /**

--- a/packages/backend/src/models/entities/meta.ts
+++ b/packages/backend/src/models/entities/meta.ts
@@ -97,13 +97,6 @@ export class Meta {
 	@Column('varchar', {
 		length: 512,
 		nullable: true,
-		default: '/assets/ai.png',
-	})
-	public mascotImageUrl: string | null;
-
-	@Column('varchar', {
-		length: 512,
-		nullable: true,
 	})
 	public bannerUrl: string | null;
 
@@ -118,13 +111,6 @@ export class Meta {
 		nullable: true,
 	})
 	public logoImageUrl: string | null;
-
-	@Column('varchar', {
-		length: 512,
-		nullable: true,
-		default: 'https://xn--931a.moe/aiart/yubitun.png',
-	})
-	public errorImageUrl: string | null;
 
 	@Column('varchar', {
 		length: 512,

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -53,6 +53,21 @@ export const meta = {
 				type: 'string',
 				optional: false, nullable: false,
 			},
+			errorImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/error.jpg',
+			},
+			notFoundImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/not-found.jpg',
+			},
+			infoImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/info.jpg',
+			},
 			iconUrl: {
 				type: 'string',
 				optional: false, nullable: true,
@@ -333,6 +348,9 @@ export default define(meta, paramDef, async (ps, me) => {
 		swPublickey: instance.swPublicKey,
 		themeColor: instance.themeColor,
 		bannerUrl: instance.bannerUrl,
+		errorImageUrl: config.images.error,
+		notFoundImageUrl: config.images.not_found,
+		infoImageUrl: config.images.info,
 		iconUrl: instance.iconUrl,
 		backgroundImageUrl: instance.backgroundImageUrl,
 		logoImageUrl: instance.logoImageUrl,

--- a/packages/backend/src/server/api/endpoints/admin/meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/meta.ts
@@ -49,19 +49,9 @@ export const meta = {
 				type: 'string',
 				optional: false, nullable: true,
 			},
-			mascotImageUrl: {
-				type: 'string',
-				optional: false, nullable: false,
-				default: '/assets/ai.png',
-			},
 			bannerUrl: {
 				type: 'string',
 				optional: false, nullable: false,
-			},
-			errorImageUrl: {
-				type: 'string',
-				optional: false, nullable: false,
-				default: 'https://xn--931a.moe/aiart/yubitun.png',
 			},
 			iconUrl: {
 				type: 'string',
@@ -342,9 +332,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		recaptchaSiteKey: instance.recaptchaSiteKey,
 		swPublickey: instance.swPublicKey,
 		themeColor: instance.themeColor,
-		mascotImageUrl: instance.mascotImageUrl,
 		bannerUrl: instance.bannerUrl,
-		errorImageUrl: instance.errorImageUrl,
 		iconUrl: instance.iconUrl,
 		backgroundImageUrl: instance.backgroundImageUrl,
 		logoImageUrl: instance.logoImageUrl,

--- a/packages/backend/src/server/api/endpoints/admin/update-meta.ts
+++ b/packages/backend/src/server/api/endpoints/admin/update-meta.ts
@@ -28,9 +28,7 @@ export const paramDef = {
 			type: 'string',
 		} },
 		themeColor: { type: 'string', nullable: true, pattern: '^#[0-9a-fA-F]{6}$' },
-		mascotImageUrl: { type: 'string', nullable: true },
 		bannerUrl: { type: 'string', nullable: true },
-		errorImageUrl: { type: 'string', nullable: true },
 		iconUrl: { type: 'string', nullable: true },
 		backgroundImageUrl: { type: 'string', nullable: true },
 		logoImageUrl: { type: 'string', nullable: true },
@@ -134,10 +132,6 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	if (ps.themeColor !== undefined) {
 		set.themeColor = ps.themeColor;
-	}
-
-	if (ps.mascotImageUrl !== undefined) {
-		set.mascotImageUrl = ps.mascotImageUrl;
 	}
 
 	if (ps.bannerUrl !== undefined) {
@@ -302,10 +296,6 @@ export default define(meta, paramDef, async (ps, me) => {
 
 	if (ps.smtpPass !== undefined) {
 		set.smtpPass = ps.smtpPass;
-	}
-
-	if (ps.errorImageUrl !== undefined) {
-		set.errorImageUrl = ps.errorImageUrl;
 	}
 
 	if (ps.enableServiceWorker !== undefined) {

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -120,19 +120,9 @@ export const meta = {
 				type: 'string',
 				optional: false, nullable: true,
 			},
-			mascotImageUrl: {
-				type: 'string',
-				optional: false, nullable: false,
-				default: '/assets/ai.png',
-			},
 			bannerUrl: {
 				type: 'string',
 				optional: false, nullable: false,
-			},
-			errorImageUrl: {
-				type: 'string',
-				optional: false, nullable: false,
-				default: 'https://xn--931a.moe/aiart/yubitun.png',
 			},
 			iconUrl: {
 				type: 'string',
@@ -352,9 +342,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		recaptchaSiteKey: instance.recaptchaSiteKey,
 		swPublickey: instance.swPublicKey,
 		themeColor: instance.themeColor,
-		mascotImageUrl: instance.mascotImageUrl,
 		bannerUrl: instance.bannerUrl,
-		errorImageUrl: instance.errorImageUrl,
 		iconUrl: instance.iconUrl,
 		backgroundImageUrl: instance.backgroundImageUrl,
 		logoImageUrl: instance.logoImageUrl,

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -124,6 +124,21 @@ export const meta = {
 				type: 'string',
 				optional: false, nullable: false,
 			},
+			errorImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/error.jpg',
+			},
+			notFoundImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/not-found.jpg',
+			},
+			infoImageUrl: {
+				type: 'string',
+				optional: false, nullable: false,
+				default: 'https://xn--931a.moe/assets/info.jpg',
+			},
 			iconUrl: {
 				type: 'string',
 				optional: false, nullable: true,
@@ -343,6 +358,9 @@ export default define(meta, paramDef, async (ps, me) => {
 		swPublickey: instance.swPublicKey,
 		themeColor: instance.themeColor,
 		bannerUrl: instance.bannerUrl,
+		errorImageUrl: config.images.error,
+		notFoundImageUrl: config.images.not_found,
+		infoImageUrl: config.images.info,
 		iconUrl: instance.iconUrl,
 		backgroundImageUrl: instance.backgroundImageUrl,
 		logoImageUrl: instance.logoImageUrl,

--- a/packages/backend/src/server/web/views/base.pug
+++ b/packages/backend/src/server/web/views/base.pug
@@ -33,9 +33,9 @@ html
 		link(rel='icon' href= icon || '/favicon.ico')
 		link(rel='apple-touch-icon' href= icon || '/apple-touch-icon.png')
 		link(rel='manifest' href='/manifest.json')
-		link(rel='prefetch' href='https://xn--931a.moe/assets/info.jpg')
-		link(rel='prefetch' href='https://xn--931a.moe/assets/not-found.jpg')
-		link(rel='prefetch' href='https://xn--931a.moe/assets/error.jpg')
+		link(rel='prefetch' href=config.images.info)
+		link(rel='prefetch' href=config.images.not_found)
+		link(rel='prefetch' href=config.images.error)
 		link(rel='stylesheet' href='/assets/fontawesome/css/all.css')
 		link(rel='modulepreload' href=`/assets/${clientEntry.file}`)
 

--- a/packages/client/src/components/global/error.vue
+++ b/packages/client/src/components/global/error.vue
@@ -1,7 +1,7 @@
 <template>
 <transition :name="$store.state.animation ? 'zoom' : ''" appear>
 	<div class="mjndxjcg">
-		<img src="https://xn--931a.moe/assets/error.jpg" class="_ghost"/>
+		<img :src="instance.errorImageUrl" class="_ghost"/>
 		<p><i class="fas fa-exclamation-triangle"></i> {{ $ts.somethingHappened }}</p>
 		<MkButton class="button" @click="() => $emit('retry')">{{ $ts.retry }}</MkButton>
 	</div>
@@ -9,6 +9,7 @@
 </template>
 
 <script lang="ts" setup>
+import { instance } from '@/instance';
 import MkButton from '@/components/ui/button.vue';
 </script>
 

--- a/packages/client/src/components/notes.vue
+++ b/packages/client/src/components/notes.vue
@@ -2,7 +2,7 @@
 <MkPagination ref="pagingComponent" :pagination="pagination">
 	<template #empty>
 		<div class="_fullinfo">
-			<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+			<img :src="instance.infoImageUrl" class="_ghost"/>
 			<div>{{ $ts.noNotes }}</div>
 		</div>
 	</template>
@@ -23,6 +23,7 @@ import XNote from '@/components/note.vue';
 import XList from '@/components/date-separated-list.vue';
 import MkPagination from '@/components/ui/pagination.vue';
 import { Paging } from '@/components/ui/pagination.vue';
+import { instance } from '@/instance';
 
 const props = defineProps<{
 	pagination: Paging;

--- a/packages/client/src/components/notifications.vue
+++ b/packages/client/src/components/notifications.vue
@@ -2,7 +2,7 @@
 <MkPagination ref="pagingComponent" :pagination="pagination">
 	<template #empty>
 		<div class="_fullinfo">
-			<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+			<img :src="instance.infoImageUrl" class="_ghost"/>
 			<div>{{ $ts.noNotifications }}</div>
 		</div>
 	</template>
@@ -27,6 +27,7 @@ import XNote from '@/components/note.vue';
 import * as os from '@/os';
 import { stream } from '@/stream';
 import { $i } from '@/account';
+import { instance } from '@/instance';
 
 const props = defineProps<{
 	includeTypes?: typeof notificationTypes[number][];

--- a/packages/client/src/components/ui/pagination.vue
+++ b/packages/client/src/components/ui/pagination.vue
@@ -7,7 +7,7 @@
 	<div v-else-if="empty" key="_empty_" class="empty">
 		<slot name="empty">
 			<div class="_fullinfo">
-				<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+				<img :src="instance.infoImageUrl" class="_ghost"/>
 				<div>{{ $ts.nothing }}</div>
 			</div>
 		</slot>
@@ -37,6 +37,7 @@ import * as misskey from 'misskey-js';
 import * as os from '@/os';
 import { onScrollTop, isTopVisible, getScrollPosition, getScrollContainer } from '@/scripts/scroll';
 import MkButton from '@/components/ui/button.vue';
+import { instance } from '@/instance';
 
 const SECOND_FETCH_LIMIT = 30;
 

--- a/packages/client/src/components/user-list.vue
+++ b/packages/client/src/components/user-list.vue
@@ -2,7 +2,7 @@
 <MkPagination ref="pagingComponent" :pagination="pagination">
 	<template #empty>
 		<div class="_fullinfo">
-			<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+			<img :src="instance.infoImageUrl" class="_ghost"/>
 			<div>{{ $ts.noUsers }}</div>
 		</div>
 	</template>
@@ -21,6 +21,7 @@ import MkUserInfo from '@/components/user-info.vue';
 import MkPagination from '@/components/ui/pagination.vue';
 import { Paging } from '@/components/ui/pagination.vue';
 import { userPage } from '@/filters/user';
+import { instance } from '@/instance';
 
 const props = defineProps<{
 	pagination: Paging;

--- a/packages/client/src/pages/_error_.vue
+++ b/packages/client/src/pages/_error_.vue
@@ -2,7 +2,7 @@
 <MkLoading v-if="!loaded"/>
 <transition :name="$store.state.animation ? 'zoom' : ''" appear>
 	<div v-show="loaded" class="mjndxjch">
-		<img src="https://xn--931a.moe/assets/error.jpg" class="_ghost"/>
+		<img :src="meta.errorImageUrl" class="_ghost"/>
 		<p><b><i class="fas fa-exclamation-triangle"></i> {{ i18n.ts.pageLoadError }}</b></p>
 		<p v-if="meta && (version === meta.version)">{{ i18n.ts.pageLoadErrorDescription }}</p>
 		<p v-else-if="serverIsDead">{{ i18n.ts.serverIsDead }}</p>

--- a/packages/client/src/pages/favorites.vue
+++ b/packages/client/src/pages/favorites.vue
@@ -3,7 +3,7 @@
 	<MkPagination ref="pagingComponent" :pagination="pagination">
 		<template #empty>
 			<div class="_fullinfo">
-				<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+				<img :src="instance.infoImageUrl" class="_ghost"/>
 				<div>{{ $ts.noNotes }}</div>
 			</div>
 		</template>
@@ -24,6 +24,7 @@ import XNote from '@/components/note.vue';
 import XList from '@/components/date-separated-list.vue';
 import * as symbols from '@/symbols';
 import { i18n } from '@/i18n';
+import { instance } from '@/instance';
 
 const pagination = {
 	endpoint: 'i/favorites' as const,

--- a/packages/client/src/pages/follow-requests.vue
+++ b/packages/client/src/pages/follow-requests.vue
@@ -3,7 +3,7 @@
 	<MkPagination ref="paginationComponent" :pagination="pagination">
 		<template #empty>
 			<div class="_fullinfo">
-				<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+				<img :src="instance.infoImageUrl" class="_ghost"/>
 				<div>{{ $ts.noFollowRequests }}</div>
 			</div>
 		</template>
@@ -38,6 +38,7 @@ import { userPage, acct } from '@/filters/user';
 import * as os from '@/os';
 import * as symbols from '@/symbols';
 import { i18n } from '@/i18n';
+import { instance } from '@/instance';
 
 const paginationComponent = ref<InstanceType<typeof MkPagination>>();
 

--- a/packages/client/src/pages/messaging/index.vue
+++ b/packages/client/src/pages/messaging/index.vue
@@ -30,7 +30,7 @@
 			</MkA>
 		</div>
 		<div v-if="!fetching && messages.length == 0" class="_fullinfo">
-			<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+			<img :src="hinstance.infoImageUrl" class="_ghost"/>
 			<div>{{ $ts.noHistory }}</div>
 		</div>
 		<MkLoading v-if="fetching"/>
@@ -46,6 +46,7 @@ import { acct } from '@/filters/user';
 import * as os from '@/os';
 import { stream } from '@/stream';
 import * as symbols from '@/symbols';
+import { instancen } from '@/instance';
 
 export default defineComponent({
 	components: {

--- a/packages/client/src/pages/not-found.vue
+++ b/packages/client/src/pages/not-found.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="ipledcug">
 	<div class="_fullinfo">
-		<img src="https://xn--931a.moe/assets/not-found.jpg" class="_ghost"/>
+		<img :src="instance.notFoundImageUrl" class="_ghost"/>
 		<div>{{ $ts.notFoundDescription }}</div>
 	</div>
 </div>
@@ -10,6 +10,7 @@
 <script lang="ts" setup>
 import * as symbols from '@/symbols';
 import { i18n } from '@/i18n';
+import { instance } from '@/instance';
 
 defineExpose({
 	[symbols.PAGE_INFO]: {

--- a/packages/client/src/pages/settings/apps.vue
+++ b/packages/client/src/pages/settings/apps.vue
@@ -3,7 +3,7 @@
 	<FormPagination ref="list" :pagination="pagination">
 		<template #empty>
 			<div class="_fullinfo">
-				<img src="https://xn--931a.moe/assets/info.jpg" class="_ghost"/>
+				<img :src="instance.infoImageUrl" class="_ghost"/>
 				<div>{{ i18n.ts.nothing }}</div>
 			</div>
 		</template>
@@ -43,6 +43,7 @@ import FormPagination from '@/components/ui/pagination.vue';
 import * as os from '@/os';
 import * as symbols from '@/symbols';
 import { i18n } from '@/i18n';
+import { instance } from '@/instance';
 
 const list = ref<any>(null);
 


### PR DESCRIPTION
# What
Make the error images configurable. They are configurable in `.config/default.yml`. With the default values the behaviour stays the same as it is currently.

The `mascotImageUrl` and `errorImageUrl` columns are removed from the `meta` database table because they were not used before. The possibility to adjust them via the admin API is also removed.

# Why
Some people want to either theme their instance with special images or do not find the currently used images appropriate for their use cases. Some people also do not want their instances to link to external resources.

fix #7043
fix #8356
related: https://github.com/misskey-dev/misskey/pull/3589#issuecomment-446121344