### PR TITLE
chore: Add missing peer dependency for nsfwjs

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,6 +31,7 @@
 		"@peertube/http-signature": "1.7.0",
 		"@sinonjs/fake-timers": "10.0.0",
 		"@syuilo/aiscript": "0.11.1",
+		"@tensorflow/tfjs": "4.0.0",
 		"ajv": "8.11.2",
 		"archiver": "5.3.1",
 		"autobind-decorator": "2.4.0",


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Add `@tensorflow/tfjs`, a peer dependency of `nsfwjs`, as a dependency of `packages/backend`.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
As described in #9202, optional support for tensorflow is incomplete and the server won't work without `@tensorflow/tfjs-node`.
In platforms which don't support libtensorflow, this would be a problem because `@tensorflow/tfjs-node` cannot be installed due to missing prebuilt binaries.
