### PR TITLE
fix(client): explicitly depend on `@vue/runtime-core`

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -80,6 +80,7 @@
 		"@types/ws": "8.5.3",
 		"@typescript-eslint/eslint-plugin": "5.47.0",
 		"@typescript-eslint/parser": "5.47.0",
+		"@vue/runtime-core": "3.2.45",
 		"cross-env": "7.0.3",
 		"cypress": "12.2.0",
 		"eslint": "8.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5157,6 +5157,7 @@ __metadata:
     "@typescript-eslint/parser": 5.47.0
     "@vitejs/plugin-vue": 4.0.0
     "@vue/compiler-sfc": 3.2.45
+    "@vue/runtime-core": 3.2.45
     autobind-decorator: 2.4.0
     autosize: 5.0.2
     blurhash: 2.0.4


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

`@vue/runtime-core`えの明示的な異存を追加 / Explicitly depend on `@vue/runtime-core`

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

GlobalComponentsの定義のために `declare module "@vue/runtime-core"` を使っていますが `package.json` に直接加えないと `node_modules/@vue/runtime-core` じゃなく `node_modules/vue/node_modules/@vue/runtime-dom/node_modules/@vue/runtime-core` に設置されるのでTypeScriptで使えません。

`.yarnrc.yml` の `packageExtensions` も使えますが、[文書によるとあれは異存グラフ壊れてるpackage専用](https://yarnpkg.com/configuration/yarnrc)ですので今回は使わなかったです。

GlobalComponents is defined through `declare module "@vue/runtime-core"`, but it's not directly in `package.json` and thus is installed to `node_modules/vue/node_modules/@vue/runtime-dom/node_modules/@vue/runtime-core` instead of `node_modules/@vue/runtime-core`. This blocks usage in TypeScript.

The `packageExtensions` of `.yarnrc.yml` also works but [per the docs it's only for packages with broken dependency graph](https://yarnpkg.com/configuration/yarnrc), so I didn't use it here.

https://github.com/misskey-dev/misskey/blob/cd6a8c31a6db2a040dc5a7b2f83c61645b4f617c/packages/client/src/components/index.ts#L41-L61

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
