### PR TITLE
fix: CLIページが動作していない問題を修正

### DIFF
--- a/packages/backend/src/server/web/cli.js
+++ b/packages/backend/src/server/web/cli.js
@@ -11,6 +11,9 @@ window.onload = async () => {
 	
 			// Send request
 			fetch(endpoint.indexOf('://') > -1 ? endpoint : `/api/${endpoint}`, {
+				headers: {
+					'Content-Type': 'application/json'
+				},
 				method: 'POST',
 				body: JSON.stringify(data),
 				credentials: 'omit',


### PR DESCRIPTION
# What
- CLIページにおいてAPIリクエスト送信時に`Content-Type: application/json`ヘッダを付与するように変更

# Why
- 現状`Content-Type: text/plain` が送信されており、Fastifyがリクエストボディをパースできずに認証に失敗しているため

# Additional info (optional)
Closes #9886