### PR TITLE
fix: some fixes of multiple notification read

### DIFF
--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -9,6 +9,8 @@ export async function readNotification(
 	userId: User['id'],
 	notificationIds: Notification['id'][]
 ) {
+	if (notificationIds.length === 0) return;
+
 	// Update documents
 	await Notifications.update({
 		id: In(notificationIds),

--- a/packages/backend/src/server/api/endpoints/notifications/read.ts
+++ b/packages/backend/src/server/api/endpoints/notifications/read.ts
@@ -34,7 +34,11 @@ export const paramDef = {
 		{
 			type: 'object',
 			properties: {
-				notificationIds: { type: 'array', items: { type: 'string', format: 'misskey:id' } },
+				notificationIds: {
+					type: 'array',
+					items: { type: 'string', format: 'misskey:id' },
+					maxItems: 100,
+				},
 			},
 			required: ['notificationIds'],
 		},

--- a/packages/sw/src/scripts/notification-read.ts
+++ b/packages/sw/src/scripts/notification-read.ts
@@ -39,7 +39,10 @@ class SwNotificationReadManager {
 
 		if (account.queue.length >= 20) {
 			if (account.timeout) clearTimeout(account.timeout);
-			return api('notifications/read', data.userId, { notificationIds: account.queue });
+			const notificationIds = account.queue;
+			account.queue = [];
+			await api('notifications/read', data.userId, { notificationIds });
+			return
 		}
 
 		// 最後の呼び出しから200ms待ってまとめて処理する
@@ -47,7 +50,9 @@ class SwNotificationReadManager {
 		account.timeout = setTimeout(() => {
 			account.timeout = null;
 
-			api('notifications/read', data.userId, { notificationIds: account.queue });
+			const notificationIds = account.queue;
+			account.queue = [];
+			api('notifications/read', data.userId, { notificationIds });
 		}, 200);
 	}
 }

--- a/packages/sw/src/scripts/notification-read.ts
+++ b/packages/sw/src/scripts/notification-read.ts
@@ -37,6 +37,11 @@ class SwNotificationReadManager {
 
 		account.queue.push(data.body.id as string);
 
+		if (account.queue.length >= 20) {
+			if (account.timeout) clearTimeout(account.timeout);
+			return api('notifications/read', data.userId, { notificationIds: account.queue });
+		}
+
 		// 最後の呼び出しから200ms待ってまとめて処理する
 		if (account.timeout) clearTimeout(account.timeout);
 		account.timeout = setTimeout(() => {

--- a/packages/sw/src/scripts/notification-read.ts
+++ b/packages/sw/src/scripts/notification-read.ts
@@ -42,7 +42,7 @@ class SwNotificationReadManager {
 			const notificationIds = account.queue;
 			account.queue = [];
 			await api('notifications/read', data.userId, { notificationIds });
-			return
+			return;
 		}
 
 		// 最後の呼び出しから200ms待ってまとめて処理する


### PR DESCRIPTION
Related to #8816 

# What
- readNotificationで配列が空の場合は処理を行わないように https://github.com/misskey-dev/misskey/blob/12.111.0/CONTRIBUTING.md#-in-sql
- notifications/readのnotificationIdsの数を100に制限
- Service Workerの既読処理の際は20ずつに送信するように
- Service Workerの既読処理でキューを空にしていなかったのを修正

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
