### PR TITLE
fix(backend):  calculate drive capacity apart from return

### DIFF
--- a/packages/backend/src/server/api/endpoints/drive.ts
+++ b/packages/backend/src/server/api/endpoints/drive.ts
@@ -35,11 +35,12 @@ export const paramDef = {
 export default define(meta, paramDef, async (ps, user) => {
 	const instance = await fetchMeta(true);
 
-	// Calculate drive usage
+	// Calculate drive usage and capacity
 	const usage = await DriveFiles.calcDriveUsageOf(user.id);
+	const capacity = user.driveCapacityOverrideMb || instance.localDriveCapacityMb;
 
 	return {
-		capacity: 1024 * 1024 * (user.driveCapacityOverrideMb || instance.localDriveCapacityMb),
+		capacity: 1024 * 1024 * capacity,
 		usage: usage,
 	};
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- ドライブ上限を読み込む処理をreturnから切り離す

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- returnと同じ行だと`driveCapacityOverrideMb`が反映されない場合があります

