### PR TITLE
fix: 登録時のフォームにおいて送信できる条件を修正

### DIFF
--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -52,12 +52,25 @@ describe('After setup instance', () => {
 		cy.intercept('POST', '/api/signup').as('signup');
 
 		cy.get('[data-cy-signup]').click();
+		cy.get('[data-cy-signup-submit]').should('be.disabled');
 		cy.get('[data-cy-signup-username] input').type('alice');
+		cy.get('[data-cy-signup-submit]').should('be.disabled');
 		cy.get('[data-cy-signup-password] input').type('alice1234');
+		cy.get('[data-cy-signup-submit]').should('be.disabled');
 		cy.get('[data-cy-signup-password-retype] input').type('alice1234');
+		cy.get('[data-cy-signup-submit]').should('not.be.disabled');
 		cy.get('[data-cy-signup-submit]').click();
 
 		cy.wait('@signup');
+
+		cy.visitHome();
+
+		// ユーザー名が重複している場合の挙動確認
+		cy.get('[data-cy-signup]').click();
+		cy.get('[data-cy-signup-username] input').type('alice');
+		cy.get('[data-cy-signup-password] input').type('alice1234');
+		cy.get('[data-cy-signup-password-retype] input').type('alice1234');
+		cy.get('[data-cy-signup-submit]').should('be.disabled');
   });
 });
 

--- a/packages/frontend/src/components/MkSignup.vue
+++ b/packages/frontend/src/components/MkSignup.vue
@@ -117,7 +117,9 @@ const shouldDisableSubmitting = $computed((): boolean => {
 		instance.enableHcaptcha && !hCaptchaResponse ||
 		instance.enableRecaptcha && !reCaptchaResponse ||
 		instance.enableTurnstile && !turnstileResponse ||
-		passwordRetypeState === 'not-match';
+		instance.emailRequiredForSignup && emailState !== 'ok' ||
+		usernameState !== 'ok' ||
+		passwordRetypeState !== 'match';
 });
 
 function onChangeUsername(): void {


### PR DESCRIPTION
# What
- アカウント作成時のフォームにおいてユーザー名の重複やメールアドレスの重複などが発生している場合にフォームの送信ボタンを無効にするように
- パスワードの一致状況が `match` である場合にのみフォームを送信できるように

# Why
- 警告が出ているにも関わらず送信ボタンが押下出来る状態となっていることで、ユーザーの混乱を招くため
- パスワードを入力していない状態の場合、パスワードの一致状況が`null`となってしまい、`passwordRetypeState === 'not-match'`がfalseになってしまっていたため。

# Additional info (optional)
- partially fixes #10076
- メール登録を必須にしているインスタンスにおいて、以下の状況で動作確認済み
  1. メールアドレスが既に使用されている場合、送信ボタンが無効になること
  2. ユーザー名が重複している場合、送信ボタンが無効になること
  3. 上記の両方を満たしている状態で送信ボタンが無効になること
  4. パスワードフィールドが空の場合に送信ボタンが無効になること
  5. 全てのフィールドが適切に記入されている場合に送信ボタンが有効になること
- メール登録が必須でないインスタンスにおいて、以下の状況で動作確認済み
  1. ユーザー名が重複している場合、送信ボタンが無効になること
  2. パスワードフィールドが空の場合に送信ボタンが無効になること
  3. ユーザー名とパスワードが適切に記入されている場合に送信ボタンが有効になること