### PR TITLE
エラー画像表示崩れ修正

### DIFF
--- a/packages/frontend/src/components/global/MkError.vue
+++ b/packages/frontend/src/components/global/MkError.vue
@@ -17,6 +17,7 @@ import { i18n } from '@/i18n';
 .root {
 	padding: 32px;
 	text-align: center;
+  align-items: center;
 }
 
 .text {
@@ -29,6 +30,7 @@ import { i18n } from '@/i18n';
 
 .img {
 	vertical-align: bottom;
+  width: 128px;
 	height: 128px;
 	margin-bottom: 16px;
 	border-radius: 16px;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

お知らせのエラー画像を縦横同じ比率で中央に配置します。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Fix https://github.com/misskey-dev/misskey/issues/9597

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
