### PR TITLE
fix: チャンネルの編集権限をチャンネル所有者とモデレーターに限定する

### DIFF
--- a/packages/backend/src/server/api/endpoints/channels/update.ts
+++ b/packages/backend/src/server/api/endpoints/channels/update.ts
@@ -4,6 +4,7 @@ import type { DriveFilesRepository, ChannelsRepository } from '@/models/index.js
 import { ChannelEntityService } from '@/core/entities/ChannelEntityService.js';
 import { DI } from '@/di-symbols.js';
 import { ApiError } from '../../error.js';
+import { RoleService } from '@/core/RoleService.js';
 
 export const meta = {
 	tags: ['channels'],
@@ -61,7 +62,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 		private driveFilesRepository: DriveFilesRepository,
 
 		private channelEntityService: ChannelEntityService,
-	) {
+
+		private roleService: RoleService,
+		) {
 		super(meta, paramDef, async (ps, me) => {
 			const channel = await this.channelsRepository.findOneBy({
 				id: ps.channelId,
@@ -71,7 +74,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 				throw new ApiError(meta.errors.noSuchChannel);
 			}
 
-			if (channel.userId !== me.id) {
+			const iAmModerator = await this.roleService.isModerator(me);
+			if (channel.userId !== me.id && !iAmModerator) {
 				throw new ApiError(meta.errors.accessDenied);
 			}
 

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -92,7 +92,7 @@ function openPostForm() {
 
 const headerActions = $computed(() => {
 	if (channel && channel.userId) {
-		const everyOne = {
+		const share = {
 			icon: 'ti ti-share',
 			text: i18n.ts.share,
 			handler: async (): Promise<void> => {
@@ -105,11 +105,11 @@ const headerActions = $computed(() => {
 		};
 
 		const canEdit = ($i && $i.id === channel.userId) || iAmModerator;
-		return canEdit ? [everyOne, {
+		return canEdit ? [share, {
 			icon: 'ti ti-settings',
 			text: i18n.ts.edit,
 			handler: edit,
-		}] : [everyOne];
+		}] : [share];
 	} else {
 		return null;
 	}

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -46,7 +46,7 @@ import MkTimeline from '@/components/MkTimeline.vue';
 import XChannelFollowButton from '@/components/MkChannelFollowButton.vue';
 import * as os from '@/os';
 import { useRouter } from '@/router';
-import { $i } from '@/account';
+import { $i, iAmModerator } from '@/account';
 import { i18n } from '@/i18n';
 import { definePageMetadata } from '@/scripts/page-metadata';
 import { deviceKind } from '@/scripts/device-kind';
@@ -90,7 +90,7 @@ function openPostForm() {
 	});
 }
 
-const headerActions = $computed(() => channel && channel.userId ? [{
+const headerActions = $computed(() => channel && channel.userId && ($i.id === channel.UserId || iAmModerator) ? [{
 	icon: 'ti ti-share',
 	text: i18n.ts.share,
 	handler: async (): Promise<void> => {

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -90,21 +90,30 @@ function openPostForm() {
 	});
 }
 
-const headerActions = $computed(() => channel && channel.userId && ($i.id === channel.UserId || iAmModerator) ? [{
-	icon: 'ti ti-share',
-	text: i18n.ts.share,
-	handler: async (): Promise<void> => {
-		navigator.share({
-			title: channel.name,
-			text: channel.description,
-			url: `${url}/channels/${channel.id}`,
-		});
-	},
-}, {
-	icon: 'ti ti-settings',
-	text: i18n.ts.edit,
-	handler: edit,
-}] : null);
+const headerActions = $computed(() => {
+	if (channel && channel.userId) {
+		const everyOne = {
+			icon: 'ti ti-share',
+			text: i18n.ts.share,
+			handler: async (): Promise<void> => {
+				navigator.share({
+					title: channel.name,
+					text: channel.description,
+					url: `${url}/channels/${channel.id}`,
+				});
+			},
+		};
+
+		const canEdit = ($i && $i.id === channel.userId) || iAmModerator;
+		return canEdit ? [everyOne, {
+			icon: 'ti ti-settings',
+			text: i18n.ts.edit,
+			handler: edit,
+		}] : [everyOne];
+	} else {
+		return null;
+	}
+});
 
 const headerTabs = $computed(() => [{
 	key: 'overview',


### PR DESCRIPTION
# What

- チャンネルの編集ボタンはチャンネル所有者かモデレーターにしか表示しない

# Why

- 編集できないのに編集ボタンが押せてしまうのは不自然なため

# Additional info (optional)

- fix #9934
- チャンネル所有者が行方不明になったときを考えて、チャンネル所有者の切り替えが編集時にできると良いかも…（今後のチャンネルの構想次第かもしれません）、
