### PR TITLE
fix: 広告のexpiresAtをLocalTZ分ずらして初期化

### DIFF
--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -57,7 +57,6 @@ import FormSplit from '@/components/form/split.vue';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
-import date from '@/filters/date';
 
 let ads: any[] = $ref([]);
 

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -57,14 +57,21 @@ import FormSplit from '@/components/form/split.vue';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
+import date from '@/filters/date';
 
 let ads: any[] = $ref([]);
 
+// ISO形式はTZがUTCになってしまうので、TZ分ずらして時間を初期化
+const localTime = new Date();
+const localTimeDiff = localTime.getTimezoneOffset() * 60 * 1000;
+
 os.api('admin/ad/list').then(adsResponse => {
 	ads = adsResponse.map(r => {
+		const date = new Date(r.expiresAt);
+		date.setMilliseconds(date.getMilliseconds() - localTimeDiff);
 		return {
 			...r,
-			expiresAt: new Date(r.expiresAt).toISOString().slice(0, 16),
+			expiresAt: date.toISOString().slice(0, 16),
 		};
 	});
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
#9875 の修正です。
Fix #9875

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

inputにISO stringのUTC時間が渡された結果、タイムゾーンずつずれて表示、登録されていました。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

修正前
![image](https://user-images.githubusercontent.com/91118218/218240765-a45aade3-4617-46b2-bf3f-bbc5ae1c9436.png)
修正後
![image](https://user-images.githubusercontent.com/91118218/218240776-09289b91-31a9-4da1-bf17-1959f1fd31ee.png)


