### PR TITLE
@username@servernameで検索できるようにする

### DIFF
--- a/packages/frontend/src/pages/search.vue
+++ b/packages/frontend/src/pages/search.vue
@@ -83,10 +83,13 @@ onMounted(() => {
 });
 
 async function search() {
-	const query = searchQuery.toString().trim();
+	let query = searchQuery.toString().trim();
 
 	if (query == null || query === '') return;
 
+	if (/^@.+@.+$/.test(query)) {
+		query = query.replace(/^@(.+)@(.+)$/, 'https://$2/@$1');
+	}
 	if (query.startsWith('https://')) {
 		const promise = os.api('ap/show', {
 			uri: query,


### PR DESCRIPTION
## What
検索クエリが「@username@servername」の場合に「https://servername/@username 」扱いで検索する

## Why
検索機能で他サーバーのユーザーを検索する際に、「@username@servername」形式を入れたくなるが、それだと結果無しになる。
一方「https://servername/@username 」形式で検索すると該当ユーザーが表示されるようになっており、その動作を利用したいと考えた。

## Additional info (optional)
自サーバーで動作確認済
仕様の不理解がありましたらすみません。

## Checklist
- [✓] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [✓] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
