### PR TITLE
fix(client): make note visibility inheritance behave correctly when default is set to followers-only

### DIFF
--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -262,7 +262,12 @@ if (props.channel) {
 
 // 公開以外へのリプライ時は元の公開範囲を引き継ぐ
 if (props.reply && ['home', 'followers', 'specified'].includes(props.reply.visibility)) {
-	visibility = props.reply.visibility;
+	if (props.reply.visibility === 'home' && visibility === 'followers') {
+		visibility = 'followers';
+	}
+	else {
+		visibility = props.reply.visibility;
+	}
 	if (props.reply.visibility === 'specified') {
 		os.api('users/show', {
 			userIds: props.reply.visibleUserIds.filter(uid => uid !== $i.id && uid !== props.reply.userId),

--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -264,11 +264,13 @@ if (props.channel) {
 if (props.reply && ['home', 'followers', 'specified'].includes(props.reply.visibility)) {
 	if (props.reply.visibility === 'home' && visibility === 'followers') {
 		visibility = 'followers';
-	}
-	else {
+	} else if (['home', 'followers'].includes(props.reply.visibility) && visibility === 'specified') {
+		visibility = 'specified';
+	} else {
 		visibility = props.reply.visibility;
 	}
-	if (props.reply.visibility === 'specified') {
+
+	if (visibility === 'specified') {
 		os.api('users/show', {
 			userIds: props.reply.visibleUserIds.filter(uid => uid !== $i.id && uid !== props.reply.userId),
 		}).then(users => {

--- a/packages/client/src/components/MkPostForm.vue
+++ b/packages/client/src/components/MkPostForm.vue
@@ -271,11 +271,13 @@ if (props.reply && ['home', 'followers', 'specified'].includes(props.reply.visib
 	}
 
 	if (visibility === 'specified') {
-		os.api('users/show', {
-			userIds: props.reply.visibleUserIds.filter(uid => uid !== $i.id && uid !== props.reply.userId),
-		}).then(users => {
-			users.forEach(pushVisibleUser);
-		});
+		if (props.reply.visibleUserIds) {
+			os.api('users/show', {
+				userIds: props.reply.visibleUserIds.filter(uid => uid !== $i.id && uid !== props.reply.userId),
+			}).then(users => {
+				users.forEach(pushVisibleUser);
+			});
+		}
 
 		if (props.reply.userId !== $i.id) {
 			os.api('users/show', { userId: props.reply.userId }).then(user => {


### PR DESCRIPTION
# What
Fixes an edge case where posts might accidentally end up unlisted instead of follower-only when responding to an unlisted note

# Why
I repeatedly posted notes more public than I intended because of this bug, I'm sure others encountered the same issue