### PR TITLE
fix/enhance(sw): プッシュ通知 (バックグラウンドで開いている場合も通知, リアクション通知はノートにつき1つに)

### DIFF
--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -10,6 +10,13 @@ import { getAccountFromId } from '@/scripts/get-account-from-id';
 import { char2fileName } from '@/scripts/twemoji-base';
 import * as url from '@/scripts/url';
 
+const closeNotificationsByTags = async (tags: string[]) => {
+	// Chromeはtagを指定すると以前の通知を上書きするが、Safariは上書きしないので閉じてあげる
+	for (const n of (await Promise.all(tags.map(tag => globalThis.registration.getNotifications({ tag })))).flat()) {
+		n.close();
+	}
+}
+
 const iconUrl = (name: badgeNames) => `/static-assets/tabler-badges/${name}.png`;
 /* How to add a new badge:
  * 1. Find the icon and download png from https://tabler-icons.io/
@@ -161,6 +168,8 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 						badge = iconUrl('plus');
 					}
 
+					const tag = `reaction:${data.body.note.id}`;
+					await closeNotificationsByTags([tag]);
 					return [`${reaction} ${getUserName(data.body.user)}`, {
 						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
@@ -176,10 +185,12 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 				}
 
 				case 'pollEnded':
+					const tag = `poll:${data.body.note.id}`;
+					await closeNotificationsByTags([tag]);
 					return [t('_notification.pollEnded'), {
 						body: data.body.note.text || '',
 						badge: iconUrl('chart-arrows'),
-						tag: `poll:${data.body.note.id}`,
+						tag,
 						data,
 					}];
 
@@ -220,11 +231,13 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 					return null;
 			}
 		case 'unreadAntennaNote':
+			const tag = `antenna:${data.body.antenna.id}`;
+			await closeNotificationsByTags([tag]);
 			return [t('_notification.unreadAntennaNote', { name: data.body.antenna.name }), {
 				body: `${getUserName(data.body.note.user)}: ${data.body.note.text ?? ''}`,
 				icon: data.body.note.user.avatarUrl,
 				badge: iconUrl('antenna'),
-				tag: `antenna:${data.body.antenna.id}`,
+				tag,
 				data,
 				renotify: true,
 			}];
@@ -250,12 +263,7 @@ export async function createEmptyNotification() {
 
 		setTimeout(async () => {
 			try {
-				for (const n of [
-					...(await globalThis.registration.getNotifications({ tag: 'user_visible_auto_notification' })),
-					...(await globalThis.registration.getNotifications({ tag: 'read_notification' })),
-				]) {
-					n.close();
-				}
+				await closeNotificationsByTags(['user_visible_auto_notification', 'read_notification']);
 			} finally {
 				res();
 			}

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -11,7 +11,6 @@ import { char2fileName } from '@/scripts/twemoji-base';
 import * as url from '@/scripts/url';
 
 const closeNotificationsByTags = async (tags: string[]) => {
-	// Chromeはtagを指定すると以前の通知を上書きするが、Safariは上書きしないので閉じてあげる
 	for (const n of (await Promise.all(tags.map(tag => globalThis.registration.getNotifications({ tag })))).flat()) {
 		n.close();
 	}
@@ -169,7 +168,6 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 					}
 
 					const tag = `reaction:${data.body.note.id}`;
-					await closeNotificationsByTags([tag]);
 					return [`${reaction} ${getUserName(data.body.user)}`, {
 						body: data.body.note.text ?? '',
 						icon: data.body.user.avatarUrl,
@@ -186,7 +184,6 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 
 				case 'pollEnded':
 					const tag = `poll:${data.body.note.id}`;
-					await closeNotificationsByTags([tag]);
 					return [t('_notification.pollEnded'), {
 						body: data.body.note.text || '',
 						badge: iconUrl('chart-arrows'),
@@ -232,7 +229,6 @@ async function composeNotification(data: pushNotificationDataMap[keyof pushNotif
 			}
 		case 'unreadAntennaNote':
 			const tag = `antenna:${data.body.antenna.id}`;
-			await closeNotificationsByTags([tag]);
 			return [t('_notification.unreadAntennaNote', { name: data.body.antenna.name }), {
 				body: `${getUserName(data.body.note.user)}: ${data.body.note.text ?? ''}`,
 				icon: data.body.note.user.avatarUrl,

--- a/packages/sw/src/scripts/create-notification.ts
+++ b/packages/sw/src/scripts/create-notification.ts
@@ -248,16 +248,16 @@ export async function createEmptyNotification() {
 			},
 		);
 
-		res();
-
 		setTimeout(async () => {
-			for (const n of
-				[
+			try {
+				for (const n of [
 					...(await globalThis.registration.getNotifications({ tag: 'user_visible_auto_notification' })),
 					...(await globalThis.registration.getNotifications({ tag: 'read_notification' })),
-				]
-			) {
-				n.close();
+				]) {
+					n.close();
+				}
+			} finally {
+				res();
 			}
 		}, 1000);
 	});

--- a/packages/sw/src/sw.ts
+++ b/packages/sw/src/sw.ts
@@ -53,9 +53,6 @@ globalThis.addEventListener('push', ev => {
 				// 1日以上経過している場合は無視
 				if ((new Date()).getTime() - data.dateTime > 1000 * 60 * 60 * 24) break;
 
-				// クライアントがあったらストリームに接続しているということなので通知しない
-				if (clients.length !== 0) break;
-
 				return createNotification(data);
 			case 'readAllNotifications':
 				for (const n of await globalThis.registration.getNotifications()) {
@@ -83,7 +80,8 @@ globalThis.addEventListener('push', ev => {
 				break;
 		}
 
-		return createEmptyNotification();
+		await createEmptyNotification();
+		return;
 	}));
 });
 


### PR DESCRIPTION
- クライアントがあってもpush notificationを無視しない
  * 「プッシュ通知を更新しました」の原因になるため
- リアクション通知は1つのノートにつき1つしか表示しない
