### PR TITLE
enhance: make pwa icon maskable

### DIFF
--- a/packages/backend/src/server/web/manifest.json
+++ b/packages/backend/src/server/web/manifest.json
@@ -9,12 +9,14 @@
 		{
 			"src": "/static-assets/icons/192.png",
 			"sizes": "192x192",
-			"type": "image/png"
+			"type": "image/png",
+			"purpose": "maskable"
 		},
 		{
 			"src": "/static-assets/icons/512.png",
 			"sizes": "512x512",
-			"type": "image/png"
+			"type": "image/png",
+			"purpose": "maskable"
 		}
 	],
 	"share_target": {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

# What

Make [the current icon for PWA maskable](https://web.dev/i18n/ja/maskable-icon/).

# Why

Because an installed PWA looks like below.

![](https://web-dev.imgix.net/image/admin/jzjx6dGkXN9EdqnUzAeg.png?auto=format&w=800)

And current icon seems to be maskable already so by having this change PWA users would see a better-looking misskey icon on their desktop.