### PR TITLE
fix(frontend): デッキモードかつ直接/以外を表示したときにデッキが表示されない問題を修正

### DIFF
--- a/packages/frontend/src/boot/main-boot.ts
+++ b/packages/frontend/src/boot/main-boot.ts
@@ -16,7 +16,7 @@ import { initializeSw } from '@/scripts/initialize-sw';
 
 export async function mainBoot() {
 	const { isClientUpdated } = await common(() => createApp(
-		new URLSearchParams(window.location.search).has('zen') || (ui === 'deck' && location.pathname !== '/') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
+		new URLSearchParams(window.location.search).has('zen') ? defineAsyncComponent(() => import('@/ui/zen.vue')) :
 		!$i ? defineAsyncComponent(() => import('@/ui/visitor.vue')) :
 		ui === 'deck' ? defineAsyncComponent(() => import('@/ui/deck.vue')) :
 		ui === 'classic' ? defineAsyncComponent(() => import('@/ui/classic.vue')) :

--- a/packages/frontend/src/ui/deck.vue
+++ b/packages/frontend/src/ui/deck.vue
@@ -130,6 +130,14 @@ mainRouter.navHook = (path, flag): boolean => {
 	return false;
 };
 
+if (mainRouter.currentRoute.value.path !== '/') {
+	const noMainColumn = !deckStore.state.columns.some(x => x.type === 'main');
+	if (deckStore.state.navWindow || noMainColumn) {
+		os.pageWindow(mainRouter.currentRoute.value.path);
+		mainRouter.replace('/');
+	}
+}
+
 const isMobile = ref(window.innerWidth <= 500);
 window.addEventListener('resize', () => {
 	isMobile.value = window.innerWidth <= 500;

--- a/packages/frontend/src/ui/deck.vue
+++ b/packages/frontend/src/ui/deck.vue
@@ -133,7 +133,7 @@ mainRouter.navHook = (path, flag): boolean => {
 if (mainRouter.currentRoute.value.path !== '/') {
 	const noMainColumn = !deckStore.state.columns.some(x => x.type === 'main');
 	if (deckStore.state.navWindow || noMainColumn) {
-		os.pageWindow(mainRouter.currentRoute.value.path);
+		os.pageWindow(location.pathname + location.search + location.hash);
 		mainRouter.replace('/');
 	}
 }


### PR DESCRIPTION
Fix #10905

## What
ui/deckのsetupで、デフォルトのナビゲーションをウィンドウにしている場合やメインカラムがない場合はウィンドウで表示し`/`にreplaceする処理を追加

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
