### PR TITLE
refactor: use awaitAll to reduce duplication

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/stats.ts
+++ b/packages/backend/src/server/api/endpoints/users/stats.ts
@@ -97,7 +97,7 @@ export default define(meta, paramDef, async (ps, me) => {
 	});
 
 	result.followingCount = result.localFollowingCount + result.remoteFollowingCount;
-	result.followersCount = result.localFollowerCount + result.remoteFollowersCount;
+	result.followersCount = result.localFollowersCount + result.remoteFollowersCount;
 
 	return result;
 });

--- a/packages/backend/src/server/api/endpoints/users/stats.ts
+++ b/packages/backend/src/server/api/endpoints/users/stats.ts
@@ -32,7 +32,7 @@ export default define(meta, paramDef, async (ps, me) => {
 		throw new ApiError(meta.errors.noSuchUser);
 	}
 
-	let result = await awaitAll({
+	const result = await awaitAll({
 		notesCount: Notes.createQueryBuilder('note')
 			.where('note.userId = :userId', { userId: user.id })
 			.getCount(),


### PR DESCRIPTION
# What
Refactor the `/api/users/stats` endpoint to reduce code duplication. By making use of `awaitAll`, most of the property names only need to be written once instead of twice.

# Why
improve code quality