### PR TITLE
fix(frontend): ユーザーページのバッジ表示を適切に折り返すように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - 
 
 ### Bugfixes
--
+- ユーザーページのバッジ表示を適切に折り返すように @arrow2nd
 
 You should also include the user name that made the change.
 -->

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -352,6 +352,9 @@ onUnmounted(() => {
 				> .roles {
 					padding: 24px 24px 0 154px;
 					font-size: 0.95em;
+					display: flex;
+					flex-wrap: wrap;
+					gap: 8px;
 
 					> .role {
 						border: solid 1px var(--color, var(--divider));
@@ -493,7 +496,7 @@ onUnmounted(() => {
 
 				> .roles {
 					padding: 16px 16px 0 16px;
-					text-align: center;
+					justify-content: center;
 				}
 
 				> .description {


### PR DESCRIPTION
# What

ユーザーページのバッジ表示を画面幅に合わせて適切に折り返すようにしました。

# Why

バッジの数が多いユーザーの場合、バッジが途中で折り返されてしまい見づらくなっているから。

> 関連する issue : #10219 

# Additional info (optional)

## 修正箇所のプレビュー

<details>
<summary>スマホ</summary>

### Before

![mobile](https://user-images.githubusercontent.com/44780846/222961070-63abe9f0-8c3c-4051-ba22-e6a562553720.png)

### After

![fixed_mobile](https://user-images.githubusercontent.com/44780846/222961007-e5cf9bda-1b9e-43b3-896f-59af3df87756.png)

</details>

<details>
<summary>デスクトップ</summary>

### Before

![desktop](https://user-images.githubusercontent.com/44780846/222961162-7f29b651-c43e-4cd8-a506-4c8a51b0cb53.png)

### After

![fixed_desktop](https://user-images.githubusercontent.com/44780846/222961118-37cfca4d-9adc-4448-b911-487513627ff6.png)

</details>

