### PR TITLE
chore: local test が redis version 起因で落ちるのを修正

### DIFF
--- a/packages/backend/test/docker-compose.yml
+++ b/packages/backend/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   redistest:
-    image: redis:6
+    image: redis:7
     ports:
       - "127.0.0.1:56312:6379"
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`docker compose -f packages/backend/test/docker-compose.yml up`
で立ち上がる redis が v7 になる


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md#run-test
の通りにすると、#10464 と同様のエラーが出るため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
