### PR TITLE
fix(backend): ブロックホストがない場合はINクエリを生成しない。

### DIFF
--- a/packages/backend/src/server/api/endpoints/federation/instances.ts
+++ b/packages/backend/src/server/api/endpoints/federation/instances.ts
@@ -76,9 +76,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			if (typeof ps.blocked === 'boolean') {
 				const meta = await this.metaService.fetch(true);
 				if (ps.blocked) {
-					query.andWhere('instance.host IN (:...blocks)', { blocks: meta.blockedHosts });
+					query.andWhere(meta.blockedHosts.length === 0 ? '1=0': 'instance.host IN (:...blocks)', { blocks: meta.blockedHosts });
 				} else {
-					query.andWhere('instance.host NOT IN (:...blocks)', { blocks: meta.blockedHosts });
+					query.andWhere(meta.blockedHosts.length === 0 ? '1=1': 'instance.host NOT IN (:...blocks)', { blocks: meta.blockedHosts });
 				}
 			}
 


### PR DESCRIPTION
Fix #10246

空のINクエリはシンタックスエラーとなるため。