### PR TITLE
ApRequestService: don't generate our own Host header

### DIFF
--- a/packages/backend/src/core/activitypub/ApRequestService.ts
+++ b/packages/backend/src/core/activitypub/ApRequestService.ts
@@ -47,7 +47,7 @@ export class ApRequestService {
 			method: 'POST',
 			headers: this.objectAssignWithLcKey({
 				'Date': new Date().toUTCString(),
-				'Host': u.hostname,
+				'Host': u.host,
 				'Content-Type': 'application/activity+json',
 				'Digest': digestHeader,
 			}, args.additionalHeaders),
@@ -73,7 +73,7 @@ export class ApRequestService {
 			headers: this.objectAssignWithLcKey({
 				'Accept': 'application/activity+json, application/ld+json',
 				'Date': new Date().toUTCString(),
-				'Host': new URL(args.url).hostname,
+				'Host': new URL(args.url).host,
 			}, args.additionalHeaders),
 		};
 
@@ -96,6 +96,8 @@ export class ApRequestService {
 		request.headers = this.objectAssignWithLcKey(request.headers, {
 			Signature: signatureHeader,
 		});
+		// node-fetch will generate this for us. if we keep 'Host', it won't change with redirects!
+		delete request.headers['host'];
 
 		return {
 			request,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Though it's needed for signatures, including our own `Host` header means `node-fetch` won't generate a new one for us when we encounter a redirect, leading to breakage!

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
This is necessary for compatibility with some weird instances like https://sleeping.town which redirect to https://mastodon.sleeping.town

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Something strange, misskey.io doesn't seem to have issues resolving users, but my instance does! Not sure what to make of this...
Also changes `Host` header we generate to use the `host` property, which will include the port.
It could be interesting to see the signature stuff implemented as an agent instead, which would allow us to modify the request right before it's sent, hopefully including the exact headers we need to sign!