### PR TITLE
fix : メールのやつが崩れてたのを直した

### DIFF
--- a/packages/backend/src/core/EmailService.ts
+++ b/packages/backend/src/core/EmailService.ts
@@ -89,11 +89,7 @@ export class EmailService {
 					padding: 32px;
 					background: #86b300;
 				}
-					main > header > img {
-						max-width: 128px;
-						max-height: 28px;
-						vertical-align: bottom;
-					}
+
 				main > article {
 					padding: 32px;
 				}
@@ -108,7 +104,7 @@ export class EmailService {
 			nav {
 				box-sizing: border-box;
 				max-width: 500px;
-				margin: 16px auto 0 auto;
+				margin: 16px auto 16px auto;
 				padding: 0 32px;
 			}
 				nav > a {
@@ -119,7 +115,7 @@ export class EmailService {
 	<body>
 		<main>
 			<header>
-				<img src="${ meta.logoImageUrl ?? meta.iconUrl ?? iconUrl }"/>
+				<img style="max-width: 128px; max-height: 28px; vertical-align: bottom;" src="${ meta.logoImageUrl ?? meta.iconUrl ?? iconUrl }"/>
 			</header>
 			<article>
 				<h1>${ subject }</h1>


### PR DESCRIPTION
imgタグにそのままstyleを書き込むことで解決させたけどこれが正しいのかは不明です

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
cssをそのままimgのタグに書きこんだ
bottomのマージンを下も16pxに指定するようにした
# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
メールのhtmlが崩れていたため

修正前(左)後(右)
![image](https://user-images.githubusercontent.com/56515516/219851416-aa3013b2-1ed8-4931-90e0-a59d735eb38c.png)
