### PR TITLE
fix(sw): プッシュ通知の操作でZenUIなクライアントが開かれてしまう場合がある問題を修正 (#10497)

### DIFF
--- a/packages/sw/src/scripts/operations.ts
+++ b/packages/sw/src/scripts/operations.ts
@@ -59,7 +59,7 @@ export async function findClient() {
 		type: 'window',
 	});
 	for (const c of clients) {
-		if (c.url.indexOf('?zen') < 0) return c;
+		if (!new URL(c.url).searchParams.has('zen')) return c;
 	}
 	return null;
 }


### PR DESCRIPTION
## What

このPRはIssue #10497 を解決することを目的としたものです。プッシュ通知が操作されたときに開くクライアントを得る処理のうち、そのクライアントがZenUIかどうかを判定する部分を変更しました。

変更前：クライアントのURLに`'?zen'`という文字列が含まれる場合、そのクライアントはZenUIであるとする
変更後：クライアントのURLのクエリに`'zen'`というキーのパラメータが含まれる場合、そのクライアントはZenUIであるとする

## Why

変更前の方法では、クエリとして`'zen'`が最初に存在するときしかそのクライアントがZenUIであると判定されません。これまではIssue #10468 によって報告されているバグによって、そもそもそのようなときしかZenUIが適用されないため、このような実装でも問題ありませんでした。

しかしそのバグを修正するPR #10477 がマージされた場合、クエリに`'zen'`というキーのパラメータが含まれる場合は必ずZenUIが使われるようになります。これにより、最初に挙げたIssue #10497 が問題になってくると考えられます。

## Additional info (optional)

このPRの作成に際し周辺のコードを読んだのですが、[型定義が不十分である](https://github.com/misskey-dev/misskey/blob/a561b83/packages/sw/src/scripts/operations.ts#L36)ことや、[URLにおけるクエリ文字列が文字列操作によって作られている](https://github.com/misskey-dev/misskey/blob/a561b83/packages/sw/src/scripts/operations.ts#L37-L41)ことでバグが混入しやすい状態になってしまっている（そしておそらく混入している[^1]）ことなどが気になりました。軽く整理して、別のPRとして提出する予定です。

[^1]: [ここ](https://github.com/misskey-dev/misskey/blob/a561b83/packages/sw/src/scripts/operations.ts#L39)で`encodeURIComponent`のようなことをすべきかと

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
