### PR TITLE
enhance(server): 環境変数MISSKEY_CONFIG_YMLでdefault.ymlを任意のymlに変更可能に

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - 新しい実績を追加
 
 ### Server
+- 環境変数MISSKEY_CONFIG_YMLで設定ファイルをdefault.ymlから変更可能に
 - Fix: エクスポートデータの拡張子がunknownになる問題を修正
 - Fix: Content-Dispositionのパースでエラーが発生した場合にダウンロードが完了しない問題を修正
 - Fix: API: i/update avatarIdとbannerIdにnullを渡した時、画像がリセットされない問題を修正

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -4,7 +4,7 @@
 
 import * as fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import * as yaml from 'js-yaml';
 
 /**
@@ -132,10 +132,11 @@ const dir = `${_dirname}/../../../.config`;
 /**
  * Path of configuration file
  */
-const path = process.env.NODE_ENV === 'test'
-	? `${dir}/test.yml`
-	: `${dir}/default.yml`;
-
+const path = process.env.MISSKEY_CONFIG_YML
+	? resolve(dir, process.env.MISSKEY_CONFIG_YML)
+	: process.env.NODE_ENV === 'test'
+		? resolve(dir, 'test.yml')
+		: resolve(dir, 'config.yml');
 export function loadConfig() {
 	const meta = JSON.parse(fs.readFileSync(`${_dirname}/../../../built/meta.json`, 'utf-8'));
 	const clientManifestExists = fs.existsSync(_dirname + '/../../../built/_vite_/manifest.json');


### PR DESCRIPTION
## What
Misskeyサーバー起動時に環境変数としてMISSKEY_CONFIG_YMLを設定することで、default.ymlから任意のymlへ変更できるようにします。

## Why
同じディレクトリ・ビルトファイルで複数のサーバーを建てたい時がある

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
