### PR TITLE
fix: Allow configuring of the host/address to listen/bind to

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -30,6 +30,9 @@ url: https://example.tld/
 # The port that your Misskey server should listen on.
 port: 3000
 
+# The hostname or address to listen on (default: all)
+#host: "127.0.0.1"
+
 #   ┌──────────────────────────┐
 #───┘ PostgreSQL configuration └────────────────────────────────
 

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -78,7 +78,7 @@ export async function masterMain() {
 		await spawnWorkers(config.clusterLimit);
 	}
 
-	bootLogger.succ(`Now listening on port ${config.port} on ${config.url}`, null, true);
+	bootLogger.succ(`Now listening on ${config.host ? `[${config.host}]:` : ''}${config.port} for ${config.url}`, null, true);
 }
 
 function showEnvironment(): void {

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -15,6 +15,7 @@ export type Source = {
 	feedback_url?: string;
 	url: string;
 	port: number;
+	host: string;
 	disableHsts?: boolean;
 	db: {
 		host: string;
@@ -125,6 +126,7 @@ export function loadConfig() {
 	config.url = url.origin;
 
 	config.port = config.port ?? parseInt(process.env.PORT ?? '', 10);
+	config.host = config.host ?? process.env.HOST;
 
 	mixin.version = meta.version;
 	mixin.host = url.host;

--- a/packages/backend/src/server/ServerService.ts
+++ b/packages/backend/src/server/ServerService.ts
@@ -177,10 +177,10 @@ export class ServerService {
 		fastify.server.on('error', err => {
 			switch ((err as any).code) {
 				case 'EACCES':
-					this.logger.error(`You do not have permission to listen on port ${this.config.port}.`);
+					this.logger.error(`You do not have permission to listen on port ${this.config.port}${this.config.host ? ` of host ${this.config.host}` : ''}`);
 					break;
 				case 'EADDRINUSE':
-					this.logger.error(`Port ${this.config.port} is already in use by another process.`);
+					this.logger.error(`Port ${this.config.port}${this.config.host ? ` on ${this.config.host}` : ''} is already in use by another process.`);
 					break;
 				default:
 					this.logger.error(err);
@@ -195,6 +195,6 @@ export class ServerService {
 			}
 		});
 
-		fastify.listen({ port: this.config.port, host: '0.0.0.0' });
+		fastify.listen({ port: this.config.port, host: this.config.host });
 	}
 }

--- a/packages/backend/test/utils.ts
+++ b/packages/backend/test/utils.ts
@@ -19,6 +19,7 @@ const _dirname = dirname(_filename);
 
 const config = loadConfig();
 export const port = config.port;
+export const host = config.host || "localhost";
 
 export const api = async (endpoint: string, params: any, me?: any) => {
 	endpoint = endpoint.replace(/^\//, '');
@@ -28,7 +29,7 @@ export const api = async (endpoint: string, params: any, me?: any) => {
 	} : {};
 
 	try {
-		const res = await got<string>(`http://localhost:${port}/api/${endpoint}`, {
+		const res = await got<string>(`http://${host}:${port}/api/${endpoint}`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
@@ -66,7 +67,7 @@ export const request = async (path: string, params: any, me?: any): Promise<{ bo
 		i: me.token,
 	} : {};
 
-	const res = await fetch(`http://localhost:${port}/${path}`, {
+	const res = await fetch(`http://${host}:${port}/${path}`, {
 		method: 'POST',
 		headers: {
 			'Content-Type': 'application/json',
@@ -123,7 +124,7 @@ export const uploadFile = async (user: any, _path?: string): Promise<any> => {
 	formData.append('file', fs.createReadStream(absPath));
 	formData.append('force', 'true');
 
-	const res = await got<string>(`http://localhost:${port}/api/drive/files/create`, {
+	const res = await got<string>(`http://${host}:${port}/api/drive/files/create`, {
 		method: 'POST',
 		body: formData,
 		retry: {
@@ -160,7 +161,7 @@ export const uploadUrl = async (user: any, url: string) => {
 
 export function connectStream(user: any, channel: string, listener: (message: Record<string, any>) => any, params?: any): Promise<WebSocket> {
 	return new Promise((res, rej) => {
-		const ws = new WebSocket(`ws://localhost:${port}/streaming?i=${user.token}`);
+		const ws = new WebSocket(`ws://${host}:${port}/streaming?i=${user.token}`);
 
 		ws.on('open', () => {
 			ws.on('message', data => {
@@ -222,7 +223,7 @@ export const waitFire = async (user: any, channel: string, trgr: () => any, cond
 export const simpleGet = async (path: string, accept = '*/*'): Promise<{ status?: number, type?: string, location?: string }> => {
 	// node-fetchだと3xxを取れない
 	return await new Promise((resolve, reject) => {
-		const req = http.request(`http://localhost:${port}${path}`, {
+		const req = http.request(`http://${host}:${port}${path}`, {
 			headers: {
 				Accept: accept,
 			},


### PR DESCRIPTION
First of all, the default behavior of node.js server is to listen on all addresses of **both** IPv4 and IPv6. However, Misskey was hard-coded to listen on `"0.0.0.0"`, which makes node.js listen on IPv4 only.

Second, the administrator should be able to configure the host, **just like any other server allows you to do**. In production, when the server is behind a reverse proxy, it is a good idea to make the backend listen only on a loopback address, so that it is not publicly exposed. There are also other possible reasons, for example, binding to port 80 of an IPv6 address to connect directly to Cloudflare, without conflicting with other web servers on the same system.

So with this PR, `host` can be configured just like `port`, and it defaults to `undefined` so node.js listens on both stacks, not just IPv4. Closes #7738 