### PR TITLE
fix(client): Android ChromeでPWAとしてインストールできない問題を修正

### DIFF
--- a/packages/backend/src/server/web/manifest.json
+++ b/packages/backend/src/server/web/manifest.json
@@ -7,6 +7,12 @@
 	"theme_color": "#86b300",
 	"icons": [
 		{
+			"src": "/static-assets/splash.png",
+			"sizes": "300x300",
+			"type": "image/png",
+			"purpose": "any"
+		},
+		{
 			"src": "/static-assets/icons/192.png",
 			"sizes": "192x192",
 			"type": "image/png",
@@ -21,6 +27,8 @@
 	],
 	"share_target": {
 		"action": "/share/",
+		"method": "GET",
+		"enctype": "application/x-www-form-urlencoded",
 		"params": {
 			"title": "title",
 			"text": "text",

--- a/packages/backend/src/server/web/manifest.json
+++ b/packages/backend/src/server/web/manifest.json
@@ -7,12 +7,6 @@
 	"theme_color": "#86b300",
 	"icons": [
 		{
-			"src": "/static-assets/splash.png",
-			"sizes": "300x300",
-			"type": "image/png",
-			"purpose": "any"
-		},
-		{
 			"src": "/static-assets/icons/192.png",
 			"sizes": "192x192",
 			"type": "image/png",
@@ -23,6 +17,12 @@
 			"sizes": "512x512",
 			"type": "image/png",
 			"purpose": "maskable"
+		},
+		{
+			"src": "/static-assets/splash.png",
+			"sizes": "300x300",
+			"type": "image/png",
+			"purpose": "any"
 		}
 	],
 	"share_target": {


### PR DESCRIPTION
Fix #10068

- Android ChromeでPWAとしてインストールできない問題を修正
  * "purpose": "any"の画像を追加
  * `理想的には、 "any"目的のアイコンには透明な領域があり、サイトのファビコンのように余分なパディングがないようにする必要があります。` https://web.dev/maskable-icon/
- share_targetにmethod, enctypeを追加（ChromeのF12で△！が表示されるため）