### PR TITLE
enhance(client): emojisはIndexedDBに保存する

### DIFF
--- a/packages/frontend/src/custom-emojis.ts
+++ b/packages/frontend/src/custom-emojis.ts
@@ -40,16 +40,17 @@ export async function fetchCustomEmojis(force = false) {
 	if (force || needsMigration) {
 		res = await api('emojis', {});
 	} else {
-		const lastFetchedAt = miLocalStorage.getItem('lastEmojisFetchedAt');
-		if (lastFetchedAt && (now - parseInt(lastFetchedAt)) < 1000 * 60 * 60) return;
+		const lastFetchedAt = await get('lastEmojisFetchedAt');
+		if (lastFetchedAt && (now - lastFetchedAt) < 1000 * 60 * 60) return;
 		res = await apiGet('emojis', {});
 	}
 
 	customEmojis.value = res.emojis;
 	set('emojis', res.emojis);
-	miLocalStorage.setItem('lastEmojisFetchedAt', now.toString());
+	set('lastEmojisFetchedAt', now);
 	if (needsMigration) {
 		miLocalStorage.removeItem('emojis');
+		miLocalStorage.removeItem('lastEmojisFetchedAt');
 	}
 }
 

--- a/packages/frontend/src/custom-emojis.ts
+++ b/packages/frontend/src/custom-emojis.ts
@@ -3,9 +3,10 @@ import * as Misskey from 'misskey-js';
 import { api, apiGet } from './os';
 import { miLocalStorage } from './local-storage';
 import { stream } from '@/stream';
+import { get, set } from '@/scripts/idb-proxy';
 
-const storageCache = miLocalStorage.getItem('emojis');
-export const customEmojis = shallowRef<Misskey.entities.CustomEmoji[]>(storageCache ? JSON.parse(storageCache) : []);
+const storageCache = await get('emojis');
+export const customEmojis = shallowRef<Misskey.entities.CustomEmoji[]>(Array.isArray(storageCache) ? storageCache : []);
 export const customEmojiCategories = computed<[ ...string[], null ]>(() => {
 	const categories = new Set<string>();
 	for (const emoji of customEmojis.value) {
@@ -18,21 +19,25 @@ export const customEmojiCategories = computed<[ ...string[], null ]>(() => {
 
 stream.on('emojiAdded', emojiData => {
 	customEmojis.value = [emojiData.emoji, ...customEmojis.value];
+	set('emojis', customEmojis.value);
 });
 
 stream.on('emojiUpdated', emojiData => {
 	customEmojis.value = customEmojis.value.map(item => emojiData.emojis.find(search => search.name === item.name) as Misskey.entities.CustomEmoji ?? item);
+	set('emojis', customEmojis.value);
 });
 
 stream.on('emojiDeleted', emojiData => {
 	customEmojis.value = customEmojis.value.filter(item => !emojiData.emojis.some(search => search.name === item.name));
+	set('emojis', customEmojis.value);
 });
 
 export async function fetchCustomEmojis(force = false) {
 	const now = Date.now();
+	const needsMigration = miLocalStorage.getItem('emojis') != null;
 
 	let res;
-	if (force) {
+	if (force || needsMigration) {
 		res = await api('emojis', {});
 	} else {
 		const lastFetchedAt = miLocalStorage.getItem('lastEmojisFetchedAt');
@@ -41,8 +46,11 @@ export async function fetchCustomEmojis(force = false) {
 	}
 
 	customEmojis.value = res.emojis;
-	miLocalStorage.setItem('emojis', JSON.stringify(res.emojis));
+	set('emojis', res.emojis);
 	miLocalStorage.setItem('lastEmojisFetchedAt', now.toString());
+	if (needsMigration) {
+		miLocalStorage.removeItem('emojis');
+	}
 }
 
 let cachedTags;

--- a/packages/frontend/src/local-storage.ts
+++ b/packages/frontend/src/local-storage.ts
@@ -2,7 +2,6 @@ type Keys =
 	'v' |
 	'lastVersion' |
 	'instance' |
-	'lastEmojisFetchedAt' |
 	'account' |
 	'accounts' |
 	'latestDonationInfoShownAt' |
@@ -28,6 +27,7 @@ type Keys =
 	`ui:folder:${string}` |
 	`themes:${string}` |
 	`aiscript:${string}` |
+	'lastEmojisFetchedAt' | // DEPRECATED, stored in indexeddb (13.9.0~)
 	'emojis' // DEPRECATED, stored in indexeddb (13.9.0~);
 
 export const miLocalStorage = {

--- a/packages/frontend/src/local-storage.ts
+++ b/packages/frontend/src/local-storage.ts
@@ -2,7 +2,6 @@ type Keys =
 	'v' |
 	'lastVersion' |
 	'instance' |
-	'emojis' | // TODO: indexed db
 	'lastEmojisFetchedAt' |
 	'account' |
 	'accounts' |
@@ -28,7 +27,8 @@ type Keys =
 	`miux:${string}` |
 	`ui:folder:${string}` |
 	`themes:${string}` |
-	`aiscript:${string}`;
+	`aiscript:${string}` |
+	'emojis' // DEPRECATED, stored in indexeddb (13.9.0~);
 
 export const miLocalStorage = {
 	getItem: (key: Keys) => window.localStorage.getItem(key),


### PR DESCRIPTION
- ~~#10117 用に~~ emojis, [lastEmojisFetchedAt](https://github.com/misskey-dev/misskey/pull/10121/commits/314592da96e0d0076a4095693c3e5e3cbb72464f)をIndexedDBに保存する (TODOにあったため)
- WebSocket経由で絵文字の更新を受け取った際もストレージに保存するように Related to #9618