### PR TITLE
Deny UNIX domain socket

### DIFF
--- a/packages/backend/src/core/DownloadService.ts
+++ b/packages/backend/src/core/DownloadService.ts
@@ -33,6 +33,11 @@ export class DownloadService {
 
 	@bindThis
 	public async downloadUrl(url: string, path: string): Promise<void> {
+		const u = new URL(url);
+		if (!u.protocol.match(/^https?:$/) || u.hostname === 'unix') {
+			throw new StatusError('Invalid protocol', 400);
+		}
+
 		this.logger.info(`Downloading ${chalk.cyan(url)} to ${chalk.cyanBright(path)} ...`);
 
 		const timeout = 30 * 1000;

--- a/packages/backend/src/core/DownloadService.ts
+++ b/packages/backend/src/core/DownloadService.ts
@@ -33,11 +33,6 @@ export class DownloadService {
 
 	@bindThis
 	public async downloadUrl(url: string, path: string): Promise<void> {
-		const u = new URL(url);
-		if (!u.protocol.match(/^https?:$/) || u.hostname === 'unix') {
-			throw new StatusError('Invalid protocol', 400);
-		}
-
 		this.logger.info(`Downloading ${chalk.cyan(url)} to ${chalk.cyanBright(path)} ...`);
 
 		const timeout = 30 * 1000;
@@ -65,6 +60,7 @@ export class DownloadService {
 			retry: {
 				limit: 0,
 			},
+			enableUnixSockets: false,
 		}).on('response', (res: Got.Response) => {
 			if ((process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test') && !this.config.proxy && res.ip) {
 				if (this.isPrivateIp(res.ip)) {


### PR DESCRIPTION
# What
DownloadのリクエストでUNIXドメインソケットなどの意図しないプロトコルを拒否するように

# Why
Downloadで使用しているgotでは以下のようなURLでUNIXドメインソケットにアクセスを試みてしまう模様。
```
unix:/tmp/unix.sock:/x
http://unix:/tmp/unix.sock:/x
```

# Additional info (optional)
現状gotのUNIXドメインソケットの実装が壊れているので悪用は出来ないと思う
<!-- テスト観点など -->
<!-- Test perspective, etc -->
