### PR TITLE
fix: postinstall script doesn’t respect the original install args

### DIFF
--- a/scripts/install-packages.js
+++ b/scripts/install-packages.js
@@ -3,7 +3,9 @@ const execa = require('execa');
 (async () => {
 	console.log('installing dependencies of packages/backend ...');
 
-	await execa('yarn', ['--force', 'install'], {
+	const args = process.env.npm_config_argv?.original || ['install'];
+
+	await execa('yarn', ['--force'].concat(aegs), {
 		cwd: __dirname + '/../packages/backend',
 		stdout: process.stdout,
 		stderr: process.stderr,
@@ -11,7 +13,7 @@ const execa = require('execa');
 
 	console.log('installing dependencies of packages/client ...');
 
-	await execa('yarn', ['install'], {
+	await execa('yarn', args, {
 		cwd: __dirname + '/../packages/client',
 		stdout: process.stdout,
 		stderr: process.stderr,
@@ -19,7 +21,7 @@ const execa = require('execa');
 
 	console.log('installing dependencies of packages/sw ...');
 
-	await execa('yarn', ['install'], {
+	await execa('yarn', args, {
 		cwd: __dirname + '/../packages/sw',
 		stdout: process.stdout,
 		stderr: process.stderr,

--- a/scripts/install-packages.js
+++ b/scripts/install-packages.js
@@ -1,9 +1,9 @@
 const execa = require('execa');
 
 (async () => {
-	console.log('installing dependencies of packages/backend ...');
-
 	const args = process.env.npm_config_argv?.original || ['install'];
+
+	console.log('installing dependencies of packages/backend ...');
 
 	await execa('yarn', ['--force'].concat(args), {
 		cwd: __dirname + '/../packages/backend',

--- a/scripts/install-packages.js
+++ b/scripts/install-packages.js
@@ -5,7 +5,7 @@ const execa = require('execa');
 
 	const args = process.env.npm_config_argv?.original || ['install'];
 
-	await execa('yarn', ['--force'].concat(aegs), {
+	await execa('yarn', ['--force'].concat(args), {
 		cwd: __dirname + '/../packages/backend',
 		stdout: process.stdout,
 		stderr: process.stderr,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

`yarn install` 時のコマンドライン引数を postinstall で実行される子プロセスにも伝播させる。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

`--frozen-lockfile` や `--update-checksums` などが正常に動作しないため。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
