### PR TITLE
fix: macOS上でDev Containersが動作しない問題を修正

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - external_network
 
   redis:
-    restart: always
+    restart: unless-stopped
     image: redis:7-alpine
     networks:
       - internal_network

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -4,6 +4,7 @@ set -xe
 
 sudo chown -R node /workspace
 git submodule update --init
+pnpm config set store-dir /home/node/.local/share/pnpm/store
 pnpm install --frozen-lockfile
 cp .devcontainer/devcontainer.yml .config/default.yml
 pnpm build


### PR DESCRIPTION
# What
- Dev Containers実行時にpnpm storeの場所を変更するように変更
- Dev ContainersのRedisに対して`restart: unless-stopped`を使用するように変更

# Why
- macOS上においてDev Containers内で実行された`pnpm install`に失敗していたため
- `restart: always`を指定しているとDev Containersを使用していない際にもRedisが立ち上がってしまうため

# Additional info (optional)
- fixes #10201
- #10206 がマージされるまでpnpmがないので動作しません
- pnpmが通常使用するディレクトリを使用しています
- pnpm install実行時に`EXDEV: cross-device link not permitted`という警告が発生しますが、`Falling back to copying packages from store`という表示の通りフォールバックするため動作します
- WSL on WindowsとmacOS上のDockerで #10206 をマージした状態で動作確認済みです
- Docker Desktopの設定でVirtioFSを使っているとinit.sh実行中にコケるのでgRPC FUSEを使用してください
- #10208 により起動後に`pnpm dev`を実行してもバックエンドが上がってきません。