### PR TITLE
dbヘルスチェックでFATALの表示が出ないように

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./db:/var/lib/postgresql/data
     healthcheck:
-      test: "pg_isready"
+      test: "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
       interval: 5s
       retries: 20
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
related: #9569

動作には支障ないが、
```sh
FATAL:  role "root" does not exist
```
というログが残り続けるをの解消しました。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

before([d0157b3](https://github.com/misskey-dev/misskey/commit/d0157b3bfdb35b85286bbadc2a798f46f710ad77))
<img width="854" alt="image" src="https://user-images.githubusercontent.com/49822810/212533638-0040382b-b9f8-4030-9553-64a8d8b028cd.png">

after([bbad024](https://github.com/misskey-dev/misskey/pull/9593/commits/bbad024d4dc7c4aa2232675d6c144460e27f9bdb))

<img width="868" alt="image" src="https://user-images.githubusercontent.com/49822810/212533685-397d36a0-84f1-4897-a6e7-5ac4bf935da3.png">


# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

[同様の変更](https://github.com/na2na-p/misskey/commit/9ec421ed4a809c6730daf7ce9c7730d13ba987e0)をしたものが`https://nmnm.na2na.dev`で動作中
