### PR TITLE
enhance(frontend): improve signup complete ui

### DIFF
--- a/packages/frontend/src/_boot_.ts
+++ b/packages/frontend/src/_boot_.ts
@@ -5,7 +5,7 @@ import '@/style.scss';
 import { mainBoot } from './boot/main-boot';
 import { subBoot } from './boot/sub-boot';
 
-if (['/share', '/auth', '/miauth'].includes(location.pathname)) {
+if (['/share', '/auth', '/miauth', '/signup-complete'].includes(location.pathname)) {
 	subBoot();
 } else {
 	mainBoot();

--- a/packages/frontend/src/_boot_.ts
+++ b/packages/frontend/src/_boot_.ts
@@ -5,7 +5,9 @@ import '@/style.scss';
 import { mainBoot } from './boot/main-boot';
 import { subBoot } from './boot/sub-boot';
 
-if (['/share', '/auth', '/miauth', '/signup-complete'].includes(location.pathname)) {
+const subBootPaths = ['/share', '/auth', '/miauth', '/signup-complete'];
+
+if (subBootPaths.some(i => location.pathname === i || location.pathname.startsWith(i + '/'))) {
 	subBoot();
 } else {
 	mainBoot();

--- a/packages/frontend/src/boot/main-boot.ts
+++ b/packages/frontend/src/boot/main-boot.ts
@@ -16,9 +16,7 @@ import { initializeSw } from '@/scripts/initialize-sw';
 
 export async function mainBoot() {
 	const { isClientUpdated } = await common(() => createApp(
-		new URLSearchParams(window.location.search).has('zen') ||
-		(location.pathname.startsWith('/signup-complete/') && location.pathname !== '/signup-complete/') ||
-		(ui === 'deck' && location.pathname !== '/') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
+		new URLSearchParams(window.location.search).has('zen') || (ui === 'deck' && location.pathname !== '/') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
 		!$i ? defineAsyncComponent(() => import('@/ui/visitor.vue')) :
 		ui === 'deck' ? defineAsyncComponent(() => import('@/ui/deck.vue')) :
 		ui === 'classic' ? defineAsyncComponent(() => import('@/ui/classic.vue')) :

--- a/packages/frontend/src/boot/main-boot.ts
+++ b/packages/frontend/src/boot/main-boot.ts
@@ -16,7 +16,9 @@ import { initializeSw } from '@/scripts/initialize-sw';
 
 export async function mainBoot() {
 	const { isClientUpdated } = await common(() => createApp(
-		new URLSearchParams(window.location.search).has('zen') || (ui === 'deck' && location.pathname !== '/') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
+		new URLSearchParams(window.location.search).has('zen') ||
+		(location.pathname.startsWith('/signup-complete/') && location.pathname !== '/signup-complete/') ||
+		(ui === 'deck' && location.pathname !== '/') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
 		!$i ? defineAsyncComponent(() => import('@/ui/visitor.vue')) :
 		ui === 'deck' ? defineAsyncComponent(() => import('@/ui/deck.vue')) :
 		ui === 'classic' ? defineAsyncComponent(() => import('@/ui/classic.vue')) :

--- a/packages/frontend/src/pages/signup-complete.vue
+++ b/packages/frontend/src/pages/signup-complete.vue
@@ -22,10 +22,10 @@
 <script lang="ts" setup>
 import { } from 'vue';
 import MkButton from '@/components/MkButton.vue';
-import * as os from '@/os';
+import MkAnimBg from '@/components/MkAnimBg.vue';
 import { login } from '@/account';
 import { i18n } from '@/i18n';
-import MkAnimBg from '@/components/MkAnimBg.vue';
+import * as os from '@/os';
 
 let submitting = $ref(false);
 

--- a/packages/frontend/src/pages/signup-complete.vue
+++ b/packages/frontend/src/pages/signup-complete.vue
@@ -1,37 +1,83 @@
 <template>
-<div>
-	{{ i18n.ts.processing }}
+<div :class="$style.root">
+	<MkAnimBg style="position: fixed; top: 0;"/>
+	<div :class="$style.formContainer">
+		<form :class="$style.form" class="_panel" @submit.prevent="submit()">
+			<div :class="$style.banner">
+				<i class="ti ti-user-check"></i>
+			</div>
+			<div class="_gaps_m" style="padding: 32px;">
+				<div>{{ i18n.t('clickToFinishEmailVerification', { ok: i18n.ts.gotIt }) }}</div>
+				<div>
+					<MkButton gradate large rounded type="submit" :disabled="submitting" data-cy-admin-ok style="margin: 0 auto;">
+						{{ submitting ? i18n.ts.processing : i18n.ts.gotIt }}<MkEllipsis v-if="submitting"/>
+					</MkButton>
+				</div>
+			</div>
+		</form>
+	</div>
 </div>
 </template>
 
 <script lang="ts" setup>
-import { onMounted } from 'vue';
+import { } from 'vue';
+import MkButton from '@/components/MkButton.vue';
 import * as os from '@/os';
 import { login } from '@/account';
 import { i18n } from '@/i18n';
-import { definePageMetadata } from '@/scripts/page-metadata';
+import MkAnimBg from '@/components/MkAnimBg.vue';
+
+let submitting = $ref(false);
 
 const props = defineProps<{
 	code: string;
 }>();
 
-onMounted(async () => {
-	await os.alert({
-		type: 'info',
-		text: i18n.t('clickToFinishEmailVerification', { ok: i18n.ts.gotIt }),
-	});
-	const res = await os.apiWithDialog('signup-pending', {
+function submit() {
+	if (submitting) return;
+	submitting = true;
+
+	os.api('signup-pending', {
 		code: props.code,
+	}).then(res => {
+		return login(res.i, '/');
+	}).catch(() => {
+		submitting = false;
+
+		os.alert({
+			type: 'error',
+			text: i18n.ts.somethingHappened,
+		});
 	});
-	login(res.i, '/');
-});
-
-const headerActions = $computed(() => []);
-
-const headerTabs = $computed(() => []);
-
-definePageMetadata({
-	title: i18n.ts.signup,
-	icon: 'ti ti-user',
-});
+}
 </script>
+
+<style lang="scss" module>
+.root {
+}
+
+.formContainer {
+	min-height: 100svh;
+	padding: 32px 32px 64px 32px;
+	box-sizing: border-box;
+display: grid;
+place-content: center;
+}
+
+.form {
+	position: relative;
+	z-index: 10;
+	border-radius: var(--radius);
+	box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+	overflow: clip;
+	max-width: 500px;
+}
+
+.banner {
+	padding: 16px;
+	text-align: center;
+	font-size: 26px;
+	background-color: var(--accentedBg);
+	color: var(--accent);
+}
+</style>


### PR DESCRIPTION
## What
Improved the ui of signup complete.

## Why
I thought the new MkAnimBg would be more colorful and improved than before if I used it together.

## Additional info (optional)
Actually, while contemplating the application of Zen UI, I made some modifications to `main-boot.ts`. If you happen to know a better method, I would appreciate it.

<img alt="signup-complete" src="https://github.com/misskey-dev/misskey/assets/54402969/2f12f693-00b5-40a4-ad86-7874c71d7ca0">
<video alt="signup-complete" src="https://github.com/misskey-dev/misskey/assets/54402969/67890c43-32b0-43dd-8c3d-dc6af28813cc" controls></video>

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
