### PR TITLE
fix: encodeURIComponent for static image proxy filename

### DIFF
--- a/packages/client/src/scripts/get-static-image-url.ts
+++ b/packages/client/src/scripts/get-static-image-url.ts
@@ -8,7 +8,10 @@ export function getStaticImageUrl(baseUrl: string): string {
 		u.searchParams.set('static', '1');
 		return u.href;
 	}
-	const dummy = `${u.host}${u.pathname}`;	// 拡張子がないとキャッシュしてくれないCDNがあるので
+
+	// 拡張子がないとキャッシュしてくれないCDNがあるのでダミーの名前を指定する
+	const dummy = `${encodeURIComponent(`${u.host}${u.pathname}`)}.webp`;
+
 	return `${instanceUrl}/proxy/${dummy}?${url.query({
 		url: u.href,
 		static: '1',

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -137,7 +137,8 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 								u.searchParams.set('badge', '1');
 								badge = u.href;
 							} else {
-								const dummy = `${u.host}${u.pathname}`;	// 拡張子がないとキャッシュしてくれないCDNがあるので
+								// 拡張子がないとキャッシュしてくれないCDNがあるので
+								const dummy = `${encodeURIComponent(`${u.host}${u.pathname}`)}.png`;
 								badge = `${origin}/proxy/${dummy}?${url.query({
 									url: u.href,
 									badge: '1'


### PR DESCRIPTION
Fix #9409

disableShowingAnimatedImagesでのproxyのファイル名をencodeURIComponentしてスラッシュなどをエンコードするように