### PR TITLE
fix: 外部メディアプロキシ使用時にアバタークロップができない問題を修正

### DIFF
--- a/packages/backend/src/server/FileServerService.ts
+++ b/packages/backend/src/server/FileServerService.ts
@@ -226,7 +226,10 @@ export class FileServerService {
 			return;
 		}
 
-		if (this.config.externalMediaProxyEnabled) {
+		// アバタークロップなど、画像の参照元がオリジンである必要がある場合
+		const mustOrigin = 'origin' in request.headers && (!request.headers.origin || request.headers.origin === this.config.url);
+
+		if (this.config.externalMediaProxyEnabled || !mustOrigin) {
 			// 外部のメディアプロキシが有効なら、そちらにリダイレクト
 
 			reply.header('Cache-Control', 'public, max-age=259200'); // 3 days

--- a/packages/backend/src/server/FileServerService.ts
+++ b/packages/backend/src/server/FileServerService.ts
@@ -226,10 +226,10 @@ export class FileServerService {
 			return;
 		}
 
-		// アバタークロップなど、画像の参照元がオリジンである必要がある場合
-		const mustOrigin = 'origin' in request.headers && (!request.headers.origin || request.headers.origin === this.config.url);
+		// アバタークロップなど、どうしてもオリジンである必要がある場合
+		const mustOrigin = 'origin' in request.query;
 
-		if (this.config.externalMediaProxyEnabled || !mustOrigin) {
+		if (this.config.externalMediaProxyEnabled && !mustOrigin) {
 			// 外部のメディアプロキシが有効なら、そちらにリダイレクト
 
 			reply.header('Cache-Control', 'public, max-age=259200'); // 3 days

--- a/packages/frontend/src/components/MkCropperDialog.vue
+++ b/packages/frontend/src/components/MkCropperDialog.vue
@@ -18,7 +18,7 @@
 				</div>
 			</Transition>
 			<div class="container">
-				<img ref="imgEl" :src="imgUrl" style="display: none;" crossorigin="anonymous" @load="onImageLoad">
+				<img ref="imgEl" :src="imgUrl" style="display: none;" @load="onImageLoad">
 			</div>
 		</div>
 	</template>
@@ -49,7 +49,7 @@ const props = defineProps<{
 	aspectRatio: number;
 }>();
 
-const imgUrl = getProxiedImageUrl(props.file.url);
+const imgUrl = getProxiedImageUrl(props.file.url, undefined, true);
 let dialogEl = $shallowRef<InstanceType<typeof MkModalWindow>>();
 let imgEl = $shallowRef<HTMLImageElement>();
 let cropper: Cropper | null = null;

--- a/packages/frontend/src/scripts/media-proxy.ts
+++ b/packages/frontend/src/scripts/media-proxy.ts
@@ -2,16 +2,15 @@ import { query, appendQuery } from '@/scripts/url';
 import { url } from '@/config';
 import { instance } from '@/instance';
 
-export function getProxiedImageUrl(imageUrl: string, type?: 'preview'): string {
-	if (imageUrl.startsWith(instance.mediaProxy + '/') || imageUrl.startsWith('/proxy/')) {
-		// もう既にproxyっぽそうだったらsearchParams付けるだけ
-		return appendQuery(imageUrl, query({
-			fallback: '1',
-			...(type ? { [type]: '1' } : {}),
-		}));
+export function getProxiedImageUrl(imageUrl: string, type?: 'preview', mustOrigin: boolean = false): string {
+	const localProxy = `${url}/proxy`;
+
+	if (imageUrl.startsWith(instance.mediaProxy + '/') || imageUrl.startsWith('/proxy/') || imageUrl.startsWith(localProxy + '/')) {
+		// もう既にproxyっぽそうだったらurlを取り出す
+		imageUrl = (new URL(imageUrl)).searchParams.get('url') || imageUrl;
 	}
 
-	return `${instance.mediaProxy}/image.webp?${query({
+	return `${mustOrigin ? localProxy : instance.mediaProxy}/image.webp?${query({
 		url: imageUrl,
 		fallback: '1',
 		...(type ? { [type]: '1' } : {}),

--- a/packages/frontend/src/scripts/media-proxy.ts
+++ b/packages/frontend/src/scripts/media-proxy.ts
@@ -7,7 +7,7 @@ export function getProxiedImageUrl(imageUrl: string, type?: 'preview', mustOrigi
 
 	if (imageUrl.startsWith(instance.mediaProxy + '/') || imageUrl.startsWith('/proxy/') || imageUrl.startsWith(localProxy + '/')) {
 		// もう既にproxyっぽそうだったらurlを取り出す
-		imageUrl = (new URL(imageUrl)).searchParams.get('url') || imageUrl;
+		imageUrl = (new URL(imageUrl)).searchParams.get('url') ?? imageUrl;
 	}
 
 	return `${mustOrigin ? localProxy : instance.mediaProxy}/image.webp?${query({

--- a/packages/frontend/src/scripts/media-proxy.ts
+++ b/packages/frontend/src/scripts/media-proxy.ts
@@ -1,4 +1,4 @@
-import { query, appendQuery } from '@/scripts/url';
+import { query } from '@/scripts/url';
 import { url } from '@/config';
 import { instance } from '@/instance';
 
@@ -14,6 +14,7 @@ export function getProxiedImageUrl(imageUrl: string, type?: 'preview', mustOrigi
 		url: imageUrl,
 		fallback: '1',
 		...(type ? { [type]: '1' } : {}),
+		...(mustOrigin ? { origin: '1' } : {}),
 	})}`;
 }
 


### PR DESCRIPTION
Fix #9815

- 本体メディアプロキシにoriginクエリを追加し、これを指定すると本体での処理を強制する
- アバタークロップではoriginクエリを追加するように