### PR TITLE
fix: restore menu entries

### DIFF
--- a/packages/client/src/components/launch-pad.vue
+++ b/packages/client/src/components/launch-pad.vue
@@ -62,7 +62,7 @@ const modal = $ref<InstanceType<typeof MkModal>>();
 
 const menu = defaultStore.state.menu;
 
-const items = Object.keys(menuDef).filter(k => !menu.includes(k)).map(k => menuDef[k]).filter(def => def.show == null ? true : def.show).map(def => ({
+const items = Object.keys(menuDef).filter(k => !menu.includes(k)).map(k => menuDef[k]).filter(def => (def.show ?? true) && !(def.optional ?? false)).map(def => ({
 	type: def.to ? 'link' : 'button',
 	text: i18n.ts[def.title],
 	icon: def.icon,

--- a/packages/client/src/menu.ts
+++ b/packages/client/src/menu.ts
@@ -112,6 +112,20 @@ export const menuDef = reactive({
 			os.popupMenu(items, ev.currentTarget ?? ev.target);
 		},
 	},
+	mentions: {
+		title: 'mentions',
+		icon: 'fas fa-at',
+		show: computed(() => $i != null),
+		indicated: computed(() => $i != null && $i.hasUnreadMentions),
+		to: '/my/notifications#mentions',
+	},
+	messages: {
+		title: 'directNotes',
+		icon: 'fas fa-envelope',
+		show: computed(() => $i != null),
+		indicated: computed(() => $i != null && $i.hasUnreadSpecifiedNotes),
+		to: '/my/notifications#directNotes',
+	},
 	favorites: {
 		title: 'favorites',
 		icon: 'fas fa-star',
@@ -138,6 +152,21 @@ export const menuDef = reactive({
 		title: 'channel',
 		icon: 'fas fa-satellite-dish',
 		to: '/channels',
+	},
+	federation: {
+		title: 'federation',
+		icon: 'fas fa-globe',
+		to: '/about#federation',
+	},
+	emojis: {
+		title: 'emojis',
+		icon: 'fas fa-laugh',
+		to: '/about#emojis',
+	},
+	scratchpad: {
+		title: 'scratchpad',
+		icon: 'fas fa-terminal',
+		to: '/scratchpad',
 	},
 	ui: {
 		title: 'switchUi',

--- a/packages/client/src/menu.ts
+++ b/packages/client/src/menu.ts
@@ -118,6 +118,7 @@ export const menuDef = reactive({
 		show: computed(() => $i != null),
 		indicated: computed(() => $i != null && $i.hasUnreadMentions),
 		to: '/my/notifications#mentions',
+		optional: true,
 	},
 	messages: {
 		title: 'directNotes',
@@ -125,6 +126,7 @@ export const menuDef = reactive({
 		show: computed(() => $i != null),
 		indicated: computed(() => $i != null && $i.hasUnreadSpecifiedNotes),
 		to: '/my/notifications#directNotes',
+		optional: true,
 	},
 	favorites: {
 		title: 'favorites',
@@ -157,16 +159,19 @@ export const menuDef = reactive({
 		title: 'federation',
 		icon: 'fas fa-globe',
 		to: '/about#federation',
+		optional: true,
 	},
 	emojis: {
 		title: 'emojis',
 		icon: 'fas fa-laugh',
 		to: '/about#emojis',
+		optional: true,
 	},
 	scratchpad: {
 		title: 'scratchpad',
 		icon: 'fas fa-terminal',
 		to: '/scratchpad',
+		optional: true,
 	},
 	ui: {
 		title: 'switchUi',

--- a/packages/client/src/pages/notifications.vue
+++ b/packages/client/src/pages/notifications.vue
@@ -24,7 +24,18 @@ import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
 
-let tab = $ref('all');
+const props = withDefaults(defineProps<{
+	initialTab?: string;
+}>(), {
+	initialTab: 'all',
+});
+
+// check if it is an existing tab
+if (!['all', 'unread', 'mentions', 'directNotes'].includes(props.initialTab)) {
+	props.initialTab = 'all';
+}
+
+let tab = $ref(props.initialTab);
 let includeTypes = $ref<string[] | null>(null);
 let unreadOnly = $computed(() => tab === 'unread');
 

--- a/packages/client/src/router.ts
+++ b/packages/client/src/router.ts
@@ -160,6 +160,7 @@ export const routes = [{
 	path: '/my/notifications',
 	component: page(() => import('./pages/notifications.vue')),
 	loginRequired: true,
+	hash: 'initialTab',
 }, {
 	path: '/my/favorites',
 	component: page(() => import('./pages/favorites.vue')),


### PR DESCRIPTION
# What
Add ability to determine the initial tab for `/my/notifications` using URL hash.

Add back the menu entries for mentions, direct notes, federation, custom emojis and the scratchpad that were removed in commit 0f1c0a42a253dcc5758e4811aaa116708d482305.

# Why
> I think some of the menu items you removed here, especially mentions, direct notes and federation, are commonly used. So I think they should be reintroduced.
-- https://github.com/misskey-dev/misskey/commit/0f1c0a42a253dcc5758e4811aaa116708d482305#commitcomment-77260033

I also noticed there was no Changelog entry for these user-facing changes so I thought that it was the intention to add them back.