### PR TITLE
feat: Support web+ap URIs in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ You should also include the user name that made the change.
 - Client: show Unicode emoji tooltip with its name in MkReactionsViewer.reaction @saschanaz
 - Client: OpenSearch support @SoniEx2 @chaoticryptidz
 - Client: Support remote objects in search @SoniEx2
+- Client: Support remote objects by web+ap URI in search @SoniEx2
 - Client: user activity page @syuilo
 - Client: Make widgets of universal/classic sync between devices @tamaina
 - Client: add user list widget @syuilo

--- a/packages/frontend/src/pages/search.vue
+++ b/packages/frontend/src/pages/search.vue
@@ -26,9 +26,16 @@ const props = defineProps<{
 const query = props.query;
 
 if ($i != null) {
-	if (query.startsWith('https://') || (query.startsWith('@') && !query.includes(' '))) {
+	if (
+		query.startsWith('https://')
+		||
+		query.startsWith('web+ap://')
+		||
+		(query.startsWith('@') && !query.includes(' '))
+	) {
+		const uri = query.replace(/^web\+ap:\/\//, 'https://');
 		const promise = os.api('ap/show', {
-			uri: props.query,
+			uri: uri,
 		});
 
 		os.promiseDialog(promise, null, null, i18n.ts.fetchingAsApObject);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Allows the use of web+ap URIs in search. They're functionally equivalent to https for search purposes.

Closes #9504 

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

First step towards supporting web-first protocol handlers.

(This does not add a protocol handler, it only allows the URIs to work in search.)

See also https://fedi-to.net/.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
