### PR TITLE
refactor: fix broken Vue component custom properties

### DIFF
--- a/packages/client/@types/vue.d.ts
+++ b/packages/client/@types/vue.d.ts
@@ -1,7 +1,16 @@
 /// <reference types="vue/macros-global" />
 
-declare module '*.vue' {
-	import type { DefineComponent } from 'vue';
-	const component: DefineComponent<{}, {}, any>;
-	export default component;
+import type { $i } from '@/account';
+import type { defaultStore } from '@/store';
+import type { instance } from '@/instance';
+import type { i18n } from '@/i18n';
+
+declare module 'vue' {
+	interface ComponentCustomProperties {
+		$i: typeof $i;
+		$store: typeof defaultStore;
+		$instance: typeof instance;
+		$t: typeof i18n['t'];
+		$ts: typeof i18n['ts'];
+	}
 }

--- a/packages/client/src/i18n.ts
+++ b/packages/client/src/i18n.ts
@@ -3,11 +3,3 @@ import { locale } from '@/config';
 import { I18n } from '@/scripts/i18n';
 
 export const i18n = markRaw(new I18n(locale));
-
-// このファイルに書きたくないけどここに書かないと何故かVeturが認識しない
-declare module '@vue/runtime-core' {
-	interface ComponentCustomProperties {
-		$t: typeof i18n['t'];
-		$ts: typeof i18n['locale'];
-	}
-}

--- a/packages/client/src/instance.ts
+++ b/packages/client/src/instance.ts
@@ -43,10 +43,3 @@ export const emojiTags = computed(() => {
 	}
 	return Array.from(tags);
 });
-
-// このファイルに書きたくないけどここに書かないと何故かVeturが認識しない
-declare module '@vue/runtime-core' {
-	interface ComponentCustomProperties {
-		$instance: typeof instance;
-	}
-}

--- a/packages/client/src/store.ts
+++ b/packages/client/src/store.ts
@@ -381,10 +381,3 @@ export class ColdDeviceStorage {
 		};
 	}
 }
-
-// このファイルに書きたくないけどここに書かないと何故かVeturが認識しない
-declare module '@vue/runtime-core' {
-	interface ComponentCustomProperties {
-		$store: typeof defaultStore;
-	}
-}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

1. Removed DefineComponent
2. Changed `typeof i18n['locale']` to `typeof i18n['ts']`
3. Moved all custom property declarations to `vue.d.ts`
4. Imported `vue` instead of `@vue/runtime-core`

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

1. It has been broken as DefineComponent doesn't exist now in Vue, and importing Vue components works well without it.
2. Reflected the change from 57ec04d9ecc51060225bb15867215c7475685f92
3. Because the comments didn't like the current positions and I saw 0a235e5e482b260ab4b3597f380eb462e74707b1 from #6976 initially wanted to put them in `vue.d.ts`. It seems Volar is happy with it.
4. Importing `runtime-core` directly does not work (probably because Misskey don't install it directly). The official docs recommend `vue` so I just followed it. https://vuejs.org/api/utility-types.html#componentcustomproperties

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->