### PR TITLE
fix(backend): Set correct access control of admin/drive/files

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/drive/files.ts
+++ b/packages/backend/src/server/api/endpoints/admin/drive/files.ts
@@ -8,7 +8,7 @@ import { DriveFileEntityService } from '@/core/entities/DriveFileEntityService.j
 export const meta = {
 	tags: ['admin'],
 
-	requireCredential: false,
+	requireCredential: true,
 	requireModerator: true,
 
 	res: {


### PR DESCRIPTION
# What
admin/drive/files は絶対ログインしていないといけないのに認証情報が不要になっている。
（モデレーター以上であることが必須となっているため今まで問題は発生していない。）
```js
{
        requireCredential: false,
	requireModerator: true,
}
```

# Why
あまり望ましくないものだと思うので念のため

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
