### PR TITLE
fix(docker): cannot build docker image on some environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ RUN apt-get update \
 	&& corepack enable \
 	&& groupadd -g "${GID}" misskey \
 	&& useradd -l -u "${UID}" -g "${GID}" -m -d /misskey misskey \
-	&& find / -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
-	&& find / -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; \
+	&& find / -type d -path /proc -prune -o -type f -perm /u+s -ignore_readdir_race -exec chmod u-s {} \; \
+	&& find / -type d -path /proc -prune -o -type f -perm /g+s -ignore_readdir_race -exec chmod g-s {} \; \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
Docker のデーモンが立っている環境によっては `find /` が `/proc` を触ってしまい `find: '/proc/1/map_files': Operation not permitted` が出て Docker イメージがビルドできない問題を修正

Since https://github.com/misskey-dev/misskey/pull/9568#discussion_r1070350847