### PR TITLE
Fix: サーバーでメール配信が無効になっている場合は設定ページにその旨を表示する

### DIFF
--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -955,6 +955,7 @@ exploreOtherServers: "他のサーバーを探す"
 letsLookAtTimeline: "タイムラインを見てみる"
 disableFederationWarn: "連合が無効になっています。無効にしても投稿が非公開にはなりません。ほとんどの場合、このオプションを有効にする必要はありません。"
 invitationRequiredToRegister: "現在このサーバーは招待制です。招待コードをお持ちの方のみ登録できます。"
+emailNotSupported: "このサーバーではメール配信はサポートされていません"
 
 _achievements:
   earnedAt: "獲得日時"

--- a/packages/frontend/src/pages/settings/email.vue
+++ b/packages/frontend/src/pages/settings/email.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="_gaps_m">
+<div v-if="instance.enableEmail" class="_gaps_m">
 	<FormSection first>
 		<template #label>{{ i18n.ts.emailAddress }}</template>
 		<MkInput v-model="emailAddress" type="email" manual-save>
@@ -37,17 +37,22 @@
 		</div>
 	</FormSection>
 </div>
+<div v-if="!instance.enableEmail" class="_gaps_m">
+	<MkInfo>{{ i18n.ts.emailNotSupported }}</MkInfo>
+</div>
 </template>
 
 <script lang="ts" setup>
 import { onMounted, ref, watch } from 'vue';
 import FormSection from '@/components/form/section.vue';
+import MkInfo from '@/components/MkInfo.vue';
 import MkInput from '@/components/MkInput.vue';
 import MkSwitch from '@/components/MkSwitch.vue';
 import * as os from '@/os';
 import { $i } from '@/account';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
+import { instance } from '@/instance';
 
 const emailAddress = ref($i!.email);
 


### PR DESCRIPTION
Resolve: #9745   
サーバーでメール配信が無効の場合は設定画面に以下のようなメッセージを示すようにしました。<br><br>
![Screenshot from 2023-03-04 07-41-09](https://user-images.githubusercontent.com/61890205/222846477-54c0022e-5282-4e15-ad2f-c99d86844cdc.png)
