### PR TITLE
[Fix] - Bug fix for Pinned Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You should also include the user name that made the change.
 ### Improvements
 
 ### Bugfixes
+- Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 
 ## 12.119.0 (2022/09/10)
 

--- a/packages/backend/src/server/api/endpoints/pinned-users.ts
+++ b/packages/backend/src/server/api/endpoints/pinned-users.ts
@@ -43,12 +43,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 		super(meta, paramDef, async (ps, me) => {
 			const meta = await this.metaService.fetch();
 
-			const users = await Promise.all(meta.pinnedthis.usersRepository.map(acct => Acct.parse(acct)).map(acct => this.usersRepository.findOneBy({
+			const users = await Promise.all(meta.pinnedUsers.map(acct => Acct.parse(acct)).map(acct => this.usersRepository.findOneBy({
 				usernameLower: acct.username.toLowerCase(),
 				host: acct.host ?? IsNull(),
 			})));
 
-			return await this.userEntityService.packMany(users.filter(x => x !== undefined) as User[], me, { detail: true });
+			return await this.userEntityService.packMany(users.filter(x => x !== null) as User[], me, { detail: true });
 		});
 	}
 }


### PR DESCRIPTION
## Minor Bug Fix - Pinned Users

### Issue Details/Description
Noticed that pinned users were not showing on instance after latest update.  Console/Log shows error thrown API call for this.

### Resolution
It seems this issue was introduced recently due to a typo..
This Pull Request fixes issues with Pinned users not loading due to the bug in `pinned-users.ts` API endpoint for looking up of pinned users for the instance. 

## Tested Changes
- Updated file `packages/backend/src/server/api/endpoints/pinned-users.ts`
- Tested on local develop instance, and production instance.
- The API error shown in console was resolved.
- Pinned users are shown once again on instance.