### PR TITLE
fix(client): 「新しいノートがあります」背後のリンク・ボタンが押せない問題を修正

### DIFF
--- a/packages/frontend/src/pages/antenna-timeline.vue
+++ b/packages/frontend/src/pages/antenna-timeline.vue
@@ -99,12 +99,14 @@ definePageMetadata(computed(() => antenna ? {
 		z-index: 1000;
 		width: 100%;
 		margin: calc(-0.675em - 8px - var(--margin)) 0 calc(-0.675em - 8px);
+		pointer-events: none;
 
 		> button {
 			display: block;
-			margin: var(--margin) auto 0 auto;
+			margin: 0 auto;
 			padding: 8px 16px;
 			border-radius: 32px;
+			pointer-events: all;
 		}
 	}
 

--- a/packages/frontend/src/pages/antenna-timeline.vue
+++ b/packages/frontend/src/pages/antenna-timeline.vue
@@ -106,7 +106,7 @@ definePageMetadata(computed(() => antenna ? {
 			margin: 0 auto;
 			padding: 8px 16px;
 			border-radius: 32px;
-			pointer-events: all;
+			pointer-events: auto;
 		}
 	}
 

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -194,7 +194,7 @@ definePageMetadata(computed(() => ({
 		margin: 0 auto;
 		padding: 8px 16px;
 		border-radius: 32px;
-		pointer-events: all;
+		pointer-events: auto;
 	}
 }
 

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -183,6 +183,7 @@ definePageMetadata(computed(() => ({
 	z-index: 1000;
 	width: 100%;
 	margin: calc(-0.675em - 8px) 0;
+	pointer-events: none;
 
 	&:first-child {
 		margin-top: calc(-0.675em - 8px - var(--margin));
@@ -190,9 +191,10 @@ definePageMetadata(computed(() => ({
 
 	> button {
 		display: block;
-		margin: var(--margin) auto 0 auto;
+		margin: 0 auto;
 		padding: 8px 16px;
 		border-radius: 32px;
+		pointer-events: all;
 	}
 }
 

--- a/packages/frontend/src/pages/user-list-timeline.vue
+++ b/packages/frontend/src/pages/user-list-timeline.vue
@@ -92,12 +92,14 @@ definePageMetadata(computed(() => list ? {
 		z-index: 1000;
 		width: 100%;
 		margin: calc(-0.675em - 8px - var(--margin)) 0 calc(-0.675em - 8px);
+		pointer-events: none;
 
 		> button {
 			display: block;
-			margin: var(--margin) auto 0 auto;
+			margin: 0 auto;
 			padding: 8px 16px;
 			border-radius: 32px;
+			pointer-events: all;
 		}
 	}
 

--- a/packages/frontend/src/pages/user-list-timeline.vue
+++ b/packages/frontend/src/pages/user-list-timeline.vue
@@ -99,7 +99,7 @@ definePageMetadata(computed(() => list ? {
 			margin: 0 auto;
 			padding: 8px 16px;
 			border-radius: 32px;
-			pointer-events: all;
+			pointer-events: auto;
 		}
 	}
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->
fix #10696

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
赤枠で囲まれた部分にあるボタンを押せるように修正しました

![image](https://user-images.githubusercontent.com/67428053/233823436-da5c98de-e02a-41c1-af47-9de76cb7f63e.png)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
この部分が押せない仕様になっていると混乱するため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
