### PR TITLE
fix(frontend): Safariでプラグインが複数ある場合に正常に読み込まれない問題を修正

### DIFF
--- a/packages/frontend/src/init.ts
+++ b/packages/frontend/src/init.ts
@@ -343,7 +343,9 @@ stream.on('_disconnected_', async () => {
 });
 
 for (const plugin of ColdDeviceStorage.get('plugins').filter(p => p.active)) {
-	import('./plugin').then(({ install }) => {
+	import('./plugin').then(async ({ install }) => {
+		// これがないとIOS(Safari)で動かない、なんでかはしらん
+		await new Promise(r => setTimeout(() => r(), 0));
 		install(plugin);
 	});
 }

--- a/packages/frontend/src/init.ts
+++ b/packages/frontend/src/init.ts
@@ -345,7 +345,7 @@ stream.on('_disconnected_', async () => {
 for (const plugin of ColdDeviceStorage.get('plugins').filter(p => p.active)) {
 	import('./plugin').then(async ({ install }) => {
 		// Workaround for https://bugs.webkit.org/show_bug.cgi?id=242740
-		await new Promise(r => setTimeout(() => r(), 0));
+		await new Promise(r => setTimeout(r, 0));
 		install(plugin);
 	});
 }

--- a/packages/frontend/src/init.ts
+++ b/packages/frontend/src/init.ts
@@ -344,7 +344,7 @@ stream.on('_disconnected_', async () => {
 
 for (const plugin of ColdDeviceStorage.get('plugins').filter(p => p.active)) {
 	import('./plugin').then(async ({ install }) => {
-		// これがないとIOS(Safari)で動かない、なんでかはしらん
+		// Workaround for https://bugs.webkit.org/show_bug.cgi?id=242740
 		await new Promise(r => setTimeout(() => r(), 0));
 		install(plugin);
 	});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`Plugin:register_post_form_action`を使用したプラグインを公開した際に、Safariを使用している方々から「1つは反映されているがプラグインが反映されていない」との報告を受けたため、Safariでも正常にプラグインが読み込めるように修正しました。

同様のissueが #9829 にありました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
#9829 の問題を調べた結果、[createAiScriptEnv](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/plugin.ts#L50)で`ReferenceError: Cannot access uninitialized variable`が発生しており、それに関連した他のissue( sveltejs/kit#2889 sveltejs/kit#7805 )から[webkitのバグ](https://bugs.webkit.org/show_bug.cgi?id=242740)が問題であるらしく、ロード時に同時に読み込もうとすると起こるバグのようなので、`import`の処理の開始を少し遅らせることによって問題が解決した。

`setTimeout`の値が0の場合でも読み込まれていたので、読み込み速度にあまり影響が出ないようにしてあります。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
