### PR TITLE
fix(users/show): ユーザーが見つからなかった場合に404ステータスコードを返す

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/show.ts
+++ b/packages/backend/src/server/api/endpoints/users/show.ts
@@ -48,6 +48,7 @@ export const meta = {
 			message: 'No such user.',
 			code: 'NO_SUCH_USER',
 			id: '4362f8dc-731f-4ad8-a694-be5a88922a24',
+			httpStatusCode: 404,
 		},
 	},
 } as const;

--- a/packages/backend/test/e2e/endpoints.ts
+++ b/packages/backend/test/e2e/endpoints.ts
@@ -162,14 +162,14 @@ describe('Endpoints', () => {
 			const res = await api('/users/show', {
 				userId: '000000000000000000000000',
 			});
-			assert.strictEqual(res.status, 400);
+			assert.strictEqual(res.status, 404);
 		});
 
 		test('間違ったIDで怒られる', async () => {
 			const res = await api('/users/show', {
 				userId: 'kyoppie',
 			});
-			assert.strictEqual(res.status, 400);
+			assert.strictEqual(res.status, 404);
 		});
 	});
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
エンドポイント `/users/show` において、ユーザーが見つからなかった場合に 404 ステータスコードを返すようにしました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

現状、ApiError の実装上 `kind` が指定されていない場合に `client` が代入される実装となっています。
上記により `httpStatusCode` が設定されていない場合はステータスコード 400 で返却されます。

データが見つからない場合のエラーコードとしては不適切と思ったため PR を作成しました。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
