### PR TITLE
Fix MetaService unit tests

### DIFF
--- a/packages/backend/jest.config.cjs
+++ b/packages/backend/jest.config.cjs
@@ -115,7 +115,7 @@ module.exports = {
 	resolver: './jest-resolver.cjs',
 
 	// Automatically restore mock state between every test
-	// restoreMocks: false,
+	restoreMocks: true,
 
 	// The root directory that Jest should scan for tests and modules within
 	// rootDir: undefined,

--- a/packages/backend/test/unit/MetaService.ts
+++ b/packages/backend/test/unit/MetaService.ts
@@ -10,14 +10,10 @@ import { MetaService } from '@/core/MetaService.js';
 import { CoreModule } from '@/core/CoreModule.js';
 import type { DataSource } from 'typeorm';
 import type { TestingModule } from '@nestjs/testing';
-import type { MockFunctionMetadata } from 'jest-mock';
-
-const moduleMocker = new ModuleMocker(global);
 
 describe('MetaService', () => {
 	let app: TestingModule;
 	let metaService: MetaService;
-	let metasRepository: MetasRepository;
 
 	beforeAll(async () => {
 		app = await Test.createTestingModule({
@@ -30,40 +26,32 @@ describe('MetaService', () => {
 		app.enableShutdownHooks();
 
 		metaService = app.get<MetaService>(MetaService, { strict: false });
-		metasRepository = app.get<MetasRepository>(DI.metasRepository, { strict: false });
+
+		// Make it cached
+		await metaService.fetch();
 	});
 
 	afterAll(async () => {
 		await app.close();
 	});
 
-	/* なんか動かない
 	it('fetch (cache)', async () => {
 		const db = app.get<DataSource>(DI.db);
-		const originalFunction = db.transaction;
 		const spy = jest.spyOn(db, 'transaction');
-		spy.mockImplementation((...args) => originalFunction(...args));
 
 		const result = await metaService.fetch();
 
 		expect(result.id).toBe('x');
 		expect(spy).toHaveBeenCalledTimes(0);
-
-		spy.mockRestore();
 	});
 
 	it('fetch (force)', async () => {
 		const db = app.get<DataSource>(DI.db);
-		const originalFunction = db.transaction;
 		const spy = jest.spyOn(db, 'transaction');
-		// 何故かここで無限再帰する db.transaction がspyのままになっている？
-		spy.mockImplementation((...args) => originalFunction(...args));
 
 		const result = await metaService.fetch(true);
 
 		expect(result.id).toBe('x');
 		expect(spy).toHaveBeenCalledTimes(1);
-
-		spy.mockRestore();
-	});*/
+	});
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

1. Removes `mockImplementation` calls
2. Adds `restoreMocks: true` configuration

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

1. The mock function by `spyOn` should already call the original implementation. Using `mockImplementation` is redundant and is also wrong, since it should do `originalFunction.call(db, args)` rather than calling `originalFunction` directly.
2. As described in the comment, somehow `spy.mockRestore()` didn't work and kept the spy alive. The `restoreMocks` configuration does the work.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
