### PR TITLE
ユーザーページのヘッダーを真ん中に持ってきてみる

### DIFF
--- a/packages/frontend/src/components/global/MkPageHeader.tabs.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.tabs.vue
@@ -55,6 +55,8 @@ const tabRefs: Record<string, HTMLElement | null> = {};
 const tabHighlightEl = shallowRef<HTMLElement | null>(null);
 
 function onTabMousedown(tab: Tab, ev: MouseEvent): void {
+	emit('tabClick', tab.key);
+
 	// ユーザビリティの観点からmousedown時にはonClickは呼ばない
 	if (tab.key) {
 		emit('update:tab', tab.key);

--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -81,7 +81,6 @@ const preventDrag = (ev: TouchEvent) => {
 };
 
 const top = () => {
-	console.log(props.scrollToTop)
 	if (props.scrollToTop) {
 		props.scrollToTop();
 	} else if (el) {
@@ -144,7 +143,7 @@ onUnmounted(() => {
 }
 
 .upper {
-	--height: 50px;
+	--height: var(--headerHeight, 50px);
 	display: flex;
 	gap: var(--margin);
 	height: var(--height);

--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -53,6 +53,7 @@ const props = withDefaults(defineProps<{
 	}[];
 	thin?: boolean;
 	displayMyAvatar?: boolean;
+	scrollToTop?: (x?: ScrollOptions) => void;
 }>(), {
 	tabs: () => ([] as Tab[]),
 });
@@ -80,7 +81,10 @@ const preventDrag = (ev: TouchEvent) => {
 };
 
 const top = () => {
-	if (el) {
+	console.log(props.scrollToTop)
+	if (props.scrollToTop) {
+		props.scrollToTop();
+	} else if (el) {
 		scrollToTop(el as HTMLElement, { behavior: 'smooth' });
 	}
 };

--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script lang="ts" setup>
-import { onMounted, onUnmounted, ref, inject } from 'vue';
+import { onMounted, onUnmounted, ref, inject, nextTick } from 'vue';
 import tinycolor from 'tinycolor2';
 import { scrollToTop } from '@/scripts/scroll';
 import { globalEvents } from '@/events';
@@ -81,11 +81,13 @@ const preventDrag = (ev: TouchEvent) => {
 };
 
 const top = () => {
-	if (props.scrollToTop) {
-		props.scrollToTop();
-	} else if (el) {
-		scrollToTop(el as HTMLElement, { behavior: 'smooth' });
-	}
+	nextTick(() => {
+		if (props.scrollToTop) {
+			props.scrollToTop();
+		} else if (el) {
+			scrollToTop(el as HTMLElement, { behavior: 'smooth' });
+		}
+	});
 };
 
 function openAccountMenu(ev: MouseEvent) {

--- a/packages/frontend/src/components/global/MkStickyContainer.vue
+++ b/packages/frontend/src/components/global/MkStickyContainer.vue
@@ -1,8 +1,5 @@
 <template>
 <div ref="rootEl">
-	<div ref="beforeEl">
-		<slot name="beforeHeader"></slot>
-	</div>
 	<div ref="headerEl">
 		<slot name="header"></slot>
 	</div>
@@ -20,10 +17,9 @@ const CURRENT_STICKY_TOP = 'CURRENT_STICKY_TOP';
 
 <script lang="ts" setup>
 import { scroll } from '@/scripts/scroll';
-import { onMounted, onUnmounted, provide, inject, Ref, ref, watch, nextTick } from 'vue';
+import { onMounted, onUnmounted, provide, inject, Ref, ref, watch } from 'vue';
 
 const rootEl = $shallowRef<HTMLElement>();
-const beforeEl = $shallowRef<HTMLElement>();
 const headerEl = $shallowRef<HTMLElement>();
 const bodyEl = $shallowRef<HTMLElement>();
 
@@ -39,9 +35,9 @@ const calc = () => {
 };
 
 const scrollToTop = (options: ScrollToOptions = {}) => {
-	if (!bodyEl || !beforeEl) return;
+	if (!bodyEl || !rootEl) return;
 	scroll($$(bodyEl).value, {
-		top: 0 + parentStickyTop.value + beforeEl.offsetHeight,
+		top: 0 + rootEl.offsetTop - parentStickyTop.value,
 		behavior: 'smooth',
 		...options,
 	});

--- a/packages/frontend/src/components/global/MkStickyContainer.vue
+++ b/packages/frontend/src/components/global/MkStickyContainer.vue
@@ -1,5 +1,8 @@
 <template>
 <div ref="rootEl">
+	<div ref="beforeEl">
+		<slot name="beforeHeader"></slot>
+	</div>
 	<div ref="headerEl">
 		<slot name="header"></slot>
 	</div>

--- a/packages/frontend/src/components/global/MkStickyContainer.vue
+++ b/packages/frontend/src/components/global/MkStickyContainer.vue
@@ -31,6 +31,7 @@ const parentStickyTop = inject<Ref<number>>(CURRENT_STICKY_TOP, ref(0));
 provide(CURRENT_STICKY_TOP, $$(childStickyTop));
 
 const calc = () => {
+	if (!headerEl) return;
 	childStickyTop = parentStickyTop.value + headerEl.offsetHeight;
 	headerHeight = headerEl.offsetHeight.toString();
 };
@@ -47,16 +48,19 @@ onMounted(() => {
 	watch(parentStickyTop, calc);
 
 	watch($$(childStickyTop), () => {
+		if (!bodyEl) return;
 		bodyEl.style.setProperty('--stickyTop', `${childStickyTop}px`);
 	}, {
 		immediate: true,
 	});
 
-	headerEl.style.position = 'sticky';
-	headerEl.style.top = 'var(--stickyTop, 0)';
-	headerEl.style.zIndex = '1000';
+	if (headerEl) {
+		headerEl.style.position = 'sticky';
+		headerEl.style.top = 'var(--stickyTop, 0)';
+		headerEl.style.zIndex = '1000';
 
-	observer.observe(headerEl);
+		observer.observe(headerEl);
+	}
 });
 
 onUnmounted(() => {

--- a/packages/frontend/src/components/global/MkStickyContainer.vue
+++ b/packages/frontend/src/components/global/MkStickyContainer.vue
@@ -19,9 +19,11 @@ const CURRENT_STICKY_TOP = 'CURRENT_STICKY_TOP';
 </script>
 
 <script lang="ts" setup>
-import { onMounted, onUnmounted, provide, inject, Ref, ref, watch } from 'vue';
+import { scroll } from '@/scripts/scroll';
+import { onMounted, onUnmounted, provide, inject, Ref, ref, watch, nextTick } from 'vue';
 
 const rootEl = $shallowRef<HTMLElement>();
+const beforeEl = $shallowRef<HTMLElement>();
 const headerEl = $shallowRef<HTMLElement>();
 const bodyEl = $shallowRef<HTMLElement>();
 
@@ -35,6 +37,15 @@ const calc = () => {
 	childStickyTop = parentStickyTop.value + headerEl.offsetHeight;
 	headerHeight = headerEl.offsetHeight.toString();
 };
+
+const scrollToTop = (options: ScrollToOptions = {}) => {
+	if (!bodyEl || !beforeEl) return;
+	scroll($$(bodyEl).value, {
+		top: 0 + parentStickyTop.value + beforeEl.offsetHeight,
+		behavior: 'smooth',
+		...options,
+	});
+}
 
 const observer = new ResizeObserver(() => {
 	window.setTimeout(() => {
@@ -65,6 +76,11 @@ onMounted(() => {
 
 onUnmounted(() => {
 	observer.disconnect();
+});
+
+defineExpose({
+	scrollToTop,
+	stickyTop: $$(childStickyTop),
 });
 </script>
 

--- a/packages/frontend/src/pages/user/index.contents.vue
+++ b/packages/frontend/src/pages/user/index.contents.vue
@@ -4,7 +4,7 @@
 	<div ref="contentEl">
 		<Transition name="fade" mode="out-in">
 			<div v-if="user">
-				<XTimeline v-if="tab === 'notes'" :user="user" />
+				<XTimeline v-if="tab === 'notes' || tab === 'files' || tab === 'replies'" :tab="tab" :user="user" />
 				<XActivity v-else-if="tab === 'activity'" :user="user"/>
 				<XAchievements v-else-if="tab === 'achievements'" :user="user"/>
 				<XReactions v-else-if="tab === 'reactions'" :user="user"/>
@@ -21,7 +21,6 @@
 
 <script lang="ts" setup>
 import { defineAsyncComponent, provide, watchEffect } from 'vue';
-import * as misskey from 'misskey-js';
 import { i18n } from '@/i18n';
 import { $i } from '@/account';
 import type MkStickyContainer from '@/components/global/MkStickyContainer.vue';
@@ -39,7 +38,7 @@ const XGallery = defineAsyncComponent(() => import('./gallery.vue'));
 const props = withDefaults(defineProps<{
 	acct: string;
 	user: any;
-	page?: 'notes' | 'activity' | 'achievements' | 'reactions' | 'clips' | 'pages' | 'gallery';
+	page?: 'notes' | 'replies' | 'files' | 'activity' | 'achievements' | 'reactions' | 'clips' | 'pages' | 'gallery';
 }>(), {
 	page: 'notes',
 });
@@ -75,6 +74,14 @@ const headerTabs = $computed(() => props.user ? [{
 	key: 'notes',
 	title: i18n.ts.notes,
 	icon: 'ti ti-pencil',
+}, {
+	key: 'replies',
+	title: i18n.ts.notesAndReplies,
+	icon: 'ti ti-arrow-back-up',
+}, {
+	key: 'files',
+	title: i18n.ts.withFiles,
+	icon: 'ti ti-photo',
 }, {
 	key: 'activity',
 	title: i18n.ts.activity,

--- a/packages/frontend/src/pages/user/index.contents.vue
+++ b/packages/frontend/src/pages/user/index.contents.vue
@@ -1,0 +1,114 @@
+<template>
+<MkStickyContainer ref="containerEl">
+	<template #header><MkPageHeader v-model:tab="tab" :tabs="headerTabs" :scroll-to-top="scrollToTop" :actions="headerActions" :hide-title="true" style="--headerHeight: 40px"/></template>
+	<div ref="contentEl">
+		<Transition name="fade" mode="out-in">
+			<div v-if="user">
+				<XTimeline v-if="tab === 'notes'" :user="user" />
+				<XActivity v-else-if="tab === 'activity'" :user="user"/>
+				<XAchievements v-else-if="tab === 'achievements'" :user="user"/>
+				<XReactions v-else-if="tab === 'reactions'" :user="user"/>
+				<XClips v-else-if="tab === 'clips'" :user="user"/>
+				<XPages v-else-if="tab === 'pages'" :user="user"/>
+				<XGallery v-else-if="tab === 'gallery'" :user="user"/>
+			</div>
+			<MkError v-else-if="error" @retry="emit('requestRetry')"/>
+			<MkLoading v-else/>
+		</Transition>
+	</div>
+</MkStickyContainer>
+</template>
+
+<script lang="ts" setup>
+import { defineAsyncComponent, provide, watchEffect } from 'vue';
+import * as misskey from 'misskey-js';
+import { i18n } from '@/i18n';
+import { $i } from '@/account';
+import type MkStickyContainer from '@/components/global/MkStickyContainer.vue';
+import type { Tab } from '@/components/global/MkPageHeader.tabs.vue';
+import { getScrollContainer } from '@/scripts/scroll';
+
+const XTimeline = defineAsyncComponent(() => import('./index.timeline.vue'));
+const XActivity = defineAsyncComponent(() => import('./activity.vue'));
+const XAchievements = defineAsyncComponent(() => import('./achievements.vue'));
+const XReactions = defineAsyncComponent(() => import('./reactions.vue'));
+const XClips = defineAsyncComponent(() => import('./clips.vue'));
+const XPages = defineAsyncComponent(() => import('./pages.vue'));
+const XGallery = defineAsyncComponent(() => import('./gallery.vue'));
+
+const props = withDefaults(defineProps<{
+	acct: string;
+	user: any;
+	page?: 'notes' | 'activity' | 'achievements' | 'reactions' | 'clips' | 'pages' | 'gallery';
+}>(), {
+	page: 'notes',
+});
+
+const emit = defineEmits<{
+	(e: 'requestRetry'): void;
+}>()
+
+provide('shouldOmitHeaderTitle', true);
+
+let tab = $ref(props.page);
+let error = $ref(null);
+
+let containerEl = $shallowRef<InstanceType<typeof MkStickyContainer>>();
+let contentEl = $shallowRef<HTMLElement>();
+
+const scrollToTop = $computed(() => {
+	if (containerEl) return containerEl.scrollToTop;
+	return () => undefined;
+});
+
+watchEffect(() => {
+	if (contentEl && containerEl) {
+		const scrollContainer = getScrollContainer(contentEl);
+		const scrollHeight = scrollContainer ? scrollContainer.clientHeight : window.innerHeight;
+		contentEl.style.minHeight = `calc(${scrollHeight - containerEl.stickyTop}px - var(--minBottomSpacing))`;
+	}
+});
+
+const headerActions = $computed(() => []);
+
+const headerTabs = $computed(() => props.user ? [{
+	key: 'notes',
+	title: i18n.ts.notes,
+	icon: 'ti ti-pencil',
+}, {
+	key: 'activity',
+	title: i18n.ts.activity,
+	icon: 'ti ti-chart-line',
+}, ...(props.user.host == null ? [{
+	key: 'achievements',
+	title: i18n.ts.achievements,
+	icon: 'ti ti-medal',
+}] : []), ...($i && ($i.id === props.user.id)) || props.user.publicReactions ? [{
+	key: 'reactions',
+	title: i18n.ts.reaction,
+	icon: 'ti ti-mood-happy',
+}] : [], {
+	key: 'clips',
+	title: i18n.ts.clips,
+	icon: 'ti ti-paperclip',
+}, {
+	key: 'pages',
+	title: i18n.ts.pages,
+	icon: 'ti ti-news',
+}, {
+	key: 'gallery',
+	title: i18n.ts.gallery,
+	icon: 'ti ti-icons',
+}] as Tab[] : []);
+</script>
+
+<style lang="scss" scoped>
+.fade-enter-active,
+.fade-leave-active {
+	transition: opacity 0.125s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+	opacity: 0;
+}
+</style>

--- a/packages/frontend/src/pages/user/index.contents.vue
+++ b/packages/frontend/src/pages/user/index.contents.vue
@@ -1,6 +1,6 @@
 <template>
 <MkStickyContainer ref="containerEl">
-	<template #header><MkPageHeader v-model:tab="tab" :tabs="headerTabs" :scroll-to-top="scrollToTop" :actions="headerActions" :hide-title="true" style="--headerHeight: 40px"/></template>
+	<template #header><MkPageHeader v-model:tab="tab" :tabs="headerTabs" :scroll-to-top="scrollToTop" :actions="headerActions" :hide-title="true" style="--headerHeight: 46px"/></template>
 	<div ref="contentEl">
 		<Transition name="fade" mode="out-in">
 			<div v-if="user">

--- a/packages/frontend/src/pages/user/index.timeline.vue
+++ b/packages/frontend/src/pages/user/index.timeline.vue
@@ -1,50 +1,31 @@
 <template>
 <MkSpacer :content-max="800" style="padding-top: 0">
-	<MkStickyContainer>
-		<template #header>
-			<MkTab v-model="include" :class="$style.tab">
-				<option :value="null">{{ i18n.ts.notes }}</option>
-				<option value="replies">{{ i18n.ts.notesAndReplies }}</option>
-				<option value="files">{{ i18n.ts.withFiles }}</option>
-			</MkTab>
-		</template>
-		<XNotes :no-gap="true" :pagination="pagination" :class="$style.tl"/>
-	</MkStickyContainer>
+	<XNotes :no-gap="true" :pagination="pagination" :class="$style.tl"/>
 </MkSpacer>
 </template>
 
 <script lang="ts" setup>
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import * as misskey from 'misskey-js';
 import XNotes from '@/components/MkNotes.vue';
-import MkTab from '@/components/MkTab.vue';
-import * as os from '@/os';
-import { i18n } from '@/i18n';
 
 const props = defineProps<{
 	user: misskey.entities.UserDetailed;
+	tab: 'notes' | 'replies' | 'files';
 }>();
-
-const include = ref<string | null>(null);
 
 const pagination = {
 	endpoint: 'users/notes' as const,
 	limit: 10,
 	params: computed(() => ({
 		userId: props.user.id,
-		includeReplies: include.value === 'replies',
-		withFiles: include.value === 'files',
+		includeReplies: props.tab === 'replies',
+		withFiles: props.tab === 'files',
 	})),
 };
 </script>
 
 <style lang="scss" module>
-.tab {
-	margin: calc(var(--margin) / 2) 0;
-	padding: calc(var(--margin) / 2) 0;
-	background: var(--bg);
-}
-
 .tl {
 	background: var(--bg);
     border-radius: var(--radius);

--- a/packages/frontend/src/pages/user/index.timeline.vue
+++ b/packages/frontend/src/pages/user/index.timeline.vue
@@ -1,5 +1,5 @@
 <template>
-<MkSpacer :content-max="800" style="padding-top: 0">
+<MkSpacer :content-max="800">
 	<XNotes :no-gap="true" :pagination="pagination" :class="$style.tl"/>
 </MkSpacer>
 </template>

--- a/packages/frontend/src/pages/user/index.vue
+++ b/packages/frontend/src/pages/user/index.vue
@@ -44,9 +44,9 @@ const XGallery = defineAsyncComponent(() => import('./gallery.vue'));
 
 const props = withDefaults(defineProps<{
 	acct: string;
-	page?: string;
+	page?: 'notes' | 'activity' | 'achievements' | 'reactions' | 'clips' | 'pages' | 'gallery';
 }>(), {
-	page: 'home',
+	page: 'notes',
 });
 
 let tab = $ref(props.page);

--- a/packages/frontend/src/pages/user/index.vue
+++ b/packages/frontend/src/pages/user/index.vue
@@ -1,11 +1,13 @@
 <template>
 <MkStickyContainer>
+	<template #beforeHeader>
+		<XHome v-if="user" :user="user"/>
+	</template>
 	<template #header><MkPageHeader v-model:tab="tab" :actions="headerActions" :tabs="headerTabs"/></template>
 	<div>
 		<Transition name="fade" mode="out-in">
 			<div v-if="user">
-				<XHome v-if="tab === 'home'" :user="user"/>
-				<XTimeline v-else-if="tab === 'notes'" :user="user" />
+				<XTimeline v-if="tab === 'notes'" :user="user" />
 				<XActivity v-else-if="tab === 'activity'" :user="user"/>
 				<XAchievements v-else-if="tab === 'achievements'" :user="user"/>
 				<XReactions v-else-if="tab === 'reactions'" :user="user"/>
@@ -68,10 +70,6 @@ watch(() => props.acct, fetchUser, {
 const headerActions = $computed(() => []);
 
 const headerTabs = $computed(() => user ? [{
-	key: 'home',
-	title: i18n.ts.overview,
-	icon: 'ti ti-home',
-}, {
 	key: 'notes',
 	title: i18n.ts.notes,
 	icon: 'ti ti-pencil',

--- a/packages/frontend/src/pages/user/index.vue
+++ b/packages/frontend/src/pages/user/index.vue
@@ -1,48 +1,21 @@
 <template>
-<MkStickyContainer ref="containerEl">
-	<template #beforeHeader>
-		<XHome v-if="user" :user="user" :class="$style.home"/>
-	</template>
-	<template #header><MkPageHeader v-model:tab="tab" :actions="headerActions" :tabs="headerTabs" :scroll-to-top="scrollToTop"/></template>
-	<div ref="contentEl" style="min-height: calc(100% - var(--stickyTop));">
-		<Transition name="fade" mode="out-in">
-			<div v-if="user">
-				<XTimeline v-if="tab === 'notes'" :user="user" />
-				<XActivity v-else-if="tab === 'activity'" :user="user"/>
-				<XAchievements v-else-if="tab === 'achievements'" :user="user"/>
-				<XReactions v-else-if="tab === 'reactions'" :user="user"/>
-				<XClips v-else-if="tab === 'clips'" :user="user"/>
-				<XPages v-else-if="tab === 'pages'" :user="user"/>
-				<XGallery v-else-if="tab === 'gallery'" :user="user"/>
-			</div>
-			<MkError v-else-if="error" @retry="fetchUser()"/>
-			<MkLoading v-else/>
-		</Transition>
-	</div>
+<MkStickyContainer>
+	<template #header><MkPageHeader :actions="headerActions"/></template>
+	<XHome v-if="user" :user="user" :class="$style.home"/>
+	<XContents v-if="user" :acct="acct" :user="user" :page="page" @request-retry="fetchUser"></XContents>
 </MkStickyContainer>
 </template>
 
 <script lang="ts" setup>
-import { defineAsyncComponent, computed, watch, watchEffect } from 'vue';
+import { computed, watch } from 'vue';
 import * as Acct from 'misskey-js/built/acct';
 import * as misskey from 'misskey-js';
 import { acct as getAcct } from '@/filters/user';
 import * as os from '@/os';
 import { definePageMetadata } from '@/scripts/page-metadata';
-import { i18n } from '@/i18n';
-import { $i } from '@/account';
 import type MkStickyContainer from '@/components/global/MkStickyContainer.vue';
-import type { Tab } from '@/components/global/MkPageHeader.tabs.vue';
-import { getScrollContainer } from '@/scripts/scroll';
-
-const XHome = defineAsyncComponent(() => import('./home.vue'));
-const XTimeline = defineAsyncComponent(() => import('./index.timeline.vue'));
-const XActivity = defineAsyncComponent(() => import('./activity.vue'));
-const XAchievements = defineAsyncComponent(() => import('./achievements.vue'));
-const XReactions = defineAsyncComponent(() => import('./reactions.vue'));
-const XClips = defineAsyncComponent(() => import('./clips.vue'));
-const XPages = defineAsyncComponent(() => import('./pages.vue'));
-const XGallery = defineAsyncComponent(() => import('./gallery.vue'));
+import XHome from './home.vue';
+import XContents from './index.contents.vue';
 
 const props = withDefaults(defineProps<{
 	acct: string;
@@ -51,17 +24,7 @@ const props = withDefaults(defineProps<{
 	page: 'notes',
 });
 
-let tab = $ref(props.page);
 let user = $ref<null | misskey.entities.UserDetailed>(null);
-let error = $ref(null);
-
-let containerEl = $shallowRef<InstanceType<typeof MkStickyContainer>>();
-let contentEl = $shallowRef<HTMLElement>();
-
-const scrollToTop = $computed(() => {
-	if (containerEl) return containerEl.scrollToTop;
-	return () => undefined;
-});
 
 function fetchUser(): void {
 	if (props.acct == null) return;
@@ -77,45 +40,7 @@ watch(() => props.acct, fetchUser, {
 	immediate: true,
 });
 
-watchEffect(() => {
-	if (contentEl && containerEl) {
-		const scrollContainer = getScrollContainer(contentEl);
-		const scrollHeight = scrollContainer ? scrollContainer.clientHeight : window.innerHeight;
-		contentEl.style.minHeight = `calc(${scrollHeight - containerEl.stickyTop}px - var(--minBottomSpacing))`;
-	}
-});
-
 const headerActions = $computed(() => []);
-
-const headerTabs = $computed(() => user ? [{
-	key: 'notes',
-	title: i18n.ts.notes,
-	icon: 'ti ti-pencil',
-}, {
-	key: 'activity',
-	title: i18n.ts.activity,
-	icon: 'ti ti-chart-line',
-}, ...(user.host == null ? [{
-	key: 'achievements',
-	title: i18n.ts.achievements,
-	icon: 'ti ti-medal',
-}] : []), ...($i && ($i.id === user.id)) || user.publicReactions ? [{
-	key: 'reactions',
-	title: i18n.ts.reaction,
-	icon: 'ti ti-mood-happy',
-}] : [], {
-	key: 'clips',
-	title: i18n.ts.clips,
-	icon: 'ti ti-paperclip',
-}, {
-	key: 'pages',
-	title: i18n.ts.pages,
-	icon: 'ti ti-news',
-}, {
-	key: 'gallery',
-	title: i18n.ts.gallery,
-	icon: 'ti ti-icons',
-}] as Tab[] : []);
 
 definePageMetadata(computed(() => user ? {
 	icon: 'ti ti-user',
@@ -129,17 +54,6 @@ definePageMetadata(computed(() => user ? {
 	},
 } : null));
 </script>
-
-<style lang="scss" scoped>
-.fade-enter-active,
-.fade-leave-active {
-	transition: opacity 0.125s ease;
-}
-.fade-enter-from,
-.fade-leave-to {
-	opacity: 0;
-}
-</style>
 
 <style lang="scss" module>
 .home {


### PR DESCRIPTION
#9869 の続き

# What
MkStickyContainerでヘッダーの上側にコンテンツを配置するモードを追加し、ユーザーページで概要をそこに配置するように

# Why

# Additional info (optional)
なんもテストしとらん

タブをクリックするとページの一番上までいってしまうはずなのでなんとかしたい  
（stickyTopの元の位置のoffsetTopを取得する方法がいまいちわからない。MkStickyContainerからtop関数を提供し、srcoll to topの際にbeforeHeaderのサイズ分を足すみたいな処理が手っ取り早い？）

