### PR TITLE
fix: pnpm dev時にファイルが空ならバックエンドの起動を待つように

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -40,8 +40,9 @@ const fs = require('fs');
 
 	const start = async () => {
 		try {
-			const exist = fs.existsSync(__dirname + '/../packages/backend/built/boot/index.js')
-			if (!exist) throw new Error('not exist yet');
+			const stat = fs.statSync(__dirname + '/../packages/backend/built/boot/index.js');
+			if (!stat) throw new Error('not exist yet');
+			if (stat.size === 0) throw new Error('not built yet');
 
 			await execa('pnpm', ['start'], {
 				cwd: __dirname + '/../',


### PR DESCRIPTION
# What
- `pnpm dev`実行時に、`pnpm start`を実行するタイミングを`packages/backend/built/boot/index.js`が作成された際ではなく`packages/backend/built/boot/index.js`へ書き込まれた際へ変更

# Why
- 一部のビルドが遅い環境 (macOS上のDev Containersなど)において、ビルド中にファイルが空である時間が長い場合、ファイルが空の状態でバックエンドの実行を試み、結果として何も発生しないという現象が起こるため

# Additional info (optional)
- fixes #10208