### PR TITLE
enhance: use tag for federating quotes

### DIFF
--- a/packages/backend/src/remote/activitypub/models/note.ts
+++ b/packages/backend/src/remote/activitypub/models/note.ts
@@ -7,7 +7,7 @@ import { resolvePerson } from './person.js';
 import { resolveImage } from './image.js';
 import { CacheableRemoteUser } from '@/models/entities/user.js';
 import { htmlToMfm } from '../misc/html-to-mfm.js';
-import { extractApHashtags } from './tag.js';
+import { extractApHashtags, extractQuoteUrl } from './tag.js';
 import { unique, toArray, toSingle } from '@/prelude/array.js';
 import { extractPollFromQuestion } from './question.js';
 import vote from '@/services/note/polls/vote.js';
@@ -155,8 +155,9 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 
 	// 引用
 	let quote: Note | undefined | null;
+	const quoteUrl = extractQuoteUrl(note.tag);
 
-	if (note._misskey_quote || note.quoteUrl) {
+	if (quoteUrl || note._misskey_quote || note.quoteUrl) {
 		const tryResolveNote = async (uri: string): Promise<{
 			status: 'ok';
 			res: Note | null;
@@ -183,7 +184,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 			}
 		};
 
-		const uris = unique([note._misskey_quote, note.quoteUrl].filter((x): x is string => typeof x === 'string'));
+		const uris = unique([quoteUrl, note._misskey_quote, note.quoteUrl].filter((x): x is string => typeof x === 'string'));
 		const results = await Promise.all(uris.map(uri => tryResolveNote(uri)));
 
 		quote = results.filter((x): x is { status: 'ok', res: Note | null } => x.status === 'ok').map(x => x.res).find(x => x);

--- a/packages/backend/src/remote/activitypub/models/note.ts
+++ b/packages/backend/src/remote/activitypub/models/note.ts
@@ -155,7 +155,7 @@ export async function createNote(value: string | IObject, resolver?: Resolver, s
 
 	// 引用
 	let quote: Note | undefined | null;
-	const quoteUrl = extractQuoteUrl(note.tag);
+	const quoteUrl = extractQuoteUrl(note.attachment.concat(note.tag));
 
 	if (quoteUrl || note._misskey_quote || note.quoteUrl) {
 		const tryResolveNote = async (uri: string): Promise<{

--- a/packages/backend/src/remote/activitypub/models/tag.ts
+++ b/packages/backend/src/remote/activitypub/models/tag.ts
@@ -24,10 +24,20 @@ export function extractQuoteUrl(tags: IObject | IObject[] | null | undefined): s
 		.filter(isLink)
 		.filter(link => link.mediaType === 'application/activity+json');
 
+	// Multiple quotes are not supported, try to reduce to only 1.
 	if (quotes.length > 1) {
-		// There are multiple quotes? Not supported.
 		// Check if there maybe is one intended for Misskey.
 		quotes = quotes.filter(link => toArray(link.rel).includes('https://misskey-hub.net/ns#_misskey_quote'));
+	}
+	if (quotes.length > 1) {
+		// Deduplicate by href value.
+		const hrefs = new Set();
+		quotes = quotes.filter(link => {
+			if (hrefs.has(link.href)) return false;
+
+			hrefs.add(link.href);
+			return true;
+		});
 	}
 
 	if (quotes.length === 1) {

--- a/packages/backend/src/remote/activitypub/models/tag.ts
+++ b/packages/backend/src/remote/activitypub/models/tag.ts
@@ -1,5 +1,5 @@
 import { toArray } from '@/prelude/array.js';
-import { IObject, isHashtag, IApHashtag } from '../type.js';
+import { IObject, isHashtag, IApHashtag, isLink, ILink } from '../type.js';
 
 export function extractApHashtags(tags: IObject | IObject[] | null | undefined) {
 	if (tags == null) return [];
@@ -15,4 +15,18 @@ export function extractApHashtags(tags: IObject | IObject[] | null | undefined) 
 export function extractApHashtagObjects(tags: IObject | IObject[] | null | undefined): IApHashtag[] {
 	if (tags == null) return [];
 	return toArray(tags).filter(isHashtag);
+}
+
+export function extractQuoteUrl(tags: IObject | IObject[] | null | undefined): string | null {
+	if (tags == null) return null;
+	const quotes: ILink[] = toArray(tags)
+		.filter(isLink)
+		.filter((link) => toArray(tag.rel).includes('https://misskey-hub.net/ns#_misskey_quote'));
+
+	if (quotes.length === 1) {
+		return quotes.href;
+	} else {
+		// either multiple quotes (unsupported) or no quote
+		return null;
+	}
 }

--- a/packages/backend/src/remote/activitypub/models/tag.ts
+++ b/packages/backend/src/remote/activitypub/models/tag.ts
@@ -19,9 +19,16 @@ export function extractApHashtagObjects(tags: IObject | IObject[] | null | undef
 
 export function extractQuoteUrl(tags: IObject | IObject[] | null | undefined): string | null {
 	if (tags == null) return null;
-	const quotes: ILink[] = toArray(tags)
+
+	let quotes: ILink[] = toArray(tags)
 		.filter(isLink)
-		.filter((link) => toArray(tag.rel).includes('https://misskey-hub.net/ns#_misskey_quote'));
+		.filter(link => link.mediaType === 'application/activity+json');
+
+	if (quotes.length > 1) {
+		// There are multiple quotes? Not supported.
+		// Check if there maybe is one intended for Misskey.
+		quotes = quotes.filter(link => toArray(link.rel).includes('https://misskey-hub.net/ns#_misskey_quote'));
+	}
 
 	if (quotes.length === 1) {
 		return quotes.href;

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -111,10 +111,8 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		...apemojis,
 	];
 
-	const attachment = files.map(renderDocument);
-
 	if (quote) {
-		attachment.push({
+		tag.push({
 			type: 'Link',
 			rel: 'https://misskey-hub.net/ns#_misskey_quote',
 			mediaType: 'application/activity+json',
@@ -160,7 +158,7 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		to,
 		cc,
 		inReplyTo,
-		attachment,
+		attachment: files.map(renderDocument),
 		sensitive: note.cw != null || files.some(file => file.isSensitive),
 		tag,
 		...asPoll,

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -111,6 +111,16 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		...apemojis,
 	];
 
+	if (quote) {
+		tag.push({
+			type: 'Link',
+			rel: 'https://misskey-hub.net/ns#_misskey_quote',
+			mediaType: 'application/activity+json',
+			href: quote,
+			name: `RE: ${quote}`,
+		});
+	}
+
 	const asPoll = poll ? {
 		type: 'Question',
 		content: toHtml(Object.assign({}, note, {

--- a/packages/backend/src/remote/activitypub/renderer/note.ts
+++ b/packages/backend/src/remote/activitypub/renderer/note.ts
@@ -111,8 +111,10 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		...apemojis,
 	];
 
+	const attachment = files.map(renderDocument);
+
 	if (quote) {
-		tag.push({
+		attachment.push({
 			type: 'Link',
 			rel: 'https://misskey-hub.net/ns#_misskey_quote',
 			mediaType: 'application/activity+json',
@@ -158,7 +160,7 @@ export default async function renderNote(note: Note, dive = true, isTalk = false
 		to,
 		cc,
 		inReplyTo,
-		attachment: files.map(renderDocument),
+		attachment,
 		sensitive: note.cw != null || files.some(file => file.isSensitive),
 		tag,
 		...asPoll,

--- a/packages/backend/src/remote/activitypub/type.ts
+++ b/packages/backend/src/remote/activitypub/type.ts
@@ -224,6 +224,7 @@ export const isEmoji = (object: IObject): object is IApEmoji =>
 
 export interface ILink extends IObject {
 	type: 'Link';
+	mediaType?: string;
 	rel?: string | string[];
 	href: string;
 }

--- a/packages/backend/src/remote/activitypub/type.ts
+++ b/packages/backend/src/remote/activitypub/type.ts
@@ -222,6 +222,15 @@ export interface IApEmoji extends IObject {
 export const isEmoji = (object: IObject): object is IApEmoji =>
 	getApType(object) === 'Emoji' && !Array.isArray(object.icon) && object.icon.url != null;
 
+export interface ILink extends IObject {
+	type: 'Link';
+	rel?: string | string[];
+	href: string;
+}
+
+export const isLink = (object: IObject): object is ILink =>
+	getApType(object) === 'Link' && object.href != null;
+
 export interface ICreate extends IActivity {
 	type: 'Create';
 }


### PR DESCRIPTION
# What
Use a `Link` tag to federate quotes instead of the custom `_misskey_quote` property.

# Why
related to #8722

# Additional info
This uses the same namespace URL that the `_misskey_quote` property uses in JSON-LD for the `rel` attribute.

With this change the deprecated properties will still be sent so this is for now fully backwards compatible. It should be reviewed at a later date whether the `_misskey_quote` property (and maybe the `quoteUrl` property as well) are still necessary or should be removed to reduce network traffic.