### PR TITLE
CI Deploy preview environmentの不要なトリガー削除

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,7 +1,5 @@
 # Run secret-dependent integration tests only after /deploy approval
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   repository_dispatch:
     types: [deploy-command]
 

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -10,7 +10,6 @@ jobs:
   deploy-preview-environment:
     runs-on: ubuntu-latest
     if:
-      github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.sha != '' &&
       contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
     steps:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
CI `Deploy preview environment` のトリガー `pull_request` を削除します。
また、それに合わせて不要になる条件も削除します。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

`repository_dispatch` の場合のみ実行するようになっているため。
https://github.com/misskey-dev/misskey/blob/170cfc6a0e20d3c66221bd9ca2d8c1551a8060a4/.github/workflows/pr-preview-deploy.yml#L15

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
