### PR TITLE
fix: mocha テストが動かないのを修正 v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
 
 jobs:
   mocha:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches:
-      - master
-      - develop
-  pull_request:
+on: [push]
 
 jobs:
   mocha:

--- a/packages/backend/.mocharc.json
+++ b/packages/backend/.mocharc.json
@@ -5,6 +5,6 @@
 		"loader=./test/loader.js"
 	],
 	"slow": 1000,
-	"timeout": 10000,
+	"timeout": 30000,
 	"exit": true
 }

--- a/packages/backend/src/server/api/limiter.ts
+++ b/packages/backend/src/server/api/limiter.ts
@@ -7,6 +7,8 @@ import { IEndpointMeta } from './endpoints.js';
 const logger = new Logger('limiter');
 
 export const limiter = (limitation: IEndpointMeta['limit'] & { key: NonNullable<string> }, actor: string) => new Promise<void>((ok, reject) => {
+	if (process.env.NODE_ENV === 'test') ok();
+
 	const hasShortTermLimit = typeof limitation.minInterval === 'number';
 
 	const hasLongTermLimit =

--- a/packages/backend/test/mute.ts
+++ b/packages/backend/test/mute.ts
@@ -2,7 +2,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, react, connectStream, startServer, shutdownServer, sleep } from './utils.js';
+import { async, signup, request, post, react, startServer, shutdownServer, waitFire } from './utils.js';
 
 describe('Mute', () => {
 	let p: childProcess.ChildProcess;
@@ -55,44 +55,24 @@ describe('Mute', () => {
 		assert.strictEqual(res.body.hasUnreadMentions, false);
 	}));
 
-	it('ミュートしているユーザーからメンションされても、ストリームに unreadMention イベントが流れてこない', async(async () => {
+	it('ミュートしているユーザーからメンションされても、ストリームに unreadMention イベントが流れてこない', async () => {
 		// 状態リセット
 		await request('/i/read-all-unread-notes', {}, alice);
 
-		let fired = false;
+		const fired = await waitFire(alice, 'main', () => post(carol, { text: '@alice hi' }), msg => msg.type === 'unreadMention');
 
-		const ws = await connectStream(alice, 'main', ({ type }) => {
-			if (type == 'unreadMention') {
-				fired = true;
-			}
-		});
-
-		await post(carol, { text: '@alice hi' });
-
-		await sleep(5000);
 		assert.strictEqual(fired, false);
-		ws.close();
-	}));
+	});
 
-	it('ミュートしているユーザーからメンションされても、ストリームに unreadNotification イベントが流れてこない', async(async () => {
+	it('ミュートしているユーザーからメンションされても、ストリームに unreadNotification イベントが流れてこない', async () => {
 		// 状態リセット
 		await request('/i/read-all-unread-notes', {}, alice);
 		await request('/notifications/mark-all-as-read', {}, alice);
 
-		let fired = false;
+		const fired = await waitFire(alice, 'main', () => post(carol, { text: '@alice hi' }), msg => msg.type === 'unreadNotification');
 
-		const ws = await connectStream(alice, 'main', ({ type }) => {
-			if (type == 'unreadNotification') {
-				fired = true;
-			}
-		});
-
-		await post(carol, { text: '@alice hi' });
-
-		await sleep(5000);
 		assert.strictEqual(fired, false);
-		ws.close();
-	}));
+	});
 
 	describe('Timeline', () => {
 		it('タイムラインにミュートしているユーザーの投稿が含まれない', async(async () => {

--- a/packages/backend/test/mute.ts
+++ b/packages/backend/test/mute.ts
@@ -2,7 +2,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { async, signup, request, post, react, connectStream, startServer, shutdownServer } from './utils.js';
+import { async, signup, request, post, react, connectStream, startServer, shutdownServer, sleep } from './utils.js';
 
 describe('Mute', () => {
 	let p: childProcess.ChildProcess;
@@ -55,7 +55,7 @@ describe('Mute', () => {
 		assert.strictEqual(res.body.hasUnreadMentions, false);
 	}));
 
-	it('ミュートしているユーザーからメンションされても、ストリームに unreadMention イベントが流れてこない', () => new Promise(async done => {
+	it('ミュートしているユーザーからメンションされても、ストリームに unreadMention イベントが流れてこない', async(async () => {
 		// 状態リセット
 		await request('/i/read-all-unread-notes', {}, alice);
 
@@ -67,16 +67,14 @@ describe('Mute', () => {
 			}
 		});
 
-		post(carol, { text: '@alice hi' });
+		await post(carol, { text: '@alice hi' });
 
-		setTimeout(() => {
-			assert.strictEqual(fired, false);
-			ws.close();
-			done();
-		}, 5000);
+		await sleep(5000);
+		assert.strictEqual(fired, false);
+		ws.close();
 	}));
 
-	it('ミュートしているユーザーからメンションされても、ストリームに unreadNotification イベントが流れてこない', () => new Promise(async done => {
+	it('ミュートしているユーザーからメンションされても、ストリームに unreadNotification イベントが流れてこない', async(async () => {
 		// 状態リセット
 		await request('/i/read-all-unread-notes', {}, alice);
 		await request('/notifications/mark-all-as-read', {}, alice);
@@ -89,13 +87,11 @@ describe('Mute', () => {
 			}
 		});
 
-		post(carol, { text: '@alice hi' });
+		await post(carol, { text: '@alice hi' });
 
-		setTimeout(() => {
-			assert.strictEqual(fired, false);
-			ws.close();
-			done();
-		}, 5000);
+		await sleep(5000);
+		assert.strictEqual(fired, false);
+		ws.close();
 	}));
 
 	describe('Timeline', () => {

--- a/packages/backend/test/note.ts
+++ b/packages/backend/test/note.ts
@@ -3,7 +3,7 @@ process.env.NODE_ENV = 'test';
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
 import { Note } from '../src/models/entities/note.js';
-import { async, signup, request, post, uploadFile, startServer, shutdownServer, initTestDb, api } from './utils.js';
+import { async, signup, request, post, uploadUrl, startServer, shutdownServer, initTestDb, api } from './utils.js';
 
 describe('Note', () => {
 	let p: childProcess.ChildProcess;
@@ -37,7 +37,7 @@ describe('Note', () => {
 	}));
 
 	it('ファイルを添付できる', async(async () => {
-		const file = await uploadFile(alice);
+		const file = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.jpg');
 
 		const res = await request('/notes/create', {
 			fileIds: [file.id],
@@ -49,7 +49,7 @@ describe('Note', () => {
 	}));
 
 	it('他人のファイルは無視', async(async () => {
-		const file = await uploadFile(bob);
+		const file = await uploadUrl(bob, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.jpg');
 
 		const res = await request('/notes/create', {
 			text: 'test',

--- a/packages/backend/test/note.ts
+++ b/packages/backend/test/note.ts
@@ -3,7 +3,7 @@ process.env.NODE_ENV = 'test';
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
 import { Note } from '../src/models/entities/note.js';
-import { async, signup, request, post, uploadFile, startServer, shutdownServer, initTestDb } from './utils.js';
+import { async, signup, request, post, uploadFile, startServer, shutdownServer, initTestDb, api } from './utils.js';
 
 describe('Note', () => {
 	let p: childProcess.ChildProcess;
@@ -72,11 +72,13 @@ describe('Note', () => {
 		assert.deepStrictEqual(res.body.createdNote.fileIds, []);
 	}));
 
-	it('不正なファイルIDで怒られる', async(async () => {
+	it('不正なファイルIDは無視', async(async () => {
 		const res = await request('/notes/create', {
 			fileIds: ['kyoppie'],
 		}, alice);
-		assert.strictEqual(res.status, 400);
+		assert.strictEqual(res.status, 200);
+		assert.strictEqual(typeof res.body === 'object' && !Array.isArray(res.body), true);
+		assert.deepStrictEqual(res.body.createdNote.fileIds, []);
 	}));
 
 	it('返信できる', async(async () => {
@@ -136,7 +138,7 @@ describe('Note', () => {
 
 	it('文字数ぎりぎりで怒られない', async(async () => {
 		const post = {
-			text: '!'.repeat(500),
+			text: '!'.repeat(3000),
 		};
 		const res = await request('/notes/create', post, alice);
 		assert.strictEqual(res.status, 200);
@@ -144,7 +146,7 @@ describe('Note', () => {
 
 	it('文字数オーバーで怒られる', async(async () => {
 		const post = {
-			text: '!'.repeat(501),
+			text: '!'.repeat(3001),
 		};
 		const res = await request('/notes/create', post, alice);
 		assert.strictEqual(res.status, 400);
@@ -207,7 +209,7 @@ describe('Note', () => {
 		assert.strictEqual(typeof res.body === 'object' && !Array.isArray(res.body), true);
 		assert.strictEqual(res.body.createdNote.text, post.text);
 
-		const noteDoc = await Notes.findOne(res.body.createdNote.id);
+		const noteDoc = await Notes.findOneBy({ id: res.body.createdNote.id });
 		assert.deepStrictEqual(noteDoc.mentions, [bob.id]);
 	}));
 
@@ -336,32 +338,32 @@ describe('Note', () => {
 
 	describe('notes/delete', () => {
 		it('delete a reply', async(async () => {
-			const mainNoteRes = await request('/notes/create', {
+			const mainNoteRes = await api('notes/create', {
 				text: 'main post',
 			}, alice);
-			const replyOneRes = await request('/notes/create', {
+			const replyOneRes = await api('notes/create', {
 				text: 'reply one',
 				replyId: mainNoteRes.body.createdNote.id,
 			}, alice);
-			const replyTwoRes = await request('/notes/create', {
+			const replyTwoRes = await api('notes/create', {
 				text: 'reply two',
 				replyId: mainNoteRes.body.createdNote.id,
 			}, alice);
 
-			const deleteOneRes = await request('/notes/delete', {
+			const deleteOneRes = await api('notes/delete', {
 				noteId: replyOneRes.body.createdNote.id,
 			}, alice);
 
 			assert.strictEqual(deleteOneRes.status, 204);
-			let mainNote = await Notes.findOne({ id: mainNoteRes.body.createdNote.id });
+			let mainNote = await Notes.findOneBy({ id: mainNoteRes.body.createdNote.id });
 			assert.strictEqual(mainNote.repliesCount, 1);
 
-			const deleteTwoRes = await request('/notes/delete', {
+			const deleteTwoRes = await api('notes/delete', {
 				noteId: replyTwoRes.body.createdNote.id,
 			}, alice);
 
 			assert.strictEqual(deleteTwoRes.status, 204);
-			mainNote = await Notes.findOne({ id: mainNoteRes.body.createdNote.id });
+			mainNote = await Notes.findOneBy({ id: mainNoteRes.body.createdNote.id });
 			assert.strictEqual(mainNote.repliesCount, 0);
 		}));
 	});

--- a/packages/backend/test/user-notes.ts
+++ b/packages/backend/test/user-notes.ts
@@ -15,8 +15,8 @@ describe('users/notes', () => {
 	before(async () => {
 		p = await startServer();
 		alice = await signup({ username: 'alice' });
-		const jpg = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.jpg'); 
-		const png = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.png'); 
+		const jpg = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.jpg');
+		const png = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.png');
 		jpgNote = await post(alice, {
 			fileIds: [jpg.id],
 		});

--- a/packages/backend/test/user-notes.ts
+++ b/packages/backend/test/user-notes.ts
@@ -2,12 +2,7 @@ process.env.NODE_ENV = 'test';
 
 import * as assert from 'assert';
 import * as childProcess from 'child_process';
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { async, signup, request, post, uploadFile, startServer, shutdownServer } from './utils.js';
-
-const _filename = fileURLToPath(import.meta.url);
-const _dirname = dirname(_filename);
+import { async, signup, request, post, uploadUrl, startServer, shutdownServer } from './utils.js';
 
 describe('users/notes', () => {
 	let p: childProcess.ChildProcess;
@@ -20,8 +15,8 @@ describe('users/notes', () => {
 	before(async () => {
 		p = await startServer();
 		alice = await signup({ username: 'alice' });
-		const jpg = await uploadFile(alice, _dirname + '/resources/Lenna.jpg');
-		const png = await uploadFile(alice, _dirname + '/resources/Lenna.png');
+		const jpg = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.jpg'); 
+		const png = await uploadUrl(alice, 'https://raw.githubusercontent.com/misskey-dev/misskey/develop/packages/backend/test/resources/Lenna.png'); 
 		jpgNote = await post(alice, {
 			fileIds: [jpg.id],
 		});

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -139,6 +139,26 @@ export const uploadFile = async (user: any, _path?: string): Promise<any> => {
 	return body;
 };
 
+export const uploadUrl = async (user: any, url: string) => {
+	let file: any;
+
+	const ws = await connectStream(user, 'main', (msg) => {
+		if (msg.type === 'driveFileCreated') {
+			file = msg.body;
+		}
+	});
+
+	await api('drive/files/upload-from-url', {
+		url,
+		force: true,
+	}, user);
+
+	await sleep(5000);
+	ws.close();
+
+	return file;
+};
+
 export function connectStream(user: any, channel: string, listener: (message: Record<string, any>) => any, params?: any): Promise<WebSocket> {
 	return new Promise((res, rej) => {
 		const ws = new WebSocket(`ws://localhost:${port}/streaming?i=${user.token}`);

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -190,13 +190,18 @@ export const waitFire = async (user: any, channel: string, trgr: () => any, cond
 	return new Promise<boolean>(async (res, rej) => {
 		let timer: NodeJS.Timeout;
 
-		const ws = await connectStream(user, channel, msg => {
-			if (cond(msg)) {
-				ws.close();
-				if (timer) clearTimeout(timer);
-				res(true);
-			}
-		});
+		let ws: WebSocket;
+		try {
+			ws = await connectStream(user, channel, msg => {
+				if (cond(msg)) {
+					ws.close();
+					if (timer) clearTimeout(timer);
+					res(true);
+				}
+			});
+		} catch (e) {
+			rej(e);
+		}
 
 		timer = setTimeout(() => {
 			ws.close();

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -4,7 +4,7 @@ import { dirname } from 'node:path';
 import * as childProcess from 'child_process';
 import * as http from 'node:http';
 import { SIGKILL } from 'constants';
-import * as WebSocket from 'ws';
+import WebSocket from 'ws';
 import * as misskey from 'misskey-js';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
@@ -176,7 +176,7 @@ export async function initTestDb(justBorrow = false, initEntities?: any[]) {
 	return db;
 }
 
-export function startServer(timeout = 30 * 1000): Promise<childProcess.ChildProcess> {
+export function startServer(timeout = 60 * 1000): Promise<childProcess.ChildProcess> {
 	return new Promise((res, rej) => {
 		const t = setTimeout(() => {
 			p.kill(SIGKILL);
@@ -212,5 +212,13 @@ export function shutdownServer(p: childProcess.ChildProcess, timeout = 20 * 1000
 		});
 
 		p.kill();
+	});
+}
+
+export function sleep(msec: number) {
+	return new Promise<void>(res => {
+		setTimeout(() => {
+			res();
+		}, msec);
 	});
 }

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -203,6 +203,8 @@ export const waitFire = async (user: any, channel: string, trgr: () => any, cond
 			rej(e);
 		}
 
+		if (!ws!) return;
+
 		timer = setTimeout(() => {
 			ws.close();
 			res(false);


### PR DESCRIPTION
# What
mocha テストが動かないのを修正

#8891 で multipartアップロードがどうしてもCI環境で安定しないのでURLからアップロードにするようにした版
また、develop最新で検証しなおし

- タイムアウトを増加
- Ratelimit でテストがコケるのを修正 (前テスト環境は除外だった気がするけどどこ行った？)
- 不正なファイルIDは無視 => 今は普通に通る ので条件変更
- 文字数制限 500 => 3000 に変わってる ので条件変更
- ESM WebSocket の import でStreaming系がコケるのを修正
- findOneBy
- util:uploadFile node-fetchでコケるようなのでgotで書き直し (結局使用していないが)
- Streaming待つ系で失敗時にPromiseが戻ってこなくなるので対処 (一部のみ)
- APIリクエスト用の新しい util:api()
  util:request() はAPI失敗時にもエラーにならずステータスコードを返す仕組みなので
  テストの準備などの必ず成功すると見込んでる場所で使用すると、エラー時のトラブルシューティングが難しくなる。
  失敗したらエラーになりerror bodyも出力する util:api() を追加。(一部置き換え)
- multipartアップロードがどうしてもCI環境で安定しないのでURLからアップロードにするように

# Why
Fix #8782

# Additional info (optional)
