### PR TITLE
Hide the value of the object storage secret key input form in the admin page

### DIFF
--- a/packages/frontend/src/pages/admin/object-storage.vue
+++ b/packages/frontend/src/pages/admin/object-storage.vue
@@ -38,7 +38,7 @@
 							<template #label>Access key</template>
 						</MkInput>
 
-						<MkInput v-model="objectStorageSecretKey">
+						<MkInput v-model="objectStorageSecretKey" type="password">
 							<template #prefix><i class="ti ti-key"></i></template>
 							<template #label>Secret key</template>
 						</MkInput>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
コントロールパネル内のオブジェクトストレージのシークレットキー入力フォームのtypeを`password`にし、値を隠すようにします。
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

# Why
 - 過去に鯖缶が誤って背景にコントロールパネル内のオブジェクトストレージのシークレットキーが移っているスクリーンショットをアップロードしてしまった事例を見かけたから  
 - Emailのパスワード等は隠されているので同様に隠すべきだと思った
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
