### PR TITLE
enhance(e2e): more resilient version of `visit('/')`

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -10,14 +10,14 @@ describe('Before setup instance', () => {
 	});
 
   it('successfully loads', () => {
-    cy.visit('/');
+    cy.visitHome();
   });
 
 	it('setup instance', () => {
-    cy.visit('/');
+    cy.visitHome();
 
 		cy.intercept('POST', '/api/admin/accounts/create').as('signup');
-	
+
 		cy.get('[data-cy-admin-username] input').type('admin');
 		cy.get('[data-cy-admin-password] input').type('admin1234');
 		cy.get('[data-cy-admin-ok]').click();
@@ -43,11 +43,11 @@ describe('After setup instance', () => {
 	});
 
   it('successfully loads', () => {
-    cy.visit('/');
+    cy.visitHome();
   });
 
 	it('signup', () => {
-		cy.visit('/');
+		cy.visitHome();
 
 		cy.intercept('POST', '/api/signup').as('signup');
 
@@ -79,11 +79,11 @@ describe('After user signup', () => {
 	});
 
   it('successfully loads', () => {
-    cy.visit('/');
+    cy.visitHome();
   });
 
 	it('signin', () => {
-		cy.visit('/');
+		cy.visitHome();
 
 		cy.intercept('POST', '/api/signin').as('signin');
 
@@ -101,7 +101,7 @@ describe('After user signup', () => {
 			userId: this.alice.id,
 		});
 
-		cy.visit('/');
+		cy.visitHome();
 
 		cy.get('[data-cy-signin]').click();
 		cy.get('[data-cy-signin-username] input').type('alice');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,11 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+Cypress.Commands.add('visitHome', () => {
+	cy.visit('/');
+	cy.get('button', { timeout: 30000 }).should('be.visible');
+})
+
 Cypress.Commands.add('resetState', () => {
 	cy.window(win => {
 		win.indexedDB.deleteDatabase('keyval-store');
@@ -43,7 +48,7 @@ Cypress.Commands.add('registerUser', (username, password, isAdmin = false) => {
 });
 
 Cypress.Commands.add('login', (username, password) => {
-	cy.visit('/');
+	cy.visitHome();
 
 	cy.intercept('POST', '/api/signin').as('signin');
 


### PR DESCRIPTION
やっぱりPR template消えました。

# なにを

`visitHome` コマンドを追加、なにかボタンが現れるまで待つようにする

# なんで

ローカルで`pnpm dev`を対象にテスト回したらバックエンド遅すぎて失敗しますが、ちゃんとページロード終わったのかの確認がないので、エラーメッセージだけ読んだらなんか本当に壊れているように見えるのを何とかしました。