### PR TITLE
enhance(client): add webhook delete button

### DIFF
--- a/packages/frontend/src/pages/settings/webhook.edit.vue
+++ b/packages/frontend/src/pages/settings/webhook.edit.vue
@@ -31,6 +31,7 @@
 
 	<div class="_buttons">
 		<MkButton primary inline @click="save"><i class="ti ti-check"></i> {{ i18n.ts.save }}</MkButton>
+		<MkButton danger inline @click="del"><i class="ti ti-trash"></i> {{ i18n.ts.delete }}</MkButton>
 	</div>
 </div>
 </template>
@@ -44,6 +45,9 @@ import MkButton from '@/components/MkButton.vue';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
+import { useRouter } from '@/router';
+
+const router = useRouter();
 
 const props = defineProps<{
 	webhookId: string;
@@ -86,6 +90,19 @@ async function save(): Promise<void> {
 	});
 }
 
+async function del(): Promise<void> {
+	const { canceled } = await os.confirm({
+		type: 'warning',
+		text: i18n.t('deleteAreYouSure', { x: webhook.name }),
+	});
+	if (canceled) return;
+
+	await os.apiWithDialog('i/webhooks/delete', {
+		webhookId: props.webhookId,
+	});
+
+	router.push('/settings/webhook');
+}
 const headerActions = $computed(() => []);
 
 const headerTabs = $computed(() => []);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Resolve #9805
A button for deleting a webhook has been added to the webhook edit page.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
The lack of a delete button on the webhook edit page made the process of deleting a webhook cumbersome, as it required using the API. To improve the user experience, a delete button has been added.

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
![image](https://user-images.githubusercontent.com/54402969/216807686-934d21a8-23d1-4436-8314-4af242019af7.png)
<img width="625" alt="image" src="https://user-images.githubusercontent.com/54402969/216807792-8bceed85-de2d-4c5d-851d-b88244378724.png">
