### PR TITLE
feat(client): Navbar の設定項目に「プロフィール」を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ You should also include the user name that made the change.
 - 付箋ウィジェットの高さを設定可能に
 - 配送先サーバーが410 Goneで応答してきた場合は自動で配送停止をするように
 - avatarBlurHash/bannerBlurHashの型をstringに限定
+- ナビゲーションバーの項目に「プロフィール」を追加できるように
 
 ### Bugfixes
 - プロフィールで設定した情報が削除できない問題を修正

--- a/packages/frontend/src/navbar.ts
+++ b/packages/frontend/src/navbar.ts
@@ -136,4 +136,10 @@ export const navbarItemDef = reactive({
 			location.reload();
 		},
 	},
+	profile: {
+		title: i18n.ts.profile,
+		icon: 'ti ti-user',
+		show: computed(() => $i != null),
+		to: `/@${$i?.username}`,
+	},
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
Fix #10330 

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
左端ナビゲーションバーで設定できる項目に「プロフィール」が追加されます

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
自プロフィールをどこからでも一発で呼び出せるようになります

詳しくは #10330 を参照してください

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
追加後のイメージ画像は #10330 に掲載しています

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
