### PR TITLE
fix(client): only enable hotkeys for logged in users

### DIFF
--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -335,16 +335,16 @@ for (const plugin of ColdDeviceStorage.get('plugins').filter(p => p.active)) {
 	});
 }
 
+const hotkeys = {
+	'd': (): void => {
+		defaultStore.set('darkMode', !defaultStore.state.darkMode);
+	},
+	's': search,
+};
+
 if ($i) {
-	// shortcut
-	document.addEventListener('keydown', makeHotkey({
-		'd': () => {
-			defaultStore.set('darkMode', !defaultStore.state.darkMode);
-		},
-		'p|n': post,
-		's': search,
-		//TODO: 'h|/': help
-	}));
+	// only add post shortcuts if logged in
+	hotkeys['p|n'] = post;
 
 	if ($i.isDeleted) {
 		alert({
@@ -440,3 +440,6 @@ if ($i) {
 		signout();
 	});
 }
+
+// shortcut
+document.addEventListener('keydown', makeHotkey(hotkeys));

--- a/packages/client/src/init.ts
+++ b/packages/client/src/init.ts
@@ -293,16 +293,6 @@ fetchInstanceMetaPromise.then(() => {
 	}
 });
 
-// shortcut
-document.addEventListener('keydown', makeHotkey({
-	'd': () => {
-		defaultStore.set('darkMode', !defaultStore.state.darkMode);
-	},
-	'p|n': post,
-	's': search,
-	//TODO: 'h|/': help
-}));
-
 watch(defaultStore.reactiveState.useBlurEffectForModal, v => {
 	document.documentElement.style.setProperty('--modalBgFilter', v ? 'blur(4px)' : 'none');
 }, { immediate: true });
@@ -346,6 +336,16 @@ for (const plugin of ColdDeviceStorage.get('plugins').filter(p => p.active)) {
 }
 
 if ($i) {
+	// shortcut
+	document.addEventListener('keydown', makeHotkey({
+		'd': () => {
+			defaultStore.set('darkMode', !defaultStore.state.darkMode);
+		},
+		'p|n': post,
+		's': search,
+		//TODO: 'h|/': help
+	}));
+
 	if ($i.isDeleted) {
 		alert({
 			type: 'warning',


### PR DESCRIPTION
# What

This PR disables hotkeys for non-logged in users.

# Why

Most of them aren't really useful for site visitors anyway and the post dialog does not work if a user is not logged in.

Fixes #8491