### PR TITLE
enhance(federation): use ActivityPub defined property in favour of proprietary property.

### DIFF
--- a/packages/backend/src/remote/activitypub/models/note.ts
+++ b/packages/backend/src/remote/activitypub/models/note.ts
@@ -197,7 +197,14 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 	const cw = note.summary === '' ? null : note.summary;
 
 	// テキストのパース
-	const text = typeof note._misskey_content !== 'undefined' ? note._misskey_content : (note.content ? htmlToMfm(note.content, note.tag) : null);
+	let text: string | null = null;
+	if (note.source?.mediaType === 'text/x.misskeymarkdown' && typeof note.source?.content === 'string') {
+		text = note.source.content;
+	} else if (typeof note._misskey_content === 'string') {
+		text = note._misskey_content;
+	} else if (typeof note.content === 'string') {
+		text = htmlToMfm(note.content, note.tag);
+	}
 
 	// vote
 	if (reply && reply.hasPoll) {

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -138,6 +138,10 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		summary,
 		content,
 		_misskey_content: text,
+		source: {
+			content: text,
+			mediaType: "text/x.misskeymarkdown",
+		},
 		_misskey_quote: quote,
 		quoteUrl: quote,
 		published: note.createdAt.toISOString(),

--- a/packages/backend/src/remote/activitypub/type.ts
+++ b/packages/backend/src/remote/activitypub/type.ts
@@ -106,7 +106,10 @@ export const isPost = (object: IObject): object is IPost =>
 
 export interface IPost extends IObject {
 	type: 'Note' | 'Question' | 'Article' | 'Audio' | 'Document' | 'Image' | 'Page' | 'Video' | 'Event';
-	_misskey_content?: string;
+	source?: {
+		content: string;
+		mediaType: string;
+	};
 	_misskey_quote?: string;
 	quoteUrl?: string;
 	_misskey_talk: boolean;
@@ -114,7 +117,10 @@ export interface IPost extends IObject {
 
 export interface IQuestion extends IObject {
 	type: 'Note' | 'Question';
-	_misskey_content?: string;
+	source?: {
+		content: string;
+		mediaType: string;
+	};
 	_misskey_quote?: string;
 	quoteUrl?: string;
 	oneOf?: IQuestionChoice[];


### PR DESCRIPTION
# What
Add ActivityPub `source` property.

For now this continues to write and read the `_misskey_content` property. This change is therefore fully backward compatible.

# Why
related to #8785. This PR does not completely fix that issue yet: The `_misskey_content` attribute should be removed in the future. I think we should wait *at least* 3 months after initial release of this change before removing `_misskey_content`.