### PR TITLE
fix: prevent clipping audio plyr's tooltip

### DIFF
--- a/packages/frontend/src/components/MkMediaBanner.vue
+++ b/packages/frontend/src/components/MkMediaBanner.vue
@@ -56,7 +56,7 @@ onMounted(() => {
 	width: 100%;
 	border-radius: 4px;
 	margin-top: 4px;
-	overflow: clip;
+	// overflow: clip;
 
 	--plyr-color-main: var(--accent);
 	--plyr-audio-controls-background: var(--bg);
@@ -99,7 +99,7 @@ onMounted(() => {
 
 	> .audio {
 		border-radius: 8px;
-		overflow: clip;
+		// overflow: clip;
 	}
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Audio plyr's tooltip was wrongly clipped by this style.

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
To show audio plyr tooltip properly

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

Before:
![image](https://user-images.githubusercontent.com/20502130/217863284-c1f2b62f-741e-4f1f-b94a-fb38500bc61c.png)

After:
![image](https://user-images.githubusercontent.com/20502130/217863457-526c6cd2-9ffa-4bcd-9f40-f612f50a7493.png)
