### PR TITLE
Bump Postgres 12.2 to 15.x on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   db:
     restart: always
-    image: postgres:12.2-alpine
+    image: postgres:15-alpine
     networks:
       - internal_network
     env_file:


### PR DESCRIPTION
# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Bump Postgres 12.2 to 15.x on docker-compose.yml

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Misskey v13 requires Postgres 15.x

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Should work properly 🥴 
User needs to manually update PostgreSQL.

## Part 1 - Backup DB from PostgreSQL 12.2
```
# Shutdown app containers (keeping db online)
$ docker-compose stop web

# Create backup of misskey db to local file
$ docker-compose exec db pg_dumpall -U example-misskey-user > ~/12.2.backup

# Shutdown db container
$ docker-compose down --remove-orphans

# Move Old db volume
$ sudo mv db ~/12.2db
```

## Part 2 - Import DB to PostgreSQL 15
```
# Checkout for Misskey 
$ git fetch && VERSION=$(curl -s https://api.github.com/repos/misskey-dev/misskey/releases/latest | grep tag_name | cut -d '"' -f 4) && echo "Latest Misskey version is $VERSION" && git checkout ${VERSION}

# Boot the new DB - PostgreSQL 15
$ docker-compose up -d db

# Import the backup
$ cat ~/12.2.backup | docker-compose exec -T db psql -U example-misskey-user -d misskey
```

## Part 3 -  Confirm import of DB has no serious errors

`$ docker-compose logs db` and confirm there are not any errors in the import stage. Below is a list of known errors, and their resolution.

Error 1

> `
> db_1 | ERROR: invalid input syntax for type <something>
> `

These errors are bad and need to be investigated.

Running `vacuumdb` has apparently resolved these issues. Please read the optional command as an alternative to step 1.

Error 2

> ```
> db_1 | LOG:  checkpoints are occurring too frequently (20 seconds apart)
> db_1 | HINT:  Consider increasing the configuration parameter "max_wal_size".
> ```

These errors can be ignored.


## Part 4 - Upgrade Misskey

- Follow standard Upgrade notes.

## Alternative Step 1 - Vacuum DB before backup


```
# Shutdown app containers (keeping db online)
$ docker-compose stop web

# Vacuum your db (untested command)
## Note: If you believe your 12.2 DB might be corrupted or experience errors with the importing stage, 
$ docker-compose exec db pg_dumpall -U example-misskey-user > ~/12.2.novacuum.backup
$ docker-compose exec db vacuumdb -U example-misskey-user --all --full --analyze --verbose 
$ docker-compose exec db pg_dumpall -U example-misskey-user > ~/12.2.backup

# Shutdown db container
$ docker-compose down --remove-orphans
```