### PR TITLE
Option to force error

### DIFF
--- a/packages/backend/src/server/web/boot.js
+++ b/packages/backend/src/server/web/boot.js
@@ -22,6 +22,11 @@
 
 	const v = localStorage.getItem('v') || VERSION;
 
+	let forceError = localStorage.getItem('forceError');
+	if (forceError != null) {
+		renderError('FORCED_ERROR', 'This error is forced by having forceError in local storage.')
+	}
+
 	//#region Detect language & fetch translations
 	const localeVersion = localStorage.getItem('localeVersion');
 	const localeOutdated = (localeVersion == null || localeVersion !== v);


### PR DESCRIPTION
# What
You can now force an error by adding an item `forceError` to local storage.

# Why
Close #8945
