### PR TITLE
enhance: read theme color nodeinfo

### DIFF
--- a/packages/backend/src/server/nodeinfo.ts
+++ b/packages/backend/src/server/nodeinfo.ts
@@ -78,6 +78,7 @@ const nodeinfo2 = async () => {
 			enableEmail: meta.enableEmail,
 			enableServiceWorker: meta.enableServiceWorker,
 			proxyAccountName: proxyAccount ? proxyAccount.username : null,
+			themeColor: meta.themeColor || '#86b300',
 		},
 	};
 };

--- a/packages/backend/src/services/fetch-instance-metadata.ts
+++ b/packages/backend/src/services/fetch-instance-metadata.ts
@@ -34,7 +34,7 @@ export async function fetchInstanceMetadata(instance: Instance, force = false): 
 		const [favicon, icon, themeColor, name, description] = await Promise.all([
 			fetchFaviconUrl(instance, dom).catch(() => null),
 			fetchIconUrl(instance, dom, manifest).catch(() => null),
-			getThemeColor(dom, manifest).catch(() => null),
+			getThemeColor(info, dom, manifest).catch(() => null),
 			getSiteName(info, dom, manifest).catch(() => null),
 			getDescription(info, dom, manifest).catch(() => null),
 		]);
@@ -208,8 +208,8 @@ async function fetchIconUrl(instance: Instance, doc: DOMWindow['document'] | nul
 	return null;
 }
 
-async function getThemeColor(doc: DOMWindow['document'] | null, manifest: Record<string, any> | null): Promise<string | null> {
-	const themeColor = doc?.querySelector('meta[name="theme-color"]')?.getAttribute('content') || manifest?.theme_color;
+async function getThemeColor(info: NodeInfo | null, doc: DOMWindow['document'] | null, manifest: Record<string, any> | null): Promise<string | null> {
+	const themeColor = info?.metadata?.themeColor || doc?.querySelector('meta[name="theme-color"]')?.getAttribute('content') || manifest?.theme_color;
 
 	if (themeColor) {
 		const color = new tinycolor(themeColor);


### PR DESCRIPTION
# What
Provide the theme color in the nodeinfo and read it from there when fetching metadata of another instance.

# Why
fix #8897