### PR TITLE
fix: retrieve remote user again when migrating

### DIFF
--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -736,12 +736,16 @@ export class ApInboxService {
 		// fetch the new and old accounts
 		const targetUri = getApHrefNullable(activity.target);
 		if (!targetUri) return 'skip: invalid activity target';
-		const new_acc = await this.apPersonService.resolvePerson(targetUri);
-		const old_acc = await this.apPersonService.resolvePerson(actor.uri);
+		let new_acc = await this.apPersonService.resolvePerson(targetUri);
+		let old_acc = await this.apPersonService.resolvePerson(actor.uri);
 
 		// update them if they're remote
 		if (new_acc.uri) await this.apPersonService.updatePerson(new_acc.uri);
 		if (old_acc.uri) await this.apPersonService.updatePerson(old_acc.uri);
+
+		// retrieve updated users
+		new_acc = await this.apPersonService.resolvePerson(targetUri);
+		old_acc = await this.apPersonService.resolvePerson(actor.uri);
 
 		// check if alsoKnownAs of the new account is valid
 		let isValidMove = true;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

アカウント引っ越し時、及びMoveアクティビティ受信時にリモートユーザーのalsoKnownAsをアップデートするためにもう一度取得するようにする。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

一度リモートアカウントをフェッチしてデータベースに保存された状態だとalsoKnownAsが古い可能性があり再フォローしないことがあるため。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

#10507 と同じ組み合わせで動作確認をしました。
#10507 に含めるつもりでしたがマージされたためこのPRで修正します。すみません。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
