### PR TITLE
DockerでAlpineではなくDebianを使用するように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ You should also include the user name that made the change.
 
 ### Bugfixes
 - Fix Docker doesn't work @mei23  
-  Probably still not working on arm64 environment.
+  Still not working on arm64 environment. (See 12.112.0)
 
 ## 12.112.1 (2022/07/07)
 same as 12.112.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 You should also include the user name that made the change.
 -->
 
+## 12.x.x (unreleased)
+
+### Improvements
+
+### Bugfixes
+- Fix Docker doesn't work @mei23  
+  Probably still not working on arm64 environment.
+
 ## 12.112.1 (2022/07/07)
 same as 12.112.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,24 @@
-FROM node:18.0.0-alpine3.15 AS base
+FROM node:16.15.1-bullseye AS builder
 
 ARG NODE_ENV=production
 
 WORKDIR /misskey
 
-ENV BUILD_DEPS autoconf automake file g++ gcc libc-dev libtool make nasm pkgconfig python3 zlib-dev git
-
-FROM base AS builder
-
 COPY . ./
 
-RUN apk add --no-cache $BUILD_DEPS && \
-	git submodule update --init && \
-	yarn install && \
-	yarn build && \
-	rm -rf .git
+RUN apt-get update
+RUN apt-get install -y build-essential
+RUN git submodule update --init
+RUN yarn install
+RUN yarn build
+RUN rm -rf .git
 
-FROM base AS runner
+FROM node:16.15.1-bullseye-slim AS runner
 
-RUN apk add --no-cache \
-	ffmpeg \
-	tini
+WORKDIR /misskey
 
-ENTRYPOINT ["/sbin/tini", "--"]
+RUN apt-get update
+RUN apt-get install -y ffmpeg tini
 
 COPY --from=builder /misskey/node_modules ./node_modules
 COPY --from=builder /misskey/built ./built
@@ -32,5 +28,5 @@ COPY --from=builder /misskey/packages/client/node_modules ./packages/client/node
 COPY . ./
 
 ENV NODE_ENV=production
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["npm", "run", "migrateandstart"]
-


### PR DESCRIPTION
# What
DockerでAlpineではなくDebianを使用するように。
Dockerが動くようになります。

ここだけ Node v18.0.0 を 使っているのは変なので v16.15.1 に。
v16.x の最新は [v16.16.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#16.16.0) だけどまだイメージがない。

# Why
Fix #8961

# Additional info (optional)
Docker on amd64 で動くことを確認。
Docker on arm64 は確認してないけどたぶん動かない。