### PR TITLE
fix(frontend): URLに他のクエリがあるときにもZen UIが適用されるように

### DIFF
--- a/packages/frontend/src/init.ts
+++ b/packages/frontend/src/init.ts
@@ -187,7 +187,7 @@ try {
 } catch (err) {}
 
 const app = createApp(
-	window.location.search === '?zen' ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
+	new URLSearchParams(window.location.search).has('zen') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
 	!$i ? defineAsyncComponent(() => import('@/ui/visitor.vue')) :
 	ui === 'deck' ? defineAsyncComponent(() => import('@/ui/deck.vue')) :
 	ui === 'classic' ? defineAsyncComponent(() => import('@/ui/classic.vue')) :


### PR DESCRIPTION
## What

- https://github.com/misskey-dev/misskey/issues/10468

このPRでは上記のIssueを解決します。具体的には、Zen UI適用のためのURLクエリを使った判定方法を次のように変えます。

変更前：クエリ文字列（`location.search`）が`'?zen'`と完全一致するかどうか
変更後：クエリパラメータ（`URLSearchParams`）が`'zen'`というキーのパラメータを持つかどうか

## Why

変更前の判定方法では、`'zen'`以外のパラメータが含まれていたときにZen UIが適用されません。現バージョンのMisskeyにおいてクエリを使う場面は限られていると記憶していますが、そのような場面がないわけではなく、共有用URL（`/share`）では`'text'`をキーとするパラメータを使うことができるようになっています。このPRは、そのような場面でも適切にZen UIが使われるようになることを期待したものです。

## Additional info (optional)

`'?zen'`との完全一致による判定をしている処理としては、このPRで修正した部分の他に1箇所見付けられました。

- https://github.com/misskey-dev/misskey/blob/ecaf152/packages/sw/src/scripts/operations.ts#L62

どういったことをするための部分なのか理解できていないので、今の私にはどうすることもできません。すみません。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
