### PR TITLE
migrate parse5 to 7.0.0

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -75,7 +75,7 @@
 		"node-fetch": "3.2.6",
 		"nodemailer": "6.7.6",
 		"os-utils": "0.0.14",
-		"parse5": "6.0.1",
+		"parse5": "7.0.0",
 		"pg": "8.7.3",
 		"private-ip": "2.3.3",
 		"probe-image-size": "7.2.3",

--- a/packages/backend/src/mfm/from-html.ts
+++ b/packages/backend/src/mfm/from-html.ts
@@ -1,6 +1,8 @@
 import { URL } from 'node:url';
 import * as parse5 from 'parse5';
-import treeAdapter from 'parse5/lib/tree-adapters/default.js';
+import * as TreeAdapter from '../../node_modules/parse5/dist/tree-adapters/default.js';
+
+const treeAdapter = TreeAdapter.defaultTreeAdapter;
 
 const urlRegex = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+/;
 const urlRegexFull = /^https?:\/\/[\w\/:%#@$&?!()\[\]~.,=+\-]+$/;
@@ -19,7 +21,7 @@ export function fromHtml(html: string, hashtagNames?: string[]): string {
 
 	return text.trim();
 
-	function getText(node: parse5.Node): string {
+	function getText(node: TreeAdapter.Node): string {
 		if (treeAdapter.isTextNode(node)) return node.value;
 		if (!treeAdapter.isElementNode(node)) return '';
 		if (node.nodeName === 'br') return '\n';
@@ -31,7 +33,7 @@ export function fromHtml(html: string, hashtagNames?: string[]): string {
 		return '';
 	}
 
-	function appendChildren(childNodes: parse5.ChildNode[]): void {
+	function appendChildren(childNodes: TreeAdapter.ChildNode[]): void {
 		if (childNodes) {
 			for (const n of childNodes) {
 				analyze(n);
@@ -39,7 +41,7 @@ export function fromHtml(html: string, hashtagNames?: string[]): string {
 		}
 	}
 
-	function analyze(node: parse5.Node) {
+	function analyze(node: TreeAdapter.Node) {
 		if (treeAdapter.isTextNode(node)) {
 			text += node.value;
 			return;

--- a/packages/backend/yarn.lock
+++ b/packages/backend/yarn.lock
@@ -5243,22 +5243,22 @@ parse5-htmlparser2-tree-adapter@^6.0.0:
   dependencies:
     parse5 "^6.0.1"
 
-parse5@6.0.1, parse5@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
-  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+parse5@7.0.0, parse5@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
+  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
+  dependencies:
+    entities "^4.3.0"
 
 parse5@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
-parse5@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
-  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
-  dependencies:
-    entities "^4.3.0"
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
 parseurl@^1.3.2:
   version "1.3.3"


### PR DESCRIPTION
# What
Resolve #8915

普通にやると ERR_PACKAGE_PATH_NOT_EXPORTED になるのでこうするしかないけど、おすすめしない。

# Why
Resolve #8915

# Additional info (optional)

<!-- テスト観点など -->
<!-- Test perspective, etc -->
