### PR TITLE
fix(backend/DriveService): gracely skip when getting NoSuchKey error from S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ You should also include the user name that made the change.
 - ロールで広告を無効にするとadmin/adsでプレビューがでてこない問題を修正
 - /api-consoleページにアクセスすると404が出る問題を修正
 - SMTP Login id length is too short
+- AWS S3からのファイル削除でNoSuchKeyエラーが出ると進めらない状態になる問題を修正
 
 ## 13.9.2 (2023/03/06)
 

--- a/packages/backend/test/unit/DriveService.ts
+++ b/packages/backend/test/unit/DriveService.ts
@@ -1,0 +1,55 @@
+process.env.NODE_ENV = 'test';
+
+import { jest } from '@jest/globals';
+import { Test } from '@nestjs/testing';
+import { GlobalModule } from '@/GlobalModule.js';
+import { DriveService } from '@/core/DriveService.js';
+import { CoreModule } from '@/core/CoreModule.js';
+import { S3Service } from '@/core/S3Service';
+import { Meta } from '@/models';
+import type { DeleteObjectOutput } from 'aws-sdk/clients/s3';
+import type { AWSError } from 'aws-sdk/lib/error';
+import type { PromiseResult, Request } from 'aws-sdk/lib/request';
+import type { TestingModule } from '@nestjs/testing';
+
+describe('DriveService', () => {
+	let app: TestingModule;
+	let driveService: DriveService;
+
+	beforeEach(async () => {
+		app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+			providers: [DriveService, S3Service],
+		}).compile();
+		app.enableShutdownHooks();
+		driveService = app.get<DriveService>(DriveService);
+
+		const s3Service = app.get<S3Service>(S3Service);
+		const s3 = s3Service.getS3({} as Meta);
+
+		// new S3() surprisingly does not return an instance of class S3.
+		// Let's use getPrototypeOf here to get a real prototype, since spying on S3.prototype doesn't work.
+		// TODO: Use `aws-sdk-client-mock` package when upgrading to AWS SDK v3.
+		jest.spyOn(Object.getPrototypeOf(s3), 'deleteObject').mockImplementation(() => {
+			// Roughly mock AWS request object
+			return {
+				async promise(): Promise<PromiseResult<DeleteObjectOutput, AWSError>> {
+					const err = new Error('mock') as AWSError;
+					err.code = 'NoSuchKey';
+					throw err;
+				},
+			} as Request<DeleteObjectOutput, AWSError>;
+		});
+	});
+
+	describe('Object storage', () => {
+		test('delete a file with no valid key', async () => {
+			try {
+				await driveService.deleteObjectStorageFile('lol no way');
+			} catch (err: any) {
+				console.log(err.cause);
+				throw err;
+			}
+		});
+	});
+});

--- a/packages/backend/test/unit/DriveService.ts
+++ b/packages/backend/test/unit/DriveService.ts
@@ -6,7 +6,7 @@ import { GlobalModule } from '@/GlobalModule.js';
 import { DriveService } from '@/core/DriveService.js';
 import { CoreModule } from '@/core/CoreModule.js';
 import { S3Service } from '@/core/S3Service';
-import { Meta } from '@/models';
+import type { Meta } from '@/models';
 import type { DeleteObjectOutput } from 'aws-sdk/clients/s3';
 import type { AWSError } from 'aws-sdk/lib/error';
 import type { PromiseResult, Request } from 'aws-sdk/lib/request';


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

AWS S3でNoSuchKeyエラーが出たら警告と共にスキップする

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

削除したいファイルがもう存在しなかったらそのまま進めてもいいはずですので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests

Fixes #10124