### PR TITLE
enhance(dev): non-production環境でhttpサーバー間でもユーザー、ノートの連合が可能なように

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,11 @@ pnpm jest -- foo.ts
 ### e2e tests
 TODO
 
+## Environment Variable
+
+- `MISSKEY_CONFIG_YML`: Specify the file path of config.yml instead of default.yml (e.g. `2nd.yml`).
+- `MISSKEY_WEBFINGER_USE_HTTP`: If it's set true, WebFinger requests will be http instead of https, useful for testing federation between servers in localhost.
+
 ## Continuous integration
 Misskey uses GitHub Actions for executing automated tests.
 Configuration files are located in [`/.github/workflows`](/.github/workflows).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ TODO
 ## Environment Variable
 
 - `MISSKEY_CONFIG_YML`: Specify the file path of config.yml instead of default.yml (e.g. `2nd.yml`).
-- `MISSKEY_WEBFINGER_USE_HTTP`: If it's set true, WebFinger requests will be http instead of https, useful for testing federation between servers in localhost.
+- `MISSKEY_WEBFINGER_USE_HTTP`: If it's set true, WebFinger requests will be http instead of https, useful for testing federation between servers in localhost. NEVER USE IN PRODUCTION.
 
 ## Continuous integration
 Misskey uses GitHub Actions for executing automated tests.

--- a/packages/backend/src/core/WebfingerService.ts
+++ b/packages/backend/src/core/WebfingerService.ts
@@ -43,7 +43,8 @@ export class WebfingerService {
 		const m = query.match(/^([^@]+)@(.*)/);
 		if (m) {
 			const hostname = m[2];
-			return `http${process.env.NODE_ENV === 'production' ? 's' : ''}://${hostname}/.well-known/webfinger?${urlQuery({ resource: `acct:${query}` })}`;
+			const useHttp = process.env.MISSKEY_WEBFINGER_USE_HTTP && process.env.MISSKEY_WEBFINGER_USE_HTTP.toLowerCase() === 'true';
+			return `http${useHttp ? '' : 's'}://${hostname}/.well-known/webfinger?${urlQuery({ resource: `acct:${query}` })}`;
 		}
 
 		throw new Error(`Invalid query (${query})`);

--- a/packages/backend/src/core/WebfingerService.ts
+++ b/packages/backend/src/core/WebfingerService.ts
@@ -43,7 +43,7 @@ export class WebfingerService {
 		const m = query.match(/^([^@]+)@(.*)/);
 		if (m) {
 			const hostname = m[2];
-			return `https://${hostname}/.well-known/webfinger?` + urlQuery({ resource: `acct:${query}` });
+			return `http${process.env.NODE_ENV === 'production' ? 's' : ''}://${hostname}/.well-known/webfinger?${urlQuery({ resource: `acct:${query}` })}`;
 		}
 
 		throw new Error(`Invalid query (${query})`);

--- a/packages/backend/src/core/activitypub/models/ApImageService.ts
+++ b/packages/backend/src/core/activitypub/models/ApImageService.ts
@@ -12,6 +12,7 @@ import type Logger from '@/logger.js';
 import { bindThis } from '@/decorators.js';
 import { ApResolverService } from '../ApResolverService.js';
 import { ApLoggerService } from '../ApLoggerService.js';
+import { checkHttps } from '@/misc/check-https.js';
 
 @Injectable()
 export class ApImageService {
@@ -48,9 +49,8 @@ export class ApImageService {
 			throw new Error('invalid image: url not privided');
 		}
 
-		if (!image.url.startsWith('https://') &&
-			!(process.env.NODE_ENV !== 'production' && image.url.startsWith('http://'))) {
-			throw new Error('invalid image: unexpected shcema of url: ' + image.url);
+		if (!checkHttps(image.url)) {
+			throw new Error('invalid image: unexpected schema of url: ' + image.url);
 		}
 
 		this.logger.info(`Creating the Image: ${image.url}`);

--- a/packages/backend/src/core/activitypub/models/ApImageService.ts
+++ b/packages/backend/src/core/activitypub/models/ApImageService.ts
@@ -48,7 +48,8 @@ export class ApImageService {
 			throw new Error('invalid image: url not privided');
 		}
 
-		if (!image.url.startsWith('https://')) {
+		if (!image.url.startsWith('https://') &&
+			!(process.env.NODE_ENV !== 'production' && image.url.startsWith('http://'))) {
 			throw new Error('invalid image: unexpected shcema of url: ' + image.url);
 		}
 

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -130,14 +130,20 @@ export class ApNoteService {
 	
 		this.logger.debug(`Note fetched: ${JSON.stringify(note, null, 2)}`);
 
-		if (note.id && !note.id.startsWith('https://')) {
-			throw new Error('unexpected shcema of note.id: ' + note.id);
+		if (note.id) {
+			if (!note.id.startsWith('https://') &&
+				!(process.env.NODE_ENV !== 'production' && note.id.startsWith('http://'))) {
+				throw new Error('unexpected shcema of note.id: ' + note.id);
+			}
 		}
 
 		const url = getOneApHrefNullable(note.url);
 
-		if (url && !url.startsWith('https://')) {
-			throw new Error('unexpected shcema of note url: ' + url);
+		if (url) {
+			if (!url.startsWith('https://') &&
+				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
+				throw new Error('unexpected shcema of note url: ' + url);
+			}
 		}
 	
 		this.logger.info(`Creating the Note: ${note.id}`);

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -32,6 +32,7 @@ import { ApQuestionService } from './ApQuestionService.js';
 import { ApImageService } from './ApImageService.js';
 import type { Resolver } from '../ApResolverService.js';
 import type { IObject, IPost } from '../type.js';
+import { checkHttps } from '@/misc/check-https.js';
 
 @Injectable()
 export class ApNoteService {
@@ -130,20 +131,14 @@ export class ApNoteService {
 	
 		this.logger.debug(`Note fetched: ${JSON.stringify(note, null, 2)}`);
 
-		if (note.id) {
-			if (!note.id.startsWith('https://') &&
-				!(process.env.NODE_ENV !== 'production' && note.id.startsWith('http://'))) {
-				throw new Error('unexpected shcema of note.id: ' + note.id);
-			}
+		if (note.id && !checkHttps(note.id)) {
+			throw new Error('unexpected shcema of note.id: ' + note.id);
 		}
 
 		const url = getOneApHrefNullable(note.url);
 
-		if (url) {
-			if (!url.startsWith('https://') &&
-				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
-				throw new Error('unexpected shcema of note url: ' + url);
-			}
+		if (url && !checkHttps(url)) {
+			throw new Error('unexpected shcema of note url: ' + url);
 		}
 	
 		this.logger.info(`Creating the Note: ${note.id}`);

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -42,6 +42,7 @@ import type { ApLoggerService } from '../ApLoggerService.js';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { ApImageService } from './ApImageService.js';
 import type { IActor, IObject } from '../type.js';
+import { checkHttps } from '@/misc/check-https.js';
 
 const nameLength = 128;
 const summaryLength = 2048;
@@ -270,11 +271,8 @@ export class ApPersonService implements OnModuleInit {
 
 		const url = getOneApHrefNullable(person.url);
 
-		if (url) {
-			if (!url.startsWith('https://') &&
-				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
-				throw new Error('unexpected shcema of person url: ' + url);
-			}
+		if (url && !checkHttps(url)) {
+			throw new Error('unexpected schema of person url: ' + url);
 		}
 
 		// Create user
@@ -468,11 +466,8 @@ export class ApPersonService implements OnModuleInit {
 
 		const url = getOneApHrefNullable(person.url);
 
-		if (url) {
-			if (!url.startsWith('https://') &&
-				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
-				throw new Error('unexpected shcema of person url: ' + url);
-			}
+		if (url && !checkHttps(url)) {
+			throw new Error('unexpected schema of person url: ' + url);
 		}
 
 		const updates = {

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -199,7 +199,7 @@ export class ApPersonService implements OnModuleInit {
 				throw new Error('invalid Actor: publicKey.id is not a string');
 			}
 
-			const publicKeyIdHost = this.utilityService.toPuny(new URL(x.publicKey.id).hostname);
+			const publicKeyIdHost = this.punyHost(x.publicKey.id);
 			if (publicKeyIdHost !== expectHost) {
 				throw new Error('invalid Actor: publicKey.id has different host');
 			}

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -134,6 +134,12 @@ export class ApPersonService implements OnModuleInit {
 		this.logger = this.apLoggerService.logger;
 	}
 
+	private punyHost(url: string): string {
+		const urlObj = new URL(url);
+		const host = `${this.utilityService.toPuny(urlObj.hostname)}${urlObj.port.length > 0 ? ':' + urlObj.port : ''}`;
+		return host;
+	}
+
 	/**
 	 * Validate and convert to actor object
 	 * @param x Fetched object
@@ -141,7 +147,7 @@ export class ApPersonService implements OnModuleInit {
 	 */
 	@bindThis
 	private validateActor(x: IObject, uri: string): IActor {
-		const expectHost = this.utilityService.toPuny(new URL(uri).hostname);
+		const expectHost = this.punyHost(uri);
 
 		if (x == null) {
 			throw new Error('invalid Actor: object is null');
@@ -182,7 +188,7 @@ export class ApPersonService implements OnModuleInit {
 			x.summary = truncate(x.summary, summaryLength);
 		}
 
-		const idHost = this.utilityService.toPuny(new URL(x.id!).hostname);
+		const idHost = this.punyHost(x.id);
 		if (idHost !== expectHost) {
 			throw new Error('invalid Actor: id has different host');
 		}
@@ -252,7 +258,7 @@ export class ApPersonService implements OnModuleInit {
 
 		this.logger.info(`Creating the Person: ${person.id}`);
 
-		const host = this.utilityService.toPuny(new URL(object.id).hostname);
+		const host = this.punyHost(object.id);
 
 		const { fields } = this.analyzeAttachments(person.attachment ?? []);
 
@@ -264,8 +270,11 @@ export class ApPersonService implements OnModuleInit {
 
 		const url = getOneApHrefNullable(person.url);
 
-		if (url && !url.startsWith('https://')) {
-			throw new Error('unexpected shcema of person url: ' + url);
+		if (url) {
+			if (!url.startsWith('https://') &&
+				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
+				throw new Error('unexpected shcema of person url: ' + url);
+			}
 		}
 
 		// Create user
@@ -459,8 +468,11 @@ export class ApPersonService implements OnModuleInit {
 
 		const url = getOneApHrefNullable(person.url);
 
-		if (url && !url.startsWith('https://')) {
-			throw new Error('unexpected shcema of person url: ' + url);
+		if (url) {
+			if (!url.startsWith('https://') &&
+				!(process.env.NODE_ENV !== 'production' && url.startsWith('http://'))) {
+				throw new Error('unexpected shcema of person url: ' + url);
+			}
 		}
 
 		const updates = {

--- a/packages/backend/src/misc/check-https.ts
+++ b/packages/backend/src/misc/check-https.ts
@@ -1,0 +1,4 @@
+export function checkHttps(url: string) {
+    return url.startsWith('https://') ||
+        (url.startsWith('http://') && process.env.NODE_ENV !== 'production');
+}


### PR DESCRIPTION
Resolve #10716

## What
- ユーザーのhostにポートが含まれていなかったのを修正
- ユーザー、ノートをproductionでない環境ではhttpも許可
- MISSKEY_WEBFINGER_USE_HTTPでtrueを指定するとWebFingerをhttpで行うように

## Why
Resolve #10716

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
