### PR TITLE
Fix type errors in packages/sw

### DIFF
--- a/packages/sw/src/@types/global.d.ts
+++ b/packages/sw/src/@types/global.d.ts
@@ -1,0 +1,7 @@
+type FIXME = any;
+
+declare const _LANGS_: string[][];
+declare const _VERSION_: string;
+declare const _ENV_: string;
+declare const _DEV_: boolean;
+declare const _PERF_PREFIX_: string;

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -228,7 +228,7 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 
 				case 'app':
 					return [data.body.header ?? data.body.body, {
-						body: data.body.header ?? data.body.body,
+						body: data.body.header ? data.body.body : '',
 						icon: data.body.icon ?? undefined,
 						data,
 					}];

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -30,7 +30,7 @@ export async function createNotification<K extends keyof pushNotificationDataMap
 	}
 }
 
-async function composeNotification<K extends keyof pushNotificationDataMap>(data: pushNotificationDataMap[K]): Promise<[string, NotificationOptions] | null> {
+async function composeNotification(data: pushNotificationDataMap[keyof pushNotificationDataMap]): Promise<[string, NotificationOptions] | null> {
 	if (!swLang.i18n) swLang.fetchLocale();
 	const i18n = await swLang.i18n as I18n<any>;
 	const { t } = i18n;
@@ -66,7 +66,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 
 				case 'mention':
 					return [t('_notification.youGotMention', { name: getUserName(data.body.user) }), {
-						body: data.body.note.text || '',
+						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
 						badge: iconUrl('at'),
 						data,
@@ -80,7 +80,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 
 				case 'reply':
 					return [t('_notification.youGotReply', { name: getUserName(data.body.user) }), {
-						body: data.body.note.text || '',
+						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
 						badge: iconUrl('arrow-back-up'),
 						data,
@@ -94,7 +94,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 
 				case 'renote':
 					return [t('_notification.youRenoted', { name: getUserName(data.body.user) }), {
-						body: data.body.note.text || '',
+						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
 						badge: iconUrl('repeat'),
 						data,
@@ -108,7 +108,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 
 				case 'quote':
 					return [t('_notification.youGotQuote', { name: getUserName(data.body.user) }), {
-						body: data.body.note.text || '',
+						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
 						badge: iconUrl('quote'),
 						data,
@@ -162,7 +162,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 					}
 
 					return [`${reaction} ${getUserName(data.body.user)}`, {
-						body: data.body.note.text || '',
+						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
 						badge,
 						data,
@@ -227,9 +227,9 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 					}];
 
 				case 'app':
-					return [data.body.header || data.body.body, {
-						body: data.body.header && data.body.body,
-						icon: data.body.icon,
+					return [data.body.header ?? data.body.body, {
+						body: data.body.header ?? data.body.body,
+						icon: data.body.icon ?? undefined,
 						data,
 					}];
 
@@ -246,7 +246,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 					renotify: true,
 				}];
 			}
-			return [t('_notification.youGotMessagingMessageFromGroup', { name: data.body.group.name }), {
+			return [t('_notification.youGotMessagingMessageFromGroup', { name: data.body.group?.name ?? '' }), {
 				icon: data.body.user.avatarUrl,
 				badge: iconUrl('messages'),
 				tag: `messaging:group:${data.body.groupId}`,
@@ -255,7 +255,7 @@ async function composeNotification<K extends keyof pushNotificationDataMap>(data
 			}];
 		case 'unreadAntennaNote':
 			return [t('_notification.unreadAntennaNote', { name: data.body.antenna.name }), {
-				body: `${getUserName(data.body.note.user)}: ${data.body.note.text || ''}`,
+				body: `${getUserName(data.body.note.user)}: ${data.body.note.text ?? ''}`,
 				icon: data.body.note.user.avatarUrl,
 				badge: iconUrl('antenna'),
 				tag: `antenna:${data.body.antenna.id}`,
@@ -272,7 +272,7 @@ export async function createEmptyNotification() {
 		if (!swLang.i18n) swLang.fetchLocale();
 		const i18n = await swLang.i18n as I18n<any>;
 		const { t } = i18n;
-	
+
 		await self.registration.showNotification(
 			t('_notification.emptyPushNotificationMessage'),
 			{

--- a/packages/sw/src/scripts/get-user-name.ts
+++ b/packages/sw/src/scripts/get-user-name.ts
@@ -1,3 +1,7 @@
 export default function(user: { name?: string | null, username: string }): string {
+	// Show username if name is empty.
+	// XXX: typescript-eslint has no configuration to allow using `||` against string.
+	// https://github.com/typescript-eslint/typescript-eslint/issues/4906
+	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 	return user.name || user.username;
 }

--- a/packages/sw/src/scripts/notification-read.ts
+++ b/packages/sw/src/scripts/notification-read.ts
@@ -28,7 +28,7 @@ class SwNotificationReadManager {
 	}
 
 	// プッシュ通知の既読をサーバーに送信
-	public async read<K extends keyof pushNotificationDataMap>(data: pushNotificationDataMap[K]) {
+	public async read(data: pushNotificationDataMap[keyof pushNotificationDataMap]) {
 		if (data.type !== 'notification' || !(data.userId in this.accounts)) return;
 
 		const account = this.accounts[data.userId];

--- a/packages/sw/tsconfig.json
+++ b/packages/sw/tsconfig.json
@@ -34,7 +34,6 @@
 	},
 	"compileOnSave": false,
 	"include": [
-		"./**/*.ts",
-		"../frontend/@types/global.d.ts"
+		"./**/*.ts"
 	]
 }

--- a/packages/sw/tsconfig.json
+++ b/packages/sw/tsconfig.json
@@ -34,6 +34,7 @@
 	},
 	"compileOnSave": false,
 	"include": [
-		"./**/*.ts"
+		"./**/*.ts",
+		"../frontend/@types/global.d.ts"
 	]
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

1. Moved `keyof T` from type parameter to index argument
2. Replaced `||` with `??` when makes sense
3. Replaced `self.` with `globalThis.`

<!-- -->

1. `keyof T`をtype parameterからindex argumentに運びました
2. 適切な場合、`||`を`??`にしました。
3. `self.`を`globalThis.`にしました。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

1. To let switch-case type assertion actually narrow the type of `data`
2. To reduce type errors
3. To workaround TypeScript issue where `self` is WorkerGlobalScope instead of ServiceWorkerGlobalScope.

<!-- -->

1. switch-caseで`data`のタイプの絞り込みを可能にするため
2. エラーの数を減らすため
3. TypeScript側の問題で`self`が`ServiceWorkerGlobalScope`ではなく`WorkerGlobalScope`になっているのでそこをなんとかするため

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

残りのエラーはｍisskey-jsの修正が必要です。