### PR TITLE
chore: Use node@18.16.0 on DevContainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,10 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+		"ghcr.io/devcontainers-contrib/features/pnpm:2": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "18.16.0"
+		}
 	},
 	"forwardPorts": [3000],
 	"postCreateCommand": "sudo chmod 755 .devcontainer/init.sh && .devcontainer/init.sh",


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

VS CodeのDevContainerのNodeのバージョンを18.16.0にする。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

#10639 でNodeの要求バージョンが18.16.0に上がったため、DevContainerのデフォルトのNodeであるv18.14.2では pnpm start したとき弾かれるようになった。
これを解決するためdevcontainer.jsonで明示的に 18.16.0 を使うようにする

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- DevContainerをRebuildしてnodeのバージョンが上がっていること。
- pnpm startしてdevサーバーが立ち上がること

Before
```
node ➜ /workspace (chore/update-node-on-devcontainer) $ node -v
v18.14.2
```

After
```
node ➜ /workspace (chore/update-node-on-devcontainer) $ node -v
v18.16.0
```

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
