### PR TITLE
fix/refaftor(client): MkTime.vueの変更

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1490,7 +1490,7 @@ _ago:
   weeksAgo: "{n}週間前"
   monthsAgo: "{n}ヶ月前"
   yearsAgo: "{n}年前"
-  invalid: "不明"
+  invalid: "ありません"
 
 _time:
   second: "秒"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1490,6 +1490,7 @@ _ago:
   weeksAgo: "{n}週間前"
   monthsAgo: "{n}ヶ月前"
   yearsAgo: "{n}年前"
+  invalid: "？"
 
 _time:
   second: "秒"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1490,7 +1490,7 @@ _ago:
   weeksAgo: "{n}週間前"
   monthsAgo: "{n}ヶ月前"
   yearsAgo: "{n}年前"
-  invalid: "？"
+  invalid: "不明"
 
 _time:
   second: "秒"

--- a/packages/frontend/src/components/global/MkTime.vue
+++ b/packages/frontend/src/components/global/MkTime.vue
@@ -1,6 +1,7 @@
 <template>
 <time :title="absolute">
-	<template v-if="mode === 'relative'">{{ relative }}</template>
+	<template v-if="invalid">{{ i18n.ts._ago.invalid }}</template>
+	<template v-else-if="mode === 'relative'">{{ relative }}</template>
 	<template v-else-if="mode === 'absolute'">{{ absolute }}</template>
 	<template v-else-if="mode === 'detail'">{{ absolute }} ({{ relative }})</template>
 </time>
@@ -18,11 +19,14 @@ const props = withDefaults(defineProps<{
 	mode: 'relative',
 });
 
-const _time = typeof props.time === 'string' ? new Date(props.time) : props.time;
-const absolute = dateTimeFormat.format(_time);
+const _time = props.time instanceof Date ? props.time : new Date(props.time);
+const invalid = Number.isNaN(_time.getTime())
+const absolute = !invalid ? dateTimeFormat.format(_time) : i18n.ts._ago.invalid;
 
 let now = $shallowRef(new Date());
 const relative = $computed(() => {
+	if (props.mode === 'absolute' || invalid) return i18n.ts._ago.invalid;
+
 	const ago = (now.getTime() - _time.getTime()) / 1000/*ms*/;
 	return (
 		ago >= 31536000 ? i18n.t('_ago.yearsAgo', { n: Math.round(ago / 31536000).toString() }) :

--- a/packages/frontend/src/components/global/MkTime.vue
+++ b/packages/frontend/src/components/global/MkTime.vue
@@ -13,13 +13,13 @@ import { i18n } from '@/i18n';
 import { dateTimeFormat } from '@/scripts/intl-const';
 
 const props = withDefaults(defineProps<{
-	time: Date | string;
+	time: Date | string | number;
 	mode?: 'relative' | 'absolute' | 'detail';
 }>(), {
 	mode: 'relative',
 });
 
-const _time = (props.time instanceof Date ? props.time : new Date(props.time)).getTime();
+const _time = typeof props.time === 'number' ? props.time : (props.time instanceof Date ? props.time : new Date(props.time).getTime());
 const invalid = Number.isNaN(_time)
 const absolute = !invalid ? dateTimeFormat.format(_time) : i18n.ts._ago.invalid;
 

--- a/packages/frontend/src/components/global/MkTime.vue
+++ b/packages/frontend/src/components/global/MkTime.vue
@@ -19,15 +19,16 @@ const props = withDefaults(defineProps<{
 	mode: 'relative',
 });
 
-const _time = props.time instanceof Date ? props.time : new Date(props.time);
-const invalid = Number.isNaN(_time.getTime())
+const _time = (props.time instanceof Date ? props.time : new Date(props.time)).getTime();
+const invalid = Number.isNaN(_time)
 const absolute = !invalid ? dateTimeFormat.format(_time) : i18n.ts._ago.invalid;
 
-let now = $shallowRef(new Date());
-const relative = $computed(() => {
-	if (props.mode === 'absolute' || invalid) return i18n.ts._ago.invalid;
+let now = $ref((new Date()).getTime());
+const relative = $computed<string>(() => {
+	if (props.mode === 'absolute') return ''; // absoluteではrelativeを使わないので計算しない
+	if (invalid) return i18n.ts._ago.invalid;
 
-	const ago = (now.getTime() - _time.getTime()) / 1000/*ms*/;
+	const ago = (now - _time) / 1000/*ms*/;
 	return (
 		ago >= 31536000 ? i18n.t('_ago.yearsAgo', { n: Math.round(ago / 31536000).toString() }) :
 		ago >= 2592000 ? i18n.t('_ago.monthsAgo', { n: Math.round(ago / 2592000).toString() }) :
@@ -43,8 +44,8 @@ const relative = $computed(() => {
 let tickId: number;
 
 function tick() {
-	now = new Date();
-	const ago = (now.getTime() - _time.getTime()) / 1000/*ms*/;
+	now = (new Date()).getTime();
+	const ago = (now - _time) / 1000/*ms*/;
 	const next = ago < 60 ? 10000 : ago < 3600 ? 60000 : 180000;
 
 	tickId = window.setTimeout(tick, next);

--- a/packages/frontend/src/components/global/MkTime.vue
+++ b/packages/frontend/src/components/global/MkTime.vue
@@ -13,13 +13,15 @@ import { i18n } from '@/i18n';
 import { dateTimeFormat } from '@/scripts/intl-const';
 
 const props = withDefaults(defineProps<{
-	time: Date | string | number;
+	time: Date | string | number | null;
 	mode?: 'relative' | 'absolute' | 'detail';
 }>(), {
 	mode: 'relative',
 });
 
-const _time = typeof props.time === 'number' ? props.time : (props.time instanceof Date ? props.time : new Date(props.time).getTime());
+const _time = props.time == null ? NaN :
+	typeof props.time === 'number' ? props.time :
+	(props.time instanceof Date ? props.time : new Date(props.time).getTime());
 const invalid = Number.isNaN(_time)
 const absolute = !invalid ? dateTimeFormat.format(_time) : i18n.ts._ago.invalid;
 

--- a/packages/frontend/src/components/global/MkTime.vue
+++ b/packages/frontend/src/components/global/MkTime.vue
@@ -21,8 +21,8 @@ const props = withDefaults(defineProps<{
 
 const _time = props.time == null ? NaN :
 	typeof props.time === 'number' ? props.time :
-	(props.time instanceof Date ? props.time : new Date(props.time).getTime());
-const invalid = Number.isNaN(_time)
+	(props.time instanceof Date ? props.time : new Date(props.time)).getTime();
+const invalid = Number.isNaN(_time);
 const absolute = !invalid ? dateTimeFormat.format(_time) : i18n.ts._ago.invalid;
 
 let now = $ref((new Date()).getTime());


### PR DESCRIPTION
- stringでもDateでない値が入った場合、invalid「ありません」を表示（user-infoでなぜかそういうことが起きた）
- props.timeにnullを許容（本当は呼び出し元で何とかする必要はあるが面倒）
- Dateは保持せずgetTime()の数値だけを保持しておく（メモリをちょっとだけ削減できる？）