### PR TITLE
fix(backend): Use SSL option for Meilisearch

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -102,6 +102,7 @@ redis:
 #  host: meilisearch
 #  port: 7700
 #  apiKey: ''
+#  ssl: true
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -102,6 +102,7 @@ redis:
 #  host: localhost
 #  port: 7700
 #  apiKey: ''
+#  ssl: true
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────

--- a/.devcontainer/devcontainer.yml
+++ b/.devcontainer/devcontainer.yml
@@ -102,6 +102,7 @@ redis:
 #  host: meilisearch
 #  port: 7700
 #  apiKey: ''
+#  ssl: true
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────

--- a/chart/files/default.yml
+++ b/chart/files/default.yml
@@ -123,6 +123,7 @@ redis:
 #  host: localhost
 #  port: 7700
 #  apiKey: ''
+#  ssl: true
 
 #   ┌───────────────┐
 #───┘ ID generation └───────────────────────────────────────────

--- a/packages/backend/src/GlobalModule.ts
+++ b/packages/backend/src/GlobalModule.ts
@@ -28,7 +28,7 @@ const $meilisearch: Provider = {
 	useFactory: (config) => {
 		if (config.meilisearch) {
 			return new MeiliSearch({
-				host: `http://${config.meilisearch.host}:${config.meilisearch.port}`, 
+				host: `${config.meilisearch.ssl ? 'https' : 'http' }://${config.meilisearch.host}:${config.meilisearch.port}`,
 				apiKey: config.meilisearch.apiKey,
 			});
 		} else {

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -61,6 +61,7 @@ export type Source = {
 		host: string;
 		port: string;
 		apiKey: string;
+		ssl?: boolean;
 	};
 
 	proxy?: string;


### PR DESCRIPTION
## What
Resolve #10767
Added SSL option to Meilisearch configuration.

## Why
The current code uses an HTTP connection to communicate with the Meilisearch server. However, when the server has SSL configured, this results in connection failures. To solve this problem, the SSL option has been added to the configuration.

## Additional info (optional)
Configuring SSL in Meilisearch itself with `MEILI_SSL_CERT_PATH` (`--ssl-cert-path`) and `MEILI_SSL_KEY_PATH` (`--ssl-key-path`) still doesn't seem to work. Therefore, it appears that using a separate reverse proxy is necessary to enable SSL.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
