### PR TITLE
refactor: schema中のavatarBlurHash/bannerBlurHashの型を絞り込んだ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ You should also include the user name that made the change.
 - Playのソースコード上限文字数を2倍に拡張
 - 付箋ウィジェットの高さを設定可能に
 - 配送先サーバーが410 Goneで応答してきた場合は自動で配送停止をするように
+- avatarBlurHash/bannerBlurHashの型をstringに限定
 
 ### Bugfixes
 - プロフィールで設定した情報が削除できない問題を修正

--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -29,7 +29,7 @@ export const packedUserLiteSchema = {
 			nullable: true, optional: false,
 		},
 		avatarBlurhash: {
-			type: 'any',
+			type: 'string',
 			nullable: true, optional: false,
 		},
 		isAdmin: {
@@ -93,7 +93,7 @@ export const packedUserDetailedNotMeOnlySchema = {
 			nullable: true, optional: false,
 		},
 		bannerBlurhash: {
-			type: 'any',
+			type: 'string',
 			nullable: true, optional: false,
 		},
 		isLocked: {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
OpenAPIv3ドキュメントに記載される `avatarBlurHash`/`bannerBlurHash` の型がstringになります。
これによって、[misskey-hubに保存されるであろうOpenAPIv3ドキュメント](https://github.com/misskey-dev/misskey-hub/blob/main/src/.vuepress/api.json)でも、正しい値になります。

## Why

#10308 
## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカルでテストを走らせた所、e2eテストが全てコケました。その際、developで試しても同様のコケかたをしたので恐らくこの変更による影響ではないだろうと考えたのでPRを作成させて頂きました。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
