### PR TITLE
fix: some type errors around fastify plugins

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -20,6 +20,19 @@ packageExtensions:
   koa-views@*:
     dependencies:
       pug: "*"
+  # these are needed to extend fastify types
+  "@fastify/accepts@*":
+    peerDependencies:
+      fastify: "*"
+  "@fastify/cookie@*":
+    peerDependencies:
+      fastify: "*"
+  "@fastify/static@*":
+    peerDependencies:
+      fastify: "*"
+  "@fastify/view@*":
+    peerDependencies:
+      fastify: "*"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs


### PR DESCRIPTION
TypeScript の `declare module "..."` で拡張するやつは近くの `node_modules` にないとなんかうまくいかないらしい