### PR TITLE
fix(ap): ld signature normalizer

### DIFF
--- a/packages/backend/src/core/activitypub/LdSignatureService.ts
+++ b/packages/backend/src/core/activitypub/LdSignatureService.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import { Inject, Injectable } from '@nestjs/common';
+import jsonld from 'jsonld';
 import { HttpRequestService } from '@/core/HttpRequestService.js';
 import { bindThis } from '@/decorators.js';
 import { CONTEXTS } from './misc/contexts.js';
@@ -84,7 +85,9 @@ class LdSignature {
 	@bindThis
 	public async normalize(data: any) {
 		const customLoader = this.getLoader();
-		return 42;
+		return await jsonld.normalize(data, {
+			documentLoader: customLoader,
+		});
 	}
 
 	@bindThis


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fix #9752

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
The signature function has changed during major migration, and thus breaks the json-ld signature, causing misskey's isolation with other fediverse instances.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
