### PR TITLE
FIX: フォロー中のボタンに重なる「フォロー解除」の文字色を変更

### DIFF
--- a/packages/frontend/src/components/MkFollowButton.vue
+++ b/packages/frontend/src/components/MkFollowButton.vue
@@ -178,7 +178,7 @@ onBeforeUnmount(() => {
 	}
 
 	&.active {
-		color: #fff;
+		color: var(--fgOnAccent);
 		background: var(--accent);
 
 		&:hover {


### PR DESCRIPTION
## What
フォロー中のユーザープロフィールに表示される「フォロー解除」ボタンについて、
背景色に対して適切な色指定になっていなかった物を修正しました。

背景色は `accent` であるのに対し、元々は `#fff` で固定されていることから、組み合わせ上見づらいパターンがあったものを、
`accent` に対して重なる文字色として用意されて居るであろう `fgOnAccent` に変更しました。

背景色が `accent` であるその他のボタンと同じ状態に揃えた格好です。

## Why
明るい色を背景にしたテーマを活用した際に文字の視認性が著しく下がり、フォローできたのかどうかがわからなかったため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
