### PR TITLE
fix(backend): return HTTP 404 for any unknown api endpoint paths

### DIFF
--- a/cypress/e2e/api.cy.js
+++ b/cypress/e2e/api.cy.js
@@ -1,0 +1,11 @@
+describe('API', () => {
+	it('returns HTTP 400 to invalid API endpoint paths', () => {
+		cy.request({
+			url: '/api/foo',
+			failOnStatusCode: false,
+		}).then((response) => {
+			expect(response.status).to.eq(400);
+			expect(response.body.error.code).to.eq('INVALID_API_ENDPOINT');
+		});
+	});
+});

--- a/cypress/e2e/api.cy.js
+++ b/cypress/e2e/api.cy.js
@@ -1,11 +1,11 @@
 describe('API', () => {
-	it('returns HTTP 400 to invalid API endpoint paths', () => {
+	it('returns HTTP 404 to unknown API endpoint paths', () => {
 		cy.request({
 			url: '/api/foo',
 			failOnStatusCode: false,
 		}).then((response) => {
-			expect(response.status).to.eq(400);
-			expect(response.body.error.code).to.eq('INVALID_API_ENDPOINT');
+			expect(response.status).to.eq(404);
+			expect(response.body.error.code).to.eq('UNKNOWN_API_ENDPOINT');
 		});
 	});
 });

--- a/packages/backend/src/server/api/ApiServerService.ts
+++ b/packages/backend/src/server/api/ApiServerService.ts
@@ -160,16 +160,16 @@ export class ApiServerService {
 			}
 		});
 
-		// Make sure any incorrect path under /api returns HTTP 400 Bad Request,
+		// Make sure any unknown path under /api returns HTTP 404 Not Found,
 		// because otherwise ClientServerService will return the base client HTML
 		// page with HTTP 200.
 		fastify.get('*', (request, reply) => {
-			reply.code(400);
+			reply.code(404);
 			// Mock ApiCallService.send's error handling
 			reply.send({
 				error: {
-					message: 'Invalid API endpoint.',
-					code: 'INVALID_API_ENDPOINT',
+					message: 'Unknown API endpoint.',
+					code: 'UNKNOWN_API_ENDPOINT',
 					id: '2ca3b769-540a-4f08-9dd5-b5a825b6d0f1',
 					kind: 'client',
 				},

--- a/packages/backend/src/server/api/ApiServerService.ts
+++ b/packages/backend/src/server/api/ApiServerService.ts
@@ -79,7 +79,7 @@ export class ApiServerService {
 						reply.send();
 						return;
 					}
-		
+
 					this.apiCallService.handleMultipartRequest(ep, request, reply);
 				});
 			} else {
@@ -93,7 +93,7 @@ export class ApiServerService {
 						reply.send();
 						return;
 					}
-		
+
 					this.apiCallService.handleRequest(ep, request, reply);
 				});
 			}
@@ -158,6 +158,22 @@ export class ApiServerService {
 					ok: false,
 				};
 			}
+		});
+
+		// Make sure any incorrect path under /api returns HTTP 400 Bad Request,
+		// because otherwise ClientServerService will return the base client HTML
+		// page with HTTP 200.
+		fastify.get('*', (request, reply) => {
+			reply.code(400);
+			// Mock ApiCallService.send's error handling
+			reply.send({
+				error: {
+					message: 'Invalid API endpoint.',
+					code: 'INVALID_API_ENDPOINT',
+					id: '2ca3b769-540a-4f08-9dd5-b5a825b6d0f1',
+					kind: 'client',
+				},
+			});
 		});
 
 		done();


### PR DESCRIPTION
...PR template...

# なにを

`/api/`下の不正なアドレスにアクセスしたらHTTP 404が出るようにしました

# なんで

いままではHTTP 200とクライアントのHTMLページを出して混乱を招いていましたので

Fixes #9714