### PR TITLE
docker: build assets on native arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ FROM --platform=$TARGETPLATFORM node:${NODE_VERSION}-slim AS runner
 ARG UID="991"
 ARG GID="991"
 
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 	ffmpeg tini curl \
 	&& corepack enable \
 	&& groupadd -g "${GID}" misskey \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@
 
 ARG NODE_VERSION=18.13.0-bullseye
 
-FROM node:${NODE_VERSION} AS builder
+# build assets & compile TypeScript
+
+FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS native-builder
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	--mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -33,33 +35,48 @@ RUN git submodule update --init
 RUN pnpm build
 RUN rm -rf .git/
 
-FROM node:${NODE_VERSION}-slim AS runner
+# build native dependencies for target platform
+
+FROM --platform=$TARGETPLATFORM node:${NODE_VERSION} AS target-builder
+
+RUN apt-get update \
+	&& apt-get install -yqq --no-install-recommends \
+	build-essential
+
+RUN corepack enable
+
+WORKDIR /misskey
+
+COPY --link ["pnpm-lock.yaml", "pnpm-workspace.yaml", "package.json", "./"]
+COPY --link ["scripts", "./scripts"]
+COPY --link ["packages/backend/package.json", "./packages/backend/"]
+
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
+	pnpm i --frozen-lockfile --aggregate-output
+
+FROM --platform=$TARGETPLATFORM node:${NODE_VERSION}-slim AS runner
 
 ARG UID="991"
 ARG GID="991"
 
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-	--mount=type=cache,target=/var/lib/apt,sharing=locked \
-	rm -f /etc/apt/apt.conf.d/docker-clean \
-	; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
-	&& apt-get update \
-	&& apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
 	ffmpeg tini curl \
 	&& corepack enable \
 	&& groupadd -g "${GID}" misskey \
 	&& useradd -l -u "${UID}" -g "${GID}" -m -d /misskey misskey \
 	&& find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
-	&& find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \;
+	&& find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists
 
 USER misskey
 WORKDIR /misskey
 
-COPY --chown=misskey:misskey --from=builder /misskey/node_modules ./node_modules
-COPY --chown=misskey:misskey --from=builder /misskey/built ./built
-COPY --chown=misskey:misskey --from=builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
-COPY --chown=misskey:misskey --from=builder /misskey/packages/backend/built ./packages/backend/built
-COPY --chown=misskey:misskey --from=builder /misskey/packages/frontend/node_modules ./packages/frontend/node_modules
-COPY --chown=misskey:misskey --from=builder /misskey/fluent-emojis /misskey/fluent-emojis
+COPY --chown=misskey:misskey --from=target-builder /misskey/node_modules ./node_modules
+COPY --chown=misskey:misskey --from=target-builder /misskey/packages/backend/node_modules ./packages/backend/node_modules
+COPY --chown=misskey:misskey --from=native-builder /misskey/built ./built
+COPY --chown=misskey:misskey --from=native-builder /misskey/packages/backend/built ./packages/backend/built
+COPY --chown=misskey:misskey --from=native-builder /misskey/fluent-emojis /misskey/fluent-emojis
 COPY --chown=misskey:misskey . ./
 
 ENV NODE_ENV=production


### PR DESCRIPTION
わざわざ TypeScript のコードとかクライアントのアセットのビルドをエミュレーション上でやる必要はないのでビルド環境と同じplatformでやるように

## 留意すべき点
* エミュレーション上で実行されうるところはキャッシュ処理を消した
  * エミュレーション部分は遅いのもあり、キャッシュをロックされると結果的にかなり時間を損する順番で処理が走ることがあるため
    * runnerの apt install で待たされて target-builder の apt install ができず後続の target-builder の pnpm install がいつまで立っても走らない ことがあった
      * runner は `apt install` 後すぐ target-builder と native-builder が終わるまで待つことになるのでここで runner が target-builder の実行を阻害するのはよくない
  * ひょっとすると `sharing=private` のほうがいい？どういう挙動になるのかよくわからないが… cc @ikuradon 