### PR TITLE
fix : use channels/my-favorites on deck/channel-column/setChannel

### DIFF
--- a/packages/frontend/src/ui/deck/channel-column.vue
+++ b/packages/frontend/src/ui/deck/channel-column.vue
@@ -40,7 +40,7 @@ if (props.column.channelId == null) {
 }
 
 async function setChannel() {
-	const channels = await os.api('channels/followed', {
+	const channels = await os.api('channels/my-favorites', {
 		limit: 100,
 	});
 	const { canceled, result: channel } = await os.select({


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
デッキ表示時のカラムのチャンネル選択肢一覧をフォロー中チャンネルからお気に入りチャンネルに変更します。
close https://github.com/misskey-dev/misskey/issues/10661

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
フォロー中チャンネルは既にホームに流れてくるためカラム表示する必要性が薄く、また、 https://github.com/misskey-dev/misskey/commit/3cb0cc798914ff9057f4032a9b79e21402f72ec8#diff-9d0ecf3d29c90746cf6d45be08336b3ac3c4a9b3bb75be8638dbdc8ab5e6384aR86 でデフォルト表示時はお気に入りチャンネルを見るように変更されており、実装漏れでないかと考えています。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
