### PR TITLE
fix(frontend): Disable prefer-nullish-coalescing eslint rule

### DIFF
--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -21,8 +21,9 @@ module.exports = {
 				'allowSingleExtends': true,
 			},
 		],
+		// frontendでは空文字列のようなfalsyなオブジェクトでもフォールバックしたいことが多いため
 		'@typescript-eslint/prefer-nullish-coalescing': [
-			'error',
+			'off',
 		],
 		// window の禁止理由: グローバルスコープと衝突し、予期せぬ結果を招くため
 		// e の禁止理由: error や event など、複数のキーワードの頭文字であり分かりにくいため


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

frontendではeslintの`@typescript/prefer-nullish-coalescing`ルールを無効化しました。

# Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

ソースコードのコメントにも書きましたが、frontendでは空文字列のようなfalsyなオブジェクトでもフォールバックしたいことが多いためです。

# Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
