### PR TITLE
enhance(client): case insensitive emoji search

### DIFF
--- a/packages/client/src/components/MkEmojiPicker.vue
+++ b/packages/client/src/components/MkEmojiPicker.vue
@@ -135,7 +135,7 @@ watch(q, () => {
 		return;
 	}
 
-	const newQ = q.value.replace(/:/g, '');
+	const newQ = q.value.replace(/:/g, '').toLowerCase();
 
 	const searchCustom = () => {
 		const max = 8;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
MkEmojiPicker now searches emojis in case insensitive way

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Mobile OSes by default writes words with autocapitalization and thus mobile users have to explicitly switch to lowercase to properly search for emojis. HTML [`autocapitalize`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize) attribute is still Chromium only, so case insensitivity is the next option.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
(Filed #9345 for test)

Fixes #9279