### PR TITLE
fix(client): PWA時の絵文字ピッカーの位置をホームバーに重ならないように調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 			- 右耳は上からおよそ 10%, 左からおよそ 80% の位置で決定します
 	- 「UIのアニメーションを減らす」 (`reduceAnimation`) で猫耳を撫でられなくなります
 - Add Minimizing ("folding") of windows
+- PWA時の絵文字ピッカーの位置をホームバーに重ならないように調整
 
 ### Server
 - PostgreSQLのレプリケーション対応

--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -439,6 +439,7 @@ defineExpose({
 
 	&.asDrawer {
 		width: 100% !important;
+		padding: 12px 0 max(env(safe-area-inset-bottom, 0px), 12px) 0;
 
 		> .emojis {
 			::v-deep(section) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

fix: #10532

PWA時の絵文字ピッカーの位置をホームバーに重ならないように調整しました。`MKMenu` と同じpaddingを設定しています。

|  Before | After  |
|---|---|
| <img width="227" alt="スクリーンショット 2023-04-08 19 59 09" src="https://user-images.githubusercontent.com/13767532/230732008-b7e2aed2-46a2-48c5-a076-4a2fb0fda6f6.png">  |  <img width="234" alt="スクリーンショット 2023-04-08 20 16 55" src="https://user-images.githubusercontent.com/13767532/230732024-d104ced9-b320-43ad-a344-f41d351114a1.png"> |

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

ホームバーと重なりタップがしづらいため

## Additional info (optional)

<!-- テスト観点など -->
<!-- Test perspective, etc -->

スクショのシミュレーターの他、iPhone 12 Pro Max実機で表示を確認しています。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
