### PR TITLE
aws-sdk v3 に関する仕様変更と修正

### DIFF
--- a/packages/backend/src/core/S3Service.ts
+++ b/packages/backend/src/core/S3Service.ts
@@ -42,7 +42,7 @@ export class S3Service {
 				accessKeyId: meta.objectStorageAccessKey,
 				secretAccessKey: meta.objectStorageSecretKey,
 			} : undefined,
-			region: meta.objectStorageRegion ?? undefined,
+			region: meta.objectStorageRegion ? meta.objectStorageRegion : undefined, // 空文字列もundefinedにするため ?? は使わない
 			tls: meta.objectStorageUseSSL,
 			forcePathStyle: meta.objectStorageEndpoint ? meta.objectStorageS3ForcePathStyle : false, // AWS with endPoint omitted
 			requestHandler: new NodeHttpHandler(handlerOption),


### PR DESCRIPTION
## What

オブジェクトストレージリージョンが空文字列のときAWS-SDKに渡す値をundefinedにする。  


## Why

#10408 


## Additional info (optional)

### 文言

[Crowdin](https://crowdin.com/project/misskey) の作法がわからなかったので変更案を置きます

キー objectStorageRegionDesc
```
ja-JP
'xx-east-1'のようなregionを指定してください。使用サービスにregionの概念がない場合は'us-east-1'にしてください。AWS設定ファイルまたは環境変数を参照する場合は空にしてください。 

en-US
Specify a region like 'xx-east-1'. If your service does not distinguish between regions, enter 'us-east-1' If you use a shared config file or enviroment variables, leave this blank.
```

### 仕様変更

aws-sdkが未指定のリージョンに対してv2とv3で挙動が異なるのでリリースノートへ追加が必要かと思いましたが、リリース済みのバージョンに追加してしまってよいか悩んだのでここに置きます。  

```
### Changes
- オブジェクトストレージのリージョン指定が必須になりました
  - リージョンの指定の無いサービスは us-east-1 を設定してください
  - 値が空の場合は設定ファイルまたは環境変数の使用を試みます
    - e.g. ~/aws/config, AWS_REGION
```


## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
