### PR TITLE
fix(client): prevent infinite resize loop

### DIFF
--- a/packages/client/src/components/global/MkSpacer.vue
+++ b/packages/client/src/components/global/MkSpacer.vue
@@ -24,8 +24,8 @@ let ro: ResizeObserver;
 let root = $ref<HTMLElement>();
 let content = $ref<HTMLElement>();
 let margin = $ref(0);
-let widthHistory = [null, null] as [number | null, number | null];
-let heightHistory = [null, null] as [number | null, number | null];
+const widthHistory = [null, null] as [number | null, number | null];
+const heightHistory = [null, null] as [number | null, number | null];
 const shouldSpacerMin = inject('shouldSpacerMin', false);
 
 const adjust = (rect: { width: number; height: number; }) => {

--- a/packages/client/src/components/global/MkSpacer.vue
+++ b/packages/client/src/components/global/MkSpacer.vue
@@ -48,8 +48,8 @@ onMounted(() => {
 		});
 		*/
 		adjust({
-			width: root!.offsetWidth,
-			height: root!.offsetHeight,
+			width: root!.clientWidth,
+			height: root!.clientWidth,
 		});
 	});
 	ro.observe(root!);

--- a/packages/client/src/components/global/MkSpacer.vue
+++ b/packages/client/src/components/global/MkSpacer.vue
@@ -24,6 +24,8 @@ let ro: ResizeObserver;
 let root = $ref<HTMLElement>();
 let content = $ref<HTMLElement>();
 let margin = $ref(0);
+let widthHistory = [null, null] as [number | null, number | null];
+let heightHistory = [null, null] as [number | null, number | null];
 const shouldSpacerMin = inject('shouldSpacerMin', false);
 
 const adjust = (rect: { width: number; height: number; }) => {
@@ -47,9 +49,28 @@ onMounted(() => {
 			height: entries[0].borderBoxSize[0].blockSize,
 		});
 		*/
+
+		const width = root!.offsetWidth;
+		const height = root!.offsetHeight;
+
+		//#region Prevent infinite resizing
+		// https://github.com/misskey-dev/misskey/issues/9076
+		const pastWidth = widthHistory.pop();
+		widthHistory.unshift(width);
+		const pastHeight = heightHistory.pop();
+		heightHistory.unshift(height);
+
+		console.log(pastWidth, widthHistory, pastHeight, heightHistory);
+
+		if (pastWidth === width && pastHeight === height) {
+			console.log('Prevented infinite resizing');
+			return;
+		}
+		//#endregion
+
 		adjust({
-			width: root!.clientWidth,
-			height: root!.clientWidth,
+			width,
+			height,
 		});
 	});
 	ro.observe(root!);

--- a/packages/client/src/components/global/MkSpacer.vue
+++ b/packages/client/src/components/global/MkSpacer.vue
@@ -60,10 +60,8 @@ onMounted(() => {
 		const pastHeight = heightHistory.pop();
 		heightHistory.unshift(height);
 
-		console.log(pastWidth, widthHistory, pastHeight, heightHistory);
 
 		if (pastWidth === width && pastHeight === height) {
-			console.log('Prevented infinite resizing');
 			return;
 		}
 		//#endregion

--- a/packages/client/src/directives/size.ts
+++ b/packages/client/src/directives/size.ts
@@ -42,9 +42,9 @@ function getOrderName(width: number, queue: Value): string {
 	return `${width}|${queue.max ? queue.max.join(',') : ''}|${queue.min ? queue.min.join(',') : ''}`;
 }
 
-function calc(el: Element) {
+function calc(el: HTMLElement | Element) {
 	const info = mountings.get(el);
-	const width = el.clientWidth;
+	const width = (el as HTMLElement).offsetWidth ?? el.clientWidth;
 
 	if (!info || info.previousWidth === width) return;
 


### PR DESCRIPTION
Fix #9076

# What
幅検出の際に「2つ前の幅」を検出してresizeObserverの無限ループを阻止するように

# 対象となる処理
- [x] MkSpacer
- [x] size directive

# Additional
TODO: 同様に無限ループの可能性のあるresizeObserver処理を探して対処した方が良さそう  

→ 危なそうなところはあるが、実際に無限ループが起きるような箇所はなさそうなので対処しないことにした