### PR TITLE
fix(mfm): default degree not used in rotate

### DIFF
--- a/packages/frontend/src/components/mfm.ts
+++ b/packages/frontend/src/components/mfm.ts
@@ -195,7 +195,7 @@ export default defineComponent({
 							return h(MkSparkle, {}, genEl(token.children));
 						}
 						case 'rotate': {
-							const degrees = parseFloat(token.props.args.deg) ?? '90';
+							const degrees = parseFloat(token.props.args.deg ?? '90');
 							style = `transform: rotate(${degrees}deg); transform-origin: center center;`;
 							break;
 						}


### PR DESCRIPTION
# What
parseFloatにundefinedを渡さないようにする
# Why
