### PR TITLE
Default to `animation: false` when prefers-reduced-motion is set

### DIFF
--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -156,7 +156,7 @@ export const defaultStore = markRaw(new Storage('base', {
 	},
 	animation: {
 		where: 'device',
-		default: !matchMedia('prefers-reduced-motion'),
+		default: !matchMedia('(prefers-reduced-motion)').matches,
 	},
 	animatedMfm: {
 		where: 'device',

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -156,7 +156,7 @@ export const defaultStore = markRaw(new Storage('base', {
 	},
 	animation: {
 		where: 'device',
-		default: true,
+		default: !matchMedia('prefers-reduced-motion'),
 	},
 	animatedMfm: {
 		where: 'device',


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

OSやブラウザー設定でアニメーションが無効化されているとMisskeyでもデフォルトでアニメーションをオフにする（特にログインされてない他のサーバーのページを見る時必要）

If the OS or the browser disables the animation, Misskey follows that and sets the animation option default value to off. (Especially needed when seeing pages from other servers without logging in)

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

ユーザー設定に従うため

To follow the user settings

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

https://github.com/misskey-dev/misskey/issues/6501

出来れば `@media (prefers-reduced-motion) {}`を全ての`.transition-*` CSS ruleに適用したいですが、そうしたらこの設定必要なくなりそうです。どう思いますか？