### PR TITLE
Call `tsc --noEmit` also for backend/client

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,7 @@
 		"migrate": "typeorm migration:run -d ormconfig.js",
 		"build": "tsc -p tsconfig.json || echo done. && tsc-alias -p tsconfig.json",
 		"watch": "node watch.mjs",
-		"lint": "eslint --quiet \"src/**/*.ts\"",
+		"lint": "tsc --noEmit && eslint --quiet \"src/**/*.ts\"",
 		"jest": "cross-env NODE_ENV=test node --experimental-vm-modules --experimental-import-meta-resolve node_modules/jest/bin/jest.js --forceExit --runInBand",
 		"jest-and-coverage": "cross-env NODE_ENV=test node --experimental-vm-modules --experimental-import-meta-resolve node_modules/jest/bin/jest.js --coverage --forceExit --runInBand",
 		"jest-clear": "cross-env NODE_ENV=test node --experimental-vm-modules --experimental-import-meta-resolve node_modules/jest/bin/jest.js --clearCache",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"watch": "vite build --watch --mode development",
 		"build": "vite build",
-		"lint": "eslint --quiet \"src/**/*.{ts,vue}\""
+		"lint": "tsc --noEmit && eslint --quiet \"src/**/*.{ts,vue}\""
 	},
 	"dependencies": {
 		"@discordapp/twemoji": "14.0.2",


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Call `tsc --noEmit` also for backend/client

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Backend explicitly ignores typescript errors by `|| echo done.` for some reason, and also client because vite does not do typecheck.

https://vitejs.dev/guide/features.html#typescript

>Vite only performs transpilation on .ts files and does NOT perform type checking. It assumes type checking is taken care of by your IDE and build process (you can run tsc --noEmit in the build script or install vue-tsc and run vue-tsc --noEmit to also type check your *.vue files).

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
