### PR TITLE
fix(frontend): Zen UIで、デッキ設定で直接/以外を表示したときデッキに戻るボタンを表示

### DIFF
--- a/packages/frontend/src/ui/zen.vue
+++ b/packages/frontend/src/ui/zen.vue
@@ -1,15 +1,15 @@
 <template>
-<div :class="ui === 'deck' ? $style.rootWithBottom : $style.root" style="container-type: inline-size;">
+<div :class="showBottom ? $style.rootWithBottom : $style.root" style="container-type: inline-size;">
 	<RouterView/>
 
 	<XCommon/>
 </div>
 
 <!--
-	デッキUIの場合はデッキUIに戻れるようにする
+	デッキUIが設定されている場合はデッキUIに戻れるようにする (ただし?zenが明示された場合は表示しない)
 	See https://github.com/misskey-dev/misskey/issues/10905
 -->
-<div v-if="ui === 'deck'" :class="$style.bottom">
+<div v-if="showBottom" :class="$style.bottom">
 	<button v-tooltip="i18n.ts.goToMisskey" :class="['_button', '_shadow', $style.button]" @click="goToMisskey"><i class="ti ti-home"></i></button>
 </div>
 </template>
@@ -23,6 +23,8 @@ import { instanceName, ui } from '@/config';
 import { i18n } from '@/i18n';
 
 let pageMetadata = $ref<null | ComputedRef<PageMetadata>>();
+
+const showBottom = !(new URLSearchParams(location.search)).has('zen') && ui === 'deck';
 
 provide('router', mainRouter);
 provideMetadataReceiver((info) => {

--- a/packages/frontend/src/ui/zen.vue
+++ b/packages/frontend/src/ui/zen.vue
@@ -1,16 +1,16 @@
 <template>
-<div :class="$style.root" style="container-type: inline-size;">
+<div :class="ui === 'deck' ? $style.rootWithBottom : $style.root" style="container-type: inline-size;">
 	<RouterView/>
 
 	<XCommon/>
+</div>
 
-	<!--
-		デッキUIの場合はデッキUIに戻れるようにする
-		See https://github.com/misskey-dev/misskey/issues/10905
-	-->
-	<div v-if="ui === 'deck'" :class="$style.bottom">
-		<button v-tooltip="i18n.ts.goToMisskey" :class="['_button', '_shadow', $style.button]" @click="goToMisskey"><i class="ti ti-home"></i></button>
-	</div>
+<!--
+	デッキUIの場合はデッキUIに戻れるようにする
+	See https://github.com/misskey-dev/misskey/issues/10905
+-->
+<div v-if="ui === 'deck'" :class="$style.bottom">
+	<button v-tooltip="i18n.ts.goToMisskey" :class="['_button', '_shadow', $style.button]" @click="goToMisskey"><i class="ti ti-home"></i></button>
 </div>
 </template>
 
@@ -45,17 +45,19 @@ document.documentElement.style.overflowY = 'scroll';
 	box-sizing: border-box;
 }
 
+.rootWithBottom {
+	min-height: calc(100dvh - (60px + (var(--margin) * 2) + env(safe-area-inset-bottom, 0px)));
+	box-sizing: border-box;
+}
+
 .bottom {
-	position: sticky !important;
-	z-index: 9999999;
-	bottom: 0;
-	left: 0;
 	height: calc(60px + (var(--margin) * 2) + env(safe-area-inset-bottom, 0px));
 	width: 100%;
+	margin-top: auto;
 }
 
 .button {
-	position: absolute;
+	position: fixed !important;
 	padding: 0;
 	aspect-ratio: 1;
 	width: 100%;

--- a/packages/frontend/src/ui/zen.vue
+++ b/packages/frontend/src/ui/zen.vue
@@ -3,6 +3,14 @@
 	<RouterView/>
 
 	<XCommon/>
+
+	<!--
+		デッキUIの場合はデッキUIに戻れるようにする
+		See https://github.com/misskey-dev/misskey/issues/10905
+	-->
+	<div v-if="ui === 'deck'" :class="$style.bottom">
+		<button v-tooltip="i18n.ts.goToMisskey" :class="['_button', '_shadow', $style.button]" @click="goToMisskey"><i class="ti ti-home"></i></button>
+	</div>
 </div>
 </template>
 
@@ -11,7 +19,8 @@ import { provide, ComputedRef } from 'vue';
 import XCommon from './_common_/common.vue';
 import { mainRouter } from '@/router';
 import { PageMetadata, provideMetadataReceiver } from '@/scripts/page-metadata';
-import { instanceName } from '@/config';
+import { instanceName, ui } from '@/config';
+import { i18n } from '@/i18n';
 
 let pageMetadata = $ref<null | ComputedRef<PageMetadata>>();
 
@@ -23,6 +32,10 @@ provideMetadataReceiver((info) => {
 	}
 });
 
+function goToMisskey() {
+	window.location.href = '/';
+}
+
 document.documentElement.style.overflowY = 'scroll';
 </script>
 
@@ -30,5 +43,28 @@ document.documentElement.style.overflowY = 'scroll';
 .root {
 	min-height: 100dvh;
 	box-sizing: border-box;
+}
+
+.bottom {
+	position: sticky !important;
+	z-index: 9999999;
+	bottom: 0;
+	left: 0;
+	height: calc(60px + (var(--margin) * 2) + env(safe-area-inset-bottom, 0px));
+	width: 100%;
+}
+
+.button {
+	position: absolute;
+	padding: 0;
+	aspect-ratio: 1;
+	width: 100%;
+	max-width: 60px;
+	margin: auto;
+	border-radius: 100%;
+	background: var(--panel);
+	color: var(--fg);
+	right: var(--margin);
+	bottom: calc(var(--margin) + env(safe-area-inset-bottom, 0px));
 }
 </style>


### PR DESCRIPTION
Fix #10905 

## What
右下にデッキ設定で直接/以外を表示したときのZen UIでデッキに戻るボタンを右下に表示

![image](https://github.com/misskey-dev/misskey/assets/7973572/fde302e1-a515-44f4-be28-037cabc2171e)

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
