### PR TITLE
refactor(client): explicit `showing` property for tooltips

### DIFF
--- a/packages/client/src/components/MkChartTooltip.vue
+++ b/packages/client/src/components/MkChartTooltip.vue
@@ -16,7 +16,7 @@
 import { } from 'vue';
 import MkTooltip from './MkTooltip.vue';
 
-const props = defineProps<{
+defineProps<{
 	showing: boolean;
 	x: number;
 	y: number;

--- a/packages/client/src/components/MkReactionTooltip.vue
+++ b/packages/client/src/components/MkReactionTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-<MkTooltip ref="tooltip" :target-element="targetElement" :max-width="340" @closed="emit('closed')">
+<MkTooltip ref="tooltip" :showing="showing" :target-element="targetElement" :max-width="340" @closed="emit('closed')">
 	<div class="beeadbfb">
 		<XReactionIcon :reaction="reaction" :custom-emojis="emojis" class="icon" :no-style="true"/>
 		<div class="name">{{ reaction.replace('@.', '') }}</div>
@@ -12,7 +12,8 @@ import { } from 'vue';
 import MkTooltip from './MkTooltip.vue';
 import XReactionIcon from '@/components/MkReactionIcon.vue';
 
-const props = defineProps<{
+defineProps<{
+	showing: boolean;
 	reaction: string;
 	emojis: any[]; // TODO
 	targetElement: HTMLElement;

--- a/packages/client/src/components/MkReactionsViewer.details.vue
+++ b/packages/client/src/components/MkReactionsViewer.details.vue
@@ -1,5 +1,5 @@
 <template>
-<MkTooltip ref="tooltip" :target-element="targetElement" :max-width="340" @closed="emit('closed')">
+<MkTooltip ref="tooltip" :showing="showing" :target-element="targetElement" :max-width="340" @closed="emit('closed')">
 	<div class="bqxuuuey">
 		<div class="reaction">
 			<XReactionIcon :reaction="reaction" :custom-emojis="emojis" class="icon" :no-style="true"/>
@@ -21,7 +21,8 @@ import { } from 'vue';
 import MkTooltip from './MkTooltip.vue';
 import XReactionIcon from '@/components/MkReactionIcon.vue';
 
-const props = defineProps<{
+defineProps<{
+	showing: boolean;
 	reaction: string;
 	users: any[]; // TODO
 	count: number;

--- a/packages/client/src/components/MkUsersTooltip.vue
+++ b/packages/client/src/components/MkUsersTooltip.vue
@@ -1,5 +1,5 @@
 <template>
-<MkTooltip ref="tooltip" :target-element="targetElement" :max-width="250" @closed="emit('closed')">
+<MkTooltip ref="tooltip" :showing="showing" :target-element="targetElement" :max-width="250" @closed="emit('closed')">
 	<div class="beaffaef">
 		<div v-for="u in users" :key="u.id" class="user">
 			<MkAvatar class="avatar" :user="u"/>
@@ -14,7 +14,8 @@
 import { } from 'vue';
 import MkTooltip from './MkTooltip.vue';
 
-const props = defineProps<{
+defineProps<{
+	showing: boolean;
 	users: any[]; // TODO
 	count: number;
 	targetElement: HTMLElement;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Explicitly defined `showing` properties for tooltip components and bound them to MkTooltip

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Currently it's implicitly bound to child components by callers of `os.popup` and then by `common.vue`:

https://github.com/misskey-dev/misskey/blob/bc0e600e51ad6ed24919d862dc97c5d6faf71314/packages/client/src/components/MkReactionsViewer.reaction.vue#L82-L89

https://github.com/misskey-dev/misskey/blob/bc0e600e51ad6ed24919d862dc97c5d6faf71314/packages/client/src/ui/_common_/common.vue#L2-L8

While this works, TypeScript hates this as it's not explicit whether the child MkTooltip will ever get the required `showing` property. This patch makes it explicit, following what MkChartTooltip already does.

https://github.com/misskey-dev/misskey/blob/bc0e600e51ad6ed24919d862dc97c5d6faf71314/packages/client/src/components/MkChartTooltip.vue#L2

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
