### PR TITLE
fix: tmpdir cleanup removes contained files

### DIFF
--- a/packages/backend/src/misc/create-temp.ts
+++ b/packages/backend/src/misc/create-temp.ts
@@ -11,9 +11,14 @@ export function createTemp(): Promise<[string, () => void]> {
 
 export function createTempDir(): Promise<[string, () => void]> {
 	return new Promise<[string, () => void]>((res, rej) => {
-		tmp.dir((e, path, cleanup) => {
-			if (e) return rej(e);
-			res([path, cleanup]);
-		});
+		tmp.dir(
+			{
+				unsafeCleanup: true,
+			},
+			(e, path, cleanup) => {
+				if (e) return rej(e);
+				res([path, cleanup]);
+			}
+		);
 	});
 }


### PR DESCRIPTION
# What
Delete temporary directories even if they still contain files.

# Why
This is an issue with the queue processors for importing & exporting custom emoji, as well as for thumbnail generation: https://github.com/misskey-dev/misskey/pull/8825#issuecomment-1153870036

# Additional info
This seems to be the intended way. The places where this is currently used should continue to work because the temporary files are copied to the Misskey drive directory.