### PR TITLE
画面下部に必要なスペース関連の改善

### DIFF
--- a/packages/frontend/src/components/MkLaunchPad.vue
+++ b/packages/frontend/src/components/MkLaunchPad.vue
@@ -75,7 +75,7 @@ function close() {
 
 	&.asDrawer {
 		width: 100%;
-		padding: 16px 16px calc(env(safe-area-inset-bottom, 0px) + 16px) 16px;
+		padding: 16px 16px max(env(safe-area-inset-bottom, 0px), 16px) 16px;
 		border-radius: 24px;
 		border-bottom-right-radius: 0;
 		border-bottom-left-radius: 0;

--- a/packages/frontend/src/components/MkMenu.vue
+++ b/packages/frontend/src/components/MkMenu.vue
@@ -336,7 +336,7 @@ onBeforeUnmount(() => {
 	}
 
 	&.asDrawer {
-		padding: 12px 0 calc(env(safe-area-inset-bottom, 0px) + 12px) 0;
+		padding: 12px 0 max(env(safe-area-inset-bottom, 0px), 12px) 0;
 		width: 100%;
 		border-radius: 24px;
 		border-bottom-right-radius: 0;

--- a/packages/frontend/src/pages/messaging/messaging-room.vue
+++ b/packages/frontend/src/pages/messaging/messaging-room.vue
@@ -351,7 +351,6 @@ definePageMetadata(computed(() => !fetching ? user ? {
 		z-index: 2;
 		bottom: 0;
 		padding-top: 8px;
-		bottom: calc(env(safe-area-inset-bottom, 0px) + 8px);
 
 		> .new-message {
 			width: 100%;

--- a/packages/frontend/src/style.scss
+++ b/packages/frontend/src/style.scss
@@ -6,9 +6,11 @@
 	--marginHalf: 10px;
 
 	--margin: var(--marginFull);
-
+	--minBottomSpacing: 0px;
+	
 	@media (max-width: 500px) {
 		--margin: var(--marginHalf);
+		--minBottomSpacing: calc(84px + env(safe-area-inset-bottom, 0px));
 	}
 
 	//--ad: rgb(255 169 0 / 10%);

--- a/packages/frontend/src/style.scss
+++ b/packages/frontend/src/style.scss
@@ -10,7 +10,7 @@
 	
 	@media (max-width: 500px) {
 		--margin: var(--marginHalf);
-		--minBottomSpacing: calc(84px + env(safe-area-inset-bottom, 0px));
+		--minBottomSpacing: calc(72px + max(12px, env(safe-area-inset-bottom, 0px)));
 	}
 
 	//--ad: rgb(255 169 0 / 10%);

--- a/packages/frontend/src/ui/_common_/common.vue
+++ b/packages/frontend/src/ui/_common_/common.vue
@@ -98,10 +98,10 @@ if ($i) {
 		}
 	}
 
-	@media (max-width: 700px) {
+	@media (max-width: 500px) {
 		top: initial;
-		bottom: 112px;
-		padding: 0 16px;
+		bottom: calc(var(--minBottomSpacing) + var(--margin));
+		padding: 0 var(--margin);
 		display: flex;
 		flex-direction: column-reverse;
 
@@ -111,11 +111,6 @@ if ($i) {
 				margin-bottom: 8px;
 			}
 		}
-	}
-
-	@media (max-width: 500px) {
-		bottom: calc(env(safe-area-inset-bottom, 0px) + 92px);
-		padding: 0 8px;
 	}
 }
 </style>

--- a/packages/frontend/src/ui/_common_/stream-indicator.vue
+++ b/packages/frontend/src/ui/_common_/stream-indicator.vue
@@ -38,8 +38,8 @@ onUnmounted(() => {
 .nsbbhtug {
 	position: fixed;
 	z-index: 16385;
-	bottom: 8px;
-	right: 8px;
+	bottom: calc(var(--minBottomSpacing) + var(--margin));
+	right: var(--margin);
 	margin: 0;
 	padding: 6px 12px;
 	font-size: 0.9em;

--- a/packages/frontend/src/ui/universal.vue
+++ b/packages/frontend/src/ui/universal.vue
@@ -370,12 +370,6 @@ const wallpaper = miLocalStorage.getItem('wallpaper') != null;
 }
 
 .spacer {
-	$widgets-hide-threshold: 1090px;
-
-	height: calc(env(safe-area-inset-bottom, 0px) + 96px);
-
-	@media (min-width: ($widgets-hide-threshold + 1px)) {
-		display: none;
-	}
+	height: calc(var(--minBottomSpacing));
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
#9052 を参照
`MkEmojiPicker`についてはまた今度修正します

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- スペーサーのサイズをv13～のタブバー最大サイズ(`border-top`省く) + `safe-area-inset-bottom`に合わせた
  - 色々な箇所で使われるため、`minBottomSpacing`として共通化
    - これにより、1091px以下501px以上のときタブバーが非表示であるにも関わらずスペーサーが存在する問題が解消
- スペーサーによって不要になった重複しているメッセージルームのbottom指定を削除
- 通知において、
  - 700px以下のときのbottomを修正(500px以下のときしかタブバーが表示されないのに対して不要なスペースが存在していたため)
  - 下部に表示されているとき(500px以下)、グローバルのmarginに合わせるように(スクリーンショット参照)
- サーバー切断表示についても↑と同じような処理を実施(スクリーンショット参照)
  - 結果的にセーフエリアが考慮されていなかった問題が解消
- `MkLaunchPad`、`MkMenu`に対してタブバーと同じセーフエリア処理を実施

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
| 改善前 | 改善後 |
| --- | --- |
| ![MkLaunchPad_Before](https://user-images.githubusercontent.com/44765629/211344167-9641a0d6-24bc-4c62-bd39-d5746b8c8b2f.PNG) | ![MkLaunchPad_After](https://user-images.githubusercontent.com/44765629/211344191-83f13bbc-c00e-4bc9-946b-882811295633.PNG)
| ![MkMenu_Before](https://user-images.githubusercontent.com/44765629/211344326-1ec4a230-3560-455a-bb00-714e54da5390.PNG) | ![MkMenu_After](https://user-images.githubusercontent.com/44765629/211344342-cc903fc5-f882-4d00-9f1f-73edf2a24856.PNG)
| ![Notification_Before](https://user-images.githubusercontent.com/44765629/211344368-34c2d78c-e16c-4f94-82b8-38c485867eee.PNG) | ![Notification_After](https://user-images.githubusercontent.com/44765629/211344382-a7ba4112-74e1-44e8-9e3f-88097a555553.PNG)
| ![StreamIndicator_Before](https://user-images.githubusercontent.com/44765629/211344575-3b4b3a9d-ccc9-434e-be74-8d886565202a.PNG) | ![StreamIndicator_After](https://user-images.githubusercontent.com/44765629/211344592-03d9f935-11a3-4230-adb3-a1b12a405ed0.PNG)
| ![BottomSpacing_Before](https://user-images.githubusercontent.com/44765629/211344758-3862d821-fa2b-454f-8ceb-eb4ab68bf463.PNG) | ![BottomSpacing_After](https://user-images.githubusercontent.com/44765629/211344780-9b5a227e-6300-4247-808e-8db1e8faf7a0.PNG)


デスクトップ表示でも特に問題なし