### PR TITLE
chore(client): :art: about button

### DIFF
--- a/packages/client/src/components/MkSuperMenu.vue
+++ b/packages/client/src/components/MkSuperMenu.vue
@@ -89,10 +89,9 @@ export default defineComponent({
 				}
 
 				> .text {
-					white-space: nowrap;
-					text-overflow: ellipsis;
-					overflow: hidden;
+					white-space: normal;
 					padding-right: 12px;
+					flex-shrink: 1;
 				}
 
 			}

--- a/packages/client/src/components/form/link.vue
+++ b/packages/client/src/components/form/link.vue
@@ -75,10 +75,10 @@ const props = defineProps<{
 		}
 
 		> .text {
-			white-space: nowrap;
-			text-overflow: ellipsis;
-			overflow: hidden;
+			flex-shrink: 1;
+			white-space: normal;
 			padding-right: 12px;
+			text-align: center;
 		}
 
 		> .right {

--- a/packages/client/src/style.scss
+++ b/packages/client/src/style.scss
@@ -162,6 +162,7 @@ hr {
 	font-size: 1em;
 	font-family: inherit;
 	line-height: inherit;
+	max-width: 100%;
 
 	&, * {
 		@extend ._noSelect;


### PR DESCRIPTION
- _buttonにmax-width: 100%を指定してはみ出しを防止する
- MkSuperMenuの項目やformLinkは折り返して全ての文章を表示するように