### PR TITLE
fix issue #10195 設定のバックアップ の「削除」の文字がない

### DIFF
--- a/packages/frontend/src/pages/settings/preferences-backups.vue
+++ b/packages/frontend/src/pages/settings/preferences-backups.vue
@@ -399,7 +399,7 @@ function menu(ev: MouseEvent, profileId: string) {
 		icon: 'ti ti-device-floppy',
 		action: () => save(profileId),
 	}, null, {
-		text: ts._preferencesBackups.delete,
+		text: ts.delete,
 		icon: 'ti ti-trash',
 		action: () => deleteProfile(profileId),
 		danger: true,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
issue #10195 設定のバックアップ の「削除」の文字がない の対応
設定のバックアップをクリックすると表示されるメニューには「削除」の文字がなく、ゴミ箱のアイコンのみだったため、他の項目のように「削除」の文字が表示されるように修正。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
他の項目のように「削除」の文字が表示されるのが正と思われるため。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
修正前
![修正前](https://user-images.githubusercontent.com/100684884/230773171-994f4e93-4147-4ce2-848c-33a790f387f9.png)

修正後
![修正後](https://user-images.githubusercontent.com/100684884/230773173-b3d00bbe-3e63-4045-b3e7-2a9265e4e0e0.png)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
