### PR TITLE
fix(backend/ApRendererService): allow announces with visibility: followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ You should also include the user name that made the change.
 - ロールで広告を無効にするとadmin/adsでプレビューがでてこない問題を修正
 - /api-consoleページにアクセスすると404が出る問題を修正
 - SMTP Login id length is too short
+- API上で`visibility`を`followers`に設定してrenoteすると連合や削除で不具合が発生する問題を修正
 
 ## 13.9.2 (2023/03/06)
 

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -91,6 +91,9 @@ export class ApRendererService {
 		} else if (note.visibility === 'home') {
 			to = [`${attributedTo}/followers`];
 			cc = ['https://www.w3.org/ns/activitystreams#Public'];
+		} else if (note.visibility === 'followers') {
+			to = [`${attributedTo}/followers`];
+			cc = [];
 		} else {
 			throw new Error('renderAnnounce: cannot render non-public note');
 		}

--- a/packages/backend/test/e2e/note.ts
+++ b/packages/backend/test/e2e/note.ts
@@ -136,6 +136,31 @@ describe('Note', () => {
 		assert.strictEqual(res.body.createdNote.renote.text, bobPost.text);
 	});
 
+	test('visibility: followersでrenoteできる', async () => {
+		const createRes = await api('/notes/create', {
+			text: 'test',
+			visibility: 'followers',
+		}, alice);
+
+		assert.strictEqual(createRes.status, 200);
+
+		const renoteId = createRes.body.createdNote.id;
+		const renoteRes = await api('/notes/create', {
+			visibility: 'followers',
+			renoteId,
+		}, alice);
+
+		assert.strictEqual(renoteRes.status, 200);
+		assert.strictEqual(renoteRes.body.createdNote.renoteId, renoteId);
+		assert.strictEqual(renoteRes.body.createdNote.visibility, 'followers');
+
+		const deleteRes = await api('/notes/delete', {
+			noteId: renoteRes.body.createdNote.id,
+		}, alice);
+
+		assert.strictEqual(deleteRes.status, 204);
+	});
+
 	test('文字数ぎりぎりで怒られない', async () => {
 		const post = {
 			text: '!'.repeat(3000),

--- a/packages/backend/test/unit/activitypub.ts
+++ b/packages/backend/test/unit/activitypub.ts
@@ -7,12 +7,14 @@ import { jest } from '@jest/globals';
 
 import { ApNoteService } from '@/core/activitypub/models/ApNoteService.js';
 import { ApPersonService } from '@/core/activitypub/models/ApPersonService.js';
+import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { GlobalModule } from '@/GlobalModule.js';
 import { CoreModule } from '@/core/CoreModule.js';
 import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { LoggerService } from '@/core/LoggerService.js';
 import type { IActor } from '@/core/activitypub/type.js';
 import { MockResolver } from '../misc/mock-resolver.js';
+import { Note } from '@/models/index.js';
 
 const host = 'https://host1.test';
 
@@ -33,6 +35,7 @@ function createRandomActor(): IActor & { id: string } {
 describe('ActivityPub', () => {
 	let noteService: ApNoteService;
 	let personService: ApPersonService;
+	let rendererService: ApRendererService;
 	let resolver: MockResolver;
 
 	beforeEach(async () => {
@@ -45,6 +48,7 @@ describe('ActivityPub', () => {
 
 		noteService = app.get<ApNoteService>(ApNoteService);
 		personService = app.get<ApPersonService>(ApPersonService);
+		rendererService = app.get<ApRendererService>(ApRendererService);
 		resolver = new MockResolver(await app.resolve<LoggerService>(LoggerService));
 
 		// Prevent ApPersonService from fetching instance, as it causes Jest import-after-test error
@@ -111,6 +115,15 @@ describe('ActivityPub', () => {
 			const user = await personService.createPerson(actor.id, resolver);
 
 			assert.strictEqual(user.name, null);
+		});
+	});
+
+	describe('Renderer', () => {
+		test('Render an announce with visibility: followers', () => {
+			rendererService.renderAnnounce(null, {
+				createdAt: new Date(0),
+				visibility: 'followers',
+			} as Note);
 		});
 	});
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

`renderNote`と同じように`renderAnnounce`でも`visibility: followers`を許可する

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

APIでは許可されているのにrenderAnnounceでは拒否されて不具合を起こしていたので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests

Fixes #10127