### PR TITLE
fix: 登録メール送信時に重複確認を行う

### DIFF
--- a/packages/backend/src/server/api/SignupApiService.ts
+++ b/packages/backend/src/server/api/SignupApiService.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import rndstr from 'rndstr';
 import bcrypt from 'bcryptjs';
 import { DI } from '@/di-symbols.js';
-import type { RegistrationTicketsRepository, UserPendingsRepository, UserProfilesRepository, UsersRepository } from '@/models/index.js';
+import type { RegistrationTicketsRepository, UsedUsernamesRepository, UserPendingsRepository, UserProfilesRepository, UsersRepository } from '@/models/index.js';
 import type { Config } from '@/config.js';
 import { MetaService } from '@/core/MetaService.js';
 import { CaptchaService } from '@/core/CaptchaService.js';
@@ -15,6 +15,7 @@ import { FastifyReplyError } from '@/misc/fastify-reply-error.js';
 import { bindThis } from '@/decorators.js';
 import { SigninService } from './SigninService.js';
 import type { FastifyRequest, FastifyReply } from 'fastify';
+import { IsNull } from 'typeorm';
 
 @Injectable()
 export class SignupApiService {
@@ -30,6 +31,9 @@ export class SignupApiService {
 
 		@Inject(DI.userPendingsRepository)
 		private userPendingsRepository: UserPendingsRepository,
+
+		@Inject(DI.usedUsernamesRepository)
+		private usedUsernamesRepository: UsedUsernamesRepository,
 
 		@Inject(DI.registrationTicketsRepository)
 		private registrationTicketsRepository: RegistrationTicketsRepository,
@@ -124,29 +128,42 @@ export class SignupApiService {
 		}
 	
 		if (instance.emailRequiredForSignup) {
-			const code = rndstr('a-z0-9', 16);
-	
-			// Generate hash of password
-			const salt = await bcrypt.genSalt(8);
-			const hash = await bcrypt.hash(password, salt);
-	
-			await this.userPendingsRepository.insert({
-				id: this.idService.genId(),
-				createdAt: new Date(),
-				code,
-				email: emailAddress!,
-				username: username,
-				password: hash,
-			});
-	
-			const link = `${this.config.url}/signup-complete/${code}`;
-	
-			this.emailService.sendEmail(emailAddress!, 'Signup',
-				`To complete signup, please click this link:<br><a href="${link}">${link}</a>`,
-				`To complete signup, please click this link: ${link}`);
-	
-			reply.code(204);
-			return;
+			try {
+				if (await this.usersRepository.findOneBy({ usernameLower: username.toLowerCase(), host: IsNull() })) {
+					throw new Error('DUPLICATED_USERNAME');
+				}
+			
+				// Check deleted username duplication
+				if (await this.usedUsernamesRepository.findOneBy({ username: username.toLowerCase() })) {
+					throw new Error('USED_USERNAME');
+				}
+
+				const code = rndstr('a-z0-9', 16);
+		
+				// Generate hash of password
+				const salt = await bcrypt.genSalt(8);
+				const hash = await bcrypt.hash(password, salt);
+		
+				await this.userPendingsRepository.insert({
+					id: this.idService.genId(),
+					createdAt: new Date(),
+					code,
+					email: emailAddress!,
+					username: username,
+					password: hash,
+				});
+		
+				const link = `${this.config.url}/signup-complete/${code}`;
+		
+				this.emailService.sendEmail(emailAddress!, 'Signup',
+					`To complete signup, please click this link:<br><a href="${link}">${link}</a>`,
+					`To complete signup, please click this link: ${link}`);
+		
+				reply.code(204);
+				return;
+			} catch (err) {
+				throw new FastifyReplyError(400, typeof err === 'string' ? err : (err as Error).toString());
+			}
 		} else {
 			try {
 				const { account, secret } = await this.signupService.signup({

--- a/packages/backend/src/server/api/SignupApiService.ts
+++ b/packages/backend/src/server/api/SignupApiService.ts
@@ -131,18 +131,18 @@ export class SignupApiService {
 			if (await this.usersRepository.findOneBy({ usernameLower: username.toLowerCase(), host: IsNull() })) {
 				throw new FastifyReplyError(400, 'DUPLICATED_USERNAME');
 			}
-			
+
 			// Check deleted username duplication
 			if (await this.usedUsernamesRepository.findOneBy({ username: username.toLowerCase() })) {
 				throw new FastifyReplyError(400, 'USED_USERNAME');
 			}
 
 			const code = rndstr('a-z0-9', 16);
-		
+
 			// Generate hash of password
 			const salt = await bcrypt.genSalt(8);
 			const hash = await bcrypt.hash(password, salt);
-		
+
 			await this.userPendingsRepository.insert({
 				id: this.idService.genId(),
 				createdAt: new Date(),
@@ -151,13 +151,13 @@ export class SignupApiService {
 				username: username,
 				password: hash,
 			});
-		
+
 			const link = `${this.config.url}/signup-complete/${code}`;
-		
+
 			this.emailService.sendEmail(emailAddress!, 'Signup',
 				`To complete signup, please click this link:<br><a href="${link}">${link}</a>`,
 				`To complete signup, please click this link: ${link}`);
-		
+
 			reply.code(204);
 			return;
 		} else {


### PR DESCRIPTION
# What
- `signup`エンドポイントにおいて、メールアドレスの検証が走る場合にユーザー名の重複確認が行われていなかった問題を修正

# Why
- 既に登録が完了しているユーザー名で登録メールを送れてしまい、ユーザーの混乱を招くため

# Additional info (optional)
- partially fixes #10076
- 既に登録プロセスが完了している場合に登録が出来ないようになりますが、同時に同じユーザー名で登録プロセスを開始した場合、上記Issueで説明されている問題が依然として発生します。
  - Pendingになっているユーザーのリポジトリにおいても重複確認を行うべきか検討しましたが、メールアドレスを間違えた場合などに再度登録したいというケースがあることを想定して一旦はそのままにしています。
  - そのため、メールアドレス認証ページにおいて別途エラーハンドリングを行い、適切なメッセージを表示するべきかもしれません
- メール登録を必須にしているインスタンスにおいて、以下の状況において動作確認済み
  1. ユーザー名が重複している場合、400が帰ることを確認
  2. ユーザー名が重複していない場合、204が帰りメールが飛んでくることを確認