### PR TITLE
dev: pnpm devでCtrl+Cで終了させようとしてもpnpm startのプロセスが完全に殺せないのを修正

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -44,10 +44,16 @@ const fs = require('fs');
 			if (!stat) throw new Error('not exist yet');
 			if (stat.size === 0) throw new Error('not built yet');
 
-			await execa('pnpm', ['start'], {
+			const subprocess = await execa('pnpm', ['start'], {
 				cwd: __dirname + '/../',
 				stdout: process.stdout,
 				stderr: process.stderr,
+			});
+
+			// なぜかworkerだけが終了してmasterが残るのでその対策
+			process.on('SIGINT', () => {
+				subprocess.kill('SIGINT');
+				process.exit(0);
 			});
 		} catch (e) {
 			await new Promise(resolve => setTimeout(resolve, 3000));


### PR DESCRIPTION
## What
pnpm devでCtrl+Cで終了させようとしてもpnpm startのプロセスが完全に殺せないのを修正

https://github.com/misskey-dev/misskey/blob/c427b5a9c1ae6f764b4319bf8d8afe6169b9a745/scripts/dev.js#L54-L57

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
