### PR TITLE
fix: 削除済みのユーザーが deleteActor される時に処理をスキップする

### DIFF
--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -452,7 +452,7 @@ export class ApInboxService {
 	
 		const user = await this.usersRepository.findOneByOrFail({ id: actor.id });
 		if (user.isDeleted) {
-			this.logger.info('skip: already deleted');
+			return 'skip: already deleted';
 		}
 	
 		const job = await this.queueService.createDeleteAccountJob(actor);


### PR DESCRIPTION
# What
ActivityPub でユーザーの削除を受信してユーザーの削除済みフラグを立てる処理をする際、既にそのユーザーの削除済みフラグが立っている場合に正しくスキップするようになる。

# Why
スキップするログが残るようになっているが実際にはスキップされていないため。