### PR TITLE
fix: GenerateVideoThumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 You should also include the user name that made the change.
 -->
 
+## 12.x.x (unreleased)
+
+### Improvements
+
+### Bugfixes
+- Fix GenerateVideoThumbnail failed @mei23
+
 ## 12.111.1 (2022/06/13)
 
 ### Bugfixes

--- a/packages/backend/src/services/drive/generate-video-thumbnail.ts
+++ b/packages/backend/src/services/drive/generate-video-thumbnail.ts
@@ -1,12 +1,10 @@
 import * as fs from 'node:fs';
-import * as path from 'node:path';
-import { createTemp } from '@/misc/create-temp.js';
+import { createTempDir } from '@/misc/create-temp.js';
 import { IImage, convertToJpeg } from './image-processor.js';
 import FFmpeg from 'fluent-ffmpeg';
 
 export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
-	const [file, cleanup] = await createTemp();
-	const parsed = path.parse(file);
+	const [dir, cleanup] = await createTempDir();
 
 	try {
 		await new Promise((res, rej) => {
@@ -16,15 +14,15 @@ export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
 			.on('end', res)
 			.on('error', rej)
 			.screenshot({
-				folder: parsed.dir,
-				filename: parsed.base,
+				folder: dir,
+				filename: 'out.png',	// must have .png extension
 				count: 1,
 				timestamps: ['5%'],
 			});
 		});
 
 		// JPEGに変換 (Webpでもいいが、MastodonはWebpをサポートせず表示できなくなる)
-		return await convertToJpeg(file, 498, 280);
+		return await convertToJpeg(`${dir}/out.png`, 498, 280);
 	} finally {
 		cleanup();
 	}

--- a/packages/backend/src/services/drive/generate-video-thumbnail.ts
+++ b/packages/backend/src/services/drive/generate-video-thumbnail.ts
@@ -6,8 +6,6 @@ import FFmpeg from 'fluent-ffmpeg';
 export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
 	const [dir, cleanup] = await createTempDir();
 
-	const outFile = `${dir}/out.png`;
-
 	try {
 		await new Promise((res, rej) => {
 			FFmpeg({
@@ -24,9 +22,8 @@ export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
 		});
 
 		// JPEGに変換 (Webpでもいいが、MastodonはWebpをサポートせず表示できなくなる)
-		return await convertToJpeg(outFile, 498, 280);
+		return await convertToJpeg(`${dir}/out.png`, 498, 280);
 	} finally {
-		await fs.promises.unlink(outFile);
 		cleanup();
 	}
 }

--- a/packages/backend/src/services/drive/generate-video-thumbnail.ts
+++ b/packages/backend/src/services/drive/generate-video-thumbnail.ts
@@ -6,6 +6,8 @@ import FFmpeg from 'fluent-ffmpeg';
 export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
 	const [dir, cleanup] = await createTempDir();
 
+	const outFile = `${dir}/out.png`;
+
 	try {
 		await new Promise((res, rej) => {
 			FFmpeg({
@@ -22,8 +24,9 @@ export async function GenerateVideoThumbnail(source: string): Promise<IImage> {
 		});
 
 		// JPEGに変換 (Webpでもいいが、MastodonはWebpをサポートせず表示できなくなる)
-		return await convertToJpeg(`${dir}/out.png`, 498, 280);
+		return await convertToJpeg(outFile, 498, 280);
 	} finally {
+		await fs.promises.unlink(outFile);
 		cleanup();
 	}
 }


### PR DESCRIPTION
# What
fix https://github.com/misskey-dev/misskey/issues/8814#issuecomment-1153202914

拡張子によってformatが確定するので `.png` 拡張子を付けてあげる必要がある。

# Why
fix https://github.com/misskey-dev/misskey/issues/8814#issuecomment-1153202914

# Additional info (optional)
テストした。
直接JPEGを出力すればいいのでは？と思ったけど、アスペクト比を保持する手段がなくてあきらめた。