### PR TITLE
デプロイされているプレビュー環境がない場合はプレビュー環境を削除しないようにする

### DIFF
--- a/.github/workflows/pr-preview-destroy.yml
+++ b/.github/workflows/pr-preview-destroy.yml
@@ -30,6 +30,11 @@ jobs:
             });
 
             const check = checks.check_runs.filter(c => c.name === 'deploy-preview-environment');
+
+            if (check.length === 0) {
+              return;
+            }
+
             const { data: result } = await github.rest.checks.get({
               ...context.repo,
               check_run_id: check[0].id,

--- a/.github/workflows/pr-preview-destroy.yml
+++ b/.github/workflows/pr-preview-destroy.yml
@@ -9,14 +9,41 @@ name: Destroy preview environment
 jobs:
   destroy-preview-environment:
     runs-on: ubuntu-latest
-    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
+      - uses: actions/github-script@v6.3.3
+        id: check-conclusion
+        env:
+          number: ${{ github.event.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: process.env.number
+            });
+            const ref = pull.head.sha;
+
+            const { data: checks } = await github.rest.checks.listForRef({
+              ...context.repo,
+              ref
+            });
+
+            const check = checks.check_runs.filter(c => c.name === 'deploy-preview-environment');
+            const { data: result } = await github.rest.checks.get({
+              ...context.repo,
+              check_run_id: check[0].id,
+            });
+
+            return result.conclusion;
       - name: Context
+        if: steps.check-conclusion.outputs.result == 'success'
         uses: okteto/context@latest
         with:
           token: ${{ secrets.OKTETO_TOKEN }}
 
       - name: Destroy preview environment
+        if: steps.check-conclusion.outputs.result == 'success'
         uses: okteto/destroy-preview@latest
         with:
           name: pr-${{ github.event.number }}-syuilo


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/actions/runs/4259475259/jobs/7411730738

上記のエラーが発生しないようにするため、Deploy preview environmentが実行されていない場合はプレビュー環境の削除を行わないようにします。