### PR TITLE
fix: dateの初期値が正常に入らない時がある

### DIFF
--- a/packages/frontend/src/components/MkInput.vue
+++ b/packages/frontend/src/components/MkInput.vue
@@ -42,7 +42,7 @@ import { i18n } from '@/i18n';
 
 const props = defineProps<{
 	modelValue: string | number;
-	type?: 'text' | 'number' | 'password' | 'email' | 'url' | 'date' | 'time' | 'search';
+	type?: 'text' | 'number' | 'password' | 'email' | 'url' | 'date' | 'time' | 'search' | "datetime-local";
 	required?: boolean;
 	readonly?: boolean;
 	disabled?: boolean;
@@ -68,14 +68,7 @@ const emit = defineEmits<{
 }>();
 
 const { modelValue, type, autofocus } = toRefs(props);
-let v = ref<string | number>();
-if (props.type === "date") {
-	// 2023-02-24T00:00:00.000Z -> 2023-02-24
-	// あんまりよくない気もする
-	v.value = modelValue.value.split("T")[0]
-} else {
-	v.value = modelValue.value
-}
+let v = ref<string | number>(modelValue.value);
 const id = Math.random().toString(); // TODO: uuid?
 const focused = ref(false);
 const changed = ref(false);

--- a/packages/frontend/src/components/MkInput.vue
+++ b/packages/frontend/src/components/MkInput.vue
@@ -42,7 +42,7 @@ import { i18n } from '@/i18n';
 
 const props = defineProps<{
 	modelValue: string | number;
-	type?: 'text' | 'number' | 'password' | 'email' | 'url' | 'date' | 'time' | 'search' | "datetime-local";
+	type?: 'text' | 'number' | 'password' | 'email' | 'url' | 'date' | 'time' | 'search' | 'datetime-local';
 	required?: boolean;
 	readonly?: boolean;
 	disabled?: boolean;
@@ -68,7 +68,7 @@ const emit = defineEmits<{
 }>();
 
 const { modelValue, type, autofocus } = toRefs(props);
-let v = ref<string | number>(modelValue.value);
+const v = ref(modelValue.value);
 const id = Math.random().toString(); // TODO: uuid?
 const focused = ref(false);
 const changed = ref(false);

--- a/packages/frontend/src/components/MkInput.vue
+++ b/packages/frontend/src/components/MkInput.vue
@@ -68,7 +68,14 @@ const emit = defineEmits<{
 }>();
 
 const { modelValue, type, autofocus } = toRefs(props);
-const v = ref(modelValue.value);
+let v = ref<string | number>();
+if (props.type === "date") {
+	// 2023-02-24T00:00:00.000Z -> 2023-02-24
+	// あんまりよくない気もする
+	v.value = modelValue.value.split("T")[0]
+} else {
+	v.value = modelValue.value
+}
 const id = Math.random().toString(); // TODO: uuid?
 const focused = ref(false);
 const changed = ref(false);

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts" setup>
-import {} from 'vue';
+import { } from 'vue';
 import XHeader from './_header_.vue';
 import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
@@ -63,9 +63,9 @@ let ads: any[] = $ref([]);
 os.api('admin/ad/list').then(adsResponse => {
 	ads = adsResponse.map(r => {
 		return {
-		...r,
-		expiresAt: new Date(r.expiresAt).toISOString().slice(0,16)
-		}
+			...r,
+			expiresAt: new Date(r.expiresAt).toISOString().slice(0, 16),
+		};
 	});
 });
 

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -29,7 +29,7 @@
 					<MkInput v-model="ad.ratio" type="number">
 						<template #label>{{ i18n.ts.ratio }}</template>
 					</MkInput>
-					<MkInput v-model="ad.expiresAt" type="date">
+					<MkInput v-model="ad.expiresAt" type="datetime-local">
 						<template #label>{{ i18n.ts.expiration }}</template>
 					</MkInput>
 				</FormSplit>
@@ -47,7 +47,7 @@
 </template>
 
 <script lang="ts" setup>
-import { } from 'vue';
+import {} from 'vue';
 import XHeader from './_header_.vue';
 import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
@@ -61,7 +61,12 @@ import { definePageMetadata } from '@/scripts/page-metadata';
 let ads: any[] = $ref([]);
 
 os.api('admin/ad/list').then(adsResponse => {
-	ads = adsResponse;
+	ads = adsResponse.map(r => {
+		return {
+		...r,
+		expiresAt: new Date(r.expiresAt).toISOString().slice(0,16)
+		}
+	});
 });
 
 function add() {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
広告設定欄の期限inputが入れたにもかかわらず
リロードすると入力されていないように見える問題を修正した。
![image](https://user-images.githubusercontent.com/91118218/217235018-75d4890a-47df-40db-acbc-383e60ab4e57.png)


# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リロードしてもちゃんと日付が出てほしかったので修正しました。
`<input type="date">`の時に渡してるstringがだめっぽかった
昔 `2023-02-24T00:00:00.000Z`
今 `2023-02-24`
Tで区切って0個目を読んでいるだけなので良くないかもしれないです。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカル環境では正常に動いてるように見えました。
![image](https://user-images.githubusercontent.com/91118218/217235597-1096a1e3-2d29-4bbe-8ecd-c4c2f223cc05.png)
