### PR TITLE
fix(sw, notification): Don't issue an event if there is no affect

### DIFF
--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -19,10 +19,7 @@ export async function readNotification(
 		isRead: true,
 	});
 
-	if (result.affected === 0) {
-		console.log('readNotification: no notification found');
-		return;
-	};
+	if (result.affected === 0) return;
 
 	if (!await Users.getHasUnreadNotification(userId)) return postReadAllNotifications(userId);
 	else return postReadNotifications(userId, notificationIds);

--- a/packages/backend/src/server/api/common/read-notification.ts
+++ b/packages/backend/src/server/api/common/read-notification.ts
@@ -12,12 +12,17 @@ export async function readNotification(
 	if (notificationIds.length === 0) return;
 
 	// Update documents
-	await Notifications.update({
+	const result = await Notifications.update({
 		id: In(notificationIds),
 		isRead: false,
 	}, {
 		isRead: true,
 	});
+
+	if (result.affected === 0) {
+		console.log('readNotification: no notification found');
+		return;
+	};
 
 	if (!await Users.getHasUnreadNotification(userId)) return postReadAllNotifications(userId);
 	else return postReadNotifications(userId, notificationIds);


### PR DESCRIPTION
Related to https://github.com/misskey-dev/misskey/issues/8906#issuecomment-1179101305

# What
updateの結果のうちaffectedが0である場合、readNotificationsまたはreadAllNotificationsイベントは発行されないように

# Why
https://github.com/misskey-dev/misskey/issues/8906#issuecomment-1179101305 はバグではなく仕様ではあるが、イベントを毎度送る必要もなさそうなので、affectedが0の場合はイベントを発行しない。
