### PR TITLE
fix: Dev Containerの設定を修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,10 @@
 	"name": "Misskey",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
-	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+	"workspaceFolder": "/workspace",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/pnpm:2": {}
 	},
 	"forwardPorts": [3000],
-	"postCreateCommand": ".devcontainer/init.sh"
+	"postCreateCommand": "sudo chmod 755 .devcontainer/init.sh && .devcontainer/init.sh"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile
 
     volumes:
-      - ../..:/workspaces:cached
+      - ../:/workspace:cached
 
     command: sleep infinity
 
@@ -21,7 +21,7 @@ services:
     networks:
       - internal_network
     volumes:
-      - ../redis:/data
+      - redis-data:/data
     healthcheck:
       test: "redis-cli ping"
       interval: 5s
@@ -37,7 +37,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: misskey
     volumes:
-      - ../db:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
       interval: 5s
@@ -45,6 +45,7 @@ services:
 
 volumes:
   postgres-data:
+  redis-data:
 
 networks:
   internal_network:

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -2,6 +2,7 @@
 
 set -xe
 
+sudo chown -R node /workspace
 git submodule update --init
 pnpm install --frozen-lockfile
 cp .devcontainer/devcontainer.yml .config/default.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ command.
 ### Dev Container
 Instead of running `pnpm` locally, you can use Dev Container to set up your development environment.
 To use Dev Container, open the project directory on VSCode with Dev Containers installed.
+**Note:** If you are using Windows, please clone the repository with WSL. Using Git for Windows will result in broken files due to the difference in how newlines are handled.
 
 It will run the following command automatically inside the container.
 ``` bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ command.
 
 ### Dev Container
 Instead of running `pnpm` locally, you can use Dev Container to set up your development environment.
-To use Dev Container, open the project directory on VSCode with Dev Containers installed.
+To use Dev Container, open the project directory on VSCode with Dev Containers installed.  
 **Note:** If you are using Windows, please clone the repository with WSL. Using Git for Windows will result in broken files due to the difference in how newlines are handled.
 
 It will run the following command automatically inside the container.


### PR DESCRIPTION
# What
- Dev Containerの起動時にプロジェクトディレクトリの権限を適切に変更するように
- Dev Container内にプロジェクトディレクトリの親ディレクトリが含まれていた問題を修正
- PostgreSQLとRedisのデータをマウントしたディレクトリではなくVolume内に保持するように
- CONTRIBUTING.mdにWindowsで実行する際はWSL内でcloneするべきという旨を記載

# Why
1. #9917 において一部のケースにおいてファイルの権限が適切に設定されていない場合があることが判明したため
2. プロジェクトディレクトリの親ディレクトリはMisskeyの開発環境に必要無いため
3. Git for Windowsでcloneしてしまうとファイルの改行がCRLFで行われるようになってしまい、壊れるため

# Additional info (optional)
Closes #9917 (一部の挙動が手元で再現できなかったため完全に修正されるかが確認できず)