### PR TITLE
refactor(sw): Typecheck the service worker

### DIFF
--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"watch": "node build.js watch",
 		"build": "node build.js",
-		"lint": "eslint --quiet src/**/*.ts"
+		"lint": "tsc --noEmit && eslint --quiet src/**/*.ts"
 	},
 	"dependencies": {
 		"esbuild": "^0.14.42",
@@ -14,6 +14,7 @@
 	"devDependencies": {
 		"@typescript-eslint/parser": "^5.45.0",
 		"eslint": "^8.16.0",
-		"eslint-plugin-import": "^2.26.0"
+		"eslint-plugin-import": "^2.26.0",
+		"typescript": "4.9.4"
 	}
 }

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -13,6 +13,7 @@
 	},
 	"devDependencies": {
 		"@typescript-eslint/parser": "^5.45.0",
+		"@typescript/lib-webworker": "npm:@types/serviceworker@^0.0.58",
 		"eslint": "^8.16.0",
 		"eslint-plugin-import": "^2.26.0",
 		"typescript": "4.9.4"

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -1,11 +1,6 @@
 /*
  * Notification manager for SW
  */
-
-// TODO: remove this declaration when https://github.com/microsoft/TypeScript/issues/11781 closes
-// eslint-disable-next-line no-var
-declare var self: ServiceWorkerGlobalScope;
-
 import { swLang } from '@/scripts/lang';
 import { cli } from '@/scripts/operations';
 import { pushNotificationDataMap } from '@/types';

--- a/packages/sw/src/scripts/operations.ts
+++ b/packages/sw/src/scripts/operations.ts
@@ -2,11 +2,6 @@
  * Operations
  * 各種操作
  */
-
-// TODO: remove this declaration when https://github.com/microsoft/TypeScript/issues/11781 closes
-// eslint-disable-next-line no-var
-declare var self: ServiceWorkerGlobalScope;
-
 import * as Misskey from 'misskey-js';
 import { SwMessage, swMessageOrderType } from '@/types';
 import { acct as getAcct } from '@/filters/user';

--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -1,7 +1,3 @@
-// TODO: remove this declaration when https://github.com/microsoft/TypeScript/issues/11781 closes
-// eslint-disable-next-line no-var
-declare var self: ServiceWorkerGlobalScope;
-
 import { createEmptyNotification, createNotification } from '@/scripts/create-notification';
 import { swLang } from '@/scripts/lang';
 import { swNotificationRead } from '@/scripts/notification-read';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15796,6 +15796,7 @@ __metadata:
     eslint-plugin-import: ^2.26.0
     idb-keyval: ^6.1.0
     misskey-js: 0.0.14
+    typescript: 4.9.4
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,6 +3009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/lib-webworker@npm:@types/serviceworker@^0.0.58":
+  version: 0.0.58
+  resolution: "@types/serviceworker@npm:0.0.58"
+  checksum: d6aa73d02854968ccaa0fb7f1aafb30b202870dc15b9d09e3ee8fe8131ffc26d521c1e56b5b030f39fba329143a32b2fa88351d57df3ae5aa29498384a251946
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-vue@npm:4.0.0":
   version: 4.0.0
   resolution: "@vitejs/plugin-vue@npm:4.0.0"
@@ -15791,6 +15798,7 @@ __metadata:
   resolution: "sw@workspace:packages/sw"
   dependencies:
     "@typescript-eslint/parser": ^5.45.0
+    "@typescript/lib-webworker": "npm:@types/serviceworker@^0.0.58"
     esbuild: ^0.14.42
     eslint: ^8.16.0
     eslint-plugin-import: ^2.26.0


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Run `tsc --noEmit` in the service worker build step

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Currently the service worker build never typechecks, since esbuild and typescript-eslint don't do such job.

esbuild: https://esbuild.github.io/content-types/#typescript

>However, esbuild does not do any type checking so you will still need to run tsc -noEmit in parallel with esbuild to check types. This is not something esbuild does itself.

typescript-eslint: https://typescript-eslint.io/linting/troubleshooting#why-dont-i-see-typescript-errors-in-my-eslint-output

>TypeScript's compiler (or whatever your build chain may be) is specifically designed and built to validate the correctness of your codebase. Our tooling does not reproduce the errors that TypeScript provides, because doing so would slow down the lint run [1], and duplicate the errors that TypeScript already outputs for you.

Adding this step adds tons of TS errors 😱

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
