### PR TITLE
fix(server): "forkbomb" DOS mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ You should also include the user name that made the change.
 - Server: 引用内の文章がnyaizeされてしまう問題を修正 @kabo2468
 - Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 - Client: インスタンスティッカーのfaviconを読み込む際に偽サイト警告が出ることがあるのを修正 @syuilo
-- Server: Mitigate AP reference chain DOS vector
+- Server: Mitigate AP reference chain DOS vector @skehmatics
 
 ## 12.119.0 (2022/09/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Improvements
 
 ### Bugfixes
-- 
+-
 
 You should also include the user name that made the change.
 -->
@@ -25,6 +25,7 @@ You should also include the user name that made the change.
 - Server: 引用内の文章がnyaizeされてしまう問題を修正 @kabo2468
 - Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 - Client: インスタンスティッカーのfaviconを読み込む際に偽サイト警告が出ることがあるのを修正 @syuilo
+- Server: Mitigate AP reference chain DOS vector
 
 ## 12.119.0 (2022/09/10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ You should also include the user name that made the change.
 - Server: 引用内の文章がnyaizeされてしまう問題を修正 @kabo2468
 - Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 - Client: インスタンスティッカーのfaviconを読み込む際に偽サイト警告が出ることがあるのを修正 @syuilo
-- Server: Mitigate AP reference chain DOS vector @skehmatics
+- Server: Mitigate AP reference chain DoS vector @skehmatics
 
 ## 12.119.0 (2022/09/10)
 

--- a/packages/backend/src/core/remote/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/remote/activitypub/ApInboxService.ts
@@ -731,7 +731,7 @@ export class ApInboxService {
 			await this.apPersonService.updatePerson(actor.uri!, resolver, object);
 			return 'ok: Person updated';
 		} else if (getApType(object) === 'Question') {
-			await this.apQuestionService.updateQuestion(object).catch(err => console.error(err));
+			await this.apQuestionService.updateQuestion(object, resolver).catch(err => console.error(err));
 			return 'ok: Question updated';
 		} else {
 			return `skip: Unknown type: ${getApType(object)}`;

--- a/packages/backend/src/core/remote/activitypub/ApResolverService.ts
+++ b/packages/backend/src/core/remote/activitypub/ApResolverService.ts
@@ -118,7 +118,7 @@ export class Resolver {
 		}
 
 		if (this.history.size > this.recursionLimit) {
-			throw new Error('hit recursion limit');
+			throw new Error(`hit recursion limit: ${this.utilityService.extractDbHost(value)}`);
 		}
 
 		this.history.add(value);

--- a/packages/backend/src/core/remote/activitypub/ApResolverService.ts
+++ b/packages/backend/src/core/remote/activitypub/ApResolverService.ts
@@ -76,6 +76,7 @@ export class Resolver {
 		private httpRequestService: HttpRequestService,
 		private apRendererService: ApRendererService,
 		private apDbResolverService: ApDbResolverService,
+		private recursionLimit = 100
 	) {
 		this.history = new Set();
 	}
@@ -114,6 +115,10 @@ export class Resolver {
 
 		if (this.history.has(value)) {
 			throw new Error('cannot resolve already resolved one');
+		}
+
+		if (this.history.size > this.recursionLimit) {
+			throw new Error('hit recursion limit');
 		}
 
 		this.history.add(value);

--- a/packages/backend/src/core/remote/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/remote/activitypub/models/ApPersonService.ts
@@ -390,7 +390,7 @@ export class ApPersonService implements OnModuleInit {
 	});
 	//#endregion
 
-	await this.updateFeatured(user!.id).catch(err => this.logger.error(err));
+	await this.updateFeatured(user!.id, resolver).catch(err => this.logger.error(err));
 
 	return user!;
 	}
@@ -503,7 +503,7 @@ export class ApPersonService implements OnModuleInit {
 			followerSharedInbox: person.sharedInbox ?? (person.endpoints ? person.endpoints.sharedInbox : undefined),
 		});
 
-		await this.updateFeatured(exist.id).catch(err => this.logger.error(err));
+		await this.updateFeatured(exist.id, resolver).catch(err => this.logger.error(err));
 	}
 
 	/**
@@ -551,14 +551,14 @@ export class ApPersonService implements OnModuleInit {
 		return { fields, services };
 	}
 
-	public async updateFeatured(userId: User['id']) {
+	public async updateFeatured(userId: User['id'], resolver?: Resolver) {
 		const user = await this.usersRepository.findOneByOrFail({ id: userId });
 		if (!this.userEntityService.isRemoteUser(user)) return;
 		if (!user.featured) return;
 
 		this.logger.info(`Updating the featured: ${user.uri}`);
 
-		const resolver = this.apResolverService.createResolver();
+		if (resolver == null) resolver = this.apResolverService.createResolver();
 
 		// Resolve to (Ordered)Collection Object
 		const collection = await resolver.resolveCollection(user.featured);

--- a/packages/backend/src/core/remote/activitypub/models/ApQuestionService.ts
+++ b/packages/backend/src/core/remote/activitypub/models/ApQuestionService.ts
@@ -65,7 +65,7 @@ export class ApQuestionService {
 	 * @param uri URI of AP Question object
 	 * @returns true if updated
 	 */
-	public async updateQuestion(value: any) {
+	public async updateQuestion(value: any, resolver?: Resolver) {
 		const uri = typeof value === 'string' ? value : value.id;
 
 		// URIがこのサーバーを指しているならスキップ
@@ -80,7 +80,7 @@ export class ApQuestionService {
 		//#endregion
 
 		// resolve new Question object
-		const resolver = this.apResolverService.createResolver();
+		if (resolver == null) resolver = this.apResolverService.createResolver();
 		const question = await resolver.resolve(value) as IQuestion;
 		this.logger.debug(`fetched question: ${JSON.stringify(question, null, 2)}`);
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Limit the amount of side-effects / recursions that a single activity resolution can cause.
# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
A DOS attack is possible by using a specially crafted activitypub server that will serve up an infinite stream of users with featured collections that all reference other users with the same setup. This occurred in the wild on November 30th, 2022 starting sometime around 5PM EST with instances appropriately named `misskey-forkbomb.*`
# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
The limit (100) was set for no particular reason, and could be modified / parameterized if necessary. The resolver was also chosen for the place for this logic, as it is commonly shared all throughout AP resolution