### PR TITLE
fix(client): add missing ref for MkButton

### DIFF
--- a/packages/client/src/components/MkButton.vue
+++ b/packages/client/src/components/MkButton.vue
@@ -1,5 +1,6 @@
 <template>
 <button
+	ref="el"
 	v-if="!link" class="bghgjjyj _button"
 	:class="{ inline, primary, gradate, danger, rounded, full }"
 	:type="type"


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Added missing `ref=el` to MkButton

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Because Cypress was failing because of `Cannot read properties of null (reading 'focus')`.

https://github.com/misskey-dev/misskey/blob/c3cb2189753aa74b8fc5c554577deeed89971dc6/packages/client/src/components/MkButton.vue#L51-L57

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
This now should make Cypress fully green 🎉🟩
