### PR TITLE
enhance(backend): enhance SchemaType handling of anyOf

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -90,7 +90,6 @@ export const paramDef = {
 		visibleUserIds: { type: 'array', uniqueItems: true, items: {
 			type: 'string', format: 'misskey:id',
 		} },
-		text: { type: 'string', maxLength: MAX_NOTE_TEXT_LENGTH, nullable: true },
 		cw: { type: 'string', nullable: true, maxLength: 100 },
 		localOnly: { type: 'boolean', default: false },
 		noExtractMentions: { type: 'boolean', default: false },
@@ -98,23 +97,6 @@ export const paramDef = {
 		noExtractEmojis: { type: 'boolean', default: false },
 		replyId: { type: 'string', format: 'misskey:id', nullable: true },
 		channelId: { type: 'string', format: 'misskey:id', nullable: true },
-		poll: {
-			type: 'object',
-			nullable: true,
-			properties: {
-				choices: {
-					type: 'array',
-					uniqueItems: true,
-					minItems: 2,
-					maxItems: 10,
-					items: { type: 'string', minLength: 1, maxLength: 50 },
-				},
-				multiple: { type: 'boolean', default: false },
-				expiresAt: { type: 'integer', nullable: true },
-				expiredAfter: { type: 'integer', nullable: true, minimum: 1 },
-			},
-			required: ['choices'],
-		},
 	},
 	anyOf: [
 		{
@@ -155,7 +137,23 @@ export const paramDef = {
 		{
 			// (re)note with poll, text and files are optional
 			properties: {
-				poll: { type: 'object', nullable: false },
+				poll: {
+					type: 'object',
+					nullable: true,
+					properties: {
+						choices: {
+							type: 'array',
+							uniqueItems: true,
+							minItems: 2,
+							maxItems: 10,
+							items: { type: 'string', minLength: 1, maxLength: 50 },
+						},
+						multiple: { type: 'boolean' },
+						expiresAt: { type: 'integer', nullable: true },
+						expiredAfter: { type: 'integer', nullable: true, minimum: 1 },
+					},
+					required: ['choices'],
+				},
 			},
 			required: ['poll'],
 		},

--- a/packages/backend/src/server/api/endpoints/notes/create.ts
+++ b/packages/backend/src/server/api/endpoints/notes/create.ts
@@ -96,24 +96,7 @@ export const paramDef = {
 		noExtractMentions: { type: 'boolean', default: false },
 		noExtractHashtags: { type: 'boolean', default: false },
 		noExtractEmojis: { type: 'boolean', default: false },
-		fileIds: {
-			type: 'array',
-			uniqueItems: true,
-			minItems: 1,
-			maxItems: 16,
-			items: { type: 'string', format: 'misskey:id' },
-		},
-		mediaIds: {
-			deprecated: true,
-			description: 'Use `fileIds` instead. If both are specified, this property is discarded.',
-			type: 'array',
-			uniqueItems: true,
-			minItems: 1,
-			maxItems: 16,
-			items: { type: 'string', format: 'misskey:id' },
-		},
 		replyId: { type: 'string', format: 'misskey:id', nullable: true },
-		renoteId: { type: 'string', format: 'misskey:id', nullable: true },
 		channelId: { type: 'string', format: 'misskey:id', nullable: true },
 		poll: {
 			type: 'object',
@@ -143,10 +126,30 @@ export const paramDef = {
 		},
 		{
 			// (re)note with files, text and poll are optional
+			properties: {
+				fileIds: {
+					type: 'array',
+					uniqueItems: true,
+					minItems: 1,
+					maxItems: 16,
+					items: { type: 'string', format: 'misskey:id' },
+				},
+			},
 			required: ['fileIds'],
 		},
 		{
 			// (re)note with files, text and poll are optional
+			properties: {
+				mediaIds: {
+					deprecated: true,
+					description: 'Use `fileIds` instead. If both are specified, this property is discarded.',
+					type: 'array',
+					uniqueItems: true,
+					minItems: 1,
+					maxItems: 16,
+					items: { type: 'string', format: 'misskey:id' },
+				},
+			},
 			required: ['mediaIds'],
 		},
 		{
@@ -158,6 +161,9 @@ export const paramDef = {
 		},
 		{
 			// pure renote
+			properties: {
+				renoteId: { type: 'string', format: 'misskey:id', nullable: true },
+			},
 			required: ['renoteId'],
 		},
 	],

--- a/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
+++ b/packages/backend/src/server/api/endpoints/users/search-by-username-and-host.ts
@@ -29,14 +29,22 @@ export const meta = {
 export const paramDef = {
 	type: 'object',
 	properties: {
-		username: { type: 'string', nullable: true },
-		host: { type: 'string', nullable: true },
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		detail: { type: 'boolean', default: true },
 	},
 	anyOf: [
-		{ required: ['username'] },
-		{ required: ['host'] },
+		{
+			properties: {
+				username: { type: 'string', nullable: true },
+			},
+			required: ['username']
+		},
+		{
+			properties: {
+				host: { type: 'string', nullable: true },
+			},
+			required: ['host']
+		},
 	],
 } as const;
 


### PR DESCRIPTION
Fix #8514

# What
- type: 'object'の中のanyOfの中身たちはtype: 'object'として扱うように
- propertiesとanyOfを同時指定できるように
- anyOfの中にrequiredだけ指定するのは流石にやめてほしいので直した

# Additional info (optional)
~~APIの検査が弾かれないか未テスト~~ 大丈夫っぽい
