### PR TITLE
バインドマウントではなくDocker Volumeを使う

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -57,7 +57,7 @@ services:
 #    networks:
 #      - internal_network
 #    volumes:
-#      - ./elasticsearch:/usr/share/elasticsearch/data
+#      - elasticsearch:/usr/share/elasticsearch/data
 
 networks:
   internal_network:

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -19,7 +19,7 @@ services:
       - internal_network
       - external_network
     volumes:
-      - ./files:/misskey/files
+      - files:/misskey/files
       - ./.config:/misskey/.config:ro
 
   redis:
@@ -28,7 +28,7 @@ services:
     networks:
       - internal_network
     volumes:
-      - ./redis:/data
+      - redis:/data
     healthcheck:
       test: "redis-cli ping"
       interval: 5s
@@ -42,7 +42,7 @@ services:
     env_file:
       - .config/docker.env
     volumes:
-      - ./db:/var/lib/postgresql/data
+      - db:/var/lib/postgresql/data
     healthcheck:
       test: "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"
       interval: 5s
@@ -63,3 +63,9 @@ networks:
   internal_network:
     internal: true
   external_network:
+
+volumes:
+  files:
+  redis:
+  db:
+  # elasticsearch:


### PR DESCRIPTION
# What
バインドマウントはDBなどでパフォーマンスが低下しやすい（特にmacOSやWindowsなどの異なるOSファミリーを介した起動）

また、DBはファイルを直接操作するシーンがないため、基本的にはDocker Volumeを使った方が望ましい

ただし、何も考えずに移行するとDBなどが吹っ飛んでしまうため、移行ステップとして起動時に docker cp などを用いるべき

# Why


# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
