### PR TITLE
chore: use `color-mix()` on widgets/server-metric/cpu-mem

### DIFF
--- a/packages/frontend/.storybook/generate.tsx
+++ b/packages/frontend/.storybook/generate.tsx
@@ -403,6 +403,7 @@ Promise.all([
 	glob('src/components/MkUserSetupDialog.vue'),
 	glob('src/components/MkUserSetupDialog.*.vue'),
 	glob('src/pages/user/home.vue'),
+	glob('src/widgets/server-metric/cpu-mem.vue'),
 ])
 	.then((globs) => globs.flat())
 	.then((components) => Promise.all(components.map((component) => {

--- a/packages/frontend/src/widgets/server-metric/cpu-mem.stories.impl.ts
+++ b/packages/frontend/src/widgets/server-metric/cpu-mem.stories.impl.ts
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { StoryObj } from '@storybook/vue3';
+import cpu_mem from './cpu-mem.vue';
+export const Default = {
+	render(args) {
+		return {
+			components: {
+				cpu_mem,
+			},
+			setup() {
+				return {
+					args,
+				};
+			},
+			computed: {
+				props() {
+					return {
+						...this.args,
+					};
+				},
+			},
+			template: '<cpu_mem v-bind="props" />',
+		};
+	},
+	args: {
+		stats: Array.from({ length: 50 }, (_, i) => ({
+			cpu: (i % 11) / 10,
+			mem: {
+				active: (i % 11) / 10,
+			},
+		})),
+		meta: {
+			mem: {
+				total: 1,
+			},
+		},
+	},
+	parameters: {
+		layout: 'centered',
+	},
+} satisfies StoryObj<typeof cpu_mem>;

--- a/packages/frontend/src/widgets/server-metric/cpu-mem.stories.impl.ts
+++ b/packages/frontend/src/widgets/server-metric/cpu-mem.stories.impl.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { action } from '@storybook/addon-actions';
 import { StoryObj } from '@storybook/vue3';
 import cpu_mem from './cpu-mem.vue';
 export const Default = {
@@ -33,6 +34,10 @@ export const Default = {
 			mem: {
 				total: 1,
 			},
+		},
+		connection: {
+			on: action('on'),
+			send: action('send'),
 		},
 	},
 	parameters: {

--- a/packages/frontend/src/widgets/server-metric/cpu-mem.vue
+++ b/packages/frontend/src/widgets/server-metric/cpu-mem.vue
@@ -1,10 +1,19 @@
 <template>
 <div class="lcfyofjk">
+	<!-- #15c5cd = oklch(75% 0.125 200) -->
+	<!-- #f38c8d = oklch(75% 0.125 20) -->
 	<svg :viewBox="`0 0 ${ viewBoxX } ${ viewBoxY }`">
 		<defs>
 			<linearGradient :id="cpuGradientId" x1="0" x2="0" y1="1" y2="0">
-				<stop offset="0%" stop-color="hsl(180, 80%, 70%)"></stop>
-				<stop offset="100%" stop-color="hsl(0, 80%, 70%)"></stop>
+				<stop offset="0%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 0%)"></stop>
+				<stop offset="12.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 12.5%)"></stop>
+				<stop offset="25%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 25%)"></stop>
+				<stop offset="37.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 37.5%)"></stop>
+				<stop offset="50%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 50%)"></stop>
+				<stop offset="62.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 62.5%)"></stop>
+				<stop offset="75%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 75%)"></stop>
+				<stop offset="87.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 87.5%)"></stop>
+				<stop offset="100%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 100%)"></stop>
 			</linearGradient>
 			<mask :id="cpuMaskId" x="0" y="0" :width="viewBoxX" :height="viewBoxY">
 				<polygon
@@ -36,8 +45,15 @@
 	<svg :viewBox="`0 0 ${ viewBoxX } ${ viewBoxY }`">
 		<defs>
 			<linearGradient :id="memGradientId" x1="0" x2="0" y1="1" y2="0">
-				<stop offset="0%" stop-color="hsl(180, 80%, 70%)"></stop>
-				<stop offset="100%" stop-color="hsl(0, 80%, 70%)"></stop>
+				<stop offset="0%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 0%)"></stop>
+				<stop offset="12.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 12.5%)"></stop>
+				<stop offset="25%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 25%)"></stop>
+				<stop offset="37.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 37.5%)"></stop>
+				<stop offset="50%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 50%)"></stop>
+				<stop offset="62.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 62.5%)"></stop>
+				<stop offset="75%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 75%)"></stop>
+				<stop offset="87.5%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 87.5%)"></stop>
+				<stop offset="100%" stop-color="color-mix(in oklch decreasing hue, #15c5cd, #f38c8d 100%)"></stop>
 			</linearGradient>
 			<mask :id="memMaskId" x="0" y="0" :width="viewBoxX" :height="viewBoxY">
 				<polygon
@@ -73,14 +89,24 @@
 import { onMounted, onBeforeUnmount } from 'vue';
 import { v4 as uuid } from 'uuid';
 
-const props = defineProps<{
+type Stat = {
+	cpu: number;
+	mem: {
+		active: number;
+	};
+};
+
+const props = withDefaults(defineProps<{
+	stats?: Stat[]
 	connection: any,
 	meta: any
-}>();
+}>(), {
+	stats: () => [] as Stat[],
+});
 
 let viewBoxX: number = $ref(50);
 let viewBoxY: number = $ref(30);
-let stats: any[] = $ref([]);
+let stats: Stat[] = $ref(props.stats);
 const cpuGradientId = uuid();
 const cpuMaskId = uuid();
 const memGradientId = uuid();
@@ -134,6 +160,10 @@ function onStatsLog(statsLog) {
 	for (const revStats of [...statsLog].reverse()) {
 		onStats(revStats);
 	}
+}
+
+if (stats.length) {
+	onStatsLog(stats.splice(0, stats.length).reverse());
 }
 </script>
 


### PR DESCRIPTION
## What

サーバーメトリクスウィジェットのグラデーションを水色→緑→黄色→赤にする

![Screenshot 2023-05-20 at 22-27-03 widgets _ server-metric _ cpu-mem - Default ⋅ Storybook](https://github.com/misskey-dev/misskey/assets/20679825/7ffe3d48-b48f-432b-b6fc-e4eccc9bc09c)

## Why

グラデーションが水色→灰色→赤になっているため

![Screenshot 2023-05-20 at 22-28-07 widgets _ server-metric _ cpu-mem - Default ⋅ Storybook](https://github.com/misskey-dev/misskey/assets/20679825/2108a17a-9cbc-4608-9634-75b735b1f732)

## Additional info (optional)

- https://6428f7d7b962f0b79f97d6e4-tskmikacov.chromatic.com/?path=/story/widgets-server-metric-cpu-mem--default
- Chromatic は [Chrome 105](https://www.chromatic.com/docs/infrastructure-release-notes#supported-browsers-versions) なのでモノクロになる

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [x] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
