### PR TITLE
chore: Pagesに新しく作成されたtext要素に変数を埋め込まないように

### DIFF
--- a/packages/frontend/src/components/page/page.text.vue
+++ b/packages/frontend/src/components/page/page.text.vue
@@ -28,7 +28,7 @@ export default defineComponent({
 	},
 	data() {
 		return {
-			text: this.hpml.interpolate(this.block.text),
+			text: this.block.noInterpolate ? this.block.text : this.hpml.interpolate(this.block.text),
 		};
 	},
 	computed: {
@@ -43,7 +43,7 @@ export default defineComponent({
 	watch: {
 		'hpml.vars': {
 			handler() {
-				this.text = this.hpml.interpolate(this.block.text);
+				this.text = this.block.noInterpolate ? this.block.text : this.hpml.interpolate(this.block.text);
 			},
 			deep: true,
 		},

--- a/packages/frontend/src/pages/page-editor/els/page-editor.el.text.vue
+++ b/packages/frontend/src/pages/page-editor/els/page-editor.el.text.vue
@@ -24,6 +24,9 @@ const emit = defineEmits<{
 
 const text = $ref(props.modelValue.text ?? '');
 
+// 新規ページではテキストへの変数の挿入を無効化
+if (props.modelValue.text === undefined) props.modelValue.noInterpolate = true;
+
 watch($$(text), () => {
 	emit('update:modelValue', {
 		...props.modelValue,

--- a/packages/frontend/src/pages/page-editor/page-editor.vue
+++ b/packages/frontend/src/pages/page-editor/page-editor.vue
@@ -260,6 +260,7 @@ async function init() {
 			id,
 			type: 'text',
 			text: 'Hello World!',
+			noInterpolate: true,
 		}];
 	}
 }

--- a/packages/frontend/src/scripts/hpml/block.ts
+++ b/packages/frontend/src/scripts/hpml/block.ts
@@ -8,6 +8,7 @@ export type BlockBase = {
 export type TextBlock = BlockBase & {
 	type: 'text';
 	text: string;
+	noInterpolate: boolean | undefined;
 };
 
 export type SectionBlock = BlockBase & {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
変数を埋め込まないオプションを追加し、新しく作成されたtext要素に適用するように

# Why
- fix #9908
- 互換性のため、従来からあるtext要素では引き続き変数を埋め込む
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
