### PR TITLE
fix: 特定のpng画像のアップロードの失敗

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 You should also include the user name that made the change.
 -->
 
+## 12.x.x (unreleased)
+
+### Bugfixes
+- Server: 特定のPNG画像のアップロードに失敗する問題を修正
+
 ## 12.119.2 (2022/12/04)
 ### Bugfixes
 - Server: Backported versions mitigate isn't working @mei23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ You should also include the user name that made the change.
 ## 12.x.x (unreleased)
 
 ### Bugfixes
-- Server: 特定のPNG画像のアップロードに失敗する問題を修正
+- Server: 特定のPNG画像のアップロードに失敗する問題を修正 @usbharu
 
 ## 12.119.2 (2022/12/04)
 ### Bugfixes

--- a/packages/backend/src/misc/get-file-info.ts
+++ b/packages/backend/src/misc/get-file-info.ts
@@ -357,13 +357,13 @@ function getBlurhash(path: string): Promise<string> {
 			.raw()
 			.ensureAlpha()
 			.resize(64, 64, { fit: 'inside' })
-			.toBuffer((err, buffer, { width, height }) => {
+			.toBuffer((err, buffer, outputInfo) => {
 				if (err) return reject(err);
 
 				let hash;
 
 				try {
-					hash = encode(new Uint8ClampedArray(buffer), width, height, 7, 7);
+					hash = encode(new Uint8ClampedArray(buffer), outputInfo.width, outputInfo.height, 7, 7);
 				} catch (e) {
 					return reject(e);
 				}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
特定のpng画像のアップロードが失敗するのを修正
分割代入を普通の代入にした

# Why
分割代入時にundefindが混入してエラーが発生するため、分割代入をやめる必要がある。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Misskey 12.119.2で確認しました。
Misskey v13のベータ版ではここの処理がまるごとなくなっているため発生しません。

Blenderでレンダリング画像だと発生するそうです。
[アップロードできないpng画像](https://s3misskey.usbharu.dev/misskey-minio/data/tank_2022_1_17_1.png)