### PR TITLE
Fix peers API returning suspended instances

### DIFF
--- a/packages/backend/src/server/api/ApiServerService.ts
+++ b/packages/backend/src/server/api/ApiServerService.ts
@@ -140,7 +140,7 @@ export class ApiServerService {
 				select: ['host'],
 				where: {
 					isSuspended: false,
-				}
+				},
 			});
 
 			return instances.map(instance => instance.host);

--- a/packages/backend/src/server/api/ApiServerService.ts
+++ b/packages/backend/src/server/api/ApiServerService.ts
@@ -138,6 +138,9 @@ export class ApiServerService {
 		fastify.get('/v1/instance/peers', async (request, reply) => {
 			const instances = await this.instancesRepository.find({
 				select: ['host'],
+				where: {
+					isSuspended: false,
+				}
 			});
 
 			return instances.map(instance => instance.host);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Exclude suspended instances from peers returned from `/v1/instance/peers`.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Suspended instances are not actually federated peers of the server and should not appear in the peer list. Removing them matches the behaviour of the Mastodon API that this endpoint is matching.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
I don't have a working dev environment but I think this should just work.
