### PR TITLE
Dockerfileがhadolintの指すベストプラクティスに極力従うように

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,23 @@ WORKDIR /misskey
 
 COPY . ./
 
-RUN apt-get update
-RUN apt-get install -y build-essential
-RUN git submodule update --init
-RUN yarn install
-RUN yarn build
-RUN rm -rf .git
+RUN apt-get update \
+	&& apt-get install -y build-essential --no-install-recommends \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& git submodule update --init \
+	&& yarn install \
+	&& yarn build \
+	&& rm -rf .git
 
 FROM node:16.15.1-bullseye-slim AS runner
 
 WORKDIR /misskey
 
-RUN apt-get update
-RUN apt-get install -y ffmpeg tini
+RUN apt-get update \
+	&& apt-get install -y ffmpeg tini --no-install-recommends \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /misskey/node_modules ./node_modules
 COPY --from=builder /misskey/built ./built


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Dockerfileがhadolintの指すベストプラクティスに極力従うようにします。
# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
実際の動作に不要なおすすめパッケージも入ってしまい、容量がもったいなく感じていたため。
せっかくならばということで、[hadolint](https://github.com/hadolint/hadolint)の指すベストプラクティスに極力近づけるようにしました。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
頻繁なメンテナンスが必要になる気がして、aptパッケージのバージョン指定のみ無視しています。

## before
```sh:before
na2na@Corei7-11700K:~/develop/misskey$ hadolint Dockerfile 
Dockerfile:10 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Dockerfile:10 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
Dockerfile:10 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:11 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:12 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:13 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:14 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:20 DL3009 info: Delete the apt-get lists after installing something
Dockerfile:21 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
Dockerfile:21 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Dockerfile:21 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
```

## after
```sh:after
na2na@Corei7-11700K:~/develop/misskey$ hadolint Dockerfile 
Dockerfile:9 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Dockerfile:22 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
```