### PR TITLE
Fix crash at startup if TensorFlow is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ You should also include the user name that made the change.
 ### Improvements
 
 ### Bugfixes
-- Server: Fix crash at startup in an environment that does not support TensorFlow @mei23
+- Server: Fix crash at startup if TensorFlow is not supported @mei23
 
 ## 12.112.3 (2022/07/09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 You should also include the user name that made the change.
 -->
 
+## 12.x.x (unreleased)
+
+### Improvements
+
+### Bugfixes
+- Server: Fix crash at startup in an environment that does not support TensorFlow @mei23
+
 ## 12.112.3 (2022/07/09)
 
 ### Improvements

--- a/packages/backend/src/services/detect-sensitive.ts
+++ b/packages/backend/src/services/detect-sensitive.ts
@@ -2,7 +2,6 @@ import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import * as nsfw from 'nsfwjs';
-import * as tf from '@tensorflow/tfjs-node';
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = dirname(_filename);
@@ -11,10 +10,12 @@ let model: nsfw.NSFWJS;
 
 export async function detectSensitive(path: string): Promise<nsfw.predictionType[] | null> {
 	try {
+		const tf = await import('@tensorflow/tfjs-node');
+
 		if (model == null) model = await nsfw.load(`file://${_dirname}/../../nsfw-model/`, { size: 299 });
 
 		const buffer = await fs.promises.readFile(path);
-		const image = await tf.node.decodeImage(buffer, 3) as tf.Tensor3D;
+		const image = await tf.node.decodeImage(buffer, 3) as any;
 		try {
 			const predictions = await model.classify(image);
 			return predictions;

--- a/packages/backend/src/services/detect-sensitive.ts
+++ b/packages/backend/src/services/detect-sensitive.ts
@@ -2,14 +2,28 @@ import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import * as nsfw from 'nsfwjs';
+import si from 'systeminformation';
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = dirname(_filename);
+
+const REQUIRED_CPU_FLAGS = ['avx2', 'fma'];
+let isSupportedCpu: undefined | boolean = undefined;
 
 let model: nsfw.NSFWJS;
 
 export async function detectSensitive(path: string): Promise<nsfw.predictionType[] | null> {
 	try {
+		if (isSupportedCpu === undefined) {
+			const cpuFlags = await getCpuFlags();
+			isSupportedCpu = REQUIRED_CPU_FLAGS.every(required => cpuFlags.includes(required));
+		}
+
+		if (!isSupportedCpu) {
+			console.error('This CPU cannot use TensorFlow');
+			return null;
+		}
+
 		const tf = await import('@tensorflow/tfjs-node');
 
 		if (model == null) model = await nsfw.load(`file://${_dirname}/../../nsfw-model/`, { size: 299 });
@@ -26,4 +40,9 @@ export async function detectSensitive(path: string): Promise<nsfw.predictionType
 		console.error(err);
 		return null;
 	}
+}
+
+async function getCpuFlags(): Promise<string[]> {
+	const str = await si.cpuFlags();
+	return str.split(/\s+/);
 }

--- a/packages/backend/src/services/detect-sensitive.ts
+++ b/packages/backend/src/services/detect-sensitive.ts
@@ -20,7 +20,7 @@ export async function detectSensitive(path: string): Promise<nsfw.predictionType
 		}
 
 		if (!isSupportedCpu) {
-			console.error('This CPU cannot use TensorFlow');
+			console.error('This CPU cannot use TensorFlow.');
 			return null;
 		}
 


### PR DESCRIPTION
# What
tensorflow を起動時にロードするのではなく、初回使用時に初めてロードするように変更しています。
センシティブなメディアの検出が無効の場合はそもそもロードされなくなります。

また、一度未対応環境で有効にしてしまうと管理画面に到達出来るまで無効化できないため、クラッシュしそうな環境では続行しないようにしています。

# Why
現状は Misskey 起動時に tensorflow がロードされるため、必要なCPU命令が未サポートの場合 Misskey 自体が起動しません。
初回使用時にのみロードするようにすることにより、未対応環境でも機能を有効にして実際にメディアが来るまでクラッシュしないようにします。

Related
https://github.com/misskey-dev/misskey/issues/8978
https://github.com/misskey-dev/misskey/issues/8968

# Additional info (optional)
初回正常起動時に表示される以下のメッセージが
```
2022-07-12 05:46:41.481076: I tensorflow/core/platform/cpu_feature_guard.cc:151] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
```
起動時ではなく、初めて使用される際に表示されるようになるのを確認済み。

未対応環境でWeb UIフィードバックがあると親切かもしれないけど、めんどくさいので今はなし。