### PR TITLE
fix(backend): request.body may be undefined

### DIFF
--- a/packages/backend/src/server/api/ApiCallService.ts
+++ b/packages/backend/src/server/api/ApiCallService.ts
@@ -54,21 +54,21 @@ export class ApiCallService implements OnApplicationShutdown {
 	@bindThis
 	public handleRequest(
 		endpoint: IEndpoint & { exec: any },
-		request: FastifyRequest<{ Body: Record<string, unknown>, Querystring: Record<string, unknown> }>,
+		request: FastifyRequest<{ Body: Record<string, unknown> | undefined, Querystring: Record<string, unknown> }>,
 		reply: FastifyReply,
 	) {
 		const body = request.method === 'GET'
 			? request.query
 			: request.body;
 
-		const token = body['i'];
+		const token = body?.['i'];
 		if (token != null && typeof token !== 'string') {
 			reply.code(400);
 			return;
 		}
 		this.authenticateService.authenticate(token).then(([user, app]) => {
 			this.call(endpoint, user, app, body, null, request).then((res) => {
-				if (request.method === 'GET' && endpoint.meta.cacheSec && !body['i'] && !user) {
+				if (request.method === 'GET' && endpoint.meta.cacheSec && !body?.['i'] && !user) {
 					reply.header('Cache-Control', `public, max-age=${endpoint.meta.cacheSec}`);
 				}
 				this.send(reply, res);
@@ -111,7 +111,7 @@ export class ApiCallService implements OnApplicationShutdown {
 		for (const [k, v] of Object.entries(multipartData.fields)) {
 			fields[k] = v.value;
 		}
-	
+
 		const token = fields['i'];
 		if (token != null && typeof token !== 'string') {
 			reply.code(400);
@@ -199,7 +199,7 @@ export class ApiCallService implements OnApplicationShutdown {
 			name: string;
 			path: string;
 		} | null,
-		request: FastifyRequest<{ Body: Record<string, unknown>, Querystring: Record<string, unknown> }>,
+		request: FastifyRequest<{ Body: Record<string, unknown> | undefined, Querystring: Record<string, unknown> }>,
 	) {
 		const isSecure = user != null && token == null;
 		const isModerator = user != null && (user.isModerator || user.isAdmin);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Fix backend assuming POST body always exists

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Because cypress was throwing `Cannot read properties of undefined (reading 'i')` before #9355. This can easily be reproduced by `curl -X POST http://localhost:61812/api/reset-db`.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Forgot to push this one to #9355.