### PR TITLE
fix(backend): `alsoKnownAs`の誤った定義を修正

### DIFF
--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -80,9 +80,14 @@ export const packedUserDetailedNotMeOnlySchema = {
 		},
 		alsoKnownAs: {
 			type: 'array',
-			format: 'uri',
 			nullable: true,
 			optional: false,
+			items: {
+				type: 'string',
+				format: 'uri',
+				nullable: false,
+				optional: false,
+			},
 		},
 		createdAt: {
 			type: 'string',


### PR DESCRIPTION
## What

このPRは #10724 を修正することを目的としたものです。配列を定義するオブジェクトでは`format`パラメータが使えないにも関わらず使われている問題を修正します。これは同時に、未定義だった配列の要素の型を定義することでもあります。

## Why

現時点ではこれにより不具合が発生しているということはないと思われますが、定義が不十分なことは将来的に問題となってくるだろうと考えます。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
