### PR TITLE
refactor(backend): validateNoteの引数の型を強くし、anyを除去

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -84,9 +84,10 @@ export class ApNoteService {
 		if (object.id && this.utilityService.extractDbHost(object.id) !== expectHost) {
 			return new Error(`invalid Note: id has different host. expected: ${expectHost}, actual: ${this.utilityService.extractDbHost(object.id)}`);
 		}
-	
-		if (object.attributedTo && this.utilityService.extractDbHost(getOneApId(object.attributedTo)) !== expectHost) {
-			return new Error(`invalid Note: attributedTo has different host. expected: ${expectHost}, actual: ${this.utilityService.extractDbHost(getOneApId(object.attributedTo))}`);
+
+		const actualHost = object.attributedTo && this.utilityService.extractDbHost(getOneApId(object.attributedTo));
+		if (object.attributedTo && actualHost !== expectHost) {
+			return new Error(`invalid Note: attributedTo has different host. expected: ${expectHost}, actual: ${actualHost}`);
 		}
 	
 		return null;

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -86,7 +86,7 @@ export class ApNoteService {
 		}
 	
 		if (object.attributedTo && this.utilityService.extractDbHost(getOneApId(object.attributedTo)) !== expectHost) {
-			return new Error(`invalid Note: attributedTo has different host. expected: ${expectHost}, actual: ${this.utilityService.extractDbHost(object.attributedTo)}`);
+			return new Error(`invalid Note: attributedTo has different host. expected: ${expectHost}, actual: ${this.utilityService.extractDbHost(getOneApId(object.attributedTo))}`);
 		}
 	
 		return null;

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -70,7 +70,7 @@ export class ApNoteService {
 	}
 
 	@bindThis
-	public validateNote(object: any, uri: string) {
+	public validateNote(object: IObject, uri: string) {
 		const expectHost = this.utilityService.extractDbHost(uri);
 	
 		if (object == null) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
`validateNote`メソッドから`any`を取り除きました。

## Why

#3622

## Additional info
### 議論の余地があると思われる変更点

* 8622100 の変更内容
  * アサーションの内容から推論して、actualの内容を変更しました。変更後のコードは意図された内容でしょうか？

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
  - not relevant