### PR TITLE
feat: show header with current user avatar on TL

### DIFF
--- a/packages/client/src/components/global/page-header.vue
+++ b/packages/client/src/components/global/page-header.vue
@@ -1,6 +1,9 @@
 <template>
 <div v-if="show" ref="el" class="fdidabkb" :class="{ slim: narrow, thin: thin_ }" :style="{ background: bg }" @click="onClick">
 	<template v-if="metadata">
+		<div class="buttons left">
+			<MkAvatar v-if="metadata.user" class="avatar" :user="metadata.user" :disable-preview="true"/>
+		</div>
 		<div v-if="!hideTitle" class="titleContainer" @click="showTabsPopup">
 			<MkAvatar v-if="metadata.avatar" class="avatar" :user="metadata.avatar" :disable-preview="true" :show-indicator="true"/>
 			<i v-else-if="metadata.icon" class="icon" :class="metadata.icon"></i>
@@ -194,10 +197,26 @@ onUnmounted(() => {
 	&.slim {
 		text-align: center;
 
+		> .buttons {
+			&.left {
+				display: inherit;
+				margin-right: auto;
+
+				> .avatar {
+					$size: 32px;
+					display: inline-block;
+					width: $size;
+					height: $size;
+					vertical-align: bottom;
+					margin: 0 8px;
+					pointer-events: none;
+				}
+			}
+		}
+
 		> .titleContainer {
 			flex: 1;
 			margin: 0 auto;
-			margin-left: var(--height);
 
 			> *:first-child {
 				margin-left: auto;
@@ -213,8 +232,13 @@ onUnmounted(() => {
 		--margin: 8px;
 		display: flex;
     align-items: center;
+		min-width: var(--height);
 		height: var(--height);
 		margin: 0 var(--margin);
+
+		&.left {
+			display: none;
+		}
 
 		&.right {
 			margin-left: auto;

--- a/packages/client/src/components/global/page-header.vue
+++ b/packages/client/src/components/global/page-header.vue
@@ -1,9 +1,9 @@
 <template>
 <div v-if="show" ref="el" class="fdidabkb" :class="{ slim: narrow, thin: thin_ }" :style="{ background: bg }" @click="onClick">
+	<div class="buttons left">
+		<MkAvatar v-if="props.displayMyAvatar && $i" class="avatar" :user="$i" :disable-preview="true"/>
+	</div>
 	<template v-if="metadata">
-		<div class="buttons left">
-			<MkAvatar v-if="metadata.user" class="avatar" :user="metadata.user" :disable-preview="true"/>
-		</div>
 		<div v-if="!hideTitle" class="titleContainer" @click="showTabsPopup">
 			<MkAvatar v-if="metadata.avatar" class="avatar" :user="metadata.avatar" :disable-preview="true" :show-indicator="true"/>
 			<i v-else-if="metadata.icon" class="icon" :class="metadata.icon"></i>
@@ -44,6 +44,7 @@ import { scrollToTop } from '@/scripts/scroll';
 import { i18n } from '@/i18n';
 import { globalEvents } from '@/events';
 import { injectPageMetadata } from '@/scripts/page-metadata';
+import { $i } from '@/account';
 
 type Tab = {
 	key?: string | null;
@@ -62,6 +63,7 @@ const props = defineProps<{
 		handler: (ev: MouseEvent) => void;
 	}[];
 	thin?: boolean;
+	displayMyAvatar?: boolean;
 }>();
 
 const emit = defineEmits<{

--- a/packages/client/src/components/global/page-header.vue
+++ b/packages/client/src/components/global/page-header.vue
@@ -1,6 +1,6 @@
 <template>
 <div v-if="show" ref="el" class="fdidabkb" :class="{ slim: narrow, thin: thin_ }" :style="{ background: bg }" @click="onClick">
-	<div class="buttons left">
+	<div v-if="narrow" class="buttons left">
 		<MkAvatar v-if="props.displayMyAvatar && $i" class="avatar" :user="$i" :disable-preview="true"/>
 	</div>
 	<template v-if="metadata">
@@ -199,23 +199,6 @@ onUnmounted(() => {
 	&.slim {
 		text-align: center;
 
-		> .buttons {
-			&.left {
-				display: inherit;
-				margin-right: auto;
-
-				> .avatar {
-					$size: 32px;
-					display: inline-block;
-					width: $size;
-					height: $size;
-					vertical-align: bottom;
-					margin: 0 8px;
-					pointer-events: none;
-				}
-			}
-		}
-
 		> .titleContainer {
 			flex: 1;
 			margin: 0 auto;
@@ -239,7 +222,17 @@ onUnmounted(() => {
 		margin: 0 var(--margin);
 
 		&.left {
-			display: none;
+			margin-right: auto;
+
+			> .avatar {
+				$size: 32px;
+				display: inline-block;
+				width: $size;
+				height: $size;
+				vertical-align: bottom;
+				margin: 0 8px;
+				pointer-events: none;
+			}
 		}
 
 		&.right {

--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -151,6 +151,7 @@ const headerTabs = $computed(() => [{
 definePageMetadata(computed(() => ({
 	title: i18n.ts.timeline,
 	icon: src === 'local' ? 'fas fa-comments' : src === 'social' ? 'fas fa-share-alt' : src === 'global' ? 'fas fa-globe' : 'fas fa-home',
+	user: $i,
 })));
 </script>
 

--- a/packages/client/src/pages/timeline.vue
+++ b/packages/client/src/pages/timeline.vue
@@ -1,6 +1,6 @@
 <template>
 <MkStickyContainer>
-	<template #header><MkPageHeader v-model:tab="src" :actions="headerActions" :tabs="headerTabs"/></template>
+	<template #header><MkPageHeader v-model:tab="src" :actions="headerActions" :tabs="headerTabs" :display-my-avatar="true"/></template>
 	<MkSpacer :content-max="800">
 		<div ref="rootEl" v-hotkey.global="keymap" class="cmuxhskf">
 			<XTutorial v-if="$store.reactiveState.tutorial.value != -1" class="tutorial _block"/>
@@ -151,7 +151,6 @@ const headerTabs = $computed(() => [{
 definePageMetadata(computed(() => ({
 	title: i18n.ts.timeline,
 	icon: src === 'local' ? 'fas fa-comments' : src === 'social' ? 'fas fa-share-alt' : src === 'global' ? 'fas fa-globe' : 'fas fa-home',
-	user: $i,
 })));
 </script>
 

--- a/packages/client/src/scripts/page-metadata.ts
+++ b/packages/client/src/scripts/page-metadata.ts
@@ -8,6 +8,7 @@ export type PageMetadata = {
 	title: string;
 	subtitle?: string;
 	icon?: string | null;
+	user?: misskey.entities.User | null;
 	avatar?: misskey.entities.User | null;
 	userName?: misskey.entities.User | null;
 	bg?: string;

--- a/packages/client/src/scripts/page-metadata.ts
+++ b/packages/client/src/scripts/page-metadata.ts
@@ -8,7 +8,6 @@ export type PageMetadata = {
 	title: string;
 	subtitle?: string;
 	icon?: string | null;
-	user?: misskey.entities.User | null;
 	avatar?: misskey.entities.User | null;
 	userName?: misskey.entities.User | null;
 	bg?: string;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`.fdidabkb`に`.buttons.left`を追加し、コンポーネントの`displayMyAvatar`プロパティが`true`の場合(現在はpages/timeline.vueのみ)は左側に現在ログインしているアカウントのアバターを表示します。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Resolves #9050

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
`narrow`が`true`の場合のみ表示し、その他の場合は非表示になります:
| Slim | Others |
| --- | --- |
| ![tl_slim](https://user-images.githubusercontent.com/44765629/183886949-54dbbc66-3dd2-49bd-b7ac-16cfe39c9004.png) | ![tl_normal](https://user-images.githubusercontent.com/44765629/183887032-37cd1b1f-3cec-4178-92d3-6c1ab4e8cf8b.png) |

もともと`&.slim > .titleContainer`には`margin-left: var(--header);`が指定されていましたが、これを削除します。代わりに`.buttons.left`に対して`width: var(--height);`を指定することで、左右の幅を釣り合わせます。
| Left | Left(アイテムなし) | Right |
| --- | --- | --- |
| <img width="855" alt="tl_slim_left" src="https://user-images.githubusercontent.com/44765629/183888369-18ef45de-58e7-4023-acdb-829af336aaab.png"> | <img width="845" alt="notifications_slim_left" src="https://user-images.githubusercontent.com/44765629/183888445-8836bb58-69ce-4bc9-a836-6ace79447386.png"> | <img width="865" alt="tl_slim_right" src="https://user-images.githubusercontent.com/44765629/183888508-580bc7db-f0dd-4e78-809b-528a815240a3.png"> |
| 55x55 | 55x55 | 55x55 |

### その他のケース

| 通知(Slim) | 通知(Others) |
| --- | --- |
| ![notifications_slim](https://user-images.githubusercontent.com/44765629/183889192-a96c3bff-fbf4-47b6-9d2f-03eae1e8a1a2.png) | ![notifications_normal](https://user-images.githubusercontent.com/44765629/183889213-39ef4dde-cca6-4601-ab5e-c87d5ef29665.png) |


miss.nem.oneで正常に動作中