### PR TITLE
fix(cypress): pass `{}` as a parameter for `/api/reset-db`

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,7 +28,7 @@ Cypress.Commands.add('resetState', () => {
 	cy.window(win => {
 		win.indexedDB.deleteDatabase('keyval-store');
 	});
-	cy.request('POST', '/api/reset-db').as('reset');
+	cy.request('POST', '/api/reset-db', {}).as('reset');
 	cy.get('@reset').its('status').should('equal', 204);
 	cy.reload(true);
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

1. Fix backend assuming POST body always exists
2. Pass `{}` as the parameter to reset database before cypress run

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

1. Because cypress is throwing `Cannot read properties of undefined (reading 'i')`. This can easily be reproduced by `curl -X POST http://localhost:61812/api/reset-db`.
   https://github.com/misskey-dev/misskey/blob/52cbe07a780c0542912798e1e9bc1b78a63d6806/packages/backend/src/server/api/ApiCallService.ts#L64
2. But then the `reset-db` endpoint also assumes an object as a parameter and the validation fails if not. I doubt this is actually intended, but maybe? I decided to get some feedback before proceeding to change the behavior.
   https://github.com/misskey-dev/misskey/blob/52cbe07a780c0542912798e1e9bc1b78a63d6806/packages/backend/src/server/api/endpoints/reset-db.ts#L21-L25
   https://github.com/misskey-dev/misskey/blob/52cbe07a780c0542912798e1e9bc1b78a63d6806/packages/backend/src/server/api/endpoint-base.ts#L48
   

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
