### PR TITLE
fix: alt text for videos

### DIFF
--- a/packages/client/src/components/media-video.vue
+++ b/packages/client/src/components/media-video.vue
@@ -8,7 +8,8 @@
 <div v-else class="kkjnbbplepmiyuadieoenjgutgcmtsvu">
 	<video
 		:poster="video.thumbnailUrl"
-		:title="video.name"
+		:title="video.comment"
+		:alt="video.comment"
 		preload="none"
 		controls
 		@contextmenu.stop


### PR DESCRIPTION
# What
Properly display alt text for videos.

I assume this was overlooked in #7518 since that was focused on image descriptions. But the federation and API is in place to easily make this work for videos as well.

# Why
improve accessibility