### PR TITLE
管理画面の広告を10個以上見えるように

### DIFF
--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -50,7 +50,8 @@
 				</div>
 			</div>
 			<MkButton class="button" @click="more()">
-			<i class="ti ti-reload"></i>{{ i18n.ts.more }}</MkButton>
+				<i class="ti ti-reload"></i>{{ i18n.ts.more }}
+			</MkButton>
 		</MkSpacer>
 	</MkStickyContainer>
 </template>

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -130,7 +130,7 @@ function save(ad) {
 	}
 }
 function more() {
-	os.api('admin/ad/list', { untilId: ads.reduce((acc, ad ) => {return ad.id != null ? ad : acc;}).id }).then(adsResponse => {
+	os.api('admin/ad/list', { untilId: ads.reduce((acc, ad) => ad.id != null ? ad : acc).id }).then(adsResponse => {
 	ads = ads.concat(adsResponse.map(r => {
 			const exdate = new Date(r.expiresAt);
 			const stdate = new Date(r.startsAt);

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -1,52 +1,47 @@
 <template>
-	<MkStickyContainer>
-		<template #header>
-			<XHeader :actions="headerActions" :tabs="headerTabs" />
-		</template>
-		<MkSpacer :content-max="900">
-			<div class="uqshojas">
-				<div v-for="ad in ads" class="_panel _gaps_m ad">
-					<MkAd v-if="ad.url" :specify="ad" />
-					<MkInput v-model="ad.url" type="url">
-						<template #label>URL</template>
+<MkStickyContainer>
+	<template #header><XHeader :actions="headerActions" :tabs="headerTabs"/></template>
+	<MkSpacer :content-max="900">
+		<div class="uqshojas">
+			<div v-for="ad in ads" class="_panel _gaps_m ad">
+				<MkAd v-if="ad.url" :specify="ad"/>
+				<MkInput v-model="ad.url" type="url">
+					<template #label>URL</template>
+				</MkInput>
+				<MkInput v-model="ad.imageUrl">
+					<template #label>{{ i18n.ts.imageUrl }}</template>
+				</MkInput>
+				<MkRadios v-model="ad.place">
+					<template #label>Form</template>
+					<option value="square">square</option>
+					<option value="horizontal">horizontal</option>
+					<option value="horizontal-big">horizontal-big</option>
+				</MkRadios>
+				<!--
+			<div style="margin: 32px 0;">
+				{{ i18n.ts.priority }}
+				<MkRadio v-model="ad.priority" value="high">{{ i18n.ts.high }}</MkRadio>
+				<MkRadio v-model="ad.priority" value="middle">{{ i18n.ts.middle }}</MkRadio>
+				<MkRadio v-model="ad.priority" value="low">{{ i18n.ts.low }}</MkRadio>
+			</div>
+			-->
+				<FormSplit>
+					<MkInput v-model="ad.ratio" type="number">
+						<template #label>{{ i18n.ts.ratio }}</template>
 					</MkInput>
-					<MkInput v-model="ad.imageUrl">
-						<template #label>{{ i18n.ts.imageUrl }}</template>
+					<MkInput v-model="ad.startsAt" type="datetime-local">
+						<template #label>{{ i18n.ts.startingperiod }}</template>
 					</MkInput>
-					<MkRadios v-model="ad.place">
-						<template #label>Form</template>
-						<option value="square">square</option>
-						<option value="horizontal">horizontal</option>
-						<option value="horizontal-big">horizontal-big</option>
-					</MkRadios>
-					<!--
-					<div style="margin: 32px 0;">
-						{{ i18n.ts.priority }}
-						<MkRadio v-model="ad.priority" value="high">{{ i18n.ts.high }}</MkRadio>
-						<MkRadio v-model="ad.priority" value="middle">{{ i18n.ts.middle }}</MkRadio>
-						<MkRadio v-model="ad.priority" value="low">{{ i18n.ts.low }}</MkRadio>
-					</div>
-					-->
-					<FormSplit>
-						<MkInput v-model="ad.ratio" type="number">
-							<template #label>{{ i18n.ts.ratio }}</template>
-						</MkInput>
-						<MkInput v-model="ad.startsAt" type="datetime-local">
-							<template #label>{{ i18n.ts.startingperiod }}</template>
-						</MkInput>
-						<MkInput v-model="ad.expiresAt" type="datetime-local">
-							<template #label>{{ i18n.ts.expiration }}</template>
-						</MkInput>
-					</FormSplit>
-					<MkTextarea v-model="ad.memo">
-						<template #label>{{ i18n.ts.memo }}</template>
-					</MkTextarea>
-					<div class="buttons">
-						<MkButton class="button" inline primary style="margin-right: 12px;" @click="save(ad)"><i
-								class="ti ti-device-floppy"></i> {{ i18n.ts.save }}</MkButton>
-						<MkButton class="button" inline danger @click="remove(ad)"><i class="ti ti-trash"></i> {{ i18n.ts.remove }}
-						</MkButton>
-					</div>
+					<MkInput v-model="ad.expiresAt" type="datetime-local">
+						<template #label>{{ i18n.ts.expiration }}</template>
+					</MkInput>
+				</FormSplit>
+				<MkTextarea v-model="ad.memo">
+					<template #label>{{ i18n.ts.memo }}</template>
+				</MkTextarea>
+				<div class="buttons">
+					<MkButton class="button" inline primary style="margin-right: 12px;" @click="save(ad)"><i class="ti ti-device-floppy"></i> {{ i18n.ts.save }}</MkButton>
+					<MkButton class="button" inline danger @click="remove(ad)"><i class="ti ti-trash"></i> {{ i18n.ts.remove }}</MkButton>
 				</div>
 			</div>
 			<MkButton class="button" @click="more()">

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -161,7 +161,7 @@ definePageMetadata({
 
 <style lang="scss" scoped>
 .uqshojas {
-	>.ad {
+	> .ad {
 		padding: 32px;
 
 		&:not(:last-child) {

--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -5,52 +5,52 @@
 		</template>
 		<MkSpacer :content-max="900">
 			<div class="uqshojas">
-				<MkPagination v-slot="{ items }" :pagination="pagination" :on-vnode-updated="update()">
-					<div v-for="ad in items" class="_panel _gaps_m ad">
-						<MkAd v-if="ad.url" :specify="ad" />
-						<MkInput v-model="ad.url" type="url">
-							<template #label>URL</template>
-						</MkInput>
-						<MkInput v-model="ad.imageUrl">
-							<template #label>{{ i18n.ts.imageUrl }}</template>
-						</MkInput>
-						<MkRadios v-model="ad.place">
-							<template #label>Form</template>
-							<option value="square">square</option>
-							<option value="horizontal">horizontal</option>
-							<option value="horizontal-big">horizontal-big</option>
-						</MkRadios>
-						<!--
-				<div style="margin: 32px 0;">
-					{{ i18n.ts.priority }}
-					<MkRadio v-model="ad.priority" value="high">{{ i18n.ts.high }}</MkRadio>
-					<MkRadio v-model="ad.priority" value="middle">{{ i18n.ts.middle }}</MkRadio>
-					<MkRadio v-model="ad.priority" value="low">{{ i18n.ts.low }}</MkRadio>
-				</div>
-				-->
-						<FormSplit>
-							<MkInput v-model="ad.ratio" type="number">
-								<template #label>{{ i18n.ts.ratio }}</template>
-							</MkInput>
-							<MkInput v-model="ad.startsAt" type="datetime-local">
-								<template #label>{{ i18n.ts.startingperiod }}</template>
-							</MkInput>
-							<MkInput v-model="ad.expiresAt" type="datetime-local">
-								<template #label>{{ i18n.ts.expiration }}</template>
-							</MkInput>
-						</FormSplit>
-						<MkTextarea v-model="ad.memo">
-							<template #label>{{ i18n.ts.memo }}</template>
-						</MkTextarea>
-						<div class="buttons">
-							<MkButton class="button" inline primary style="margin-right: 12px;" @click="save(ad)"><i
-									class="ti ti-device-floppy"></i> {{ i18n.ts.save }}</MkButton>
-							<MkButton class="button" inline danger @click="remove(ad)"><i class="ti ti-trash"></i> {{ i18n.ts.remove }}
-							</MkButton>
-						</div>
+				<div v-for="ad in ads" class="_panel _gaps_m ad">
+					<MkAd v-if="ad.url" :specify="ad" />
+					<MkInput v-model="ad.url" type="url">
+						<template #label>URL</template>
+					</MkInput>
+					<MkInput v-model="ad.imageUrl">
+						<template #label>{{ i18n.ts.imageUrl }}</template>
+					</MkInput>
+					<MkRadios v-model="ad.place">
+						<template #label>Form</template>
+						<option value="square">square</option>
+						<option value="horizontal">horizontal</option>
+						<option value="horizontal-big">horizontal-big</option>
+					</MkRadios>
+					<!--
+					<div style="margin: 32px 0;">
+						{{ i18n.ts.priority }}
+						<MkRadio v-model="ad.priority" value="high">{{ i18n.ts.high }}</MkRadio>
+						<MkRadio v-model="ad.priority" value="middle">{{ i18n.ts.middle }}</MkRadio>
+						<MkRadio v-model="ad.priority" value="low">{{ i18n.ts.low }}</MkRadio>
 					</div>
-				</MkPagination>
+					-->
+					<FormSplit>
+						<MkInput v-model="ad.ratio" type="number">
+							<template #label>{{ i18n.ts.ratio }}</template>
+						</MkInput>
+						<MkInput v-model="ad.startsAt" type="datetime-local">
+							<template #label>{{ i18n.ts.startingperiod }}</template>
+						</MkInput>
+						<MkInput v-model="ad.expiresAt" type="datetime-local">
+							<template #label>{{ i18n.ts.expiration }}</template>
+						</MkInput>
+					</FormSplit>
+					<MkTextarea v-model="ad.memo">
+						<template #label>{{ i18n.ts.memo }}</template>
+					</MkTextarea>
+					<div class="buttons">
+						<MkButton class="button" inline primary style="margin-right: 12px;" @click="save(ad)"><i
+								class="ti ti-device-floppy"></i> {{ i18n.ts.save }}</MkButton>
+						<MkButton class="button" inline danger @click="remove(ad)"><i class="ti ti-trash"></i> {{ i18n.ts.remove }}
+						</MkButton>
+					</div>
+				</div>
 			</div>
+			<MkButton class="button" @click="more()">
+			<i class="ti ti-reload"></i>{{ i18n.ts.more }}</MkButton>
 		</MkSpacer>
 	</MkStickyContainer>
 </template>
@@ -62,7 +62,6 @@ import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
 import MkTextarea from '@/components/MkTextarea.vue';
 import MkRadios from '@/components/MkRadios.vue';
-import MkPagination from '@/components/MkPagination.vue';
 import FormSplit from '@/components/form/split.vue';
 import * as os from '@/os';
 import { i18n } from '@/i18n';
@@ -74,24 +73,19 @@ let ads: any[] = $ref([]);
 const localTime = new Date();
 const localTimeDiff = localTime.getTimezoneOffset() * 60 * 1000;
 
-// os.api('admin/ad/list').then(adsResponse => {
-// 	ads = adsResponse.map(r => {
-// 		const exdate = new Date(r.expiresAt);
-// 		const stdate = new Date(r.startsAt);
-// 		exdate.setMilliseconds(exdate.getMilliseconds() - localTimeDiff);
-// 		stdate.setMilliseconds(stdate.getMilliseconds() - localTimeDiff);
-// 		return {
-// 			...r,
-// 			expiresAt: exdate.toISOString().slice(0, 16),
-// 			startsAt: stdate.toISOString().slice(0, 16),
-// 		};
-// 	});
-// });
-
-const pagination = {
-	endpoint: 'admin/ad/list' as const,
-	limit: 10,
-};
+os.api('admin/ad/list').then(adsResponse => {
+	ads = adsResponse.map(r => {
+		const exdate = new Date(r.expiresAt);
+		const stdate = new Date(r.startsAt);
+		exdate.setMilliseconds(exdate.getMilliseconds() - localTimeDiff);
+		stdate.setMilliseconds(stdate.getMilliseconds() - localTimeDiff);
+		return {
+			...r,
+			expiresAt: exdate.toISOString().slice(0, 16),
+			startsAt: stdate.toISOString().slice(0, 16),
+		};
+	});
+});
 
 function add() {
 	ads.unshift({
@@ -135,7 +129,21 @@ function save(ad) {
 		});
 	}
 }
-
+function more() {
+	os.api('admin/ad/list', { untilId: ads.reduce((acc, ad ) => {return ad.id != null ? ad : acc;}).id }).then(adsResponse => {
+	ads = ads.concat(adsResponse.map(r => {
+			const exdate = new Date(r.expiresAt);
+			const stdate = new Date(r.startsAt);
+			exdate.setMilliseconds(exdate.getMilliseconds() - localTimeDiff);
+			stdate.setMilliseconds(stdate.getMilliseconds() - localTimeDiff);
+			return {
+				...r,
+				expiresAt: exdate.toISOString().slice(0, 16),
+				startsAt: stdate.toISOString().slice(0, 16),
+			};
+		}));
+	});
+}
 const headerActions = $computed(() => [{
 	asFullButton: true,
 	icon: 'ti ti-plus',
@@ -160,4 +168,5 @@ definePageMetadata({
 			margin-bottom: var(--margin);
 		}
 	}
-}</style>
+}
+</style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
広告の最大が10個までとなっていたが、ボタンで対応
（できればMKPaginationで対応したかったが時間の変更が必要なため、自分の理解では実装ができなかった）
# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
広告の表示が10個以上表示されないと前回マージされた広告開始期間の設定にて影響があるため
（広告開始期間の設定時に、広告掲載終了も表示するようにしているため）
# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカル環境にて10個づつ表示されるようになった。
また、Addしても正常に処理された
内容の変更等も大丈夫だった
（ただし、ボタンの連打ができてしまう）