### PR TITLE
絵文字の名前に@や:が使用できる

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -18,6 +18,16 @@ export const meta = {
 			message: 'No such emoji.',
 			code: 'NO_SUCH_EMOJI',
 			id: '684dec9d-a8c2-4364-9aa8-456c49cb1dc8',
+		},		
+		inappropriateEmojiName: {
+			message: 'Inappropriate emoji name',
+			code: 'INAPPROPRIATE_EMOJI_NAME',
+			id: '50733374-0f01-555f-1675-87382494561f',
+		},
+		alreadyexistsemoji: {
+			message: 'Emoji already exists',
+			code: 'EMOJI_ALREADY_EXISTS',
+			id: '7180fe9d-1ee3-bff9-647d-fe9896d2ffb8',
 		},
 	},
 } as const;
@@ -56,9 +66,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const emoji = await this.emojisRepository.findOneBy({ id: ps.id });
-
+			const emojiname = await this.emojisRepository.findOneBy({name:ps.name})
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
-
+			if (ps.name.match(/[\@\:\/\?\;\-\~\|\\\&\%\$\#\"\(\)\^\=\'\!\`\*\+\-\{\}\>\<\,\[\]]/g) != null) throw new ApiError(meta.errors.inappropriateEmojiName);
+			if (ps.name.match(/(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g) != null) throw new ApiError(meta.errors.inappropriateEmojiName);
+			if (emojiname != null) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),
 				name: ps.name,

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -66,10 +66,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const emoji = await this.emojisRepository.findOneBy({ id: ps.id });
-			const emojiname = await this.emojisRepository.findOneBy({name:ps.name})
+			const emojiname = await this.emojisRepository.findOneBy({ name: ps.name });
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
 			if (ps.name.match(/^[a-zA-Z0-9_]+$/) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
-			if (emojiname != null && emojiname.id != ps.id) throw new ApiError(meta.errors.alreadyexistsemoji);
+			if (emojiname != null && emojiname.id !== ps.id) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),
 				name: ps.name,

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -18,11 +18,6 @@ export const meta = {
 			message: 'No such emoji.',
 			code: 'NO_SUCH_EMOJI',
 			id: '684dec9d-a8c2-4364-9aa8-456c49cb1dc8',
-		},		
-		inappropriateEmojiName: {
-			message: 'Inappropriate emoji name',
-			code: 'INAPPROPRIATE_EMOJI_NAME',
-			id: '50733374-0f01-555f-1675-87382494561f',
 		},
 		alreadyexistsemoji: {
 			message: 'Emoji already exists',
@@ -36,7 +31,7 @@ export const paramDef = {
 	type: 'object',
 	properties: {
 		id: { type: 'string', format: 'misskey:id' },
-		name: { type: 'string' },
+		name: { type: 'string', pattern: '^[a-zA-Z0-9_]+$' },
 		category: {
 			type: 'string',
 			nullable: true,
@@ -68,7 +63,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			const emoji = await this.emojisRepository.findOneBy({ id: ps.id });
 			const emojiname = await this.emojisRepository.findOneBy({ name: ps.name });
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
-			if (ps.name.match(/^[a-zA-Z0-9_]+$/) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
 			if (emojiname != null && emojiname.id !== ps.id) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -68,8 +68,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			const emoji = await this.emojisRepository.findOneBy({ id: ps.id });
 			const emojiname = await this.emojisRepository.findOneBy({name:ps.name})
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
-			if (ps.name.match(/[\@\:\/\?\;\-\~\|\\\&\%\$\#\"\(\)\^\=\'\!\`\*\+\-\{\}\>\<\,\[\]]/g) != null) throw new ApiError(meta.errors.inappropriateEmojiName);
-			if (ps.name.match(/(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])/g) != null) throw new ApiError(meta.errors.inappropriateEmojiName);
+			if (ps.name.match(/^[a-zA-Z0-9_]+$/)) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
 			if (emojiname != null) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -68,7 +68,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			const emoji = await this.emojisRepository.findOneBy({ id: ps.id });
 			const emojiname = await this.emojisRepository.findOneBy({name:ps.name})
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
-			if (ps.name.match(/^[a-zA-Z0-9_]+$/)) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
+			if (ps.name.match(/^[a-zA-Z0-9_]+$/) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
 			if (emojiname != null) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),

--- a/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/emoji/update.ts
@@ -69,7 +69,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			const emojiname = await this.emojisRepository.findOneBy({name:ps.name})
 			if (emoji == null) throw new ApiError(meta.errors.noSuchEmoji);
 			if (ps.name.match(/^[a-zA-Z0-9_]+$/) == null) throw new ApiError(meta.errors.inappropriateEmojiName);
-			if (emojiname != null) throw new ApiError(meta.errors.alreadyexistsemoji);
+			if (emojiname != null && emojiname.id != ps.id) throw new ApiError(meta.errors.alreadyexistsemoji);
 			await this.emojisRepository.update(emoji.id, {
 				updatedAt: new Date(),
 				name: ps.name,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

絵文字追加後のUpdateにて@や:、Unicode絵文字等をカスタム絵文字名に追加できないようにした

下記正規表現
`/^[a-z0-9_]+$/`
絵文字名の被りが無いかチェックも追加

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
絵文字名にて予想外の文字が含まれていた場合に正常に読み込めなくなる為
(#9918)
# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカル環境にてテスト済み
下記確認
・絵文字に英数字アンダーバーのみを登録できること
・日本語のみでエラー
・日本語含む英数字でエラー
・ユニコード絵文字のみでエラー
・同じ絵文字名が合った場合エラー