### PR TITLE
Fix for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"cleanall": "pnpm clean-all"
 	},
 	"resolutions": {
-		"chokidar": "^3.3.1",
+		"chokidar": "^3.5.3",
 		"lodash": "^4.17.21"
 	},
 	"dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,7 +2,7 @@
 	"name": "frontend",
 	"private": true,
 	"scripts": {
-		"watch": "vite",
+		"watch": "vite build --watch",
 		"build": "vite build",
 		"lint": "vue-tsc --noEmit && eslint --quiet \"src/**/*.{ts,vue}\""
 	},

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,7 +2,7 @@
 	"name": "frontend",
 	"private": true,
 	"scripts": {
-		"watch": "vite build --watch",
+		"watch": "vite",
 		"build": "vite build",
 		"lint": "vue-tsc --noEmit && eslint --quiet \"src/**/*.{ts,vue}\""
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 overrides:
-  chokidar: ^3.3.1
+  chokidar: ^3.5.3
   lodash: ^4.17.21
 
 importers:
@@ -125,7 +125,7 @@ importers:
       cbor: 8.1.0
       chalk: 5.2.0
       chalk-template: 0.4.0
-      chokidar: ^3.3.1
+      chokidar: ^3.5.3
       cli-highlight: 2.1.11
       color-convert: 2.0.1
       content-disposition: 0.5.4

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -14,7 +14,7 @@ const fs = require('fs');
 		stderr: process.stderr,
 	});
 
-	execa('pnpm', ['dlx', 'gulp', 'watch'], {
+	execa('pnpm', ['exec', 'gulp', 'watch'], {
 		cwd: __dirname + '/../',
 		stdout: process.stdout,
 		stderr: process.stderr,


### PR DESCRIPTION
# What
`pnpm dev` (開発モード)が動作しない問題を修正する。

・chokidarを3.3.1 → 3.5.3 にアップグレード。これによりApple Siliconにも対応し、最新のNodeにも対応する。
・frontendのwatchコマンド実行時、viteをただ起動するだけになっていたのを修正
・scripts/dev.jsでgulpを呼び出す方法を修正。
　インストール状態に依らずその場でダウンロードして使う？ `dlx` から、インストールされたものを使う `exec` に修正
