### PR TITLE
fix: newNoteReceived indicator causes Layout Shift

### DIFF
--- a/packages/frontend/src/pages/antenna-timeline.vue
+++ b/packages/frontend/src/pages/antenna-timeline.vue
@@ -98,6 +98,7 @@ definePageMetadata(computed(() => antenna ? {
 		top: calc(var(--stickyTop, 0px) + 16px);
 		z-index: 1000;
 		width: 100%;
+		margin: calc(-0.675em - 8px - var(--margin)) 0 calc(-0.675em - 8px);
 
 		> button {
 			display: block;

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -177,10 +177,10 @@ definePageMetadata(computed(() => ({
 	top: calc(var(--stickyTop, 0px) + 16px);
 	z-index: 1000;
 	width: 100%;
-	margin: -1.35em 0px -16px;
+	margin: calc(-0.675em - 8px - var(--margin)) 0;
 
 	&:first-child {
-		margin-top: calc(-1.35em - 16px);
+		margin-top: calc(-0.675em - 8px - var(--margin));
 	}
 
 	> button {

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -177,7 +177,7 @@ definePageMetadata(computed(() => ({
 	top: calc(var(--stickyTop, 0px) + 16px);
 	z-index: 1000;
 	width: 100%;
-	margin: calc(-0.675em - 8px - var(--margin)) 0;
+	margin: calc(-0.675em - 8px) 0;
 
 	&:first-child {
 		margin-top: calc(-0.675em - 8px - var(--margin));

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -177,6 +177,11 @@ definePageMetadata(computed(() => ({
 	top: calc(var(--stickyTop, 0px) + 16px);
 	z-index: 1000;
 	width: 100%;
+	margin: -1.35em 0px -16px;
+
+	&:first-child {
+		margin-top: calc(-1.35em - 16px);
+	}
 
 	> button {
 		display: block;

--- a/packages/frontend/src/pages/user-list-timeline.vue
+++ b/packages/frontend/src/pages/user-list-timeline.vue
@@ -91,7 +91,7 @@ definePageMetadata(computed(() => list ? {
 		top: calc(var(--stickyTop, 0px) + 16px);
 		z-index: 1000;
 		width: 100%;
-		margin: calc(-0.675em - 8px - var(--margin)) 0px calc(-0.675em - 8px);
+		margin: calc(-0.675em - 8px - var(--margin)) 0 calc(-0.675em - 8px);
 
 		> button {
 			display: block;

--- a/packages/frontend/src/pages/user-list-timeline.vue
+++ b/packages/frontend/src/pages/user-list-timeline.vue
@@ -91,6 +91,7 @@ definePageMetadata(computed(() => list ? {
 		top: calc(var(--stickyTop, 0px) + 16px);
 		z-index: 1000;
 		width: 100%;
+		margin: calc(-0.675em - 8px - var(--margin)) 0px calc(-0.675em - 8px);
 
 		> button {
 			display: block;


### PR DESCRIPTION
タイムラインを遡っていると「新しいノートがあります」のインジケーターが現れる瞬間に Layout Shift が起きるのを修正

![image](https://user-images.githubusercontent.com/20679825/217776733-90fbaa1f-dbb8-4508-8452-b1957f750a49.png)

# What

ネガティブマージンでインジケーターの表示領域を相殺する

# Why

improve UX

# Additional info (optional)

他のタイムラインページも同じかも
