### PR TITLE
enhahce(client): :art: 通知のノートサマリーを1行にする

### DIFF
--- a/packages/frontend/src/components/MkNotification.vue
+++ b/packages/frontend/src/components/MkNotification.vue
@@ -267,9 +267,9 @@ useTooltip(reactionRef, (showing) => {
 }
 
 .text {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	display: flex;
+	width: 100%;
+	overflow: clip;
 }
 
 .quote {

--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -10,7 +10,7 @@
 	<template #default="{ items: notifications }">
 		<MkDateSeparatedList v-slot="{ item: notification }" :class="$style.list" :items="notifications" :no-gap="true">
 			<XNote v-if="['reply', 'quote', 'mention'].includes(notification.type)" :key="notification.id" :note="notification.note"/>
-			<XNotification v-else :key="notification.id" :notification="notification" :with-time="true" :full="true" class="_panel notification"/>
+			<XNotification v-else :key="notification.id" :notification="notification" :with-time="true" :full="false" class="_panel notification"/>
 		</MkDateSeparatedList>
 	</template>
 </MkPagination>


### PR DESCRIPTION
Fix #9623

# What
![image](https://user-images.githubusercontent.com/7973572/212669983-c638f9d5-dc48-4b0f-9287-30a368af9d82.png)

p1.a9z.devに適用中