### PR TITLE
fix padding with `safe-area-inset-bottom`

### DIFF
--- a/packages/client/src/components/emoji-picker-dialog.vue
+++ b/packages/client/src/components/emoji-picker-dialog.vue
@@ -15,12 +15,13 @@
 	<MkEmojiPicker
 		ref="picker"
 		class="ryghynhb _popup _shadow"
-		:class="{ drawer: type === 'drawer' }"
+		:class="{ drawer: type === 'drawer', hasPadding: !isFocused }"
 		:show-pinned="showPinned"
 		:as-reaction-picker="asReactionPicker"
 		:as-drawer="type === 'drawer'"
 		:max-height="maxHeight"
 		@chosen="chosen"
+		@focused="focused"
 	/>
 </MkModal>
 </template>
@@ -50,6 +51,7 @@ const emit = defineEmits<{
 
 const modal = ref<InstanceType<typeof MkModal>>();
 const picker = ref<InstanceType<typeof MkEmojiPicker>>();
+const isFocused = ref(false);
 
 function chosen(emoji: any) {
 	emit('done', emoji);
@@ -60,6 +62,10 @@ function opening() {
 	picker.value?.reset();
 	picker.value?.focus();
 }
+
+function focused(v: boolean): void {
+	isFocused.value = v;
+}
 </script>
 
 <style lang="scss" scoped>
@@ -68,6 +74,10 @@ function opening() {
 		border-radius: 24px;
 		border-bottom-right-radius: 0;
 		border-bottom-left-radius: 0;
+
+		&.hasPadding {
+			padding-bottom: env(safe-area-inset-bottom);
+		}
 	}
 }
 </style>

--- a/packages/client/src/components/emoji-picker.vue
+++ b/packages/client/src/components/emoji-picker.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="omfetrab" :class="['s' + size, 'w' + width, 'h' + height, { asDrawer }]" :style="{ maxHeight: maxHeight ? maxHeight + 'px' : undefined }">
-	<input ref="search" v-model.trim="q" class="search" data-prevent-emoji-insert :class="{ filled: q != null && q != '' }" :placeholder="i18n.ts.search" type="search" @paste.stop="paste" @keyup.enter="done()">
+	<input ref="search" v-model.trim="q" class="search" data-prevent-emoji-insert :class="{ filled: q != null && q != '' }" :placeholder="i18n.ts.search" type="search" @paste.stop="paste" @keyup.enter="done()" @focus="isFocused = true" @blur="isFocused = false">
 	<div ref="emojis" class="emojis">
 		<section class="result">
 			<div v-if="searchResultCustom.length > 0" class="body">
@@ -102,6 +102,7 @@ const props = withDefaults(defineProps<{
 
 const emit = defineEmits<{
 	(ev: 'chosen', v: string): void;
+	(ev: 'focused', v: boolean): void;
 }>();
 
 const search = ref<HTMLInputElement>();
@@ -125,6 +126,11 @@ const q = ref<string | null>(null);
 const searchResultCustom = ref<Misskey.entities.CustomEmoji[]>([]);
 const searchResultUnicode = ref<UnicodeEmojiDef[]>([]);
 const tab = ref<'index' | 'custom' | 'unicode' | 'tags'>('index');
+const isFocused = ref(false);
+
+watch([isFocused], () => {
+	emit('focused', isFocused.value);
+});
 
 watch(q, () => {
 	if (emojis.value) emojis.value.scrollTop = 0;
@@ -432,10 +438,6 @@ defineExpose({
 					}
 				}
 			}
-		}
-
-		> .search:not(:focus):not(.filled) {
-			margin-bottom: env(safe-area-inset-bottom);
 		}
 	}
 

--- a/packages/client/src/components/emoji-picker.vue
+++ b/packages/client/src/components/emoji-picker.vue
@@ -433,6 +433,10 @@ defineExpose({
 				}
 			}
 		}
+
+		> .search:not(:focus):not(.filled) {
+			margin-bottom: env(safe-area-inset-bottom);
+		}
 	}
 
 	> .search {

--- a/packages/client/src/components/launch-pad.vue
+++ b/packages/client/src/components/launch-pad.vue
@@ -75,7 +75,7 @@ function close() {
 
 	&.asDrawer {
 		width: 100%;
-		padding: 16px 16px calc(env(safe-area-inset-bottom, 0px) + 16px) 16px;
+		padding: 16px 16px max(env(safe-area-inset-bottom, 0px), 16px) 16px;
 		border-radius: 24px;
 		border-bottom-right-radius: 0;
 		border-bottom-left-radius: 0;

--- a/packages/client/src/components/ui/menu.vue
+++ b/packages/client/src/components/ui/menu.vue
@@ -335,7 +335,7 @@ onBeforeUnmount(() => {
 	}
 
 	&.asDrawer {
-		padding: 12px 0 calc(env(safe-area-inset-bottom, 0px) + 12px) 0;
+		padding: 12px 0 max(env(safe-area-inset-bottom, 0), 12px) 0;
 		width: 100%;
 		border-radius: 24px;
 		border-bottom-right-radius: 0;

--- a/packages/client/src/pages/messaging/messaging-room.vue
+++ b/packages/client/src/pages/messaging/messaging-room.vue
@@ -336,7 +336,6 @@ definePageMetadata(computed(() => !fetching ? user ? {
 		z-index: 2;
 		bottom: 0;
 		padding-top: 8px;
-		bottom: calc(env(safe-area-inset-bottom, 0px) + 8px);
 
 		> .new-message {
 			width: 100%;

--- a/packages/client/src/ui/_common_/stream-indicator.vue
+++ b/packages/client/src/ui/_common_/stream-indicator.vue
@@ -38,7 +38,7 @@ onUnmounted(() => {
 .nsbbhtug {
 	position: fixed;
 	z-index: 16385;
-	bottom: 8px;
+	bottom: max(env(safe-area-inset-bottom), 8px);
 	right: 8px;
 	margin: 0;
 	padding: 6px 12px;

--- a/packages/client/src/ui/universal.vue
+++ b/packages/client/src/ui/universal.vue
@@ -288,7 +288,7 @@ const wallpaper = localStorage.getItem('wallpaper') != null;
 		z-index: 1000;
 		bottom: 0;
 		left: 0;
-		padding: 16px 16px calc(env(safe-area-inset-bottom, 0px) + 16px) 16px;
+		padding: 16px 16px max(env(safe-area-inset-bottom, 0px), 16px) 16px;
 		display: flex;
 		width: 100%;
 		box-sizing: border-box;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
To resolve #9052


# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
paddingを以下のように改善します:
| 改善前 | 改善後 |
| --- | --- |
| ![IMG_0363](https://user-images.githubusercontent.com/44765629/184531341-5e37411f-7175-41f9-8fda-ff81a946ebf7.jpg) | ![IMG_0365](https://user-images.githubusercontent.com/44765629/184531347-8e19b620-e172-477c-a07a-e2a3d0bf2aa8.jpg) |
| ![IMG_0364](https://user-images.githubusercontent.com/44765629/184531399-4ffd6142-1b68-4b0f-8066-bd0350fce85b.jpg) | ![IMG_0369](https://user-images.githubusercontent.com/44765629/184531404-24ccc189-a47a-4ba6-8f62-fcfcbd2e0fea.jpg) |


# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
emoji-pickerの挙動について、検索ボックスにフォーカスが当たっている場合や、検索ボックスが上になっている場合はmarginが発生しません。
| 検索中 | `.filled` |
| --- | --- |
| ![IMG_0370](https://user-images.githubusercontent.com/44765629/184531574-c927689d-bc70-411c-bb99-f6f225381204.jpg) | ![IMG_0371](https://user-images.githubusercontent.com/44765629/184531579-37625a27-22dd-412d-8476-d3f3bb7dbcca.jpg) |
