### PR TITLE
fix: devcontainer で pnpm が command not found になるのを修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+	},
 	"forwardPorts": [3000],
 	"postCreateCommand": "sudo chmod 755 .devcontainer/init.sh && .devcontainer/init.sh",
 	"customizations": {


### PR DESCRIPTION
https://github.com/misskey-dev/misskey/commit/c54712233cfe212b090a16c567cb1c1ed8cc8058#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-L8

この行がないと Dev Container で pnpm が command not found と怒られます。