### PR TITLE
広告・お知らせが新規登録時に増殖しないように

### DIFF
--- a/packages/frontend/src/pages/admin/ads.vue
+++ b/packages/frontend/src/pages/admin/ads.vue
@@ -113,16 +113,37 @@ function remove(ad) {
 
 function save(ad) {
 	if (ad.id == null) {
-		os.apiWithDialog('admin/ad/create', {
+		os.api('admin/ad/create', {
 			...ad,
 			expiresAt: new Date(ad.expiresAt).getTime(),
 			startsAt: new Date(ad.startsAt).getTime(),
+		}).then(() => {
+			os.alert({
+				type: 'success',
+				text: i18n.ts.saved,
+			});
+			refresh();
+		}).catch(err => {
+			os.alert({
+				type: 'error',
+				text: err,
+			});
 		});
 	} else {
-		os.apiWithDialog('admin/ad/update', {
+		os.api('admin/ad/update', {
 			...ad,
 			expiresAt: new Date(ad.expiresAt).getTime(),
 			startsAt: new Date(ad.startsAt).getTime(),
+		}).then(() => {
+			os.alert({
+				type: 'success',
+				text: i18n.ts.saved,
+			});
+		}).catch(err => {
+			os.alert({
+				type: 'error',
+				text: err,
+			});
 		});
 	}
 }
@@ -141,6 +162,25 @@ function more() {
 		}));
 	});
 }
+
+function refresh() {
+	os.api('admin/ad/list').then(adsResponse => {
+		ads = adsResponse.map(r => {
+			const exdate = new Date(r.expiresAt);
+			const stdate = new Date(r.startsAt);
+			exdate.setMilliseconds(exdate.getMilliseconds() - localTimeDiff);
+			stdate.setMilliseconds(stdate.getMilliseconds() - localTimeDiff);
+			return {
+				...r,
+				expiresAt: exdate.toISOString().slice(0, 16),
+				startsAt: stdate.toISOString().slice(0, 16),
+			};
+		});
+	});
+}
+
+refresh();
+
 const headerActions = $computed(() => [{
 	asFullButton: true,
 	icon: 'ti ti-plus',

--- a/packages/frontend/src/pages/admin/announcements.vue
+++ b/packages/frontend/src/pages/admin/announcements.vue
@@ -69,6 +69,7 @@ function save(announcement) {
 				type: 'success',
 				text: i18n.ts.saved,
 			});
+			refresh();
 		}).catch(err => {
 			os.alert({
 				type: 'error',
@@ -89,6 +90,14 @@ function save(announcement) {
 		});
 	}
 }
+
+function refresh() {
+	os.api('admin/announcements/list').then(announcementResponse => {
+		announcements = announcementResponse;
+	});
+}
+
+refresh();
 
 const headerActions = $computed(() => [{
 	asFullButton: true,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

お知らせ・広告を新規登録しようとしているのか既存のレコードを更新しようとしているのかが正しく取り扱われるようにする

問題なのは管理画面に表示されているレコードが、新規登録されたもので、かつリロードされていないものである場合には、IDがセットされていないということ。
このためちょっと強引やむしれないけど、新規登録を行なった場合にのみ、管理画面に表示されているリストの更新をかけてしまう。
広告の管理画面の方はエラーハンドリングがなかったので、それつけてエラーの場合には更新させないようにする、そうしないとエラーになるたびに一から値を入力し直すことになってしまう

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
resolves https://github.com/misskey-dev/misskey/issues/10411

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
