### PR TITLE
enhance: Improve player detection in URL preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You should also include the user name that made the change.
 ### Improvements
 - Server: Add rate limit to i/notifications @tamaina
 - Client: Improve files page of control panel @syuilo
+- Improve player detection in URL preview @mei23
 
 ### Bugfixes
 - Server: Fix GenerateVideoThumbnail failed @mei23

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -100,7 +100,7 @@
 		"strict-event-emitter-types": "2.0.0",
 		"stringz": "2.1.0",
 		"style-loader": "3.3.1",
-		"summaly": "2.5.1",
+		"summaly": "2.6.0",
 		"syslog-pro": "1.0.0",
 		"systeminformation": "5.11.16",
 		"tinycolor2": "1.4.2",

--- a/packages/backend/yarn.lock
+++ b/packages/backend/yarn.lock
@@ -6429,10 +6429,10 @@ style-loader@3.3.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
   integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
 
-summaly@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/summaly/-/summaly-2.5.1.tgz#742fe6631987f84ad2e95d2b0f7902ec57e0f6b3"
-  integrity sha512-WWvl7rLs3wm61Xc2JqgTbSuqtIOmGqKte+rkbnxe6ISy4089lQ+7F2ajooQNee6PWHl9kZ27SDd1ZMoL3/6R4A==
+summaly@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/summaly/-/summaly-2.6.0.tgz#aaac80eb8ae88b130318f44d9b98da9c2ccb328c"
+  integrity sha512-wIv6fL3aeFfXcQoZISzeUfNUgD3u8Hwx8Rg0awZliQhans62w23K3nDezwfvmYAQCgXs6e0EF7jtGmJv/qeVTA==
   dependencies:
     cheerio "0.22.0"
     debug "4.3.3"


### PR DESCRIPTION
# What
Improve player detection in URL preview
- Supports `og:video` (PeerTube, ニコニコ動画 等のプレイヤーが認識されるように)
- Fix Pleroma image posts being treated as players

# Why
Resolve #8845

![image](https://user-images.githubusercontent.com/30769358/174426368-63ee15df-9a53-4882-a8cd-608c75d3f2cd.png)

# Additional info (optional)
https://github.com/syuilo/summaly/pull/147
