### PR TITLE
Deliverキューに宛先がSharedInboxかどうかのフラグを追加 ( #10298 関係 )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ You should also include the user name that made the change.
 - アクティブユーザー数チャートの記録上限値を拡張
 - Playのソースコード上限文字数を2倍に拡張
 - 付箋ウィジェットの高さを設定可能に
+- 配送先サーバーが410 Goneで応答してきた場合は自動で配送停止をするように
 
 ### Bugfixes
 - プロフィールで設定した情報が削除できない問題を修正

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -26,7 +26,7 @@ export class QueueService {
 	) {}
 
 	@bindThis
-	public deliver(user: ThinUser, content: IActivity | null, to: string | null) {
+	public deliver(user: ThinUser, content: IActivity | null, to: string | null, isSharedInbox: boolean) {
 		if (content == null) return null;
 		if (to == null) return null;
 
@@ -36,6 +36,7 @@ export class QueueService {
 			},
 			content,
 			to,
+			isSharedInbox,
 		};
 
 		return this.deliverQueue.add(data, {

--- a/packages/backend/src/core/RelayService.ts
+++ b/packages/backend/src/core/RelayService.ts
@@ -57,7 +57,7 @@ export class RelayService {
 		const relayActor = await this.getRelayActor();
 		const follow = await this.apRendererService.renderFollowRelay(relay, relayActor);
 		const activity = this.apRendererService.addContext(follow);
-		this.queueService.deliver(relayActor, activity, relay.inbox);
+		this.queueService.deliver(relayActor, activity, relay.inbox, false);
 	
 		return relay;
 	}
@@ -76,7 +76,7 @@ export class RelayService {
 		const follow = this.apRendererService.renderFollowRelay(relay, relayActor);
 		const undo = this.apRendererService.renderUndo(follow, relayActor);
 		const activity = this.apRendererService.addContext(undo);
-		this.queueService.deliver(relayActor, activity, relay.inbox);
+		this.queueService.deliver(relayActor, activity, relay.inbox, false);
 	
 		await this.relaysRepository.delete(relay.id);
 	}
@@ -120,7 +120,7 @@ export class RelayService {
 		const signed = await this.apRendererService.attachLdSignature(copy, user);
 	
 		for (const relay of relays) {
-			this.queueService.deliver(user, signed, relay.inbox);
+			this.queueService.deliver(user, signed, relay.inbox, false);
 		}
 	}
 }

--- a/packages/backend/src/core/UserBlockingService.ts
+++ b/packages/backend/src/core/UserBlockingService.ts
@@ -118,7 +118,7 @@ export class UserBlockingService implements OnApplicationShutdown {
 
 		if (this.userEntityService.isLocalUser(blocker) && this.userEntityService.isRemoteUser(blockee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderBlock(blocking));
-			this.queueService.deliver(blocker, content, blockee.inbox);
+			this.queueService.deliver(blocker, content, blockee.inbox, false);
 		}
 	}
 
@@ -163,13 +163,13 @@ export class UserBlockingService implements OnApplicationShutdown {
 		// リモートにフォローリクエストをしていたらUndoFollow送信
 		if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(this.apRendererService.renderFollow(follower, followee), follower));
-			this.queueService.deliver(follower, content, followee.inbox);
+			this.queueService.deliver(follower, content, followee.inbox, false);
 		}
 
 		// リモートからフォローリクエストを受けていたらReject送信
 		if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderReject(this.apRendererService.renderFollow(follower, followee, request.requestId!), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 		}
 	}
 
@@ -211,13 +211,13 @@ export class UserBlockingService implements OnApplicationShutdown {
 		// リモートにフォローをしていたらUndoFollow送信
 		if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(this.apRendererService.renderFollow(follower, followee), follower));
-			this.queueService.deliver(follower, content, followee.inbox);
+			this.queueService.deliver(follower, content, followee.inbox, false);
 		}
 
 		// リモートからフォローをされていたらRejectFollow送信
 		if (this.userEntityService.isLocalUser(followee) && this.userEntityService.isRemoteUser(follower)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderReject(this.apRendererService.renderFollow(follower, followee), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 		}
 	}
 
@@ -262,7 +262,7 @@ export class UserBlockingService implements OnApplicationShutdown {
 		// deliver if remote bloking
 		if (this.userEntityService.isLocalUser(blocker) && this.userEntityService.isRemoteUser(blockee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(this.apRendererService.renderBlock(blocking), blocker));
-			this.queueService.deliver(blocker, content, blockee.inbox);
+			this.queueService.deliver(blocker, content, blockee.inbox, false);
 		}
 	}
 

--- a/packages/backend/src/core/UserFollowingService.ts
+++ b/packages/backend/src/core/UserFollowingService.ts
@@ -82,7 +82,7 @@ export class UserFollowingService {
 		if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee) && blocked) {
 			// リモートフォローを受けてブロックしていた場合は、エラーにするのではなくRejectを送り返しておしまい。
 			const content = this.apRendererService.addContext(this.apRendererService.renderReject(this.apRendererService.renderFollow(follower, followee, requestId), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 			return;
 		} else if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee) && blocking) {
 			// リモートフォローを受けてブロックされているはずの場合だったら、ブロック解除しておく。
@@ -131,7 +131,7 @@ export class UserFollowingService {
 
 		if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderAccept(this.apRendererService.renderFollow(follower, followee, requestId), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 		}
 	}
 
@@ -294,13 +294,13 @@ export class UserFollowingService {
 	
 		if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(this.apRendererService.renderFollow(follower, followee), follower));
-			this.queueService.deliver(follower, content, followee.inbox);
+			this.queueService.deliver(follower, content, followee.inbox, false);
 		}
 	
 		if (this.userEntityService.isLocalUser(followee) && this.userEntityService.isRemoteUser(follower)) {
 			// local user has null host
 			const content = this.apRendererService.addContext(this.apRendererService.renderReject(this.apRendererService.renderFollow(follower, followee), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 		}
 	}
 	
@@ -389,7 +389,7 @@ export class UserFollowingService {
 	
 		if (this.userEntityService.isLocalUser(follower) && this.userEntityService.isRemoteUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderFollow(follower, followee));
-			this.queueService.deliver(follower, content, followee.inbox);
+			this.queueService.deliver(follower, content, followee.inbox, false);
 		}
 	}
 
@@ -406,7 +406,7 @@ export class UserFollowingService {
 			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(this.apRendererService.renderFollow(follower, followee), follower));
 	
 			if (this.userEntityService.isLocalUser(follower)) { // 本来このチェックは不要だけどTSに怒られるので
-				this.queueService.deliver(follower, content, followee.inbox);
+				this.queueService.deliver(follower, content, followee.inbox, false);
 			}
 		}
 	
@@ -449,7 +449,7 @@ export class UserFollowingService {
 	
 		if (this.userEntityService.isRemoteUser(follower) && this.userEntityService.isLocalUser(followee)) {
 			const content = this.apRendererService.addContext(this.apRendererService.renderAccept(this.apRendererService.renderFollow(follower, followee, request.requestId!), followee));
-			this.queueService.deliver(followee, content, follower.inbox);
+			this.queueService.deliver(followee, content, follower.inbox, false);
 		}
 	
 		this.userEntityService.pack(followee.id, followee, {
@@ -557,7 +557,7 @@ export class UserFollowingService {
 		});
 
 		const content = this.apRendererService.addContext(this.apRendererService.renderReject(this.apRendererService.renderFollow(follower, followee, request?.requestId ?? undefined), followee));
-		this.queueService.deliver(followee, content, follower.inbox);
+		this.queueService.deliver(followee, content, follower.inbox, false);
 	}
 
 	/**

--- a/packages/backend/src/core/UserSuspendService.ts
+++ b/packages/backend/src/core/UserSuspendService.ts
@@ -54,7 +54,7 @@ export class UserSuspendService {
 			}
 	
 			for (const inbox of queue) {
-				this.queueService.deliver(user, content, inbox);
+				this.queueService.deliver(user, content, inbox, true);
 			}
 		}
 	}
@@ -84,7 +84,7 @@ export class UserSuspendService {
 			}
 	
 			for (const inbox of queue) {
-				this.queueService.deliver(user as any, content, inbox);
+				this.queueService.deliver(user as any, content, inbox, true);
 			}
 		}
 	}

--- a/packages/backend/src/queue/processors/DeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeliverProcessorService.ts
@@ -115,6 +115,18 @@ export class DeliverProcessorService {
 			if (res instanceof StatusError) {
 				// 4xx
 				if (res.isClientError) {
+					// 相手が閉鎖していることを明示しているため、配送停止する
+					if (res.statusCode === 410) {
+						this.federatedInstanceService.fetch(host).then(i => {
+							this.instancesRepository.update(i.id, {
+								isSuspended: true,
+							});
+							this.federatedInstanceService.updateCachePartial(host, {
+								isSuspended: true,
+							});
+						});
+						return `${host} is gone`;
+					}
 					// HTTPステータスコード4xxはクライアントエラーであり、それはつまり
 					// 何回再送しても成功することはないということなのでエラーにはしないでおく
 					return `${res.statusCode} ${res.statusMessage}`;

--- a/packages/backend/src/queue/processors/DeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeliverProcessorService.ts
@@ -116,7 +116,7 @@ export class DeliverProcessorService {
 				// 4xx
 				if (res.isClientError) {
 					// 相手が閉鎖していることを明示しているため、配送停止する
-					if (res.statusCode === 410) {
+					if (job.data.isSharedInbox && res.statusCode === 410) {
 						this.federatedInstanceService.fetch(host).then(i => {
 							this.instancesRepository.update(i.id, {
 								isSuspended: true,

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -12,6 +12,8 @@ export type DeliverJobData = {
 	content: unknown;
 	/** inbox URL to deliver */
 	to: string;
+	/** whether it is SharedInbox **/
+	isSharedInbox: boolean;
 };
 
 export type InboxJobData = {

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -12,7 +12,7 @@ export type DeliverJobData = {
 	content: unknown;
 	/** inbox URL to deliver */
 	to: string;
-	/** whether it is SharedInbox **/
+	/** whether it is sharedInbox */
 	isSharedInbox: boolean;
 };
 

--- a/packages/backend/src/server/api/endpoints/admin/resolve-abuse-user-report.ts
+++ b/packages/backend/src/server/api/endpoints/admin/resolve-abuse-user-report.ts
@@ -49,7 +49,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 				const actor = await this.instanceActorService.getInstanceActor();
 				const targetUser = await this.usersRepository.findOneByOrFail({ id: report.targetUserId });
 
-				this.queueService.deliver(actor, this.apRendererService.addContext(this.apRendererService.renderFlag(actor, targetUser.uri!, report.comment)), targetUser.inbox);
+				this.queueService.deliver(actor, this.apRendererService.addContext(this.apRendererService.renderFlag(actor, targetUser.uri!, report.comment)), targetUser.inbox, false);
 			}
 
 			await this.abuseUserReportsRepository.update(report.id, {

--- a/packages/backend/src/server/api/endpoints/notes/polls/vote.ts
+++ b/packages/backend/src/server/api/endpoints/notes/polls/vote.ts
@@ -161,7 +161,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 			if (note.userHost != null) {
 				const pollOwner = await this.usersRepository.findOneByOrFail({ id: note.userId }) as RemoteUser;
 
-				this.queueService.deliver(me, this.apRendererService.addContext(await this.apRendererService.renderVote(me, vote, note, poll, pollOwner)), pollOwner.inbox);
+				this.queueService.deliver(me, this.apRendererService.addContext(await this.apRendererService.renderVote(me, vote, note, poll, pollOwner)), pollOwner.inbox, false);
 			}
 
 			// リモートフォロワーにUpdate配信


### PR DESCRIPTION
## What
Fix for #10298 

## Why
現在の実装ではDeliverキューで宛先がサーバー全体のInbox (SharedInbox)なのか、個人用Inboxなのか判別ができない。
それゆえ、単純にステータスコードで判断すると削除されたユーザーのInboxにリクエストを送信したときに同じく410 Goneを受け取ってサーバー全体の配送が停止されてしまうため。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
