### PR TITLE
enhance(client): mobile twitter url can be used as widget

### DIFF
--- a/packages/client/src/components/url-preview.vue
+++ b/packages/client/src/components/url-preview.vue
@@ -68,7 +68,7 @@ let tweetHeight = $ref(150);
 
 const requestUrl = new URL(props.url);
 
-if (requestUrl.hostname === 'twitter.com') {
+if (requestUrl.hostname === 'twitter.com' || requestUrl.hostname === 'mobile.twitter.com') {
 	const m = requestUrl.pathname.match(/^\/.+\/status(?:es)?\/(\d+)/);
 	if (m) tweetId = m[1];
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
We made the Twitter widget available even when the url is [mobile.twitter.com](mobile.twitter.com).

![Untitled-1](https://user-images.githubusercontent.com/54402969/184860962-2d2835b7-19d4-4f2c-9275-cc7f257424aa.png)

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
If you look at your timeline, when you share a tweet, you see people sharing it as a mobile link. I wanted to apply it because the Twitter widget does not appear on mobile links.

<!-- # Additional info (optional) -->
<!-- テスト観点など -->
<!-- Test perspective, etc -->
