### PR TITLE
fix: Jestの自動実行を無効に

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "typescript.tsdk": "node_modules/typescript/lib",
     "files.associations": {
         "*.test.ts": "typescript"
-    }
+    },
+    "jest.autoRun": "off"
 }


### PR DESCRIPTION
# What
- VSCodeのJest拡張機能による自動実行を無効に

# Why
- `pnpm install`が完了していない段階でJestが実行され、テストに失敗するケースがあるため

# Additional info (optional)
- fixes #10211
- デフォルトで無効にするだけなので、ユーザーの好みによって変更できます