### PR TITLE
Fix: foreignkey on reports 通報の外部キーを修正

### DIFF
--- a/packages/backend/migration/1675053125067-fixforeignkeyreports.js
+++ b/packages/backend/migration/1675053125067-fixforeignkeyreports.js
@@ -1,0 +1,15 @@
+export class fixforeignkeyreports1675053125067 {
+    name = 'fixforeignkeyreports1675053125067'
+
+    async up(queryRunner) {
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_a9021cc2e1feb5f72d3db6e9f5" ON "abuse_user_report" ("targetUserId")`);
+        await queryRunner.query(`DELETE FROM "abuse_user_report" WHERE "targetUserId" NOT IN (SELECT "id" FROM "user")`);
+        await queryRunner.query(`ALTER TABLE "abuse_user_report" DROP CONSTRAINT IF EXISTS "FK_a9021cc2e1feb5f72d3db6e9f5f"`);
+        await queryRunner.query(`ALTER TABLE "abuse_user_report" ADD CONSTRAINT "FK_a9021cc2e1feb5f72d3db6e9f5f" FOREIGN KEY ("targetUserId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX "public"."IDX_a9021cc2e1feb5f72d3db6e9f5"`);
+        await queryRunner.query(`ALTER TABLE "abuse_user_report" DROP CONSTRAINT "FK_a9021cc2e1feb5f72d3db6e9f5f"`);
+    }
+}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fix: Constraint of `abuse_user_report` table
Use `CREATE INDEX IF NOT EXISTS` because the instance built before [12.116.1](https://github.com/misskey-dev/misskey/releases/tag/12.116.1) has this index.
Drop and Re-add Constraint `FK_a9021cc2e1feb5f72d3db6e9f5f` if exists because the instance built before [12.116.1](https://github.com/misskey-dev/misskey/releases/tag/12.116.1) has this constraint, and cannot use `ADD CONSTRAINT IF NOT EXISTS` because PostgreSQL doesn't have this query.
I think down method is needless because these migration does exist before. But I wrote this because last migration file on `abuse_user_report` has down method.

`abuse_user_report` テーブルを修正します。
`CREATE INDEX IF NOT EXISTS` を使用します。なぜなら[12.116.1](https://github.com/misskey-dev/misskey/releases/tag/12.116.1)より前に建たられたインスタンスはすでにこのインデックスを保持するためです。
`FK_a9021cc2e1feb5f72d3db6e9f5f`制約を削除してから再追加します。なぜなら[12.116.1](https://github.com/misskey-dev/misskey/releases/tag/12.116.1)より前に建たられたインスタンスはすでにこの制約を保持するからです。また PostgreSQL には`ADD CONSTRAINT IF NOT EXISTS` のクエリがないので使用することはできません。
私はかつて存在したマイグレーションであるためdownメソッドは不要だと思います。しかし前回の `abuse_user_report` のマイグレーションファイルには、down メソッドがあったので、これを書きました。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Reports cannot be shown on some instances. This happens on my environment.
通報が見られなくなっているインスタンスがいくらかあります。私の環境でも再現。

Resolves: https://github.com/misskey-dev/misskey/issues/9100 
Resolves: https://github.com/misskey-dev/misskey/issues/9183
Resolves: https://github.com/misskey-dev/misskey/issues/8852
Resolves: https://github.com/misskey-dev/misskey/issues/8896

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Migration has been success on the instance built before 12.116.1.
Migration has been success on the instance built on 12.119.2.
Migration has been success on the clean instance of 13.2.5.

12.116.1より前に建てられたインスタンスでマイグレーションに成功しています。
12.119.2で建てられたインスタンスでマイグレーションに成功しています。
13.2.5のクリーンなインスタンスでマイグレーションに成功しています。