### PR TITLE
enhance: Embedded all attachment, renotes and discussion history into rss feed content & improve title

### DIFF
--- a/packages/backend/src/server/web/feed.ts
+++ b/packages/backend/src/server/web/feed.ts
@@ -13,7 +13,7 @@ export default async function(user: User, threadDepth = 5, history = 20, noteint
 
 	const profile = await UserProfiles.findOneByOrFail({ userId: user.id });
 
-	let searchCriteria = {
+	const searchCriteria = {
 		userId: user.id,
 		visibility: In(['public', 'home']),
 	};

--- a/packages/backend/src/server/web/feed.ts
+++ b/packages/backend/src/server/web/feed.ts
@@ -44,8 +44,8 @@ export default async function(user: User, withAll = false, history = 5) {
 		let contentStr = await noteToString(note, true);
 		let next = note.renoteId ? note.renoteId : note.replyId;
 		let depth = history;
-		while(depth > 0 && next && withAll){
-			let finding = await findById(next);
+		while (depth > 0 && next && withAll) {
+			const finding = await findById(next);
 			contentStr += finding.text;
 			next = finding.next;
 			depth -= 1;
@@ -60,41 +60,41 @@ export default async function(user: User, withAll = false, history = 5) {
 		});
 	}
 
-	async function noteToString(note, isTheNote = false){
-		const author = isTheNote ? null : await Users.findOneBy({id: note.userId});
+	async function noteToString(note, isTheNote = false) {
+		const author = isTheNote ? null : await Users.findOneBy({ id: note.userId });
 		let outstr = author ? `${author.name}(@${author.username}@${author.host ? author.host : config.host}) ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}: <br>` : '';
 		const files = note.fileIds.length > 0 ? await DriveFiles.findBy({
 			id: In(note.fileIds),
 		}) : [];
 		let fileEle = '';
-		for (const file of files){
-			if(file.type.startsWith('image/')){
+		for (const file of files) {
+			if (file.type.startsWith('image/')) {
 				fileEle += ` <br><img src="${DriveFiles.getPublicUrl(file)}">`;
-			}else if(file.type.startsWith('audio/')){
+			} else if (file.type.startsWith('audio/')) {
 				fileEle += ` <br><audio controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
-			}else if(file.type.startsWith('video/')){
+			} else if (file.type.startsWith('video/')) {
 				fileEle += ` <br><video controls src="${DriveFiles.getPublicUrl(file)}" type="${file.type}">`;
-			}else{
+			} else {
 				fileEle += ` <br><a href="${DriveFiles.getPublicUrl(file)}" download="${file.name}">${file.name}</a>`;
 			}
 		}
 		outstr += `${note.cw ? note.cw + '<br>' : ''}${note.text || ''}${fileEle}`;
-		if(isTheNote){
-			outstr += ` <span class="${(note.renoteId ? 'renote_note' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') != -1 ? 'with_img' : 'without_img')}"></span>`;
+		if (isTheNote) {
+			outstr += ` <span class="${(note.renoteId ? 'renote_note' : (note.replyId ? 'reply_note' : 'new_note'))} ${(fileEle.indexOf('img src') !== -1 ? 'with_img' : 'without_img')}"></span>`;
 		}
 		return outstr;
 	}
 
-	async function findById(id){
+	async function findById(id) {
 		let text = '';
 		let next = null;
-		const findings = await Notes.find({where: {id: id, visibility: In(['public', 'home'])}, order: { createdAt: -1 }, take: 20});
-		for (const aFind of findings){
+		const findings = await Notes.find({ where: { id: id, visibility: In(['public', 'home']) }, order: { createdAt: -1 }, take: 20 });
+		for (const aFind of findings) {
 			text += `<hr>`;
 			text += await noteToString(aFind);
 			next = aFind.renoteId ? aFind.renoteId : aFind.replyId;
 		}
-		return {text: text, next: next};
+		return { text: text, next: next };
 	}
 
 	return feed;

--- a/packages/backend/src/server/web/feed.ts
+++ b/packages/backend/src/server/web/feed.ts
@@ -49,8 +49,22 @@ export default async function(user: User, history = 5, noteintitle = false) {
 			depth -= 1;
 		}
 
-		let title = `${author.name} ${(note.renoteId ? 'renotes' : (note.replyId ? 'replies' : 'says'))}`;
-		title += noteintitle ? `: ${note.cw ? note.cw : (note.text ? note.text : 'post a new note')}` : '';
+		let title = `${author.name} `;
+		if (note.renoteId) {
+			title += 'renotes';
+		} else if (note.replyId) {
+			title += 'replies';
+		} else {
+			title += 'says';
+		}
+		if (noteintitle) {
+			const content = note.cw ?? note.text;
+			if (content) {
+				title += `: ${content}`;
+			} else {
+				title += 'something';
+			}
+		}
 
 		feed.addItem({
 			title: title.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '').substring(0,100),

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -217,7 +217,7 @@ router.get('/api.json', async ctx => {
 	ctx.body = genOpenapiSpec();
 });
 
-const getFeed = async (acct: string) => {
+const getFeed = async (acct: string, withAll = false, history = 5) => {
 	const { username, host } = Acct.parse(acct);
 	const user = await Users.findOneBy({
 		usernameLower: username.toLowerCase(),
@@ -225,12 +225,12 @@ const getFeed = async (acct: string) => {
 		isSuspended: false,
 	});
 
-	return user && await packFeed(user);
+	return user && await packFeed(user, withAll, history);
 };
 
 // Atom
 router.get('/@:user.atom', async ctx => {
-	const feed = await getFeed(ctx.params.user);
+	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/atom+xml; charset=utf-8');
@@ -242,7 +242,7 @@ router.get('/@:user.atom', async ctx => {
 
 // RSS
 router.get('/@:user.rss', async ctx => {
-	const feed = await getFeed(ctx.params.user);
+	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/rss+xml; charset=utf-8');
@@ -254,7 +254,7 @@ router.get('/@:user.rss', async ctx => {
 
 // JSON
 router.get('/@:user.json', async ctx => {
-	const feed = await getFeed(ctx.params.user);
+	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/json; charset=utf-8');

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -217,20 +217,23 @@ router.get('/api.json', async ctx => {
 	ctx.body = genOpenapiSpec();
 });
 
-const getFeed = async (acct: string, withAll = false, history = 5) => {
+const getFeed = async (acct: string, history:string, noteintitle:string) => {
 	const { username, host } = Acct.parse(acct);
 	const user = await Users.findOneBy({
 		usernameLower: username.toLowerCase(),
 		host: host ?? IsNull(),
 		isSuspended: false,
 	});
-
-	return user && await packFeed(user, withAll, history);
+	const thread = parseInt(history, 10);
+	if (isNaN(history) || history <= 0 || history > 30) {
+		history = 3;
+	}
+	return user && await packFeed(user, history, !isNaN(noteintitle));
 };
 
 // Atom
 router.get('/@:user.atom', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
+	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/atom+xml; charset=utf-8');
@@ -242,7 +245,7 @@ router.get('/@:user.atom', async ctx => {
 
 // RSS
 router.get('/@:user.rss', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
+	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/rss+xml; charset=utf-8');
@@ -254,7 +257,7 @@ router.get('/@:user.rss', async ctx => {
 
 // JSON
 router.get('/@:user.json', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history ? true : false, parseInt(ctx.query.history) ? parseInt(ctx.query.history) : 5);
+	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/json; charset=utf-8');

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -217,23 +217,27 @@ router.get('/api.json', async ctx => {
 	ctx.body = genOpenapiSpec();
 });
 
-const getFeed = async (acct: string, history:string, noteintitle:string) => {
+const getFeed = async (acct: string, threadDepth:string, historyCount:string, noteInTitle:string, noRenotes:string, noReplies:string) => {
 	const { username, host } = Acct.parse(acct);
 	const user = await Users.findOneBy({
 		usernameLower: username.toLowerCase(),
 		host: host ?? IsNull(),
 		isSuspended: false,
 	});
-	const thread = parseInt(history, 10);
-	if (isNaN(history) || history <= 0 || history > 30) {
-		history = 3;
+	let thread = parseInt(threadDepth, 10);
+	if (isNaN(thread) || thread <= 0 || thread > 30) {
+		thread = 3;
 	}
-	return user && await packFeed(user, history, !isNaN(noteintitle));
+	let history = parseInt(historyCount, 10);
+	if (isNaN(history) || history <= 0 || history > 30) {
+		history = 20;
+	}
+	return user && await packFeed(user, thread, history, !isNaN(noteInTitle), isNaN(noRenotes), isNaN(noReplies));
 };
 
 // Atom
 router.get('/@:user.atom', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
+	const feed = await getFeed(ctx.params.user, ctx.query.thread, ctx.query.history, ctx.query.noteintitle, ctx.query.norenotes, ctx.query.noreplies);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/atom+xml; charset=utf-8');
@@ -245,7 +249,7 @@ router.get('/@:user.atom', async ctx => {
 
 // RSS
 router.get('/@:user.rss', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
+	const feed = await getFeed(ctx.params.user, ctx.query.thread, ctx.query.history, ctx.query.noteintitle, ctx.query.norenotes, ctx.query.noreplies);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/rss+xml; charset=utf-8');
@@ -257,7 +261,7 @@ router.get('/@:user.rss', async ctx => {
 
 // JSON
 router.get('/@:user.json', async ctx => {
-	const feed = await getFeed(ctx.params.user, ctx.query.history, ctx.query.noteintitle);
+	const feed = await getFeed(ctx.params.user, ctx.query.thread, ctx.query.history, ctx.query.noteintitle, ctx.query.norenotes, ctx.query.noreplies);
 
 	if (feed) {
 		ctx.set('Content-Type', 'application/json; charset=utf-8');

--- a/packages/backend/src/server/web/index.ts
+++ b/packages/backend/src/server/web/index.ts
@@ -225,10 +225,11 @@ const getFeed = async (acct: string, threadDepth:string, historyCount:string, no
 		isSuspended: false,
 	});
 	let thread = parseInt(threadDepth, 10);
-	if (isNaN(thread) || thread <= 0 || thread > 30) {
+	if (isNaN(thread) || thread < 0 || thread > 30) {
 		thread = 3;
 	}
 	let history = parseInt(historyCount, 10);
+	//cant be 0 here or it will get all posts
 	if (isNaN(history) || history <= 0 || history > 30) {
 		history = 20;
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
The feed npm module dose not support multiple files, and enclosure format may not parse correct by apps, so that embedding all files into content. Also the email field is required by some app, so add a dummy one, could improved by use user email if have one.

The feed also can track back x posts for reply and renote, by using query string e.g. https://xxx/@xxx.atom?history=5 will include 5 most recent notes in the thread

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Resolve #7004

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Change originally made for #6696 at v11, now port to v12 to match file structure, working fine on my instance for years
