### PR TITLE
Add android-arm64 bindings for swc

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,8 @@
 	},
 	"optionalDependencies": {
 		"@tensorflow/tfjs": "^4.1.0",
-		"@tensorflow/tfjs-node": "4.1.0"
+		"@tensorflow/tfjs-node": "4.1.0",
+		"@swc/core-android-arm64": "^1.3.11"
 	},
 	"dependencies": {
 		"@bull-board/api": "^4.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1881,6 +1881,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@swc/core-android-arm64@npm:^1.3.11":
+  version: 1.3.11
+  resolution: "@swc/core-android-arm64@npm:1.3.11"
+  dependencies:
+    "@swc/wasm": 1.2.130
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-arm64@npm:1.3.25":
   version: 1.3.25
   resolution: "@swc/core-darwin-arm64@npm:1.3.25"
@@ -1999,6 +2008,13 @@ __metadata:
   peerDependencies:
     "@swc/core": "*"
   checksum: 3558213098970cc2882b1f2d1299e78ccea2e18e1e4a4c1820bb669b969ced648eacb14eb78b0bc6fe66e4a60816a7ad7a72c5048ece8382647b8ceac82b708a
+  languageName: node
+  linkType: hard
+
+"@swc/wasm@npm:1.2.130":
+  version: 1.2.130
+  resolution: "@swc/wasm@npm:1.2.130"
+  checksum: 02203bfef3e382c64cbbd63c138c8fdf61865e74d923b317e9d9e9f33f5a3f0a9533b5fdbc9505e76d78e864be04a82fc847eb987a1e47ccac5850146c858292
   languageName: node
   linkType: hard
 
@@ -4178,6 +4194,7 @@ __metadata:
     "@sinonjs/fake-timers": 10.0.2
     "@swc/cli": ^0.1.59
     "@swc/core": 1.3.25
+    "@swc/core-android-arm64": ^1.3.11
     "@swc/jest": 0.2.24
     "@tensorflow/tfjs": ^4.1.0
     "@tensorflow/tfjs-node": 4.1.0
@@ -4321,6 +4338,8 @@ __metadata:
     ws: 8.11.0
     xev: 3.0.2
   dependenciesMeta:
+    "@swc/core-android-arm64":
+      optional: true
     "@tensorflow/tfjs":
       optional: true
     "@tensorflow/tfjs-node":


### PR DESCRIPTION
# What
swcは複数プラットフォーム向けにプレビルドバイナリを提供しているが、swc側のpackage.jsonには、用意されているプラットフォームの全てが含まれているわけではなく、Androidにおいては手動で追加が必要。
backendのoptionalDependenciesに`@swc/core-android-arm64` を追加する。

# Why
backendのビルド時に `Bindings not found` とエラーが出て実行できないため。

# 補足
もともとはdevDependenciesなのにoptionalDependenciesに入れても大丈夫なのかどうか...