### PR TITLE
MkContainer.vue i18n 変数をtemplateから見えるように

### DIFF
--- a/packages/frontend/src/components/MkContainer.vue
+++ b/packages/frontend/src/components/MkContainer.vue
@@ -82,6 +82,7 @@ export default defineComponent({
 			omitted: null,
 			ignoreOmit: false,
 			defaultStore,
+			i18n,
 		};
 	},
 	mounted() {


### PR DESCRIPTION
## What
MkContainer.vue で i18n が template から見えるように

## Why

setup script ではないので import した i18n が　template　で見えていない。 

```
vue-cb2a1a31.js:1 TypeError: Cannot read properties of undefined (reading 'ts')
    at MkContainer-28d1057e.js:1:3407
    at Object.s [as default] (vue-cb2a1a31.js:1:17477)
    at Proxy.<anonymous> (vue-cb2a1a31.js:1:25864)
    at wn (vue-cb2a1a31.js:1:17789)
    at rn.v [as fn] (vue-cb2a1a31.js:1:51639)
    at rn.run (vue-cb2a1a31.js:1:5061)
    at X.f.update (vue-cb2a1a31.js:1:52366)
    at De (vue-cb2a1a31.js:1:14144)
    at Ei (vue-cb2a1a31.js:1:15774)
```

## Additional info (optional)

おそらく https://github.com/misskey-dev/misskey/issues/10552 の原因

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
