### PR TITLE
test: use M PLUS Rounded 1c on Storybook

### DIFF
--- a/packages/frontend/.storybook/preview-head.html
+++ b/packages/frontend/.storybook/preview-head.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@2.12.0/tabler-icons.min.css">
-<link rel="stylesheet" href="https://www.unpkg.com/@fontsource/m-plus-rounded-1c/index.css">
+<link rel="stylesheet" href="https://unpkg.com/@fontsource/m-plus-rounded-1c/index.css">
 <style>
 	html {
 		font-family: 'Hiragino Maru Gothic Pro', 'BIZ UDGothic', Roboto, HelveticaNeue, Arial, 'M PLUS Rounded 1c', sans-serif;

--- a/packages/frontend/.storybook/preview-head.html
+++ b/packages/frontend/.storybook/preview-head.html
@@ -1,4 +1,10 @@
 <link rel="stylesheet" href="https://unpkg.com/@tabler/icons-webfont@2.12.0/tabler-icons.min.css">
+<link rel="stylesheet" href="https://www.unpkg.com/@fontsource/m-plus-rounded-1c/index.css">
+<style>
+	html {
+		font-family: 'Hiragino Maru Gothic Pro', 'BIZ UDGothic', Roboto, HelveticaNeue, Arial, 'M PLUS Rounded 1c', sans-serif;
+	}
+</style>
 <script>
   window.global = window;
 </script>


### PR DESCRIPTION
## What

Storybook 上で M PLUS Rounded 1c をフォールバックフォントに採用する

## Why

Chromatic の実行環境で適切な日本語フォントが選択されないため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
