### PR TITLE
fix: note embedding in Pages editor

### DIFF
--- a/packages/frontend/src/pages/page-editor/els/page-editor.el.note.vue
+++ b/packages/frontend/src/pages/page-editor/els/page-editor.el.note.vue
@@ -37,20 +37,16 @@ const emit = defineEmits<{
 let id: any = $ref(props.modelValue.note);
 let note: any = $ref(null);
 
-watch(id, async () => {
+watch($$(id), async () => {
 	if (id && (id.startsWith('http://') || id.startsWith('https://'))) {
-		emit('update:modelValue', {
-			...props.modelValue,
-			note: (id.endsWith('/') ? id.slice(0, -1) : id).split('/').pop(),
-		});
-	} else {
-		emit('update:modelValue', {
-			...props.modelValue,
-			note: id,
-		});
+		id = (id.endsWith('/') ? id.slice(0, -1) : id).split('/').pop();
 	}
 
-	note = await os.api('notes/show', { noteId: props.modelValue.note });
+	emit('update:modelValue', {
+		...props.modelValue,
+		note: id,
+	});
+	note = await os.api('notes/show', { noteId: id });
 }, {
 	immediate: true,
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
- watch する際 $$() でラップするように
- プレビューの noteId で props.modelValue.note ではなく id を利用するように
  - props.modelValue.note　を使うと emit のタイミングによって更新前の modelValue が使われてしまう
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

# Why
- fix #9603
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
