### PR TITLE
feat: Add detail link to note menu and note element

### DIFF
--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -87,6 +87,9 @@
 				<button ref="menuButton" class="button _button" @click="menu()">
 					<i class="fas fa-ellipsis-h"></i>
 				</button>
+				<MkA class="detailed" :to="notePage(note)">
+					<i class="fas fa-external-link-alt"></i>
+				</MkA>
 			</footer>
 		</div>
 	</article>
@@ -129,6 +132,7 @@ import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { getNoteMenu } from '@/scripts/get-note-menu';
 import { useNoteCapture } from '@/scripts/use-note-capture';
+import { notePage } from '@/filters/note';
 
 const props = defineProps<{
 	note: misskey.entities.Note;
@@ -162,6 +166,7 @@ const menuButton = ref<HTMLElement>();
 const renoteButton = ref<InstanceType<typeof XRenoteButton>>();
 const renoteTime = ref<HTMLElement>();
 const reactButton = ref<HTMLElement>();
+const detailed = ref<HTMLElement>();
 let appearNote = $computed(() => isRenote ? note.renote as misskey.entities.Note : note);
 const isMyRenote = $i && ($i.id === note.userId);
 const showContent = ref(false);

--- a/packages/client/src/components/MkNote.vue
+++ b/packages/client/src/components/MkNote.vue
@@ -166,7 +166,6 @@ const menuButton = ref<HTMLElement>();
 const renoteButton = ref<InstanceType<typeof XRenoteButton>>();
 const renoteTime = ref<HTMLElement>();
 const reactButton = ref<HTMLElement>();
-const detailed = ref<HTMLElement>();
 let appearNote = $computed(() => isRenote ? note.renote as misskey.entities.Note : note);
 const isMyRenote = $i && ($i.id === note.userId);
 const showContent = ref(false);
@@ -620,6 +619,11 @@ function readPromo() {
 							margin-right: 18px;
 						}
 					}
+					> .detailed {
+						&:not(:last-child) {
+							margin-right: 18px;
+						}
+					}
 				}
 			}
 		}
@@ -635,6 +639,11 @@ function readPromo() {
 			> .main {
 				> .footer {
 					> .button {
+						&:not(:last-child) {
+							margin-right: 12px;
+						}
+					}
+					> .detailed {
 						&:not(:last-child) {
 							margin-right: 12px;
 						}

--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -8,6 +8,7 @@ import * as os from '@/os';
 import copyToClipboard from '@/scripts/copy-to-clipboard';
 import { url } from '@/config';
 import { noteActions } from '@/store';
+import { notePage } from '@/filters/note';
 
 export function getNoteMenu(props: {
 	note: misskey.entities.Note;
@@ -173,6 +174,10 @@ export function getNoteMenu(props: {
 		});
 	}
 
+	function openDetail(): void {
+		window.open(notePage(appearNote), '_blank');
+	}
+
 	async function translate(): Promise<void> {
 		if (props.translation.value != null) return;
 		props.translating.value = true;
@@ -198,8 +203,11 @@ export function getNoteMenu(props: {
 					danger: true,
 					action: unclip,
 				}, null] : []
-			),
-			{
+			), {
+				icon: 'fas fa-external-link-alt',
+				text: i18n.ts.detailed,
+				action: openDetail,
+			}, {
 				icon: 'fas fa-copy',
 				text: i18n.ts.copyContent,
 				action: copyContent,
@@ -300,6 +308,10 @@ export function getNoteMenu(props: {
 			.filter(x => x !== undefined);
 	} else {
 		menu = [{
+			icon: 'fas fa-external-link-alt',
+			text: i18n.ts.detailed,
+			action: openDetail,
+		}, {
 			icon: 'fas fa-copy',
 			text: i18n.ts.copyContent,
 			action: copyContent,

--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -173,11 +173,9 @@ export function getNoteMenu(props: {
 			url: `${url}/notes/${appearNote.id}`,
 		});
 	}
-
-	function openDetail(): void {
-		window.open(notePage(appearNote), '_blank');
+	function notedetails(): void {
+		os.pageWindow(`/notes/${appearNote.id}`);
 	}
-
 	async function translate(): Promise<void> {
 		if (props.translation.value != null) return;
 		props.translating.value = true;
@@ -205,8 +203,8 @@ export function getNoteMenu(props: {
 				}, null] : []
 			), {
 				icon: 'fas fa-external-link-alt',
-				text: i18n.ts.detailed,
-				action: openDetail,
+				text: i18n.ts.details,
+				action: notedetails,
 			}, {
 				icon: 'fas fa-copy',
 				text: i18n.ts.copyContent,

--- a/packages/client/src/scripts/get-note-menu.ts
+++ b/packages/client/src/scripts/get-note-menu.ts
@@ -174,7 +174,7 @@ export function getNoteMenu(props: {
 		});
 	}
 	function notedetails(): void {
-		os.pageWindow(`/notes/${appearNote.id}`);
+		window.open(notePage(appearNote), '_blank')
 	}
 	async function translate(): Promise<void> {
 		if (props.translation.value != null) return;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

Fixes #9164

# What
(Hopefully) add "detail" link to note and note menu, i.e. the menu shown under "..." or on right click on a note.

![image](https://user-images.githubusercontent.com/887711/201386944-d1f86d97-807f-4d13-a94a-6e14be6f03c7.png)

![image](https://user-images.githubusercontent.com/887711/201481620-e5976ce4-2897-424c-a629-9f099ed44a4a.png)

# Why
See #9164

# Additional info 
I didn't test the functionality of the item in the note menu yet 😅 Also, it may be desirable to put either of these links in different positions within the UI, i.e. move up or down the list.
