### PR TITLE
fix: Return null from Mk:dialog

### DIFF
--- a/packages/frontend/src/scripts/aiscript/api.ts
+++ b/packages/frontend/src/scripts/aiscript/api.ts
@@ -17,6 +17,7 @@ export function createAiScriptEnv(opts) {
 				title: title.value,
 				text: text.value,
 			});
+			return values.NULL;
 		}),
 		'Mk:confirm': values.FN_NATIVE(async ([title, text, type]) => {
 			const confirm = await os.confirm({


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
AiScript APIのMk:dialogで何も返していなかったのをNULLを返すように修正します

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
close https://github.com/syuilo/aiscript/issues/256

修正前: ダイアログ表示後にエラーが表示されています
<img width="531" alt="スクリーンショット 2023-04-19 23 59 07" src="https://user-images.githubusercontent.com/2472792/233116710-8db9f3b1-e420-4d78-a8a5-4cd62d9aa2e0.png">

修正後: エラーが消え、次の式も評価されるようになります
<img width="333" alt="スクリーンショット 2023-04-19 23 54 16" src="https://user-images.githubusercontent.com/2472792/233116441-1c769015-3d53-443e-a613-2fbeb1bf89cb.png">

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
`let a = Mk:dialog("honi", "fuwa")` のように変数に代入するとエラーにならないという回避策はあったようです(なぜ動くのかまだよくわかってない)


## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
