### PR TITLE
chore: add message about server specific issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.md
@@ -10,6 +10,7 @@ assignees: ''
 <!--
 Thanks for reporting!
 First, in order to avoid duplicate Issues, please search to see if the problem you found has already been reported.
+Also PLEASE DONT REPORT misskey.io SPECIFIC ISSUES TO HERE! Please try with another misskey instances, and if your issue is only reproducible with misskey.io, contact misskey.io's admin first (Discord: https://go.misskey.io/support ).
 -->
 
 ## 💡 Summary

--- a/.github/ISSUE_TEMPLATE/01_bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!--
 Thanks for reporting!
 First, in order to avoid duplicate Issues, please search to see if the problem you found has already been reported.
-Also PLEASE DONT REPORT misskey.io SPECIFIC ISSUES TO HERE! Please try with another misskey instances, and if your issue is only reproducible with misskey.io, contact misskey.io's admin first (Discord: https://go.misskey.io/support ).
+Also, If you are NOT owner/admin of server, PLEASE DONT REPORT SERVER-SPECIFIC ISSUES TO HERE! (e.g. feature XXX is not working in misskey.example) Please try with another misskey servers, and if your issue is only reproducible with specific server, contact your server's owner/admin first.
 -->
 
 ## 💡 Summary

--- a/.github/ISSUE_TEMPLATE/01_bug-report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug-report.md
@@ -10,7 +10,7 @@ assignees: ''
 <!--
 Thanks for reporting!
 First, in order to avoid duplicate Issues, please search to see if the problem you found has already been reported.
-Also, If you are NOT owner/admin of server, PLEASE DONT REPORT SERVER-SPECIFIC ISSUES TO HERE! (e.g. feature XXX is not working in misskey.example) Please try with another misskey servers, and if your issue is only reproducible with specific server, contact your server's owner/admin first.
+Also, If you are NOT owner/admin of server, PLEASE DONT REPORT SERVER SPECIFIC ISSUES TO HERE! (e.g. feature XXX is not working in misskey.example) Please try with another misskey servers, and if your issue is only reproducible with specific server, contact your server's owner/admin first.
 -->
 
 ## 💡 Summary


### PR DESCRIPTION
# What
misskey.io 固有の問題かどうかを issue template の最初で確認させる

# Why
定期的に misskey.io 固有と思わしき問題がこっちに流れてくるため
