### PR TITLE
feat(frontend): スマホ・タブレットの場合、チャンネルの投稿フォームに自動でフォーカスしないように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 13.x.x (unreleased)
 
 ### Improvements
+- Frontend: スマホ・タブレットの場合、チャンネルの投稿フォームに自動でフォーカスしないように
 
 ### Bugfixes
 -

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -23,7 +23,8 @@
 				</div>
 			</div>
 
-			<MkPostForm v-if="$i" :channel="channel" class="post-form _panel _margin" fixed/>
+			<!-- スマホ・タブレットの場合、キーボードが表示されると投稿が見づらくなるので、デスクトップ場合のみ自動でフォーカスを当てる -->
+			<MkPostForm v-if="$i" :channel="channel" class="post-form _panel _margin" fixed :autofocus="deviceKind === 'desktop'"/>
 
 			<MkTimeline :key="channelId" class="_margin" src="channel" :channel="channelId" @before="before" @after="after"/>
 		</div>
@@ -41,6 +42,7 @@ import { useRouter } from '@/router';
 import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
+import { deviceKind } from '@/scripts/device-kind';
 
 const router = useRouter();
 


### PR DESCRIPTION
# What

スマホ・タブレットでチャンネルを開いた場合、投稿フォームに自動でフォーカスしないよう変更しました。

# Why

スマホやタブレットでチャンネルを開くと、自動でソフトウェアキーボードが表示されて投稿が見づらいため。

また、それによってキーボードを閉じる動作が必要になるのが煩わしく感じたため。

> 関連する issue : #10045 

# Additional info (optional)

## 動作プレビュー

### スマホで表示 (自動でフォーカスしない)

https://user-images.githubusercontent.com/44780846/220957862-29735be4-88c0-4a5c-90fd-9d16745190bb.mp4

### デスクトップで表示 (自動でフォーカスする)

![demo-pc](https://user-images.githubusercontent.com/44780846/220958354-9b406da8-5a54-4668-959c-84e433626349.gif)
