### PR TITLE
オブジェクトストレージのEndpointに値を一度保存した後に空にし直すとエラーになるのを解消

### DIFF
--- a/packages/backend/src/core/S3Service.ts
+++ b/packages/backend/src/core/S3Service.ts
@@ -19,12 +19,14 @@ export class S3Service {
 
 	@bindThis
 	public getS3(meta: Meta) {
-		const u = meta.objectStorageEndpoint != null
+		const u = meta.objectStorageEndpoint
 			? `${meta.objectStorageUseSSL ? 'https://' : 'http://'}${meta.objectStorageEndpoint}`
 			: `${meta.objectStorageUseSSL ? 'https://' : 'http://'}example.net`;
-	
+
 		return new S3({
-			endpoint: meta.objectStorageEndpoint ?? undefined,
+			endpoint: meta.objectStorageEndpoint && meta.objectStorageEndpoint.length > 0
+				? meta.objectStorageEndpoint
+				: undefined,
 			accessKeyId: meta.objectStorageAccessKey!,
 			secretAccessKey: meta.objectStorageSecretKey!,
 			region: meta.objectStorageRegion ?? undefined,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

コントロールパネルのオブジェクトストレージでEndpointに任意の値を入れて保存したあとに空にして保存し直してファイルアップロードを実行するとエラーになる。  
これを解消した。  
2度目の保存ではカラムの値がnullではなく空文字列になるためnull or notの判定を変えた。

## Why

<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

AWS S3を使用するときに誤って保存したあとに画面の説明通りに空にしても動かないため。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

空にしなくても `https://s3.{region}.amazonaws.com/` を入れれば動くので回避はできる。  　　

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
