### PR TITLE
カスタム絵文字のキャッシュ時に"{}"が入ってしまう問題を修正

### DIFF
--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -43,12 +43,8 @@ export class CustomEmojiService {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60 * 3, // 3m
 			fetcher: () => this.emojisRepository.find({ where: { host: IsNull() } }).then(emojis => new Map(emojis.map(emoji => [emoji.name, emoji]))),
-			toRedisConverter: (value) => JSON.stringify(value.values()),
-			fromRedisConverter: (value) => {
-				// 原因不明だが配列以外が入ってくることがあるため
-				if (!Array.isArray(JSON.parse(value))) return undefined;
-				return new Map(JSON.parse(value).map((x: Emoji) => [x.name, x]));
-			}, // TODO: Date型の変換
+			toRedisConverter: (value) => JSON.stringify(Array.from(value.values())),
+			fromRedisConverter: (value) => new Map(JSON.parse(value).map((x: Emoji) => [x.name, x])), // TODO: Date型の変換
 		});
 	}
 

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -8,7 +8,7 @@ export class RedisKVCache<T> {
 	private memoryCache: MemoryKVCache<T>;
 	private fetcher: (key: string) => Promise<T>;
 	private toRedisConverter: (value: T) => string;
-	private fromRedisConverter: (value: string) => T | undefined; // undefined means no cache
+	private fromRedisConverter: (value: string) => T;
 
 	constructor(redisClient: RedisKVCache<T>['redisClient'], name: RedisKVCache<T>['name'], opts: {
 		lifetime: RedisKVCache<T>['lifetime'];
@@ -92,7 +92,7 @@ export class RedisSingleCache<T> {
 	private memoryCache: MemorySingleCache<T>;
 	private fetcher: () => Promise<T>;
 	private toRedisConverter: (value: T) => string;
-	private fromRedisConverter: (value: string) => T | undefined; // undefined means no cache
+	private fromRedisConverter: (value: string) => T;
 
 	constructor(redisClient: RedisSingleCache<T>['redisClient'], name: RedisSingleCache<T>['name'], opts: {
 		lifetime: RedisSingleCache<T>['lifetime'];


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- カスタム絵文字の取得においてRedisを適切に使用

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- #10502 コメントに記載

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [✓] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [✓] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
