### PR TITLE
fix `navButtonIcon` not being aligned to center

### DIFF
--- a/packages/frontend/src/ui/deck.vue
+++ b/packages/frontend/src/ui/deck.vue
@@ -424,6 +424,7 @@ async function deleteProfile() {
 
 .navButtonIcon {
 	font-size: 18px;
+	vertical-align: middle;
 }
 
 .navButtonIndicator {

--- a/packages/frontend/src/ui/universal.vue
+++ b/packages/frontend/src/ui/universal.vue
@@ -376,6 +376,7 @@ $widgets-hide-threshold: 1090px;
 
 .navButtonIcon {
 	font-size: 18px;
+	vertical-align: middle;
 }
 
 .navButtonIndicator {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
| 改善前 | 改善後|
| --- | --- |
| ![navButtonIcon_Before](https://user-images.githubusercontent.com/44765629/212236242-25dc91a4-5026-4cee-aef3-dea40c5599e7.png) | ![navButtonIcon_After](https://user-images.githubusercontent.com/44765629/212236251-5fec957b-c33d-4362-8d22-4afbac075c4f.png) |

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
ボタンのアイコンが微妙に中心からズレている

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
