### PR TITLE
fix: テーマにプロパティ 'fgOnWhite' を追加してフォローボタンのスタイルを調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,190 +15,214 @@
 ## 13.13.0
 
 ### General
+
 - カスタム絵文字ごとにそれをリアクションとして使えるロールを設定できるように
 - カスタム絵文字ごとに連合するかどうか設定できるように
 - カスタム絵文字ごとにセンシティブフラグを設定できるように
 - センシティブなカスタム絵文字のリアクションを受け入れない設定が可能に
 - タイムラインにフォロイーの行った他人へのリプライを含めるかどうかの設定をアカウントに保存するのをやめるように
-	- 今後はAPI呼び出し時およびストリーミング接続時に設定するようになります
+  - 今後は API 呼び出し時およびストリーミング接続時に設定するようになります
 - リストを公開できるようになりました
 
 ### Client
+
 - リアクションの取り消し/変更時に確認ダイアログを出すように
 - 開発者モードを追加
-- AiScriptを0.13.3に更新
-- Deck UIを使用している場合、`/`以外にアクセスした際にZen UIで表示するように
-	- メインカラムを設置していない場合の問題を解決
+- AiScript を 0.13.3 に更新
+- Deck UI を使用している場合、`/`以外にアクセスした際に Zen UI で表示するように
+  - メインカラムを設置していない場合の問題を解決
 - ハッシュタグのノート一覧ページから、そのハッシュタグで投稿するボタンを追加
 - アカウント初期設定ウィザードに戻るボタンを追加
 - アカウントの初期設定ウィザードにあとでボタンを追加
 - サーバーにカスタム絵文字の種類が多い場合のパフォーマンスの改善
-- Fix: URLプレビューで情報が取得できなかった際の挙動を修正
-- Fix: Safari、Firefoxでの新規登録時、パスワードマネージャーにメールアドレスが登録されていた挙動を修正
+- Fix: URL プレビューで情報が取得できなかった際の挙動を修正
+- Fix: Safari、Firefox での新規登録時、パスワードマネージャーにメールアドレスが登録されていた挙動を修正
 - Fix: ロールタイムラインが無効でも投稿が流れてしまう問題の修正
 - Fix: ロールタイムラインにて全ての投稿が流れてしまう問題の修正
 - Fix: 「アクセストークンの管理」画面でアプリの情報が表示されない問題の修正
-- Fix: Firefoxにおける絵文字ピッカーのTabキーフォーカス問題の修正
+- Fix: Firefox における絵文字ピッカーの Tab キーフォーカス問題の修正
+- Fix: フォローボタンがテーマのカラースキームによって視認性が悪くなる問題を修正
+  - 新しいプロパティ `fgOnWhite` が追加されました
 
 ### Server
-- bullをbull-mqにアップグレードし、ジョブキューのパフォーマンスを改善
+
+- bull を bull-mq にアップグレードし、ジョブキューのパフォーマンスを改善
 - ストリーミングのパフォーマンスを改善
-- Fix: お知らせの画像URLを空にできない問題を修正
+- Fix: お知らせの画像 URL を空にできない問題を修正
 
 ## 13.12.2
 
 ## NOTE
-Meilisearchの設定に`index`が必要になりました。値はMisskeyサーバーのホスト名にすることをお勧めします(アルファベット、ハイフン、アンダーバーのみ使用可能)。例: `misskey-io`
+
+Meilisearch の設定に`index`が必要になりました。値は Misskey サーバーのホスト名にすることをお勧めします(アルファベット、ハイフン、アンダーバーのみ使用可能)。例: `misskey-io`
 過去に作成された`notes`インデックスは、`<index名>---notes`にリネームが必要です。例: `misskey-io---notes`
 
 ### General
-- 投稿したコンテンツのAIによる学習を軽減するオプションを追加
+
+- 投稿したコンテンツの AI による学習を軽減するオプションを追加
 
 ### Client
+
 - ユーザーを指定してのノート検索が可能に
 - アカウント初期設定ウィザードにプライバシー設定を追加
 - リテンション率チャートに折れ線グラフを追加
 - Fix: ブラーエフェクトを有効にしている状態で高負荷になる問題を修正
-- Fix: Pageにおいて画像ブロックに画像を設定できない問題を修正
+- Fix: Page において画像ブロックに画像を設定できない問題を修正
 - Fix: カラーバーがリプライには表示されないのを修正
 - Fix: チャンネル内の検索ボックスが挙動不審な問題を修正
 - Fix: リテンションチャートのレンダリングを修正
 - Fix: リアクションエフェクトのレンダリングの問題を修正
 
 ### Server
-- センシティブワードの登録にAnd、正規表現が使用できるようになりました。
-- Fix: ひとつのMeilisearchサーバーを複数のMisskeyサーバーで使えない問題を修正
+
+- センシティブワードの登録に And、正規表現が使用できるようになりました。
+- Fix: ひとつの Meilisearch サーバーを複数の Misskey サーバーで使えない問題を修正
 
 ## 13.12.1
 
 ### Client
+
 - プロフィール画面におけるモデレーションノートの表示を調整
 - Fix: 一部ダイアログが表示されない問題を修正
-- Fix: MkUserInfoのフォローボタンが変な位置にある問題を修正
+- Fix: MkUserInfo のフォローボタンが変な位置にある問題を修正
 
 ### Server
+
 - Fix: リモートサーバーの情報が更新できない問題を修正
-- Fix: 13.11を経験しない状態で13.12にアップデートした場合ユーザープロフィール関連の画像が消失する問題を修正
+- Fix: 13.11 を経験しない状態で 13.12 にアップデートした場合ユーザープロフィール関連の画像が消失する問題を修正
 
 ## 13.12.0
 
 ### NOTE
-- Node.js 18.6.0以上が必要になりました
+
+- Node.js 18.6.0 以上が必要になりました
 
 ### General
+
 - アカウントの引っ越し（フォロワー引き継ぎ）に対応
-- Meilisearchを全文検索に使用できるようになりました
+- Meilisearch を全文検索に使用できるようになりました
 - 新規登録前に簡潔なルールをユーザーに表示できる、サーバールール機能を追加
 - ユーザーへの自分用メモ機能
-  * ユーザーに対して、自分だけが見られるメモを追加できるようになりました。  
+  - ユーザーに対して、自分だけが見られるメモを追加できるようになりました。  
     （自分自身に対してもメモを追加できます。）
-  * ユーザーメニューから追加できます。  
-    （デスクトップ表示ではusernameの右側のボタンからも追加可能）
+  - ユーザーメニューから追加できます。  
+    （デスクトップ表示では username の右側のボタンからも追加可能）
 - チャンネルに色を設定できるようになりました。各ノートに設定した色のインジケーターが表示されます。
 - チャンネルをアーカイブできるようになりました。
-	* アーカイブすると、チャンネル一覧や検索結果に表示されなくなり、新たな書き込みもできなくなります。
+  - アーカイブすると、チャンネル一覧や検索結果に表示されなくなり、新たな書き込みもできなくなります。
 - アンテナのエクスポート・インポートができるようになりました
 - ロールタイムラインをロールごとに表示するかどうかの選択できるようになりました。
-	* デフォルトがオフになるので、ロールタイムラインを表示する場合はオンにしてください。
-- ロールに強制的にNSFWを付与するポリシーを追加
-	* アップロード済みのファイルはNSFWにならない為注意してください。
+  - デフォルトがオフになるので、ロールタイムラインを表示する場合はオンにしてください。
+- ロールに強制的に NSFW を付与するポリシーを追加
+  - アップロード済みのファイルは NSFW にならない為注意してください。
 - モデレーションノートがユーザーのプロフィールページからも閲覧および編集できるようになりました。
 - カスタム絵文字のライセンスを複数でセットできるようになりました。
 - 管理者が予約ユーザー名を設定できるようになりました。
 - Fix: フォローリクエストの通知が残る問題を修正
 
 ### Client
+
 - アカウント作成時に初期設定ウィザードを表示するように
 - チャンネル内検索ができるように
 - チャンネル検索ですべてのチャンネルの取得/表示ができるように
 - 通知の表示をカスタマイズできるように
 - ドライブのファイル一覧から直接ノートを作成できるように
-- ノートメニューからRenoteしたユーザーの一覧を見れるように
-- コントロールパネルのカスタム絵文字ページおよびaboutのカスタム絵文字の検索インプットで、`:emojiname1::emojiname2:`のように検索して絵文字を検索できるように
-  * 絵文字ピッカーから入力可能になります
+- ノートメニューから Renote したユーザーの一覧を見れるように
+- コントロールパネルのカスタム絵文字ページおよび about のカスタム絵文字の検索インプットで、`:emojiname1::emojiname2:`のように検索して絵文字を検索できるように
+  - 絵文字ピッカーから入力可能になります
 - データセーバーモードを追加
-  * 画像が全て隠れた状態で表示されるようになります
+  - 画像が全て隠れた状態で表示されるようになります
 - 閲覧注意設定された画像は表示した状態でもそれが閲覧注意だと分かる表示をするように
-- モデレーターはノートに添付された画像上から直接NSFW設定できるように
-- 1枚だけのメディアリストの画像のアスペクト比を画像に応じて縦長にするように
+- モデレーターはノートに添付された画像上から直接 NSFW 設定できるように
+- 1 枚だけのメディアリストの画像のアスペクト比を画像に応じて縦長にするように
 - プロフィール設定「追加情報」の項目の削除と並び替えができるように
 - 新しい実績を追加
-- AiScriptを0.13.2に更新
-- Fix: AiScript APIのMk:dialogで何も返していなかったのをNULLを返すように修正
-- Fix: 1:1ではない画像のリアクション通知バッジが左や上に寄ってしまっていたのを中央に来るように修正
+- AiScript を 0.13.2 に更新
+- Fix: AiScript API の Mk:dialog で何も返していなかったのを NULL を返すように修正
+- Fix: 1:1 ではない画像のリアクション通知バッジが左や上に寄ってしまっていたのを中央に来るように修正
 - Fix: リアクションをホバーした時のユーザーリストで猫耳が切れてしまっていた問題を修正
-- Fix: NSFWメディアの上に表示された｢もっと見る｣ボタンが押しづらい問題を修正
 
 ### Server
-- channel/searchのqueryが空の場合に全てのチャンネルを返すように変更
-- 環境変数MISSKEY_CONFIG_YMLで設定ファイルをdefault.ymlから変更可能に
+
+- channel/search の query が空の場合に全てのチャンネルを返すように変更
+- 環境変数 MISSKEY_CONFIG_YML で設定ファイルを default.yml から変更可能に
 - Fix: 他のサーバーの情報が取得できないことがある問題を修正
-- Fix: エクスポートデータの拡張子がunknownになる問題を修正
-- Fix: Content-Dispositionのパースでエラーが発生した場合にダウンロードが完了しない問題を修正
-- Fix: API: i/update avatarIdとbannerIdにnullを渡した時、画像がリセットされない問題を修正
-- Fix: .wav, .flacが再生できない問題を修正（新しくアップロードされたファイルのみ修正が適用されます）
-- Fix: 凍結されたユーザーが一部APIのレスポンスに含まれる問題を修正
+- Fix: エクスポートデータの拡張子が unknown になる問題を修正
+- Fix: Content-Disposition のパースでエラーが発生した場合にダウンロードが完了しない問題を修正
+- Fix: API: i/update avatarId と bannerId に null を渡した時、画像がリセットされない問題を修正
+- Fix: .wav, .flac が再生できない問題を修正（新しくアップロードされたファイルのみ修正が適用されます）
+- Fix: 凍結されたユーザーが一部 API のレスポンスに含まれる問題を修正
 - Fix: メモリの使用量を`used - buffers - cached`ではなく`total - available`で求めるように（環境によって正常に計測できていなかったため）
 
 ## 13.11.3
 
 ### General
+
 - 指定したロールを持つユーザーのノートのみが流れるロールタイムラインを追加
-	- Deckのカラムとしても追加可能
+  - Deck のカラムとしても追加可能
 - カスタム絵文字関連の改善
-  * ノートなどに含まれるemojis（populateEmojiの結果）は（プロキシされたURLではなく）オリジナルのURLを指すように
-  * MFMでx3/x4もしくはscale.x/yが2.5以上に指定されていた場合にはオリジナル品質の絵文字を使用するように
+  - ノートなどに含まれる emojis（populateEmoji の結果）は（プロキシされた URL ではなく）オリジナルの URL を指すように
+  - MFM で x3/x4 もしくは scale.x/y が 2.5 以上に指定されていた場合にはオリジナル品質の絵文字を使用するように
 - カスタム絵文字でリアクションできないことがある問題を修正
 
 ### Client
+
 - チャンネルのピン留めされたノートの順番が正しくない問題を修正
 
 ### Server
+
 - フォローインポートなどでの大量のフォロー等操作をキューイングするように #10544 @nmkj-io
-- Misskey Webでのサーバーサイドエラー画面を改善
-- Misskey Webでのサーバーサイドエラーのログが残るように
+- Misskey Web でのサーバーサイドエラー画面を改善
+- Misskey Web でのサーバーサイドエラーのログが残るように
 - ノート作成時のアンテナ追加パフォーマンスを改善
-- アンテナとロールTLのuntil/sinceプロパティが動くように
+- アンテナとロール TL の until/since プロパティが動くように
 
 ## 13.11.2
 
 ### Note
-- 13.11.0または13.11.1から13.11.2以降にアップデートする場合、Redisのカスタム絵文字のキャッシュを削除する必要があります(https://github.com/misskey-dev/misskey/issues/10502#issuecomment-1502790755 参照)
+
+- 13.11.0 または 13.11.1 から 13.11.2 以降にアップデートする場合、Redis のカスタム絵文字のキャッシュを削除する必要があります(https://github.com/misskey-dev/misskey/issues/10502#issuecomment-1502790755 参照)
 
 ### General
+
 - チャンネルの検索用ページの追加
 
 ### Client
+
 - 常に広告を見られるオプションを追加
 - ユーザーページの画像一覧が表示されない問題を修正
 - webhook, 連携アプリ一覧でコンテンツが重複して表示される問題を修正
-- iPhoneで絵文字ピッカーの表示が崩れる問題を修正
-- iPhoneでウィジェットドロワーの「ウィジェットを編集」が押しにくい問題を修正
+- iPhone で絵文字ピッカーの表示が崩れる問題を修正
+- iPhone でウィジェットドロワーの「ウィジェットを編集」が押しにくい問題を修正
 - 投稿フォームのデザインを調整
 - ギャラリーの人気の投稿が無限にページングされる問題を修正
 
 ### Server
-- channels/search Endpoint APIの追加
-- APIパラメータサイズ上限を32kbから1mbに緩和
+
+- channels/search Endpoint API の追加
+- API パラメータサイズ上限を 32kb から 1mb に緩和
 - プッシュ通知送信時のパフォーマンスを改善
 - ローカルのカスタム絵文字のキャッシュが効いていなかった問題を修正
 - アンテナのノート、チャンネルのノート、通知が正常に作成できないことがある問題を修正
-- ストリーミングのLTLチャンネルでサーバー側にエラーログが出るのを修正
+- ストリーミングの LTL チャンネルでサーバー側にエラーログが出るのを修正
 
 ### Service Worker
+
 - 「通知が既読になったらプッシュ通知を削除する」を復活
-  * 「プッシュ通知が更新されました」の挙動を変えた（ホストとバージョンを表示するようにし、一定時間後の削除は行わないように）
+  - 「プッシュ通知が更新されました」の挙動を変えた（ホストとバージョンを表示するようにし、一定時間後の削除は行わないように）
 - プッシュ通知が実績を解除 (achievementEarned) に対応
 - プッシュ通知のアクションから既存のクライアントの投稿フォームを開くことになった際の挙動を修正
-- たくさんのプッシュ通知を閉じた際、その通知の数だけnotifications/mark-all-as-readを叩くのをやめるように
+- たくさんのプッシュ通知を閉じた際、その通知の数だけ notifications/mark-all-as-read を叩くのをやめるように
 
 ## 13.11.1
 
 ### General
+
 - チャンネルの投稿を過去までさかのぼれるように
 
 ### Client
-- PWA時の絵文字ピッカーの位置をホームバーに重ならないように調整
+
+- PWA 時の絵文字ピッカーの位置をホームバーに重ならないように調整
 - リスト管理の画面でリストが無限に読み込まれる問題を修正
 - 自分のクリップが無限に読み込まれる問題を修正
 - チャンネルのお気に入りが無限に読み込まれる問題を修正
@@ -207,66 +231,74 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - ユーザープレビューが表示されない問題を修正
 
 ### Server
+
 - 通知読み込みでエラーが発生する場合がある問題を修正
 - リアクションできないことがある問題を修正
-- IDをaid以外に設定している場合の問題を修正
+- ID を aid 以外に設定している場合の問題を修正
 - 連合しているインスタンスについて予期せず配送が全て停止されることがある問題を修正
 
 ## 13.11.0
 
 ### NOTE
-- このバージョンからRedis 7.xが必要です。
+
+- このバージョンから Redis 7.x が必要です。
 - アップデートを行うと全ての通知およびアンテナのノートはリセットされます。
 
 ### General
+
 - チャンネルをお気に入りに登録できるように
-  - タイムラインのアンテナ選択などでは、フォローしているアンテナの代わりにお気に入りしたアンテナが表示されるようになっています。チャンネルをお気に入りに登録するには、当該チャンネルのページ→概要→⭐️のボタンを押します。
+  - タイムラインのアンテナ選択などでは、フォローしているアンテナの代わりにお気に入りしたアンテナが表示されるようになっています。チャンネルをお気に入りに登録するには、当該チャンネルのページ → 概要 →⭐️ のボタンを押します。
 - チャンネルにノートをピン留めできるように
 
 ### Client
+
 - 投稿フォームのデザインを改善
-- 検索ページでURLを入力した際に照会したときと同等の挙動をするように
+- 検索ページで URL を入力した際に照会したときと同等の挙動をするように
 - ノートのリアクションを大きく表示するオプションを追加
 - ギャラリー一覧にメディア表示と同じように NSFW 設定を反映するように（ホバーで表示）
 - オブジェクトストレージの設定画面を分かりやすく
-- 広告・お知らせが新規登録時に増殖しないように
--　「にゃああああああああああああああ！！！！！！！！！！！！」 (`isCat`) 有効時にアバターに表示される猫耳について挙動を変更
-  - 「UIにぼかし効果を使用」 (`useBlurEffect`) で次の挙動が有効になります
-	  - 猫耳のアバター内部部分をぼかしでマスク表示してより猫耳っぽく見えるように
-	- 「UIのアニメーションを減らす」 (`reduceAnimation`) で猫耳を撫でられなくなります
+- 広告・お知らせが新規登録時に増殖しないように -　「にゃああああああああああああああ！！！！！！！！！！！！」 (`isCat`) 有効時にアバターに表示される猫耳について挙動を変更
+  - 「UI にぼかし効果を使用」 (`useBlurEffect`) で次の挙動が有効になります
+    - 猫耳のアバター内部部分をぼかしでマスク表示してより猫耳っぽく見えるように
+    - 「UI のアニメーションを減らす」 (`reduceAnimation`) で猫耳を撫でられなくなります
 - Add Minimizing ("folding") of windows
 - 「データセーバー」モードを追加
-- 非NSFWメディアが隠れている際にも「閲覧注意」が出てしまう問題を修正
+- 非 NSFW メディアが隠れている際にも「閲覧注意」が出てしまう問題を修正
 
 ### Server
-- PostgreSQLのレプリケーション対応
-	- 設定ファイルの `dbReplications` および `dbSlaves` にて設定できます
-- イベント用Redisを別サーバーに分離できるように
-- ジョブキュー用Redisを別サーバーに分離できるように
+
+- PostgreSQL のレプリケーション対応
+  - 設定ファイルの `dbReplications` および `dbSlaves` にて設定できます
+- イベント用 Redis を別サーバーに分離できるように
+- ジョブキュー用 Redis を別サーバーに分離できるように
 - サーバーの全体的なパフォーマンスを向上
 - ノート作成時のパフォーマンスを向上
 - アンテナのタイムライン取得時のパフォーマンスを向上
 - チャンネルのタイムライン取得時のパフォーマンスを向上
 - 通知に関する全体的なパフォーマンスを向上
-- webhookがcontent-type text/plain;charset=UTF-8 で飛んでくる問題を修正
+- webhook が content-type text/plain;charset=UTF-8 で飛んでくる問題を修正
 
 ## 13.10.3
 
 ### Changes
+
 - オブジェクトストレージのリージョン指定が必須になりました
   - リージョンの指定の無いサービスは us-east-1 を設定してください
   - 値が空の場合は設定ファイルまたは環境変数の使用を試みます
     - e.g. ~/aws/config, AWS_REGION
 
 ### General
+
 - コンディショナルロールの条件に「投稿数が～以下」「投稿数が～以上」を追加
-- リアクション非対応AP実装からのLikeアクティビティの解釈を👍から♥に
+- リアクション非対応 AP 実装からの Like アクティビティの解釈を 👍 から ♥ に
 
 ### Client
+
 - クリップボタンをノートアクションに追加できるように
-- センシティブワードの一覧にピン留めユーザーのIDが表示される問題を修正
+- センシティブワードの一覧にピン留めユーザーの ID が表示される問題を修正
 
 ### Server
+
 - リモートユーザーのチャート生成を無効にするオプションを追加
 - リモートサーバーのチャート生成を無効にするオプションを追加
 - ドライブのチャートはローカルユーザーのみ生成するように
@@ -275,20 +307,24 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 13.10.2
 
 ### Server
+
 - 絵文字を編集すると保存できないことがある問題を修正
 
 ### Client
+
 - ドライブファイルのメニューが正常に動作しない問題を修正
 
 ## 13.10.1
 
 ### Client
-- Misskey PlayのPlayボタンを押した時にエラーが発生する問題を修正
+
+- Misskey Play の Play ボタンを押した時にエラーが発生する問題を修正
 
 ## 13.10.0
 
 ### General
-- ユーザーごとにRenoteをミュートできるように
+
+- ユーザーごとに Renote をミュートできるように
 - ノートごとに絵文字リアクションを受け取るか設定できるように
 - クリップをお気に入りに登録できるように
 - ノート検索の利用可否をロールで制御可能に(デフォルトでオフ)
@@ -298,41 +334,43 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - 使われてないアンテナは自動停止されるように
 
 ### Client
+
 - 設定から自分のロールを確認できるように
 - 広告一覧ページを追加
 - ドライブクリーナーを追加
-- DM作成時にメンションも含むように
+- DM 作成時にメンションも含むように
 - フォロー申請のボタンのデザインを改善
 - 付箋ウィジェットの高さを設定可能に
-- APオブジェクトを入力してフェッチする機能とユーザーやノートの検索機能を分離
+- AP オブジェクトを入力してフェッチする機能とユーザーやノートの検索機能を分離
 - ナビゲーションバーの項目に「プロフィール」を追加できるように
 - ナビゲーションバーのカスタマイズをドラッグ&ドロップで行えるように
 - ジョブキューの再試行をワンクリックでできるように
-- AiScriptを0.13.1に更新
-- oEmbedをサポートしているウェブサイトのプレビューができるように
-	- YouTubeをoEmbedでロードし、プレビューで共有ボタンを押すとOSの共有画面がでるように
-	- ([FirefoxでSpotifyのプレビューを開けるとフルサイズじゃなくプレビューサイズだけ再生できる問題](https://bugzilla.mozilla.org/show_bug.cgi?id=1792395)があります)
-	- (すでにブラウザーでキャッシュされたリンクに対しては以前のプレビュー行動が行われてます。その場合、ブラウザーのキャッシュをクリアしてまた試してください。)
+- AiScript を 0.13.1 に更新
+- oEmbed をサポートしているウェブサイトのプレビューができるように
+  - YouTube を oEmbed でロードし、プレビューで共有ボタンを押すと OS の共有画面がでるように
+  - ([Firefox で Spotify のプレビューを開けるとフルサイズじゃなくプレビューサイズだけ再生できる問題](https://bugzilla.mozilla.org/show_bug.cgi?id=1792395)があります)
+  - (すでにブラウザーでキャッシュされたリンクに対しては以前のプレビュー行動が行われてます。その場合、ブラウザーのキャッシュをクリアしてまた試してください。)
 - プロフィールで設定した情報が削除できない問題を修正
-- ロールで広告を無効にするとadmin/adsでプレビューがでてこない問題を修正
-- /api-consoleページにアクセスすると404が出る問題を修正
-- Safariでプラグインが複数ある場合に正常に読み込まれない問題を修正
-- Bookwyrmのユーザーのプロフィールページで「リモートで表示」をタップしても反応がない問題を修正
-- 非ログイン時の「Misskeyについて」の表示を修正
-- PC版にて「設定」「コントロールパネル」のリンクを2度以上続けてクリックした際に空白のページが表示される問題を修正
+- ロールで広告を無効にすると admin/ads でプレビューがでてこない問題を修正
+- /api-console ページにアクセスすると 404 が出る問題を修正
+- Safari でプラグインが複数ある場合に正常に読み込まれない問題を修正
+- Bookwyrm のユーザーのプロフィールページで「リモートで表示」をタップしても反応がない問題を修正
+- 非ログイン時の「Misskey について」の表示を修正
+- PC 版にて「設定」「コントロールパネル」のリンクを 2 度以上続けてクリックした際に空白のページが表示される問題を修正
 
 ### Server
-- OpenAPIエンドポイントを復旧
-- WebP/AVIF/JPEGのweb公開用画像は、サーバーサイドではJPEGではなくWebPに変換するように
+
+- OpenAPI エンドポイントを復旧
+- WebP/AVIF/JPEG の web 公開用画像は、サーバーサイドでは JPEG ではなく WebP に変換するように
 - アニメーション画像のサムネイルを生成するように
 - アクティブユーザー数チャートの記録上限値を拡張
-- Playのソースコード上限文字数を2倍に拡張
-- 配送先サーバーが410 Goneで応答してきた場合は自動で配送停止をするように
-- avatarBlurHash/bannerBlurHashの型をstringに限定
+- Play のソースコード上限文字数を 2 倍に拡張
+- 配送先サーバーが 410 Gone で応答してきた場合は自動で配送停止をするように
+- avatarBlurHash/bannerBlurHash の型を string に限定
 - タイムライン取得時のパフォーマンスを改善
 - SMTP Login id length is too short
-- API上で`visibility`を`followers`に設定してrenoteすると連合や削除で不具合が発生する問題を修正
-- AWS S3からのファイル削除でNoSuchKeyエラーが出ると進めらない状態になる問題を修正
+- API 上で`visibility`を`followers`に設定して renote すると連合や削除で不具合が発生する問題を修正
+- AWS S3 からのファイル削除で NoSuchKey エラーが出ると進めらない状態になる問題を修正
 - `disableCache: true`を設定している場合に絵文字管理操作でエラーが出る問題を修正
 - リテンション分析が上手く機能しないことがあるのを修正
 - 空のアンテナが作成できないように修正
@@ -342,36 +380,41 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 13.9.2 (2023/03/06)
 
 ### Improvements
+
 - クリップ、チャンネルページに共有ボタンを追加
 - チャンネルでタイムライン上部に投稿フォームを表示するかどうかのオプションを追加
 - ブラウザでメディアプロキシ(/proxy)からファイルを保存した際に、なるべくオリジナルのファイル名を継承するように
-- ドライブの「URLからアップロード」で、content-dispositionのfilenameがあればそれをファイル名に
-- Identiconがローカルとリモートで同じになるように
-  - これまでのIdenticonは異なる画像になります
+- ドライブの「URL からアップロード」で、content-disposition の filename があればそれをファイル名に
+- Identicon がローカルとリモートで同じになるように
+  - これまでの Identicon は異なる画像になります
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
+
 - ロールの権限で「一般ユーザー」のロールがいきなり設定できない問題を修正
 - ユーザーページのバッジ表示を適切に折り返すように @arrow2nd
 - fix(client): みつけるのロール一覧でコンディショナルロールが含まれるのを修正
-- macOSでDev Containerが動作しない問題を修正 @RyotaK
+- macOS で Dev Container が動作しない問題を修正 @RyotaK
 
 ## 13.9.1 (2023/03/03)
 
 ### Bugfixes
+
 - ノートに添付したファイルが表示されない場合があるのを修正
 
 ## 13.9.0 (2023/03/03)
 
 ### Improvements
+
 - 時限ロール
-- アンテナでCWも検索対象にするように
+- アンテナで CW も検索対象にするように
 - ノートの操作部をホバー時のみ表示するオプションを追加
 - サウンドを追加
-- enhance(client): MFMのx2, scale, positionが含まれていたらノートをたたむように
+- enhance(client): MFM の x2, scale, position が含まれていたらノートをたたむように
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
+
 - 外部メディアプロキシ使用時にアバタークロップができない問題を修正
 - fix(server): メールアドレス更新時にバリデーションが正しく行われていないのを修正
 - fix(server): チャンネルでミュートが正しく機能していないのを修正
@@ -380,16 +423,18 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 13.8.1 (2023/02/26)
 
 ### Bugfixes
+
 - モバイルでドロワーメニューが表示されない問題を修正
 
 ## 13.8.0 (2023/02/26)
 
 ### Improvements
+
 - チャンネル内ハイライト
 - ホームタイムラインのパフォーマンスを改善
-- renoteした際の表示を改善
+- renote した際の表示を改善
 - バックグラウンドで一定時間経過したらページネーションのアイテム更新をしない
-- enhance(client): MkUrlPreviewの閉じるボタンを見やすく
+- enhance(client): MkUrlPreview の閉じるボタンを見やすく
 - Add dialog to remove follower
 - enhance(client): improve clip menu ux
 - 検索画面の統合
@@ -397,33 +442,39 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - photoswipe 表示時に戻る操作をしても前の画面に戻らないように
 
 ### Bugfixes
-- Windows環境でswcを使うと正しくビルドできない問題の修正
-- fix(client): Android ChromeでPWAとしてインストールできない問題を修正
+
+- Windows 環境で swc を使うと正しくビルドできない問題の修正
+- fix(client): Android Chrome で PWA としてインストールできない問題を修正
 - 未知のユーザーが deleteActor されたら処理をスキップする
-- fix(server): notes/createで、fileIdsと見つかったファイルの数が異なる場合はエラーにする
-- fix(server): notes/createのバリデーションが機能していないのを修正
+- fix(server): notes/create で、fileIds と見つかったファイルの数が異なる場合はエラーにする
+- fix(server): notes/create のバリデーションが機能していないのを修正
 - fix(server): エラーのスタックトレースは返さないように
 
 ## 13.7.5 (2023/02/24)
 
 ### Note
-13.7.0以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**
+
+13.7.0 以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**
 
 ### Improvements
+
 - 紛らわしいため公開範囲の「ローカルのみ」オプションの名称を「連合なし」に変更
 - Frontend: スマホ・タブレットの場合、チャンネルの投稿フォームに自動でフォーカスしないように
 
 ### Bugfixes
+
 - 全ての通知が削除されてしまうのを修正
 
 ## 13.7.3 (2023/02/23)
 
 ### Note
-~~13.7.0以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**~~
+
+~~13.7.0 以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**~~
 
 ### Improvements
 
 ### Bugfixes
+
 - Client: 「キャッシュを削除」した後、ローカルのカスタム絵文字が表示されなくなるされなくなる問題を修正
 - Client: 通知設定画面で以前からグループの招待を有効化していた場合、通知の表示に失敗する問題の修正
 - Client: 通知設定画面に古いトグルが残っていた問題を修正
@@ -431,134 +482,158 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 13.7.2 (2023/02/23)
 
 ### Note
-13.7.0以前からアップデートする場合は全ての通知が削除されます。
+
+13.7.0 以前からアップデートする場合は全ての通知が削除されます。
 
 ### Improvements
+
 - enhance: make pwa icon maskable
 - chore(client): tweak custom emoji size
 
 ### Bugfixes
+
 - マイグレーションが失敗することがあるのを修正
 
 ## 13.7.1 (2023/02/23)
 
 ### Improvements
-- pnpm buildではswcを使うように
+
+- pnpm build では swc を使うように
 
 ### Bugfixes
-- NODE_ENV=productionでビルドできないのを修正
+
+- NODE_ENV=production でビルドできないのを修正
 
 ## 13.7.0 (2023/02/22)
 
 ### Changes
+
 - チャット機能が削除されました
 
 ### Improvements
-- Server: URLプレビュー（summaly）はプロキシを通すように
-- Client: 2FA設定のUIをまともにした
+
+- Server: URL プレビュー（summaly）はプロキシを通すように
+- Client: 2FA 設定の UI をまともにした
 - セキュリティキーの名前を変更できるように
 - enhance(client): add quiz preset for play
 - 広告開始時期を設定できるように
 - みつけるで公開ロール一覧とそのメンバーを閲覧できるように
-- enhance(client): MFMのx3, x4が含まれていたらノートをたたむように
+- enhance(client): MFM の x3, x4 が含まれていたらノートをたたむように
 - enhance(client): make possible to reload page of window
 
 ### Bugfixes
+
 - ユーザー検索ダイアログでローカルユーザーを絞って検索できない問題を修正
-- fix(client): MkHeader及びデッキのカラムでチャンネル一覧を選択したとき、最大5個までしか表示されない
-- 管理画面の広告を10個以上見えるように
+- fix(client): MkHeader 及びデッキのカラムでチャンネル一覧を選択したとき、最大 5 個までしか表示されない
+- 管理画面の広告を 10 個以上見えるように
 - Moderation note が保存できない
 - ユーザーのハッシュタグ検索が機能していないのを修正
 
 ## 13.6.1 (2023/02/12)
 
 ### Improvements
-- アニメーションを少なくする設定の時、MkPageHeaderのタブアニメーションを無効化
-- Backend: activitypub情報がcorsでブロックされないようヘッダーを追加
-- enhance: レートリミットを0%にできるように
-- チャンネル内Renoteを行えるように
+
+- アニメーションを少なくする設定の時、MkPageHeader のタブアニメーションを無効化
+- Backend: activitypub 情報が cors でブロックされないようヘッダーを追加
+- enhance: レートリミットを 0%にできるように
+- チャンネル内 Renote を行えるように
 
 ### Bugfixes
+
 - Client: ユーザーページでアクティビティを見ることができない問題を修正
 
 ## 13.6.0 (2023/02/11)
 
 ### Improvements
-- MkPageHeaderをごっそり変えた
-  * モバイルではヘッダーは上下に分割され、下段にタブが表示されるように
-  * iconOnlyのタブ項目がアクティブな場合にはタブのタイトルを表示するように
-  * メインタイムラインではタイトルを表示しない
-  * メインタイムラインかつモバイルで表示される左上のアバターを選択するとアカウントメニューが開くように
+
+- MkPageHeader をごっそり変えた
+  - モバイルではヘッダーは上下に分割され、下段にタブが表示されるように
+  - iconOnly のタブ項目がアクティブな場合にはタブのタイトルを表示するように
+  - メインタイムラインではタイトルを表示しない
+  - メインタイムラインかつモバイルで表示される左上のアバターを選択するとアカウントメニューが開くように
 - ユーザーページのノート一覧をタブとして分離
 - コンディショナルロールもバッジとして表示可能に
 - enhance(client): ロールをより簡単に付与できるように
-- enhance(client): 一度見たノートのRenoteは省略して表示するように
+- enhance(client): 一度見たノートの Renote は省略して表示するように
 - enhance(client): 迷惑になる可能性のある投稿を行う前に警告を表示
 - リアクションの数が多い場合の表示を改善
-- 一部のMFM構文をopt-outに
+- 一部の MFM 構文を opt-out に
 
 ### Bugfixes
+
 - Client: ユーザーページでタブがほとんど見れないことがないように
 
 ## 13.5.6 (2023/02/10)
 
 ### Improvements
-- 非ログイン時にMiAuthを踏んだ際にMiAuthであることを表示する
-- /auth/のUIをアップデート
-- 利用規約同意UIの調整
+
+- 非ログイン時に MiAuth を踏んだ際に MiAuth であることを表示する
+- /auth/の UI をアップデート
+- 利用規約同意 UI の調整
 - クロップ時の質問を分かりやすく
 
 ### Bugfixes
+
 - fix: prevent clipping audio plyr's tooltip
 
 ## 13.5.4 (2023/02/09)
 
 ### Improvements
-- Server: UIのHTML（ノートなどの特別なページを除く）のキャッシュ時間を15秒から30秒に
-- i/notificationsのレートリミットを緩和
+
+- Server: UI の HTML（ノートなどの特別なページを除く）のキャッシュ時間を 15 秒から 30 秒に
+- i/notifications のレートリミットを緩和
 
 ### Bugfixes
+
 - fix(client): validate url to improve security
-- fix(client): dateの初期値が正常に入らない時がある
+- fix(client): date の初期値が正常に入らない時がある
 
 ## 13.5.3 (2023/02/09)
 
 ### Improvements
+
 - Client: デッキにチャンネルカラムを追加
 
 ## 13.5.2 (2023/02/08)
 
 ### Changes
+
 - Revert: perf(client): do not render custom emojis in user names
 
 ### Bugfixes
+
 - Client: register_note_view_interruptor not working
 - Client: ログイントークンの再生成が出来ない
 
 ## 13.5.0 (2023/02/08)
 
 ### Changes
+
 - perf(client): do not render custom emojis in user names
 
 ### Improvements
-- Client: disableShowingAnimatedImagesのデフォルト値をprefers-reduced-motionにする
+
+- Client: disableShowingAnimatedImages のデフォルト値を prefers-reduced-motion にする
 - enhance(client): tweak medialist style
 
 ### Bugfixes
+
 - fix docker health check
-- Client: MkEmojiPickerでもChromeで検索ダイアログで変換確定するとそのまま検索されてしまうのを修正
+- Client: MkEmojiPicker でも Chrome で検索ダイアログで変換確定するとそのまま検索されてしまうのを修正
 - fix(mfm): default degree not used in rotate
 - fix(server): validate urls from ap to improve security
 
 ## 13.4.0 (2023/02/05)
 
 ### Improvements
+
 - ロールにアイコンを設定してユーザー名の横に表示できるように
 - feat: timeline page for non-login users
 - 実績の単なるラッキーの獲得確立を調整
 - Add Thai language support
 
 ### Bugfixes
+
 - fix(server): 自分のノートをお気に入りに登録しても実績解除される問題を修正
 - fix(server): clean up file in FileServer
 - fix(server): Deny UNIX domain socket
@@ -571,51 +646,64 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 13.3.3 (2023/02/04)
 
 ### Bugfixes
+
 - Server: improve security
 
 ## 13.3.2 (2023/02/04)
 
 ### Improvements
+
 - 外部メディアプロキシへの対応を強化しました
-  外部メディアプロキシのFastify実装を作りました
+  外部メディアプロキシの Fastify 実装を作りました
   https://github.com/misskey-dev/media-proxy
 - Server: improve performance
 
 ### Bugfixes
+
 - Client: validate urls to improve security
 
 ## 13.3.1 (2023/02/04)
 
 ### Bugfixes
+
 - Client: カスタム絵文字にアニメーション画像を再生しない設定が適用されていない問題を修正
-- Client: オートコンプリートでUnicode絵文字がカスタム絵文字として表示されてしまうのを修正
+- Client: オートコンプリートで Unicode 絵文字がカスタム絵文字として表示されてしまうのを修正
 - Client: Fix Vue-plyr CORS issue
 - Client: validate urls to improve security
 
 ## 13.3.0 (2023/02/03)
+
 ### Changes
-- twitter/github/discord連携機能が削除されました
+
+- twitter/github/discord 連携機能が削除されました
 - ハッシュタグごとのチャートが削除されました
-- syslogのサポートが削除されました
+- syslog のサポートが削除されました
 
 ### Improvements
+
 - ロールで広告の非表示が有効になっている場合は最初から広告を非表示にするように
 
 ## 13.2.6 (2023/02/01)
+
 ### Changes
-- docker-compose.ymlをdocker-compose.yml.exampleにしました。docker-compose.ymlとしてコピーしてから使用してください。
+
+- docker-compose.yml を docker-compose.yml.example にしました。docker-compose.yml としてコピーしてから使用してください。
 
 ### Improvements
+
 - 絵文字ピッカーのパフォーマンスを改善
-- AiScriptを0.12.4に更新
+- AiScript を 0.12.4 に更新
 
 ### Bugfixes
+
 - Server: リレーと通信できない問題を修正
-- Client: classicモード使用時にwindowサイズによってdefaultに変更された後に、windowサイズが元に戻ったらclassicに戻すように修正 #9669
-- Client: Chromeで検索ダイアログで変換確定するとそのまま検索されてしまう問題を修正
+- Client: classic モード使用時に window サイズによって default に変更された後に、window サイズが元に戻ったら classic に戻すように修正 #9669
+- Client: Chrome で検索ダイアログで変換確定するとそのまま検索されてしまう問題を修正
 
 ## 13.2.4 (2023/01/27)
+
 ### Improvements
+
 - リモートカスタム絵文字表示時のパフォーマンスを改善
 - Default to `animation: false` when prefers-reduced-motion is set
 - リアクション履歴が公開なら、ログインしていなくても表示できるように
@@ -623,94 +711,115 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - tweak custom emoji cache
 
 ### Bugfixes
+
 - fix aggregation of retention
 - ダッシュボードでオンラインユーザー数が表示されない問題を修正
 - フォロー申請・フォローのボタンが、通知から消えている問題を修正
 
 ## 13.2.3 (2023/01/26)
+
 ### Improvements
+
 - カスタム絵文字の更新をリアルタイムで反映するように
 
 ### Bugfixes
+
 - turnstile-failed: missing-input-secret
 
 ## 13.2.2 (2023/01/25)
+
 ### Improvements
+
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
+
 - サインイン時に誤ったレートリミットがかかることがある問題を修正
-- MFMのposition、rotate、scaleで小数が使えない問題を修正
+- MFM の position、rotate、scale で小数が使えない問題を修正
 
 ## 13.2.1 (2023/01/24)
+
 ### Improvements
+
 - デザインの調整
 - サーバーのパフォーマンスを改善
 
 ## 13.2.0 (2023/01/23)
 
 ### Improvements
+
 - onlyServer / onlyQueue オプションを復活
 - 他人の実績閲覧時は獲得条件を表示しないように
 - アニメーション減らすオプション有効時はリアクションのアニメーションを無効に
 - カスタム絵文字一覧のパフォーマンスを改善
 
 ### Bugfixes
+
 - Aiscript: button is not defined
 
 ## 13.1.7 (2023/01/22)
 
 ### Improvements
+
 - 新たな実績を追加
-- MFMにscaleタグを追加
+- MFM に scale タグを追加
 
 ## 13.1.4 (2023/01/22)
 
 ### Improvements
+
 - 新たな実績を追加
 
 ### Bugfixes
+
 - Client: ローカリゼーション更新時にリロードが繰り返されることがあるのを修正
 
 ## 13.1.3 (2023/01/22)
 
 ### Bugfixes
+
 - Client: リアクションのカスタム絵文字の表示の問題を修正
 
 ## 13.1.2 (2023/01/22)
 
 ### Bugfixes
+
 - Client: リアクションのカスタム絵文字の表示の問題を修正
 
 ## 13.1.1 (2023/01/22)
 
 ### Improvements
+
 - ローカルのカスタム絵文字を表示する際のパフォーマンスを改善
 - Client: 瞬間的に大量の実績を解除した際の挙動を改善
 
 ### Bugfixes
+
 - Client: アップデート時にローカリゼーションデータが更新されないことがあるのを修正
 
 ## 13.1.0 (2023/01/21)
 
 ### Improvements
+
 - 実績機能
-- Playのプリセットを追加
-- Playのscriptの文字数制限を緩和
-- AiScript GUIの強化
+- Play のプリセットを追加
+- Play の script の文字数制限を緩和
+- AiScript GUI の強化
 - リアクション一覧詳細ダイアログを表示できるように
 - 存在しないカスタム絵文字をテキストで表示するように
 - Alt text in image viewer
-- ジョブキューのプロセスとWebサーバーのプロセスを分離
+- ジョブキューのプロセスと Web サーバーのプロセスを分離
 
 ### Bugfixes
-- playを削除する手段がなかったのを修正
+
+- play を削除する手段がなかったのを修正
 - The … button on notes does nothing when not logged in
-- twitterと連携するときに autwh is not a function になるのを修正
+- twitter と連携するときに autwh is not a function になるのを修正
 
 ## 13.0.0 (2023/01/16)
 
 ### TL;DR
+
 - New features (Role system, Misskey Play, New widgets, New charts, 🍪👈, etc)
 - Rewriten backend
 - Better performance (backend and frontend)
@@ -718,57 +827,63 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - Various UI tweaks
 
 ### Notable features
+
 - ロール機能
-	- 従来より柔軟にユーザーのポリシーを管理できます。例えば、「インスタンスのパトロンはアンテナを30個まで作れる」「基本的にLTLは見れないが、許可した人だけ見れる」「招待制インスタンスだけどユーザーなら誰でも他者を招待できる」のような運用はもちろん、「ローカルユーザーかつアカウント作成から1日未満のユーザーはパブリックな投稿を行えない」のように複数条件を組み合わせて、自動でロールを付与する設定も可能です。
+  - 従来より柔軟にユーザーのポリシーを管理できます。例えば、「インスタンスのパトロンはアンテナを 30 個まで作れる」「基本的に LTL は見れないが、許可した人だけ見れる」「招待制インスタンスだけどユーザーなら誰でも他者を招待できる」のような運用はもちろん、「ローカルユーザーかつアカウント作成から 1 日未満のユーザーはパブリックな投稿を行えない」のように複数条件を組み合わせて、自動でロールを付与する設定も可能です。
 - Misskey Play
-	- 従来の動的なPagesに代わる、新しいプラットフォームです。動的なコンテンツ(アプリケーション)に特化していて、Pagesに比べてはるかに柔軟なアプリケーションを作成可能です。
+  - 従来の動的な Pages に代わる、新しいプラットフォームです。動的なコンテンツ(アプリケーション)に特化していて、Pages に比べてはるかに柔軟なアプリケーションを作成可能です。
 
 ### Changes
+
 #### For server admins
+
 - Node.js 18.x or later is required
 - PostgreSQL 15.x is required
-	- Misskey not using 15 specific features at 13.0.0, but may do so in the future.
-	- Docker環境でPostgreSQLのアップデートを行う際のガイドはこちら: https://github.com/misskey-dev/misskey/pull/9641#issue-1536336620
-- Elasticsearchのサポートが削除されました
-	- 代わりに今後任意の検索プロバイダを設定できる仕組みを構想しています。その仕組みを使えば今まで通りElasticsearchも利用できます
-- Yarnからpnpmに移行されました
-  corepackの有効化を推奨します: `sudo corepack enable`
+  - Misskey not using 15 specific features at 13.0.0, but may do so in the future.
+  - Docker 環境で PostgreSQL のアップデートを行う際のガイドはこちら: https://github.com/misskey-dev/misskey/pull/9641#issue-1536336620
+- Elasticsearch のサポートが削除されました
+  - 代わりに今後任意の検索プロバイダを設定できる仕組みを構想しています。その仕組みを使えば今まで通り Elasticsearch も利用できます
+- Yarn から pnpm に移行されました
+  corepack の有効化を推奨します: `sudo corepack enable`
 - インスタンスブロックはサブドメインにも適用されるようになります
 - ロールの導入に伴い、いくつかの機能がロールと統合されました
-	- モデレーターはロールに統合されました。今までのモデレーター情報は失われるため、予めモデレーター一覧を記録しておき、アップデート後にモデレーターロールを作りアサインし直してください。
-	- サイレンスはロールに統合されました。今までのユーザーは恩赦されるため、予めサイレンス一覧を記録しておくのをおすすめします。
-	- ユーザーごとのドライブ容量設定はロールに統合されました。
-	- インスタンスデフォルトのドライブ容量設定はロールに統合されました。アップデート後、ベースロールもしくはコンディショナルロールでドライブ容量を編集してください。
-	- LTL/GTLの解放状態はロールに統合されました。
-- Dockerの実行をrootで行わないようにしました。Dockerかつオブジェクトストレージを使用していない場合は`chown -hR 991.991 ./files`を実行してください。
+  - モデレーターはロールに統合されました。今までのモデレーター情報は失われるため、予めモデレーター一覧を記録しておき、アップデート後にモデレーターロールを作りアサインし直してください。
+  - サイレンスはロールに統合されました。今までのユーザーは恩赦されるため、予めサイレンス一覧を記録しておくのをおすすめします。
+  - ユーザーごとのドライブ容量設定はロールに統合されました。
+  - インスタンスデフォルトのドライブ容量設定はロールに統合されました。アップデート後、ベースロールもしくはコンディショナルロールでドライブ容量を編集してください。
+  - LTL/GTL の解放状態はロールに統合されました。
+- Docker の実行を root で行わないようにしました。Docker かつオブジェクトストレージを使用していない場合は`chown -hR 991.991 ./files`を実行してください。
   https://github.com/misskey-dev/misskey/pull/9560
 
 #### For users
+
 - ノートのウォッチ機能が削除されました
 - アンケートに投票された際に通知が作成されなくなりました
 - ノートの数式埋め込みが削除されました
-- 新たに動的なPagesを作ることはできなくなりました
-	- 代わりにAiScriptを用いてより柔軟に動的なコンテンツを作成できるMisskey Play機能が実装されています。
-- AiScriptが0.12.2にアップデートされました
-	- 0.12.xの変更点についてはこちら https://github.com/syuilo/aiscript/blob/master/CHANGELOG.md#0120
-	- 0.12.x未満のプラグインは読み込むことはできません
-- iOS15以下のデバイスはサポートされなくなりました
-- Firefox110以下はサポートされなくなりました
-  - 109でもContainerQueriesのフラグを有効にする事で問題なく使用できます
+- 新たに動的な Pages を作ることはできなくなりました
+  - 代わりに AiScript を用いてより柔軟に動的なコンテンツを作成できる Misskey Play 機能が実装されています。
+- AiScript が 0.12.2 にアップデートされました
+  - 0.12.x の変更点についてはこちら https://github.com/syuilo/aiscript/blob/master/CHANGELOG.md#0120
+  - 0.12.x 未満のプラグインは読み込むことはできません
+- iOS15 以下のデバイスはサポートされなくなりました
+- Firefox110 以下はサポートされなくなりました
+  - 109 でも ContainerQueries のフラグを有効にする事で問題なく使用できます
 
 #### For app developers
-- API: metaのレスポンスに`emojis`プロパティが含まれなくなりました
-	- カスタム絵文字一覧情報を取得するには、`emojis`エンドポイントにリクエストします
+
+- API: meta のレスポンスに`emojis`プロパティが含まれなくなりました
+  - カスタム絵文字一覧情報を取得するには、`emojis`エンドポイントにリクエストします
 - API: カスタム絵文字エンティティに`url`プロパティが含まれなくなりました
-	- 絵文字画像を表示するには、`<instance host>/emoji/<emoji name>.webp`にリクエストすると画像が返ります。
-	- e.g. `https://p1.a9z.dev/emoji/misskey.webp`
-	- remote: `https://p1.a9z.dev/emoji/syuilo_birth_present@mk.f72u.net.webp`
+  - 絵文字画像を表示するには、`<instance host>/emoji/<emoji name>.webp`にリクエストすると画像が返ります。
+  - e.g. `https://p1.a9z.dev/emoji/misskey.webp`
+  - remote: `https://p1.a9z.dev/emoji/syuilo_birth_present@mk.f72u.net.webp`
 - API: `user`および`note`エンティティに`emojis`プロパティが含まれなくなりました
 - API: `user`エンティティに`avatarColor`および`bannerColor`プロパティが含まれなくなりました
 - API: `instance`エンティティに`latestStatus`、`lastCommunicatedAt`、`latestRequestSentAt`プロパティが含まれなくなりました
 - API: `instance`エンティティの`caughtAt`は`firstRetrievedAt`に名前が変わりました
 
 ### Improvements
+
 - Role system @syuilo
 - Misskey Play @syuilo
 - Introduce retention-rate aggregation @syuilo
@@ -783,7 +898,7 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - クリップおよびクリップ内のノートの作成可能数を設定可能に @syuilo
 - ユーザーリストおよびユーザーリスト内のユーザーの作成可能数を設定可能に @syuilo
 - ハードワードミュートの最大文字数を設定可能に @syuilo
-- Webhookの作成可能数を設定可能に @syuilo
+- Webhook の作成可能数を設定可能に @syuilo
 - ノートをピン留めできる数を設定可能に @syuilo
 - Server: signToActivityPubGet is set to true by default @syuilo
 - Server: improve syslog performance @syuilo
@@ -826,24 +941,25 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - Client: add new mfm function (position, fg, bg) @syuilo
 - Client: show fireworks when visit user who today is birthday @syuilo
 - Client: show bot warning on screen when logged in as bot account @syuilo
-- Client: AiScriptからカスタム絵文字一覧を参照できるように @syuilo
+- Client: AiScript からカスタム絵文字一覧を参照できるように @syuilo
 - Client: improve overall performance of client @syuilo
 - Client: ui tweaks @syuilo
 - Client: clicker game @syuilo
 
 ### Bugfixes
+
 - Server: Fix @tensorflow/tfjs-core's MODULE_NOT_FOUND error @ikuradon
-- Server: 引用内の文章がnyaizeされてしまう問題を修正 @kabo2468
+- Server: 引用内の文章が nyaize されてしまう問題を修正 @kabo2468
 - Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 - Server: Fix peers API returning suspended instances @ineffyble
 - Server: trim long text of note from ap @syuilo
-- Server: Ap inboxの最大ペイロードサイズを64kbに制限 @syuilo
+- Server: Ap inbox の最大ペイロードサイズを 64kb に制限 @syuilo
 - Server: アンテナの作成数上限を追加 @syuilo
-- Server: pages/likeのエラーIDが重複しているのを修正 @syuilo
-- Server: pages/updateのパラメータによってはsummaryの値が更新されないのを修正 @syuilo
+- Server: pages/like のエラー ID が重複しているのを修正 @syuilo
+- Server: pages/update のパラメータによっては summary の値が更新されないのを修正 @syuilo
 - Server: Escape SQL LIKE @mei23
-- Server: 特定のPNG画像のアップロードに失敗する問題を修正 @usbharu
-- Server: 非公開のクリップのURLでOGPレンダリングされる問題を修正 @syuilo
+- Server: 特定の PNG 画像のアップロードに失敗する問題を修正 @usbharu
+- Server: 非公開のクリップの URL で OGP レンダリングされる問題を修正 @syuilo
 - Server: アンテナタイムライン（ストリーミング）が、フォローしていないユーザーの鍵投稿も拾ってしまう @syuilo
 - Server: follow request list api pagination @sim1222
 - Server: ドライブ容量超過時のエラーが適切にレスポンスされない問題を修正 @syuilo
@@ -851,31 +967,36 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 - Client: 日付形式の文字列などがカスタム絵文字として表示されるのを修正 @syuilo
 - Client: case insensitive emoji search @saschanaz
 - Client: 画面の幅が狭いとウィジェットドロワーを閉じる手段がなくなるのを修正 @syuilo
-- Client: InAppウィンドウが操作できなくなることがあるのを修正 @tamaina
+- Client: InApp ウィンドウが操作できなくなることがあるのを修正 @tamaina
 - Client: use proxied image for instance icon @syuilo
-- Client: Webhookの編集画面で、内容を保存することができない問題を修正 @m-hayabusa
-- Client: Page編集でブロックの移動が行えない問題を修正 @syuilo
+- Client: Webhook の編集画面で、内容を保存することができない問題を修正 @m-hayabusa
+- Client: Page 編集でブロックの移動が行えない問題を修正 @syuilo
 - Client: update emoji picker immediately on all input @saschanaz
 - Client: チャートのツールチップが画面に残ることがあるのを修正 @syuilo
 - Client: fix wrong link in tutorial @syuilo
 
 ### Special thanks
+
 - All contributors
 - All who have created instances for the beta test
 - All who participated in the beta test
 
 ## 12.119.1 (2022/12/03)
+
 ### Bugfixes
+
 - Server: Mitigate AP reference chain DoS vector @skehmatics
 
 ## 12.119.0 (2022/09/10)
 
 ### Improvements
+
 - Client: Add following badge to user preview popup @nvisser
 - Client: mobile twitter url can be used as widget @caipira113
 - Client: Improve clock widget @syuilo
 
 ### Bugfixes
+
 - マイグレーションに失敗する問題を修正
 - Server: 他人の通知を既読にできる可能性があるのを修正 @syuilo
 - Client: アクセストークン管理画面、アカウント管理画面表示できないのを修正 @futchitwo
@@ -883,103 +1004,123 @@ Meilisearchの設定に`index`が必要になりました。値はMisskeyサー�
 ## 12.118.1 (2022/08/08)
 
 ### Bugfixes
+
 - Client: can not show some setting pages @syuilo
 
 ## 12.118.0 (2022/08/07)
 
 ### Improvements
+
 - Client: 設定のバックアップ/リストア機能
 - Client: Add vi-VN language support
 - Client: Add unix time widget @syuilo
 
 ### Bugfixes
+
 - Server: リモートユーザーを正しくブロックできるように修正する @xianonn
-- Client: 一度作ったwebhookの設定画面を開こうとするとページがフリーズする @syuilo
-- Client: MiAuth認証ページが機能していない @syuilo
+- Client: 一度作った webhook の設定画面を開こうとするとページがフリーズする @syuilo
+- Client: MiAuth 認証ページが機能していない @syuilo
 - Client: 一部のアプリからファイルを投稿フォームへドロップできない場合がある問題を修正 @m-hayabusa
 
 ## 12.117.1 (2022/07/19)
 
 ### Improvements
-- Client: UIのブラッシュアップ @syuilo
+
+- Client: UI のブラッシュアップ @syuilo
 
 ### Bugfixes
+
 - Server: ファイルのアップロードに失敗することがある問題を修正 @acid-chicken
 - Client: リアクションピッカーがアプリ内ウィンドウの後ろに表示されてしまう問題を修正 @syuilo
 - Client: ユーザー情報の取得の再試行を修正 @xianonn
-- Client: MFMチートシートの挙動を修正 @syuilo
+- Client: MFM チートシートの挙動を修正 @syuilo
 - Client: 「インスタンスからのお知らせを受け取る」の設定を変更できない問題を修正 @syuilo
 
 ## 12.117.0 (2022/07/18)
 
 ### Improvements
+
 - Client: ウィンドウを最大化できるように @syuilo
-- Client: Shiftキーを押した状態でリンクをクリックするとアプリ内ウィンドウで開くように @syuilo
-- Client: デッキを使用している際、Ctrlキーを押した状態でリンクをクリックするとページ遷移を強制できるように @syuilo
-- Client: UIのブラッシュアップ @syuilo
+- Client: Shift キーを押した状態でリンクをクリックするとアプリ内ウィンドウで開くように @syuilo
+- Client: デッキを使用している際、Ctrl キーを押した状態でリンクをクリックするとページ遷移を強制できるように @syuilo
+- Client: UI のブラッシュアップ @syuilo
 
 ## 12.116.1 (2022/07/17)
 
 ### Bugfixes
-- Client: デッキUI時に ページで表示 ボタンが機能しない問題を修正 @syuilo
+
+- Client: デッキ UI 時に ページで表示 ボタンが機能しない問題を修正 @syuilo
 - Error During Migration Run to 12.111.x
 
 ## 12.116.0 (2022/07/16)
 
 ### Improvements
+
 - Client: registry editor @syuilo
-- Client: UIのブラッシュアップ @syuilo
+- Client: UI のブラッシュアップ @syuilo
 
 ### Bugfixes
+
 - Error During Migration Run to 12.111.x
 - Server: TypeError: Cannot convert undefined or null to object @syuilo
 
 ## 12.115.0 (2022/07/16)
 
 ### Improvements
-- Client: Deckのプロファイル切り替えを簡単に @syuilo
-- Client: UIのブラッシュアップ @syuilo
+
+- Client: Deck のプロファイル切り替えを簡単に @syuilo
+- Client: UI のブラッシュアップ @syuilo
 
 ## 12.114.0 (2022/07/15)
 
 ### Improvements
-- RSSティッカーで表示順序をシャッフルできるように @syuilo
+
+- RSS ティッカーで表示順序をシャッフルできるように @syuilo
 
 ### Bugfixes
+
 - クライアントが起動しなくなることがある問題を修正 @syuilo
 
 ## 12.113.0 (2022/07/13)
 
 ### Improvements
+
 - Support <plain> syntax for MFM
 
 ### Bugfixes
+
 - Server: Fix crash at startup if TensorFlow is not supported @mei23
-- Client: URLエンコードされたルーティングを修正
+- Client: URL エンコードされたルーティングを修正
 
 ## 12.112.3 (2022/07/09)
 
 ### Improvements
+
 - Make active email validation configurable
 
 ### Bugfixes
+
 - Server: Fix Attempts to update all notifications @mei23
 
 ## 12.112.2 (2022/07/08)
 
 ### Bugfixes
+
 - Fix Docker doesn't work @mei23
   Still not working on arm64 environment. (See 12.112.0)
 
 ## 12.112.1 (2022/07/07)
+
 same as 12.112.0
 
 ## 12.112.0 (2022/07/07)
 
 ### Known issues
-- 現在arm64環境ではインストールに失敗します。これは次のバージョンで修正される予定です。
+
+- 現在 arm64 環境ではインストールに失敗します。これは次のバージョンで修正される予定です。
 
 ### Changes
+
 - ハイライトがみつけるに統合されました
 - カスタム絵文字ページはインスタンス情報ページに統合されました
 - 連合ページはインスタンス情報ページに統合されました
@@ -989,6 +1130,7 @@ same as 12.112.0
 - メニューからリストタイムラインを表示する方法は廃止され、タイムライン上部のアイコンからアクセスするようになりました
 
 ### Improvements
+
 - Server: Allow GET method for some endpoints @syuilo
 - Server: Auto NSFW detection @syuilo
 - Server: Add rate limit to i/notifications @tamaina
@@ -1016,6 +1158,7 @@ same as 12.112.0
 - Add additional drive capacity change support @CyberRex0
 
 ### Bugfixes
+
 - Server: Fix GenerateVideoThumbnail failed @mei23
 - Server: Ensure temp directory cleanup @Johann150
 - favicons of federated instances not showing @syuilo
@@ -1028,27 +1171,31 @@ same as 12.112.0
 ## 12.111.1 (2022/06/13)
 
 ### Bugfixes
+
 - some fixes of multiple notification read @tamaina
 - some GenerateVideoThumbnail failed @Johann150
 - Client: デッキでウィジェットの情報が保存されない問題を修正 @syuilo
 - Client: ギャラリーの投稿を開こうとすると編集画面が表示される @futchitwo
 
 ## 12.111.0 (2022/06/11)
+
 ### Note
+
 - Node.js 16.15.0 or later is required
 
 ### Improvements
+
 - Supports Unicode Emoji 14.0 @mei23
 - プッシュ通知を複数アカウント対応に #7667 @tamaina
-- プッシュ通知にクリックやactionを設定 #7667 @tamaina
-- ドライブに画像ファイルをアップロードするときオリジナル画像を破棄してwebpublicのみ保持するオプション @tamaina
+- プッシュ通知にクリックや action を設定 #7667 @tamaina
+- ドライブに画像ファイルをアップロードするときオリジナル画像を破棄して webpublic のみ保持するオプション @tamaina
 - Server: always remove completed tasks of job queue @Johann150
 - Client: アバターの設定で画像をクロップできるように @syuilo
 - Client: make emoji stand out more on reaction button @Johann150
 - Client: display URL of QR code for TOTP registration @tamaina
 - Client: render quote renote CWs as MFM @pixeldesu
-- API: notifications/readは配列でも受け付けるように #7667 @tamaina
-- API: ユーザー検索で、クエリがusernameの条件を満たす場合はusernameもLIKE検索するように @tamaina
+- API: notifications/read は配列でも受け付けるように #7667 @tamaina
+- API: ユーザー検索で、クエリが username の条件を満たす場合は username も LIKE 検索するように @tamaina
 - MFM: Allow speed changes in all animated MFMs @Johann150
 - The theme color is now better validated. @Johann150
   Your own theme color may be unset if it was in an invalid format.
@@ -1058,6 +1205,7 @@ same as 12.112.0
   Admins should make sure the reverse proxy sets the `X-Forwarded-For` header to the original address.
 
 ### Bugfixes
+
 - Server: keep file order of note attachement @Johann150
 - Server: fix missing foreign key for reports leading to reports page being unusable @Johann150
 - Server: fix internal in-memory caching @Johann150
@@ -1085,36 +1233,42 @@ same as 12.112.0
 ## 12.110.1 (2022/04/23)
 
 ### Bugfixes
+
 - Fix GOP rendering @syuilo
 - Improve performance of antenna, clip, and list @xianonn
 
 ## 12.110.0 (2022/04/11)
 
 ### Improvements
+
 - Improve webhook @syuilo
 - Client: Show loading icon on splash screen @syuilo
 
 ### Bugfixes
+
 - API: parameter validation of users/show was wrong
 - Federation: リモートインスタンスへのダイレクト投稿が届かない問題を修正 @syuilo
 
 ## 12.109.2 (2022/04/03)
 
 ### Bugfixes
+
 - API: admin/update-meta was not working @syuilo
-- Client: テーマを切り替えたり読み込んだりするとmeta[name="theme-color"]のcontentがundefinedになる問題を修正 @tamaina
+- Client: テーマを切り替えたり読み込んだりすると meta[name="theme-color"]の content が undefined になる問題を修正 @tamaina
 
 ## 12.109.1 (2022/04/02)
 
 ### Bugfixes
-- API: Renoteが行えない問題を修正
+
+- API: Renote が行えない問題を修正
 
 ## 12.109.0 (2022/04/02)
 
 ### Improvements
+
 - Webhooks @syuilo
-- Bull Dashboardを組み込み、ジョブキューの確認や操作を行えるように @syuilo
-  - Bull Dashboardを開くには、最初だけ一旦ログアウトしてから再度管理者権限を持つアカウントでログインする必要があります
+- Bull Dashboard を組み込み、ジョブキューの確認や操作を行えるように @syuilo
+  - Bull Dashboard を開くには、最初だけ一旦ログアウトしてから再度管理者権限を持つアカウントでログインする必要があります
 - Check that installed Node.js version fulfills version requirement @ThatOneCalculator
 - Server: overall performance improvements @syuilo
 - Federation: avoid duplicate activity delivery @Johann150
@@ -1122,60 +1276,68 @@ same as 12.112.0
 - Client: タッチパッド・タッチスクリーンでのデッキの操作性を向上 @tamaina
 
 ### Bugfixes
+
 - email address validation was not working @ybw2016v
 - API: fix endpoint endpoint @Johann150
 - API: fix admin/meta endpoint @syuilo
 - API: improved validation and documentation for endpoints that accept different variants of input @Johann150
 - API: `notes/create`: The `mediaIds` property is now deprecated. @Johann150
   - Use `fileIds` instead, it has the same behaviour.
-- Client: URIエンコーディングが異常でdecodeURIComponentが失敗するとURLが表示できなくなる問題を修正 @tamaina
+- Client: URI エンコーディングが異常で decodeURIComponent が失敗すると URL が表示できなくなる問題を修正 @tamaina
 
 ## 12.108.1 (2022/03/12)
 
 ### Bugfixes
+
 - リレーが動作しない問題を修正 @xianonn
-- ulidを使用していると動作しない問題を修正 @syuilo
-- 外部からOGPが正しく取得できない問題を修正 @syuilo
+- ulid を使用していると動作しない問題を修正 @syuilo
+- 外部から OGP が正しく取得できない問題を修正 @syuilo
 - instance can not get the files from other instance when there are items in allowedPrivateNetworks in .config/default.yml @ybw2016v
 
 ## 12.108.0 (2022/03/09)
 
 ### NOTE
-このバージョンからNode v16.14.0以降が必要です
+
+このバージョンから Node v16.14.0 以降が必要です
 
 ### Changes
-- ノートの最大文字数を設定できる機能が廃止され、デフォルトで一律3000文字になりました @syuilo
+
+- ノートの最大文字数を設定できる機能が廃止され、デフォルトで一律 3000 文字になりました @syuilo
 - Misskey can no longer terminate HTTPS connections. @Johann150
   - If you did not use a reverse proxy (e.g. nginx) before, you will probably need to adjust
     your configuration file and set up a reverse proxy. The `https` configuration key is no
     longer recognized!
 
 ### Improvements
+
 - インスタンスデフォルトテーマを設定できるように @syuilo
 - ミュートに期限を設定できるように @syuilo
 - アンケートが終了したときに通知が作成されるように @syuilo
-- プロフィールの追加情報を最大16まで保存できるように @syuilo
-- 連合チャートにPub&Subを追加 @syuilo
-- 連合チャートにActiveを追加 @syuilo
-- デフォルトで10秒以上時間がかかるデータベースへのクエリは中断されるように @syuilo
-	- 設定ファイルの`db.extra`に`statement_timeout`を設定することでタイムアウト時間を変更できます
+- プロフィールの追加情報を最大 16 まで保存できるように @syuilo
+- 連合チャートに Pub&Sub を追加 @syuilo
+- 連合チャートに Active を追加 @syuilo
+- デフォルトで 10 秒以上時間がかかるデータベースへのクエリは中断されるように @syuilo
+  - 設定ファイルの`db.extra`に`statement_timeout`を設定することでタイムアウト時間を変更できます
 - Client: スプラッシュスクリーンにインスタンスのアイコンを表示するように @syuilo
 
 ### Bugfixes
+
 - Client: リアクションピッカーの高さが低くなったまま戻らないことがあるのを修正 @syuilo
 - Client: ユーザー名オートコンプリートが正しく動作しない問題を修正 @syuilo
 - Client: タッチ操作だとウィジェットの編集がしにくいのを修正 @xianonn
 - Client: register_note_view_interruptor()が動かないのを修正 @syuilo
-- Client: iPhone X以降(?)でページの内容が全て表示しきれないのを修正 @tamaina
+- Client: iPhone X 以降(?)でページの内容が全て表示しきれないのを修正 @tamaina
 - Client: fix image caption on mobile @nullobsi
 
 ## 12.107.0 (2022/02/12)
 
 ### Improvements
+
 - クライアント: テーマを追加 @syuilo
 
 ### Bugfixes
-- API: stats APIで内部エラーが発生する問題を修正 @syuilo
+
+- API: stats API で内部エラーが発生する問題を修正 @syuilo
 - クライアント: ソフトミュートですべてがマッチしてしまう場合があるのを修正 @tamaina
 - クライアント: デバイスのスクリーンのセーフエリアを考慮するように @syuilo
 - クライアント: 一部環境でサイドバーの投稿ボタンが表示されない問題を修正 @syuilo
@@ -1183,14 +1345,17 @@ same as 12.112.0
 ## 12.106.3 (2022/02/11)
 
 ### Improvements
+
 - クライアント: スマートフォンでの余白を調整 @syuilo
 
 ### Bugfixes
+
 - クライアント: ノートの詳細が表示されない問題を修正 @syuilo
 
 ## 12.106.2 (2022/02/11)
 
 ### Bugfixes
+
 - クライアント: 削除したノートがタイムラインから自動で消えない問題を修正 @syuilo
 - クライアント: リアクション数が正しくないことがある問題を修正 @syuilo
 - 一部環境でマイグレーションが動作しない問題を修正 @syuilo
@@ -1198,11 +1363,13 @@ same as 12.112.0
 ## 12.106.1 (2022/02/11)
 
 ### Bugfixes
+
 - クライアント: ワードミュートが保存できない問題を修正 @syuilo
 
 ## 12.106.0 (2022/02/11)
 
 ### Improvements
+
 - Improve federation chart @syuilo
 - クライアント: リアクションピッカーのサイズを設定できるように @syuilo
 - クライアント: リアクションピッカーの幅、高さ制限を緩和 @syuilo
@@ -1210,41 +1377,47 @@ same as 12.112.0
 - Update dependencies
 
 ### Bugfixes
+
 - validate regular expressions in word mutes @Johann150
 
 ## 12.105.0 (2022/02/09)
 
 ### Improvements
+
 - インスタンスのテーマカラーを設定できるように @syuilo
 
 ### Bugfixes
+
 - 一部環境でマイグレーションが失敗する問題を修正 @syuilo
 
 ## 12.104.0 (2022/02/09)
 
 ### Note
+
 ビルドする前に`yarn clean`を実行してください。
 
 このリリースはマイグレーションの規模が大きいため、インスタンスによってはマイグレーションに時間がかかる可能性があります。
 マイグレーションが終わらない場合は、チャートの情報はリセットされてしまいますが`__chart__`で始まるテーブルの**レコード**を全て削除(テーブル自体は消さないでください)してから再度試す方法もあります。
 
 ### Improvements
+
 - チャートエンジンの強化 @syuilo
-	- テーブルサイズの削減
-	- notes/instance/perUserNotesチャートに添付ファイル付きノートの数を追加
-	- activeUsersチャートに新しい項目を追加
-	- federationチャートに新しい項目を追加
-	- apRequestチャートを追加
-	- networkチャート廃止
+  - テーブルサイズの削減
+  - notes/instance/perUserNotes チャートに添付ファイル付きノートの数を追加
+  - activeUsers チャートに新しい項目を追加
+  - federation チャートに新しい項目を追加
+  - apRequest チャートを追加
+  - network チャート廃止
 - クライアント: 自インスタンス情報ページでチャートを見れるように @syuilo
 - クライアント: デバイスの種類を手動指定できるように @syuilo
-- クライアント: UIのアイコンを更新 @syuilo
-- クライアント: UIのアイコンをセルフホスティングするように @syuilo
+- クライアント: UI のアイコンを更新 @syuilo
+- クライアント: UI のアイコンをセルフホスティングするように @syuilo
 - NodeInfo のユーザー数と投稿数の内容を見直す @xianonn
 
 ### Bugfixes
+
 - Client: タイムライン種別を切り替えると「新しいノートがあります」の表示が残留してしまうのを修正 @tamaina
-- Client: UIのサイズがおかしくなる問題の修正 @tamaina
+- Client: UI のサイズがおかしくなる問題の修正 @tamaina
 - Client: Setting instance information of notes to always show breaks the timeline @Johann150
 - Client: 環境に依っては返信する際のカーソル位置が正しくない問題を修正 @syuilo
 - Client: コントロールパネルのユーザー、ファイルにて、インスタンスの表示範囲切り替えが機能しない問題を修正 @syuilo
@@ -1252,25 +1425,28 @@ same as 12.112.0
 - Client: Follows/Followers Visibility changes won't be saved unless clicking on an other checkbox @Johann150
 - API: Fix API cast @mei23
 - add instance favicon where it's missing @solfisher
-- チャートの定期resyncが動作していない問題を修正 @syuilo
+- チャートの定期 resync が動作していない問題を修正 @syuilo
 
 ## 12.103.1 (2022/02/02)
 
 ### Bugfixes
+
 - クライアント: ツールチップの表示位置が正しくない問題を修正
 
 ## 12.103.0 (2022/02/02)
 
 ### Improvements
+
 - クライアント: 連合インスタンスページからインスタンス情報再取得を行えるように
 
 ### Bugfixes
-- クライアント: 投稿のNSFW画像を表示したあとにリアクションが更新されると画像が非表示になる問題を修正
+
+- クライアント: 投稿の NSFW 画像を表示したあとにリアクションが更新されると画像が非表示になる問題を修正
 - クライアント: 「クリップ」ページが開かない問題を修正
 - クライアント: トレンドウィジェットが動作しないのを修正
 - クライアント: フェデレーションウィジェットが動作しないのを修正
 - クライアント: リアクション設定で絵文字ピッカーが開かないのを修正
-- クライアント: DMページでメンションが含まれる問題を修正
+- クライアント: DM ページでメンションが含まれる問題を修正
 - クライアント: 投稿フォームのハッシュタグ保持フィールドが動作しない問題を修正
 - クライアント: サイドビューが動かないのを修正
 - クライアント: ensure that specified users does not get duplicates
@@ -1278,25 +1454,30 @@ same as 12.112.0
   files and media proxy
 
 ## 12.102.1 (2022/01/27)
+
 ### Bugfixes
+
 - チャットが表示できない問題を修正
 
 ## 12.102.0 (2022/01/27)
 
 ### NOTE
+
 アップデート後、一部カスタム絵文字が表示できなくなる場合があります。その場合、一旦絵文字管理ページから絵文字を一括エクスポートし、再度コントロールパネルから一括インポートすると直ります。
-⚠ 12.102.0以前にエクスポートされたzipとは互換性がありません。アップデートしてからエクスポートを行なってください。
+⚠ 12.102.0 以前にエクスポートされた zip とは互換性がありません。アップデートしてからエクスポートを行なってください。
 
 ### Changes
-- Room機能が削除されました
+
+- Room 機能が削除されました
   - 後日別リポジトリとして復活予定です
 - リバーシ機能が削除されました
   - 後日別リポジトリとして復活予定です
-- Chat UIが削除されました
-- ノートに添付できるファイルの数が16に増えました
-- カスタム絵文字にSVGを指定した場合、PNGに変換されて表示されるようになりました
+- Chat UI が削除されました
+- ノートに添付できるファイルの数が 16 に増えました
+- カスタム絵文字に SVG を指定した場合、PNG に変換されて表示されるようになりました
 
 ### Improvements
+
 - カスタム絵文字一括編集機能
 - カスタム絵文字一括インポート
 - 投稿フォームで一時的に投稿するアカウントを切り替えられるように
@@ -1305,48 +1486,58 @@ same as 12.112.0
 - セキュリティの向上
 
 ### Bugfixes
+
 - アップロードエラー時の処理を修正
 
 ## 12.101.1 (2021/12/29)
 
 ### Bugfixes
-- SVG絵文字が表示できないのを修正
-- エクスポートした絵文字の拡張子がfalseになることがあるのを修正
+
+- SVG 絵文字が表示できないのを修正
+- エクスポートした絵文字の拡張子が false になることがあるのを修正
 
 ## 12.101.0 (2021/12/29)
 
 ### Improvements
+
 - クライアント: ノートプレビューの精度を改善
-- クライアント: MFM sparkleエフェクトの改善
+- クライアント: MFM sparkle エフェクトの改善
 - クライアント: デザインの調整
 - セキュリティの向上
 
 ### Bugfixes
+
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 - fix html blockquote conversion
 
 ## 12.100.2 (2021/12/18)
 
 ### Bugfixes
-- クライアント: Deckカラムの増減がページをリロードするまで正しく反映されない問題を修正
+
+- クライアント: Deck カラムの増減がページをリロードするまで正しく反映されない問題を修正
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 - クライアント: カスタム絵文字一覧ページの負荷が高いのを修正
 
 ## 12.100.1 (2021/12/17)
 
 ### Bugfixes
+
 - クライアント: デザインの調整
 
 ## 12.100.0 (2021/12/17)
 
 ### Improvements
+
 - クライアント: モバイルでの各種メニュー、リアクションピッカーの表示を改善
 
 ### Bugfixes
+
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 
 ## 12.99.3 (2021/12/14)
+
 ### Bugfixes
+
 - クライアント: オートコンプリートがダイアログの裏に隠れる問題を修正
 
 ## 12.99.2 (2021/12/14)
@@ -1356,6 +1547,7 @@ same as 12.112.0
 ## 12.99.0 (2021/12/14)
 
 ### Improvements
+
 - Added a user-level instance mute in user settings
 - フォローエクスポートでミュートしているユーザーを含めないオプションを追加
 - フォローエクスポートで使われていないアカウントを含めないオプションを追加
@@ -1364,6 +1556,7 @@ same as 12.112.0
 - グループから抜けられるように
 
 ### Bugfixes
+
 - クライアント: タッチ機能付きディスプレイを使っていてマウス操作をしている場合に一部機能が動作しない問題を修正
 - クライアント: クリップの設定を編集できない問題を修正
 - クライアント: メニューなどがウィンドウの裏に隠れる問題を修正
@@ -1371,17 +1564,19 @@ same as 12.112.0
 ## 12.98.0 (2021/12/03)
 
 ### Improvements
+
 - API: /antennas/notes API で日付による絞り込みができるように
 - クライアント: アンケートに投票する際に確認ダイアログを出すように
-- クライアント: Renoteなノート詳細ページから元のノートページに遷移できるように
+- クライアント: Renote なノート詳細ページから元のノートページに遷移できるように
 - クライアント: 画像ポップアップでクリックで閉じられるように
 - クライアント: デザインの調整
 - フォロワーを解除できる機能
 
 ### Bugfixes
-- クライアント: LTLやGTLが無効になっている場合でもUI上にタブが表示される問題を修正
+
+- クライアント: LTL や GTL が無効になっている場合でも UI 上にタブが表示される問題を修正
 - クライアント: ログインにおいてパスワードが誤っている際のエラーメッセージが正しく表示されない問題を修正
-- クライアント: リアクションツールチップ、Renoteツールチップのユーザーの並び順を修正
+- クライアント: リアクションツールチップ、Renote ツールチップのユーザーの並び順を修正
 - クライアント: サウンドのマスターボリュームが正しく保存されない問題を修正
 - クライアント: 一部環境において通知が表示されると操作不能になる問題を修正
 - クライアント: モバイルでタップしたときにツールチップが表示される問題を修正
@@ -1390,36 +1585,43 @@ same as 12.112.0
 - API: ユーザーを取得時に条件によっては内部エラーになる問題を修正
 
 ### Changes
+
 - クライアント: ノートにモデレーターバッジを表示するのを廃止
 
 ## 12.97.0 (2021/11/19)
 
 ### Improvements
-- クライアント: 返信先やRenoteに対しても自動折りたたみされるように
+
+- クライアント: 返信先や Renote に対しても自動折りたたみされるように
 - クライアント: 長いスレッドの表示を改善
-- クライアント: 翻訳にもMFMを適用し、元の文章の改行などを保持するように
+- クライアント: 翻訳にも MFM を適用し、元の文章の改行などを保持するように
 - クライアント: アカウント削除に確認ダイアログを出すように
 
 ### Bugfixes
+
 - クライアント: ユーザー検索の「全て」が動作しない問題を修正
-- クライアント: リアクション一覧、Renote一覧ツールチップのスタイルを修正
+- クライアント: リアクション一覧、Renote 一覧ツールチップのスタイルを修正
 
 ## 12.96.1 (2021/11/13)
+
 ### Improvements
-- npm scriptの互換性を向上
+
+- npm script の互換性を向上
 
 ## 12.96.0 (2021/11/13)
 
 ### Improvements
+
 - フォロー/フォロワーを非公開にできるように
 - インスタンスプロフィールレンダリング ready
 - 通知のリアクションアイコンをホバーで拡大できるように
-- RenoteボタンをホバーでRenoteしたユーザー一覧を表示するように
+- Renote ボタンをホバーで Renote したユーザー一覧を表示するように
 - 返信の際にメンションを含めるように
-- 通報があったときに管理者へEメールで通知されるように
+- 通報があったときに管理者へ E メールで通知されるように
 - メールアドレスのバリデーションを強化
 
 ### Bugfixes
+
 - アカウント削除処理があると高負荷になる問題を修正
 - クライアント: 長いメニューが画面からはみ出す問題を修正
 - クライアント: コントロールパネルのジョブキューに個々のジョブが表示されないのを修正
@@ -1427,15 +1629,18 @@ same as 12.112.0
 - fix html conversion issue with code blocks
 
 ### Changes
+
 - ノートにモバイルからの投稿か否かの情報を含めないように
 
 ## 12.95.0 (2021/10/31)
 
 ### Improvements
+
 - スレッドミュート機能
 
 ### Bugfixes
-- リレー向けのActivityが一部実装で除外されてしまうことがあるのを修正
+
+- リレー向けの Activity が一部実装で除外されてしまうことがあるのを修正
 - 削除したノートやユーザーがリモートから参照されると復活することがあるのを修正
 - クライアント: ページ編集時のドロップダウンメニューなどが動作しない問題を修正
 - クライアント: コントロールパネルのカスタム絵文字タブが切り替わらないように見える問題を修正
@@ -1446,38 +1651,45 @@ same as 12.112.0
 ### Improvements
 
 ### Bugfixes
+
 - クライアント: ユーザーページのナビゲーションが失敗する問題を修正
 
 ## 12.94.0 (2021/10/25)
 
 ### Improvements
+
 - クライアント: 画像ビューアを強化
 - クライアント: メンションにユーザーのアバターを表示するように
 - クライアント: デザインの調整
-- クライアント: twemojiをセルフホスティングするように
+- クライアント: twemoji をセルフホスティングするように
 
 ### Bugfixes
-- クライアント: CWで画像が隠されたとき、画像の高さがおかしいことになる問題を修正
+
+- クライアント: CW で画像が隠されたとき、画像の高さがおかしいことになる問題を修正
 
 ### NOTE
-- このバージョンから、iOS 15未満のサポートがされなくなります。対象のバージョンをお使いの方は、iOSのバージョンアップを行ってください。
+
+- このバージョンから、iOS 15 未満のサポートがされなくなります。対象のバージョンをお使いの方は、iOS のバージョンアップを行ってください。
 
 ## 12.93.2 (2021/10/23)
 
 ### Bugfixes
+
 - クライアント: ウィジェットを追加できない問題を修正
 
 ## 12.93.1 (2021/10/23)
 
 ### Bugfixes
+
 - クライアント: 通知上でローカルのリアクションが表示されないのを修正
 
 ## 12.93.0 (2021/10/23)
 
 ### Improvements
+
 - クライアント: コントロールパネルのパフォーマンスを改善
 - クライアント: 自分のリアクション一覧を見れるように
-	- 設定により、リアクション一覧を全員に公開することも可能
+  - 設定により、リアクション一覧を全員に公開することも可能
 - クライアント: ユーザー検索の精度を強化
 - クライアント: 新しいライトテーマを追加
 - クライアント: 新しいダークテーマを追加
@@ -1485,178 +1697,200 @@ same as 12.112.0
 - API: users/search および users/search-by-username-and-host を強化
 - ミュート及びブロックのインポートを行えるように
 - クライアント: /share のクエリでリプライやファイル等の情報を渡せるように
-- チャートのsyncを毎日0時に自動で行うように
+- チャートの sync を毎日 0 時に自動で行うように
 
 ### Bugfixes
+
 - クライアント: テーマの管理が行えない問題を修正
 - API: アプリケーション通知が取得できない問題を修正
 - クライアント: リモートノートで意図せずローカルカスタム絵文字が使われてしまうことがあるのを修正
-- ActivityPub: not reacted な Undo.Like がinboxに滞留するのを修正
+- ActivityPub: not reacted な Undo.Like が inbox に滞留するのを修正
 
 ### Changes
+
 - 連合の考慮に問題があることなどが分かったため、モデレーターをブロックできない仕様を廃止しました
 - データベースにログを保存しないようになりました
-	- ログを永続化したい場合はsyslogを利用してください
+  - ログを永続化したい場合は syslog を利用してください
 
 ## 12.92.0 (2021/10/16)
 
 ### Improvements
+
 - アカウント登録にメールアドレスの設定を必須にするオプション
-- クライアント: 全体的なUIのブラッシュアップ
-- クライアント: MFM関数構文のサジェストを実装
+- クライアント: 全体的な UI のブラッシュアップ
+- クライアント: MFM 関数構文のサジェストを実装
 - クライアント: ノート本文を投稿フォーム内でプレビューできるように
 - クライアント: 未読の通知のみ表示する機能
 - クライアント: 通知ページで通知の種類によるフィルタ
 - クライアント: アニメーションを減らす設定の適用範囲を拡充
 - クライアント: 新しいダークテーマを追加
 - クライアント: テーマコンパイラに hue と saturate 関数を追加
-- ActivityPub: HTML -> MFMの変換を強化
+- ActivityPub: HTML -> MFM の変換を強化
 - API: グループから抜ける users/groups/leave エンドポイントを実装
 - API: i/notifications に unreadOnly オプションを追加
-- API: ap系のエンドポイントをログイン必須化+レートリミット追加
+- API: ap 系のエンドポイントをログイン必須化+レートリミット追加
 - MFM: Add tag syntaxes of bold <b></b> and strikethrough <s></s>
 
 ### Bugfixes
+
 - Fix createDeleteAccountJob
 - admin inbox queue does not show individual jobs
 - クライアント: ヘッダーのタブが折り返される問題を修正
 - クライアント: ヘッダーにタブが表示されている状態でタイトルをクリックしたときにタブ選択が表示されるのを修正
 - クライアント: ユーザーページのタブが機能していない問題を修正
 - クライアント: ピン留めユーザーの設定項目がない問題を修正
-- クライアント: Deck UIにおいて、重ねたカラムの片方を畳んだ状態で右に出すと表示が壊れる問題を修正
+- クライアント: Deck UI において、重ねたカラムの片方を畳んだ状態で右に出すと表示が壊れる問題を修正
 - API: 管理者およびモデレーターをブロックできてしまう問題を修正
 - MFM: Mentions in the link label are parsed as text
 - MFM: Add a property to the URL node indicating whether it was enclosed in <>
 - MFM: Disallows < and > in hashtags
 
 ### Changes
-- 保守性やユーザビリティの観点から、Misskeyのコマンドラインオプションが削除されました。
-	- 必要であれば、代わりに環境変数で設定することができます
+
+- 保守性やユーザビリティの観点から、Misskey のコマンドラインオプションが削除されました。
+  - 必要であれば、代わりに環境変数で設定することができます
 - MFM: パフォーマンス、保守性、構文誤認識抑制の観点から、旧関数構文のサポートが削除されました。
-	- 旧構文(`[foo bar]`)を使用せず、現行の構文(`$[foo bar]`)を使用してください。
+  - 旧構文(`[foo bar]`)を使用せず、現行の構文(`$[foo bar]`)を使用してください。
 
 ## 12.91.0 (2021/09/22)
 
 ### Improvements
-- ActivityPub: リモートユーザーのDeleteアクティビティに対応
+
+- ActivityPub: リモートユーザーの Delete アクティビティに対応
 - ActivityPub: add resolver check for blocked instance
-- ActivityPub: deliverキューのメモリ使用量を削減
-- API: 管理者用アカウント削除APIを実装(/admin/accounts/delete)
-	- リモートユーザーの削除も可能に
+- ActivityPub: deliver キューのメモリ使用量を削減
+- API: 管理者用アカウント削除 API を実装(/admin/accounts/delete)
+  - リモートユーザーの削除も可能に
 - アカウントが凍結された場合に、凍結された旨を表示してからログアウトするように
 - 凍結されたアカウントにログインしようとしたときに、凍結されている旨を表示するように
 - リスト、アンテナタイムラインを個別ページとして分割
-- UIの改善
-- MFMにsparklesエフェクトを追加
+- UI の改善
+- MFM に sparkles エフェクトを追加
 - 非ログイン自は更新ダイアログを出さないように
 - クライアント起動時、アップデートが利用可能な場合エラー表示およびダイアログ表示しないように
 
 ### Bugfixes
+
 - アカウントデータのエクスポート/インポート処理ができない問題を修正
 - アンテナの既読が付かない問題を修正
-- popupで設定ページを表示すると、アカウントの削除ページにアクセスすることができない問題を修正
-- "問題が発生しました"ウィンドウを開くと☓ボタンがなくて閉じれない問題を修正
+- popup で設定ページを表示すると、アカウントの削除ページにアクセスすることができない問題を修正
+- "問題が発生しました"ウィンドウを開くと ☓ ボタンがなくて閉じれない問題を修正
 
 ## 12.90.1 (2021/09/05)
 
 ### Bugfixes
-- Dockerfileを修正
+
+- Dockerfile を修正
 - ノート翻訳時に公開範囲が考慮されていない問題を修正
 
 ## 12.90.0 (2021/09/04)
 
 ### Improvements
+
 - 藍モード、および藍ウィジェット
-	- クライアントに藍ちゃんを召喚することができるようになりました。
-- URLからのアップロード, APの添付ファイル, 外部ファイルのプロキシ等では、Privateアドレス等へのリクエストは拒否されるようになりました。
-	- developmentで動作している場合は、この制限は適用されません。
-	- Proxy使用時には、この制限は適用されません。
-		Proxy使用時に同等の制限を行いたい場合は、Proxy側で設定を行う必要があります。
-	- `default.yml`にて`allowedPrivateNetworks`にCIDRを追加することにより、宛先ネットワークを指定してこの制限から除外することが出来ます。
-- アップロード, ダウンロード出来るファイルサイズにハードリミットが適用されるようになりました。(約250MB)
-	- `default.yml`にて`maxFileSize`を変更することにより、制限値を変更することが出来ます。
+  - クライアントに藍ちゃんを召喚することができるようになりました。
+- URL からのアップロード, AP の添付ファイル, 外部ファイルのプロキシ等では、Private アドレス等へのリクエストは拒否されるようになりました。
+  - development で動作している場合は、この制限は適用されません。
+  - Proxy 使用時には、この制限は適用されません。
+    Proxy 使用時に同等の制限を行いたい場合は、Proxy 側で設定を行う必要があります。
+  - `default.yml`にて`allowedPrivateNetworks`に CIDR を追加することにより、宛先ネットワークを指定してこの制限から除外することが出来ます。
+- アップロード, ダウンロード出来るファイルサイズにハードリミットが適用されるようになりました。(約 250MB)
+  - `default.yml`にて`maxFileSize`を変更することにより、制限値を変更することが出来ます。
 
 ### Bugfixes
+
 - 管理者が最初にサインアップするページでログインされないのを修正
-- CWを維持する設定を復活
+- CW を維持する設定を復活
 - クライアントの表示を修正
 
 ## 12.89.2 (2021/08/24)
 
 ### Bugfixes
-- カスタムCSSを有効にしているとエラーになる問題を修正
+
+- カスタム CSS を有効にしているとエラーになる問題を修正
 
 ## 12.89.1 (2021/08/24)
 
 ### Improvements
+
 - クライアントのデザインの調整
 
 ### Bugfixes
-- 翻訳でDeepLのProアカウントに対応していない問題を修正
-- インスタンス設定でDeepLのAuth Keyが空で表示される問題を修正
+
+- 翻訳で DeepL の Pro アカウントに対応していない問題を修正
+- インスタンス設定で DeepL の Auth Key が空で表示される問題を修正
 - セキュリティの向上
 
 ## 12.89.0 (2021/08/21)
 
 ### Improvements
+
 - アカウント削除の安定性を向上
 - 絵文字オートコンプリートの挙動を改修
-- localStorageのaccountsはindexedDBで保持するように
+- localStorage の accounts は indexedDB で保持するように
 - ActivityPub: ジョブキューの試行タイミングを調整 (#7635)
-- API: sw/unregisterを追加
+- API: sw/unregister を追加
 - ワードミュートのドキュメントを追加
 - クライアントのデザインの調整
 - 依存関係の更新
 
 ### Bugfixes
+
 - チャンネルを作成しているとアカウントを削除できないのを修正
 - ノートの「削除して編集」をするとアンケートの選択肢が[object Object]になる問題を修正
 
 ## 12.88.0 (2021/08/17)
 
 ### Features
+
 - ノートの翻訳機能を追加
-  - 有効にするには、サーバー管理者がDeepLの無料アカウントを登録し、取得した認証キーを「インスタンス設定 > その他 > DeepL Auth Key」に設定する必要があります。
-- Misskey更新時にダイアログを表示するように
+  - 有効にするには、サーバー管理者が DeepL の無料アカウントを登録し、取得した認証キーを「インスタンス設定 > その他 > DeepL Auth Key」に設定する必要があります。
+- Misskey 更新時にダイアログを表示するように
 - ジョブキューウィジェットに警報音を鳴らす設定を追加
 
 ### Improvements
+
 - ブロックの挙動を改修
-	- ブロックされたユーザーがブロックしたユーザーに対してアクション出来ないようになりました。詳細はドキュメントをご確認ください。
-- UIデザインの調整
+  - ブロックされたユーザーがブロックしたユーザーに対してアクション出来ないようになりました。詳細はドキュメントをご確認ください。
+- UI デザインの調整
 - データベースのインデックスを最適化
-- Proxy使用時にKeep-Aliveをサポート
-- DNSキャッシュでネガティブキャッシュをサポート
+- Proxy 使用時に Keep-Alive をサポート
+- DNS キャッシュでネガティブキャッシュをサポート
 - 依存関係の更新
 
 ### Bugfixes
+
 - タッチ操作でウィンドウを閉じることができない問題を修正
-- Renoteされた時刻が投稿された時刻のように表示される問題を修正
+- Renote された時刻が投稿された時刻のように表示される問題を修正
 - コントロールパネルでファイルを削除した際の表示を修正
 - ActivityPub: 長いユーザーの名前や自己紹介の対応
 
 ## 12.87.0 (2021/08/12)
 
 ### Improvements
+
 - 絵文字オートコンプリートで一文字目は最近使った絵文字をサジェストするように
 - 絵文字オートコンプリートのパフォーマンスを改善
-- about-misskeyページにドキュメントへのリンクを追加
-- Docker: Node.jsを16.6.2に
+- about-misskey ページにドキュメントへのリンクを追加
+- Docker: Node.js を 16.6.2 に
 - 依存関係の更新
 - 翻訳の更新
 
 ### Bugfixes
-- Misskey更新時、テーマキャッシュの影響でスタイルがおかしくなる問題を修正
+
+- Misskey 更新時、テーマキャッシュの影響でスタイルがおかしくなる問題を修正
 
 ## 12.86.0 (2021/08/11)
 
 ### Improvements
+
 - ドキュメントの更新
-	- ドキュメントにchangelogを追加
+  - ドキュメントに changelog を追加
 - ぼかし効果のオプションを追加
-- Vueを3.2.1に更新
-- UIの調整
+- Vue を 3.2.1 に更新
+- UI の調整
 
 ### Bugfixes
+
 - ハッシュタグ入力が空のときに#が付くのを修正
-- フォローリクエストのEメール通知を修正
+- フォローリクエストの E メール通知を修正

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,214 +15,192 @@
 ## 13.13.0
 
 ### General
-
 - カスタム絵文字ごとにそれをリアクションとして使えるロールを設定できるように
 - カスタム絵文字ごとに連合するかどうか設定できるように
 - カスタム絵文字ごとにセンシティブフラグを設定できるように
 - センシティブなカスタム絵文字のリアクションを受け入れない設定が可能に
 - タイムラインにフォロイーの行った他人へのリプライを含めるかどうかの設定をアカウントに保存するのをやめるように
-  - 今後は API 呼び出し時およびストリーミング接続時に設定するようになります
+	- 今後はAPI呼び出し時およびストリーミング接続時に設定するようになります
 - リストを公開できるようになりました
 
 ### Client
-
 - リアクションの取り消し/変更時に確認ダイアログを出すように
 - 開発者モードを追加
-- AiScript を 0.13.3 に更新
-- Deck UI を使用している場合、`/`以外にアクセスした際に Zen UI で表示するように
-  - メインカラムを設置していない場合の問題を解決
+- AiScriptを0.13.3に更新
+- Deck UIを使用している場合、`/`以外にアクセスした際にZen UIで表示するように
+	- メインカラムを設置していない場合の問題を解決
 - ハッシュタグのノート一覧ページから、そのハッシュタグで投稿するボタンを追加
 - アカウント初期設定ウィザードに戻るボタンを追加
 - アカウントの初期設定ウィザードにあとでボタンを追加
 - サーバーにカスタム絵文字の種類が多い場合のパフォーマンスの改善
-- Fix: URL プレビューで情報が取得できなかった際の挙動を修正
-- Fix: Safari、Firefox での新規登録時、パスワードマネージャーにメールアドレスが登録されていた挙動を修正
+- Fix: URLプレビューで情報が取得できなかった際の挙動を修正
+- Fix: Safari、Firefoxでの新規登録時、パスワードマネージャーにメールアドレスが登録されていた挙動を修正
 - Fix: ロールタイムラインが無効でも投稿が流れてしまう問題の修正
 - Fix: ロールタイムラインにて全ての投稿が流れてしまう問題の修正
 - Fix: 「アクセストークンの管理」画面でアプリの情報が表示されない問題の修正
-- Fix: Firefox における絵文字ピッカーの Tab キーフォーカス問題の修正
+- Fix: Firefoxにおける絵文字ピッカーのTabキーフォーカス問題の修正
 - Fix: フォローボタンがテーマのカラースキームによって視認性が悪くなる問題を修正
   - 新しいプロパティ `fgOnWhite` が追加されました
 
 ### Server
-
-- bull を bull-mq にアップグレードし、ジョブキューのパフォーマンスを改善
+- bullをbull-mqにアップグレードし、ジョブキューのパフォーマンスを改善
 - ストリーミングのパフォーマンスを改善
-- Fix: お知らせの画像 URL を空にできない問題を修正
+- Fix: お知らせの画像URLを空にできない問題を修正
 
 ## 13.12.2
 
 ## NOTE
-
-Meilisearch の設定に`index`が必要になりました。値は Misskey サーバーのホスト名にすることをお勧めします(アルファベット、ハイフン、アンダーバーのみ使用可能)。例: `misskey-io`
+Meilisearchの設定に`index`が必要になりました。値はMisskeyサーバーのホスト名にすることをお勧めします(アルファベット、ハイフン、アンダーバーのみ使用可能)。例: `misskey-io`
 過去に作成された`notes`インデックスは、`<index名>---notes`にリネームが必要です。例: `misskey-io---notes`
 
 ### General
-
-- 投稿したコンテンツの AI による学習を軽減するオプションを追加
+- 投稿したコンテンツのAIによる学習を軽減するオプションを追加
 
 ### Client
-
 - ユーザーを指定してのノート検索が可能に
 - アカウント初期設定ウィザードにプライバシー設定を追加
 - リテンション率チャートに折れ線グラフを追加
 - Fix: ブラーエフェクトを有効にしている状態で高負荷になる問題を修正
-- Fix: Page において画像ブロックに画像を設定できない問題を修正
+- Fix: Pageにおいて画像ブロックに画像を設定できない問題を修正
 - Fix: カラーバーがリプライには表示されないのを修正
 - Fix: チャンネル内の検索ボックスが挙動不審な問題を修正
 - Fix: リテンションチャートのレンダリングを修正
 - Fix: リアクションエフェクトのレンダリングの問題を修正
 
 ### Server
-
-- センシティブワードの登録に And、正規表現が使用できるようになりました。
-- Fix: ひとつの Meilisearch サーバーを複数の Misskey サーバーで使えない問題を修正
+- センシティブワードの登録にAnd、正規表現が使用できるようになりました。
+- Fix: ひとつのMeilisearchサーバーを複数のMisskeyサーバーで使えない問題を修正
 
 ## 13.12.1
 
 ### Client
-
 - プロフィール画面におけるモデレーションノートの表示を調整
 - Fix: 一部ダイアログが表示されない問題を修正
-- Fix: MkUserInfo のフォローボタンが変な位置にある問題を修正
+- Fix: MkUserInfoのフォローボタンが変な位置にある問題を修正
 
 ### Server
-
 - Fix: リモートサーバーの情報が更新できない問題を修正
-- Fix: 13.11 を経験しない状態で 13.12 にアップデートした場合ユーザープロフィール関連の画像が消失する問題を修正
+- Fix: 13.11を経験しない状態で13.12にアップデートした場合ユーザープロフィール関連の画像が消失する問題を修正
 
 ## 13.12.0
 
 ### NOTE
-
-- Node.js 18.6.0 以上が必要になりました
+- Node.js 18.6.0以上が必要になりました
 
 ### General
-
 - アカウントの引っ越し（フォロワー引き継ぎ）に対応
-- Meilisearch を全文検索に使用できるようになりました
+- Meilisearchを全文検索に使用できるようになりました
 - 新規登録前に簡潔なルールをユーザーに表示できる、サーバールール機能を追加
 - ユーザーへの自分用メモ機能
-  - ユーザーに対して、自分だけが見られるメモを追加できるようになりました。  
+  * ユーザーに対して、自分だけが見られるメモを追加できるようになりました。  
     （自分自身に対してもメモを追加できます。）
-  - ユーザーメニューから追加できます。  
-    （デスクトップ表示では username の右側のボタンからも追加可能）
+  * ユーザーメニューから追加できます。  
+    （デスクトップ表示ではusernameの右側のボタンからも追加可能）
 - チャンネルに色を設定できるようになりました。各ノートに設定した色のインジケーターが表示されます。
 - チャンネルをアーカイブできるようになりました。
-  - アーカイブすると、チャンネル一覧や検索結果に表示されなくなり、新たな書き込みもできなくなります。
+	* アーカイブすると、チャンネル一覧や検索結果に表示されなくなり、新たな書き込みもできなくなります。
 - アンテナのエクスポート・インポートができるようになりました
 - ロールタイムラインをロールごとに表示するかどうかの選択できるようになりました。
-  - デフォルトがオフになるので、ロールタイムラインを表示する場合はオンにしてください。
-- ロールに強制的に NSFW を付与するポリシーを追加
-  - アップロード済みのファイルは NSFW にならない為注意してください。
+	* デフォルトがオフになるので、ロールタイムラインを表示する場合はオンにしてください。
+- ロールに強制的にNSFWを付与するポリシーを追加
+	* アップロード済みのファイルはNSFWにならない為注意してください。
 - モデレーションノートがユーザーのプロフィールページからも閲覧および編集できるようになりました。
 - カスタム絵文字のライセンスを複数でセットできるようになりました。
 - 管理者が予約ユーザー名を設定できるようになりました。
 - Fix: フォローリクエストの通知が残る問題を修正
 
 ### Client
-
 - アカウント作成時に初期設定ウィザードを表示するように
 - チャンネル内検索ができるように
 - チャンネル検索ですべてのチャンネルの取得/表示ができるように
 - 通知の表示をカスタマイズできるように
 - ドライブのファイル一覧から直接ノートを作成できるように
-- ノートメニューから Renote したユーザーの一覧を見れるように
-- コントロールパネルのカスタム絵文字ページおよび about のカスタム絵文字の検索インプットで、`:emojiname1::emojiname2:`のように検索して絵文字を検索できるように
-  - 絵文字ピッカーから入力可能になります
+- ノートメニューからRenoteしたユーザーの一覧を見れるように
+- コントロールパネルのカスタム絵文字ページおよびaboutのカスタム絵文字の検索インプットで、`:emojiname1::emojiname2:`のように検索して絵文字を検索できるように
+  * 絵文字ピッカーから入力可能になります
 - データセーバーモードを追加
-  - 画像が全て隠れた状態で表示されるようになります
+  * 画像が全て隠れた状態で表示されるようになります
 - 閲覧注意設定された画像は表示した状態でもそれが閲覧注意だと分かる表示をするように
-- モデレーターはノートに添付された画像上から直接 NSFW 設定できるように
-- 1 枚だけのメディアリストの画像のアスペクト比を画像に応じて縦長にするように
+- モデレーターはノートに添付された画像上から直接NSFW設定できるように
+- 1枚だけのメディアリストの画像のアスペクト比を画像に応じて縦長にするように
 - プロフィール設定「追加情報」の項目の削除と並び替えができるように
 - 新しい実績を追加
-- AiScript を 0.13.2 に更新
-- Fix: AiScript API の Mk:dialog で何も返していなかったのを NULL を返すように修正
-- Fix: 1:1 ではない画像のリアクション通知バッジが左や上に寄ってしまっていたのを中央に来るように修正
+- AiScriptを0.13.2に更新
+- Fix: AiScript APIのMk:dialogで何も返していなかったのをNULLを返すように修正
+- Fix: 1:1ではない画像のリアクション通知バッジが左や上に寄ってしまっていたのを中央に来るように修正
 - Fix: リアクションをホバーした時のユーザーリストで猫耳が切れてしまっていた問題を修正
+- Fix: NSFWメディアの上に表示された｢もっと見る｣ボタンが押しづらい問題を修正
 
 ### Server
-
-- channel/search の query が空の場合に全てのチャンネルを返すように変更
-- 環境変数 MISSKEY_CONFIG_YML で設定ファイルを default.yml から変更可能に
+- channel/searchのqueryが空の場合に全てのチャンネルを返すように変更
+- 環境変数MISSKEY_CONFIG_YMLで設定ファイルをdefault.ymlから変更可能に
 - Fix: 他のサーバーの情報が取得できないことがある問題を修正
-- Fix: エクスポートデータの拡張子が unknown になる問題を修正
-- Fix: Content-Disposition のパースでエラーが発生した場合にダウンロードが完了しない問題を修正
-- Fix: API: i/update avatarId と bannerId に null を渡した時、画像がリセットされない問題を修正
-- Fix: .wav, .flac が再生できない問題を修正（新しくアップロードされたファイルのみ修正が適用されます）
-- Fix: 凍結されたユーザーが一部 API のレスポンスに含まれる問題を修正
+- Fix: エクスポートデータの拡張子がunknownになる問題を修正
+- Fix: Content-Dispositionのパースでエラーが発生した場合にダウンロードが完了しない問題を修正
+- Fix: API: i/update avatarIdとbannerIdにnullを渡した時、画像がリセットされない問題を修正
+- Fix: .wav, .flacが再生できない問題を修正（新しくアップロードされたファイルのみ修正が適用されます）
+- Fix: 凍結されたユーザーが一部APIのレスポンスに含まれる問題を修正
 - Fix: メモリの使用量を`used - buffers - cached`ではなく`total - available`で求めるように（環境によって正常に計測できていなかったため）
 
 ## 13.11.3
 
 ### General
-
 - 指定したロールを持つユーザーのノートのみが流れるロールタイムラインを追加
-  - Deck のカラムとしても追加可能
+	- Deckのカラムとしても追加可能
 - カスタム絵文字関連の改善
-  - ノートなどに含まれる emojis（populateEmoji の結果）は（プロキシされた URL ではなく）オリジナルの URL を指すように
-  - MFM で x3/x4 もしくは scale.x/y が 2.5 以上に指定されていた場合にはオリジナル品質の絵文字を使用するように
+  * ノートなどに含まれるemojis（populateEmojiの結果）は（プロキシされたURLではなく）オリジナルのURLを指すように
+  * MFMでx3/x4もしくはscale.x/yが2.5以上に指定されていた場合にはオリジナル品質の絵文字を使用するように
 - カスタム絵文字でリアクションできないことがある問題を修正
 
 ### Client
-
 - チャンネルのピン留めされたノートの順番が正しくない問題を修正
 
 ### Server
-
 - フォローインポートなどでの大量のフォロー等操作をキューイングするように #10544 @nmkj-io
-- Misskey Web でのサーバーサイドエラー画面を改善
-- Misskey Web でのサーバーサイドエラーのログが残るように
+- Misskey Webでのサーバーサイドエラー画面を改善
+- Misskey Webでのサーバーサイドエラーのログが残るように
 - ノート作成時のアンテナ追加パフォーマンスを改善
-- アンテナとロール TL の until/since プロパティが動くように
+- アンテナとロールTLのuntil/sinceプロパティが動くように
 
 ## 13.11.2
 
 ### Note
-
-- 13.11.0 または 13.11.1 から 13.11.2 以降にアップデートする場合、Redis のカスタム絵文字のキャッシュを削除する必要があります(https://github.com/misskey-dev/misskey/issues/10502#issuecomment-1502790755 参照)
+- 13.11.0または13.11.1から13.11.2以降にアップデートする場合、Redisのカスタム絵文字のキャッシュを削除する必要があります(https://github.com/misskey-dev/misskey/issues/10502#issuecomment-1502790755 参照)
 
 ### General
-
 - チャンネルの検索用ページの追加
 
 ### Client
-
 - 常に広告を見られるオプションを追加
 - ユーザーページの画像一覧が表示されない問題を修正
 - webhook, 連携アプリ一覧でコンテンツが重複して表示される問題を修正
-- iPhone で絵文字ピッカーの表示が崩れる問題を修正
-- iPhone でウィジェットドロワーの「ウィジェットを編集」が押しにくい問題を修正
+- iPhoneで絵文字ピッカーの表示が崩れる問題を修正
+- iPhoneでウィジェットドロワーの「ウィジェットを編集」が押しにくい問題を修正
 - 投稿フォームのデザインを調整
 - ギャラリーの人気の投稿が無限にページングされる問題を修正
 
 ### Server
-
-- channels/search Endpoint API の追加
-- API パラメータサイズ上限を 32kb から 1mb に緩和
+- channels/search Endpoint APIの追加
+- APIパラメータサイズ上限を32kbから1mbに緩和
 - プッシュ通知送信時のパフォーマンスを改善
 - ローカルのカスタム絵文字のキャッシュが効いていなかった問題を修正
 - アンテナのノート、チャンネルのノート、通知が正常に作成できないことがある問題を修正
-- ストリーミングの LTL チャンネルでサーバー側にエラーログが出るのを修正
+- ストリーミングのLTLチャンネルでサーバー側にエラーログが出るのを修正
 
 ### Service Worker
-
 - 「通知が既読になったらプッシュ通知を削除する」を復活
-  - 「プッシュ通知が更新されました」の挙動を変えた（ホストとバージョンを表示するようにし、一定時間後の削除は行わないように）
+  * 「プッシュ通知が更新されました」の挙動を変えた（ホストとバージョンを表示するようにし、一定時間後の削除は行わないように）
 - プッシュ通知が実績を解除 (achievementEarned) に対応
 - プッシュ通知のアクションから既存のクライアントの投稿フォームを開くことになった際の挙動を修正
-- たくさんのプッシュ通知を閉じた際、その通知の数だけ notifications/mark-all-as-read を叩くのをやめるように
+- たくさんのプッシュ通知を閉じた際、その通知の数だけnotifications/mark-all-as-readを叩くのをやめるように
 
 ## 13.11.1
 
 ### General
-
 - チャンネルの投稿を過去までさかのぼれるように
 
 ### Client
-
-- PWA 時の絵文字ピッカーの位置をホームバーに重ならないように調整
+- PWA時の絵文字ピッカーの位置をホームバーに重ならないように調整
 - リスト管理の画面でリストが無限に読み込まれる問題を修正
 - 自分のクリップが無限に読み込まれる問題を修正
 - チャンネルのお気に入りが無限に読み込まれる問題を修正
@@ -231,74 +209,66 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - ユーザープレビューが表示されない問題を修正
 
 ### Server
-
 - 通知読み込みでエラーが発生する場合がある問題を修正
 - リアクションできないことがある問題を修正
-- ID を aid 以外に設定している場合の問題を修正
+- IDをaid以外に設定している場合の問題を修正
 - 連合しているインスタンスについて予期せず配送が全て停止されることがある問題を修正
 
 ## 13.11.0
 
 ### NOTE
-
-- このバージョンから Redis 7.x が必要です。
+- このバージョンからRedis 7.xが必要です。
 - アップデートを行うと全ての通知およびアンテナのノートはリセットされます。
 
 ### General
-
 - チャンネルをお気に入りに登録できるように
-  - タイムラインのアンテナ選択などでは、フォローしているアンテナの代わりにお気に入りしたアンテナが表示されるようになっています。チャンネルをお気に入りに登録するには、当該チャンネルのページ → 概要 →⭐️ のボタンを押します。
+  - タイムラインのアンテナ選択などでは、フォローしているアンテナの代わりにお気に入りしたアンテナが表示されるようになっています。チャンネルをお気に入りに登録するには、当該チャンネルのページ→概要→⭐️のボタンを押します。
 - チャンネルにノートをピン留めできるように
 
 ### Client
-
 - 投稿フォームのデザインを改善
-- 検索ページで URL を入力した際に照会したときと同等の挙動をするように
+- 検索ページでURLを入力した際に照会したときと同等の挙動をするように
 - ノートのリアクションを大きく表示するオプションを追加
 - ギャラリー一覧にメディア表示と同じように NSFW 設定を反映するように（ホバーで表示）
 - オブジェクトストレージの設定画面を分かりやすく
-- 広告・お知らせが新規登録時に増殖しないように -　「にゃああああああああああああああ！！！！！！！！！！！！」 (`isCat`) 有効時にアバターに表示される猫耳について挙動を変更
-  - 「UI にぼかし効果を使用」 (`useBlurEffect`) で次の挙動が有効になります
-    - 猫耳のアバター内部部分をぼかしでマスク表示してより猫耳っぽく見えるように
-    - 「UI のアニメーションを減らす」 (`reduceAnimation`) で猫耳を撫でられなくなります
+- 広告・お知らせが新規登録時に増殖しないように
+-　「にゃああああああああああああああ！！！！！！！！！！！！」 (`isCat`) 有効時にアバターに表示される猫耳について挙動を変更
+  - 「UIにぼかし効果を使用」 (`useBlurEffect`) で次の挙動が有効になります
+	  - 猫耳のアバター内部部分をぼかしでマスク表示してより猫耳っぽく見えるように
+	- 「UIのアニメーションを減らす」 (`reduceAnimation`) で猫耳を撫でられなくなります
 - Add Minimizing ("folding") of windows
 - 「データセーバー」モードを追加
-- 非 NSFW メディアが隠れている際にも「閲覧注意」が出てしまう問題を修正
+- 非NSFWメディアが隠れている際にも「閲覧注意」が出てしまう問題を修正
 
 ### Server
-
-- PostgreSQL のレプリケーション対応
-  - 設定ファイルの `dbReplications` および `dbSlaves` にて設定できます
-- イベント用 Redis を別サーバーに分離できるように
-- ジョブキュー用 Redis を別サーバーに分離できるように
+- PostgreSQLのレプリケーション対応
+	- 設定ファイルの `dbReplications` および `dbSlaves` にて設定できます
+- イベント用Redisを別サーバーに分離できるように
+- ジョブキュー用Redisを別サーバーに分離できるように
 - サーバーの全体的なパフォーマンスを向上
 - ノート作成時のパフォーマンスを向上
 - アンテナのタイムライン取得時のパフォーマンスを向上
 - チャンネルのタイムライン取得時のパフォーマンスを向上
 - 通知に関する全体的なパフォーマンスを向上
-- webhook が content-type text/plain;charset=UTF-8 で飛んでくる問題を修正
+- webhookがcontent-type text/plain;charset=UTF-8 で飛んでくる問題を修正
 
 ## 13.10.3
 
 ### Changes
-
 - オブジェクトストレージのリージョン指定が必須になりました
   - リージョンの指定の無いサービスは us-east-1 を設定してください
   - 値が空の場合は設定ファイルまたは環境変数の使用を試みます
     - e.g. ~/aws/config, AWS_REGION
 
 ### General
-
 - コンディショナルロールの条件に「投稿数が～以下」「投稿数が～以上」を追加
-- リアクション非対応 AP 実装からの Like アクティビティの解釈を 👍 から ♥ に
+- リアクション非対応AP実装からのLikeアクティビティの解釈を👍から♥に
 
 ### Client
-
 - クリップボタンをノートアクションに追加できるように
-- センシティブワードの一覧にピン留めユーザーの ID が表示される問題を修正
+- センシティブワードの一覧にピン留めユーザーのIDが表示される問題を修正
 
 ### Server
-
 - リモートユーザーのチャート生成を無効にするオプションを追加
 - リモートサーバーのチャート生成を無効にするオプションを追加
 - ドライブのチャートはローカルユーザーのみ生成するように
@@ -307,24 +277,20 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 13.10.2
 
 ### Server
-
 - 絵文字を編集すると保存できないことがある問題を修正
 
 ### Client
-
 - ドライブファイルのメニューが正常に動作しない問題を修正
 
 ## 13.10.1
 
 ### Client
-
-- Misskey Play の Play ボタンを押した時にエラーが発生する問題を修正
+- Misskey PlayのPlayボタンを押した時にエラーが発生する問題を修正
 
 ## 13.10.0
 
 ### General
-
-- ユーザーごとに Renote をミュートできるように
+- ユーザーごとにRenoteをミュートできるように
 - ノートごとに絵文字リアクションを受け取るか設定できるように
 - クリップをお気に入りに登録できるように
 - ノート検索の利用可否をロールで制御可能に(デフォルトでオフ)
@@ -334,43 +300,41 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - 使われてないアンテナは自動停止されるように
 
 ### Client
-
 - 設定から自分のロールを確認できるように
 - 広告一覧ページを追加
 - ドライブクリーナーを追加
-- DM 作成時にメンションも含むように
+- DM作成時にメンションも含むように
 - フォロー申請のボタンのデザインを改善
 - 付箋ウィジェットの高さを設定可能に
-- AP オブジェクトを入力してフェッチする機能とユーザーやノートの検索機能を分離
+- APオブジェクトを入力してフェッチする機能とユーザーやノートの検索機能を分離
 - ナビゲーションバーの項目に「プロフィール」を追加できるように
 - ナビゲーションバーのカスタマイズをドラッグ&ドロップで行えるように
 - ジョブキューの再試行をワンクリックでできるように
-- AiScript を 0.13.1 に更新
-- oEmbed をサポートしているウェブサイトのプレビューができるように
-  - YouTube を oEmbed でロードし、プレビューで共有ボタンを押すと OS の共有画面がでるように
-  - ([Firefox で Spotify のプレビューを開けるとフルサイズじゃなくプレビューサイズだけ再生できる問題](https://bugzilla.mozilla.org/show_bug.cgi?id=1792395)があります)
-  - (すでにブラウザーでキャッシュされたリンクに対しては以前のプレビュー行動が行われてます。その場合、ブラウザーのキャッシュをクリアしてまた試してください。)
+- AiScriptを0.13.1に更新
+- oEmbedをサポートしているウェブサイトのプレビューができるように
+	- YouTubeをoEmbedでロードし、プレビューで共有ボタンを押すとOSの共有画面がでるように
+	- ([FirefoxでSpotifyのプレビューを開けるとフルサイズじゃなくプレビューサイズだけ再生できる問題](https://bugzilla.mozilla.org/show_bug.cgi?id=1792395)があります)
+	- (すでにブラウザーでキャッシュされたリンクに対しては以前のプレビュー行動が行われてます。その場合、ブラウザーのキャッシュをクリアしてまた試してください。)
 - プロフィールで設定した情報が削除できない問題を修正
-- ロールで広告を無効にすると admin/ads でプレビューがでてこない問題を修正
-- /api-console ページにアクセスすると 404 が出る問題を修正
-- Safari でプラグインが複数ある場合に正常に読み込まれない問題を修正
-- Bookwyrm のユーザーのプロフィールページで「リモートで表示」をタップしても反応がない問題を修正
-- 非ログイン時の「Misskey について」の表示を修正
-- PC 版にて「設定」「コントロールパネル」のリンクを 2 度以上続けてクリックした際に空白のページが表示される問題を修正
+- ロールで広告を無効にするとadmin/adsでプレビューがでてこない問題を修正
+- /api-consoleページにアクセスすると404が出る問題を修正
+- Safariでプラグインが複数ある場合に正常に読み込まれない問題を修正
+- Bookwyrmのユーザーのプロフィールページで「リモートで表示」をタップしても反応がない問題を修正
+- 非ログイン時の「Misskeyについて」の表示を修正
+- PC版にて「設定」「コントロールパネル」のリンクを2度以上続けてクリックした際に空白のページが表示される問題を修正
 
 ### Server
-
-- OpenAPI エンドポイントを復旧
-- WebP/AVIF/JPEG の web 公開用画像は、サーバーサイドでは JPEG ではなく WebP に変換するように
+- OpenAPIエンドポイントを復旧
+- WebP/AVIF/JPEGのweb公開用画像は、サーバーサイドではJPEGではなくWebPに変換するように
 - アニメーション画像のサムネイルを生成するように
 - アクティブユーザー数チャートの記録上限値を拡張
-- Play のソースコード上限文字数を 2 倍に拡張
-- 配送先サーバーが 410 Gone で応答してきた場合は自動で配送停止をするように
-- avatarBlurHash/bannerBlurHash の型を string に限定
+- Playのソースコード上限文字数を2倍に拡張
+- 配送先サーバーが410 Goneで応答してきた場合は自動で配送停止をするように
+- avatarBlurHash/bannerBlurHashの型をstringに限定
 - タイムライン取得時のパフォーマンスを改善
 - SMTP Login id length is too short
-- API 上で`visibility`を`followers`に設定して renote すると連合や削除で不具合が発生する問題を修正
-- AWS S3 からのファイル削除で NoSuchKey エラーが出ると進めらない状態になる問題を修正
+- API上で`visibility`を`followers`に設定してrenoteすると連合や削除で不具合が発生する問題を修正
+- AWS S3からのファイル削除でNoSuchKeyエラーが出ると進めらない状態になる問題を修正
 - `disableCache: true`を設定している場合に絵文字管理操作でエラーが出る問題を修正
 - リテンション分析が上手く機能しないことがあるのを修正
 - 空のアンテナが作成できないように修正
@@ -380,41 +344,36 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 13.9.2 (2023/03/06)
 
 ### Improvements
-
 - クリップ、チャンネルページに共有ボタンを追加
 - チャンネルでタイムライン上部に投稿フォームを表示するかどうかのオプションを追加
 - ブラウザでメディアプロキシ(/proxy)からファイルを保存した際に、なるべくオリジナルのファイル名を継承するように
-- ドライブの「URL からアップロード」で、content-disposition の filename があればそれをファイル名に
-- Identicon がローカルとリモートで同じになるように
-  - これまでの Identicon は異なる画像になります
+- ドライブの「URLからアップロード」で、content-dispositionのfilenameがあればそれをファイル名に
+- Identiconがローカルとリモートで同じになるように
+  - これまでのIdenticonは異なる画像になります
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
-
 - ロールの権限で「一般ユーザー」のロールがいきなり設定できない問題を修正
 - ユーザーページのバッジ表示を適切に折り返すように @arrow2nd
 - fix(client): みつけるのロール一覧でコンディショナルロールが含まれるのを修正
-- macOS で Dev Container が動作しない問題を修正 @RyotaK
+- macOSでDev Containerが動作しない問題を修正 @RyotaK
 
 ## 13.9.1 (2023/03/03)
 
 ### Bugfixes
-
 - ノートに添付したファイルが表示されない場合があるのを修正
 
 ## 13.9.0 (2023/03/03)
 
 ### Improvements
-
 - 時限ロール
-- アンテナで CW も検索対象にするように
+- アンテナでCWも検索対象にするように
 - ノートの操作部をホバー時のみ表示するオプションを追加
 - サウンドを追加
-- enhance(client): MFM の x2, scale, position が含まれていたらノートをたたむように
+- enhance(client): MFMのx2, scale, positionが含まれていたらノートをたたむように
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
-
 - 外部メディアプロキシ使用時にアバタークロップができない問題を修正
 - fix(server): メールアドレス更新時にバリデーションが正しく行われていないのを修正
 - fix(server): チャンネルでミュートが正しく機能していないのを修正
@@ -423,18 +382,16 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 13.8.1 (2023/02/26)
 
 ### Bugfixes
-
 - モバイルでドロワーメニューが表示されない問題を修正
 
 ## 13.8.0 (2023/02/26)
 
 ### Improvements
-
 - チャンネル内ハイライト
 - ホームタイムラインのパフォーマンスを改善
-- renote した際の表示を改善
+- renoteした際の表示を改善
 - バックグラウンドで一定時間経過したらページネーションのアイテム更新をしない
-- enhance(client): MkUrlPreview の閉じるボタンを見やすく
+- enhance(client): MkUrlPreviewの閉じるボタンを見やすく
 - Add dialog to remove follower
 - enhance(client): improve clip menu ux
 - 検索画面の統合
@@ -442,39 +399,33 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - photoswipe 表示時に戻る操作をしても前の画面に戻らないように
 
 ### Bugfixes
-
-- Windows 環境で swc を使うと正しくビルドできない問題の修正
-- fix(client): Android Chrome で PWA としてインストールできない問題を修正
+- Windows環境でswcを使うと正しくビルドできない問題の修正
+- fix(client): Android ChromeでPWAとしてインストールできない問題を修正
 - 未知のユーザーが deleteActor されたら処理をスキップする
-- fix(server): notes/create で、fileIds と見つかったファイルの数が異なる場合はエラーにする
-- fix(server): notes/create のバリデーションが機能していないのを修正
+- fix(server): notes/createで、fileIdsと見つかったファイルの数が異なる場合はエラーにする
+- fix(server): notes/createのバリデーションが機能していないのを修正
 - fix(server): エラーのスタックトレースは返さないように
 
 ## 13.7.5 (2023/02/24)
 
 ### Note
-
-13.7.0 以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**
+13.7.0以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**
 
 ### Improvements
-
 - 紛らわしいため公開範囲の「ローカルのみ」オプションの名称を「連合なし」に変更
 - Frontend: スマホ・タブレットの場合、チャンネルの投稿フォームに自動でフォーカスしないように
 
 ### Bugfixes
-
 - 全ての通知が削除されてしまうのを修正
 
 ## 13.7.3 (2023/02/23)
 
 ### Note
-
-~~13.7.0 以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**~~
+~~13.7.0以前から直接このバージョンにアップデートする場合は全ての通知が削除**されません。**~~
 
 ### Improvements
 
 ### Bugfixes
-
 - Client: 「キャッシュを削除」した後、ローカルのカスタム絵文字が表示されなくなるされなくなる問題を修正
 - Client: 通知設定画面で以前からグループの招待を有効化していた場合、通知の表示に失敗する問題の修正
 - Client: 通知設定画面に古いトグルが残っていた問題を修正
@@ -482,158 +433,134 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 13.7.2 (2023/02/23)
 
 ### Note
-
-13.7.0 以前からアップデートする場合は全ての通知が削除されます。
+13.7.0以前からアップデートする場合は全ての通知が削除されます。
 
 ### Improvements
-
 - enhance: make pwa icon maskable
 - chore(client): tweak custom emoji size
 
 ### Bugfixes
-
 - マイグレーションが失敗することがあるのを修正
 
 ## 13.7.1 (2023/02/23)
 
 ### Improvements
-
-- pnpm build では swc を使うように
+- pnpm buildではswcを使うように
 
 ### Bugfixes
-
-- NODE_ENV=production でビルドできないのを修正
+- NODE_ENV=productionでビルドできないのを修正
 
 ## 13.7.0 (2023/02/22)
 
 ### Changes
-
 - チャット機能が削除されました
 
 ### Improvements
-
-- Server: URL プレビュー（summaly）はプロキシを通すように
-- Client: 2FA 設定の UI をまともにした
+- Server: URLプレビュー（summaly）はプロキシを通すように
+- Client: 2FA設定のUIをまともにした
 - セキュリティキーの名前を変更できるように
 - enhance(client): add quiz preset for play
 - 広告開始時期を設定できるように
 - みつけるで公開ロール一覧とそのメンバーを閲覧できるように
-- enhance(client): MFM の x3, x4 が含まれていたらノートをたたむように
+- enhance(client): MFMのx3, x4が含まれていたらノートをたたむように
 - enhance(client): make possible to reload page of window
 
 ### Bugfixes
-
 - ユーザー検索ダイアログでローカルユーザーを絞って検索できない問題を修正
-- fix(client): MkHeader 及びデッキのカラムでチャンネル一覧を選択したとき、最大 5 個までしか表示されない
-- 管理画面の広告を 10 個以上見えるように
+- fix(client): MkHeader及びデッキのカラムでチャンネル一覧を選択したとき、最大5個までしか表示されない
+- 管理画面の広告を10個以上見えるように
 - Moderation note が保存できない
 - ユーザーのハッシュタグ検索が機能していないのを修正
 
 ## 13.6.1 (2023/02/12)
 
 ### Improvements
-
-- アニメーションを少なくする設定の時、MkPageHeader のタブアニメーションを無効化
-- Backend: activitypub 情報が cors でブロックされないようヘッダーを追加
-- enhance: レートリミットを 0%にできるように
-- チャンネル内 Renote を行えるように
+- アニメーションを少なくする設定の時、MkPageHeaderのタブアニメーションを無効化
+- Backend: activitypub情報がcorsでブロックされないようヘッダーを追加
+- enhance: レートリミットを0%にできるように
+- チャンネル内Renoteを行えるように
 
 ### Bugfixes
-
 - Client: ユーザーページでアクティビティを見ることができない問題を修正
 
 ## 13.6.0 (2023/02/11)
 
 ### Improvements
-
-- MkPageHeader をごっそり変えた
-  - モバイルではヘッダーは上下に分割され、下段にタブが表示されるように
-  - iconOnly のタブ項目がアクティブな場合にはタブのタイトルを表示するように
-  - メインタイムラインではタイトルを表示しない
-  - メインタイムラインかつモバイルで表示される左上のアバターを選択するとアカウントメニューが開くように
+- MkPageHeaderをごっそり変えた
+  * モバイルではヘッダーは上下に分割され、下段にタブが表示されるように
+  * iconOnlyのタブ項目がアクティブな場合にはタブのタイトルを表示するように
+  * メインタイムラインではタイトルを表示しない
+  * メインタイムラインかつモバイルで表示される左上のアバターを選択するとアカウントメニューが開くように
 - ユーザーページのノート一覧をタブとして分離
 - コンディショナルロールもバッジとして表示可能に
 - enhance(client): ロールをより簡単に付与できるように
-- enhance(client): 一度見たノートの Renote は省略して表示するように
+- enhance(client): 一度見たノートのRenoteは省略して表示するように
 - enhance(client): 迷惑になる可能性のある投稿を行う前に警告を表示
 - リアクションの数が多い場合の表示を改善
-- 一部の MFM 構文を opt-out に
+- 一部のMFM構文をopt-outに
 
 ### Bugfixes
-
 - Client: ユーザーページでタブがほとんど見れないことがないように
 
 ## 13.5.6 (2023/02/10)
 
 ### Improvements
-
-- 非ログイン時に MiAuth を踏んだ際に MiAuth であることを表示する
-- /auth/の UI をアップデート
-- 利用規約同意 UI の調整
+- 非ログイン時にMiAuthを踏んだ際にMiAuthであることを表示する
+- /auth/のUIをアップデート
+- 利用規約同意UIの調整
 - クロップ時の質問を分かりやすく
 
 ### Bugfixes
-
 - fix: prevent clipping audio plyr's tooltip
 
 ## 13.5.4 (2023/02/09)
 
 ### Improvements
-
-- Server: UI の HTML（ノートなどの特別なページを除く）のキャッシュ時間を 15 秒から 30 秒に
-- i/notifications のレートリミットを緩和
+- Server: UIのHTML（ノートなどの特別なページを除く）のキャッシュ時間を15秒から30秒に
+- i/notificationsのレートリミットを緩和
 
 ### Bugfixes
-
 - fix(client): validate url to improve security
-- fix(client): date の初期値が正常に入らない時がある
+- fix(client): dateの初期値が正常に入らない時がある
 
 ## 13.5.3 (2023/02/09)
 
 ### Improvements
-
 - Client: デッキにチャンネルカラムを追加
 
 ## 13.5.2 (2023/02/08)
 
 ### Changes
-
 - Revert: perf(client): do not render custom emojis in user names
 
 ### Bugfixes
-
 - Client: register_note_view_interruptor not working
 - Client: ログイントークンの再生成が出来ない
 
 ## 13.5.0 (2023/02/08)
 
 ### Changes
-
 - perf(client): do not render custom emojis in user names
 
 ### Improvements
-
-- Client: disableShowingAnimatedImages のデフォルト値を prefers-reduced-motion にする
+- Client: disableShowingAnimatedImagesのデフォルト値をprefers-reduced-motionにする
 - enhance(client): tweak medialist style
 
 ### Bugfixes
-
 - fix docker health check
-- Client: MkEmojiPicker でも Chrome で検索ダイアログで変換確定するとそのまま検索されてしまうのを修正
+- Client: MkEmojiPickerでもChromeで検索ダイアログで変換確定するとそのまま検索されてしまうのを修正
 - fix(mfm): default degree not used in rotate
 - fix(server): validate urls from ap to improve security
 
 ## 13.4.0 (2023/02/05)
 
 ### Improvements
-
 - ロールにアイコンを設定してユーザー名の横に表示できるように
 - feat: timeline page for non-login users
 - 実績の単なるラッキーの獲得確立を調整
 - Add Thai language support
 
 ### Bugfixes
-
 - fix(server): 自分のノートをお気に入りに登録しても実績解除される問題を修正
 - fix(server): clean up file in FileServer
 - fix(server): Deny UNIX domain socket
@@ -646,64 +573,51 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 13.3.3 (2023/02/04)
 
 ### Bugfixes
-
 - Server: improve security
 
 ## 13.3.2 (2023/02/04)
 
 ### Improvements
-
 - 外部メディアプロキシへの対応を強化しました
-  外部メディアプロキシの Fastify 実装を作りました
+  外部メディアプロキシのFastify実装を作りました
   https://github.com/misskey-dev/media-proxy
 - Server: improve performance
 
 ### Bugfixes
-
 - Client: validate urls to improve security
 
 ## 13.3.1 (2023/02/04)
 
 ### Bugfixes
-
 - Client: カスタム絵文字にアニメーション画像を再生しない設定が適用されていない問題を修正
-- Client: オートコンプリートで Unicode 絵文字がカスタム絵文字として表示されてしまうのを修正
+- Client: オートコンプリートでUnicode絵文字がカスタム絵文字として表示されてしまうのを修正
 - Client: Fix Vue-plyr CORS issue
 - Client: validate urls to improve security
 
 ## 13.3.0 (2023/02/03)
-
 ### Changes
-
-- twitter/github/discord 連携機能が削除されました
+- twitter/github/discord連携機能が削除されました
 - ハッシュタグごとのチャートが削除されました
-- syslog のサポートが削除されました
+- syslogのサポートが削除されました
 
 ### Improvements
-
 - ロールで広告の非表示が有効になっている場合は最初から広告を非表示にするように
 
 ## 13.2.6 (2023/02/01)
-
 ### Changes
-
-- docker-compose.yml を docker-compose.yml.example にしました。docker-compose.yml としてコピーしてから使用してください。
+- docker-compose.ymlをdocker-compose.yml.exampleにしました。docker-compose.ymlとしてコピーしてから使用してください。
 
 ### Improvements
-
 - 絵文字ピッカーのパフォーマンスを改善
-- AiScript を 0.12.4 に更新
+- AiScriptを0.12.4に更新
 
 ### Bugfixes
-
 - Server: リレーと通信できない問題を修正
-- Client: classic モード使用時に window サイズによって default に変更された後に、window サイズが元に戻ったら classic に戻すように修正 #9669
-- Client: Chrome で検索ダイアログで変換確定するとそのまま検索されてしまう問題を修正
+- Client: classicモード使用時にwindowサイズによってdefaultに変更された後に、windowサイズが元に戻ったらclassicに戻すように修正 #9669
+- Client: Chromeで検索ダイアログで変換確定するとそのまま検索されてしまう問題を修正
 
 ## 13.2.4 (2023/01/27)
-
 ### Improvements
-
 - リモートカスタム絵文字表示時のパフォーマンスを改善
 - Default to `animation: false` when prefers-reduced-motion is set
 - リアクション履歴が公開なら、ログインしていなくても表示できるように
@@ -711,115 +625,94 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - tweak custom emoji cache
 
 ### Bugfixes
-
 - fix aggregation of retention
 - ダッシュボードでオンラインユーザー数が表示されない問題を修正
 - フォロー申請・フォローのボタンが、通知から消えている問題を修正
 
 ## 13.2.3 (2023/01/26)
-
 ### Improvements
-
 - カスタム絵文字の更新をリアルタイムで反映するように
 
 ### Bugfixes
-
 - turnstile-failed: missing-input-secret
 
 ## 13.2.2 (2023/01/25)
-
 ### Improvements
-
 - サーバーのパフォーマンスを改善
 
 ### Bugfixes
-
 - サインイン時に誤ったレートリミットがかかることがある問題を修正
-- MFM の position、rotate、scale で小数が使えない問題を修正
+- MFMのposition、rotate、scaleで小数が使えない問題を修正
 
 ## 13.2.1 (2023/01/24)
-
 ### Improvements
-
 - デザインの調整
 - サーバーのパフォーマンスを改善
 
 ## 13.2.0 (2023/01/23)
 
 ### Improvements
-
 - onlyServer / onlyQueue オプションを復活
 - 他人の実績閲覧時は獲得条件を表示しないように
 - アニメーション減らすオプション有効時はリアクションのアニメーションを無効に
 - カスタム絵文字一覧のパフォーマンスを改善
 
 ### Bugfixes
-
 - Aiscript: button is not defined
 
 ## 13.1.7 (2023/01/22)
 
 ### Improvements
-
 - 新たな実績を追加
-- MFM に scale タグを追加
+- MFMにscaleタグを追加
 
 ## 13.1.4 (2023/01/22)
 
 ### Improvements
-
 - 新たな実績を追加
 
 ### Bugfixes
-
 - Client: ローカリゼーション更新時にリロードが繰り返されることがあるのを修正
 
 ## 13.1.3 (2023/01/22)
 
 ### Bugfixes
-
 - Client: リアクションのカスタム絵文字の表示の問題を修正
 
 ## 13.1.2 (2023/01/22)
 
 ### Bugfixes
-
 - Client: リアクションのカスタム絵文字の表示の問題を修正
 
 ## 13.1.1 (2023/01/22)
 
 ### Improvements
-
 - ローカルのカスタム絵文字を表示する際のパフォーマンスを改善
 - Client: 瞬間的に大量の実績を解除した際の挙動を改善
 
 ### Bugfixes
-
 - Client: アップデート時にローカリゼーションデータが更新されないことがあるのを修正
 
 ## 13.1.0 (2023/01/21)
 
 ### Improvements
-
 - 実績機能
-- Play のプリセットを追加
-- Play の script の文字数制限を緩和
-- AiScript GUI の強化
+- Playのプリセットを追加
+- Playのscriptの文字数制限を緩和
+- AiScript GUIの強化
 - リアクション一覧詳細ダイアログを表示できるように
 - 存在しないカスタム絵文字をテキストで表示するように
 - Alt text in image viewer
-- ジョブキューのプロセスと Web サーバーのプロセスを分離
+- ジョブキューのプロセスとWebサーバーのプロセスを分離
 
 ### Bugfixes
-
-- play を削除する手段がなかったのを修正
+- playを削除する手段がなかったのを修正
 - The … button on notes does nothing when not logged in
-- twitter と連携するときに autwh is not a function になるのを修正
+- twitterと連携するときに autwh is not a function になるのを修正
 
 ## 13.0.0 (2023/01/16)
 
 ### TL;DR
-
 - New features (Role system, Misskey Play, New widgets, New charts, 🍪👈, etc)
 - Rewriten backend
 - Better performance (backend and frontend)
@@ -827,63 +720,57 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - Various UI tweaks
 
 ### Notable features
-
 - ロール機能
-  - 従来より柔軟にユーザーのポリシーを管理できます。例えば、「インスタンスのパトロンはアンテナを 30 個まで作れる」「基本的に LTL は見れないが、許可した人だけ見れる」「招待制インスタンスだけどユーザーなら誰でも他者を招待できる」のような運用はもちろん、「ローカルユーザーかつアカウント作成から 1 日未満のユーザーはパブリックな投稿を行えない」のように複数条件を組み合わせて、自動でロールを付与する設定も可能です。
+	- 従来より柔軟にユーザーのポリシーを管理できます。例えば、「インスタンスのパトロンはアンテナを30個まで作れる」「基本的にLTLは見れないが、許可した人だけ見れる」「招待制インスタンスだけどユーザーなら誰でも他者を招待できる」のような運用はもちろん、「ローカルユーザーかつアカウント作成から1日未満のユーザーはパブリックな投稿を行えない」のように複数条件を組み合わせて、自動でロールを付与する設定も可能です。
 - Misskey Play
-  - 従来の動的な Pages に代わる、新しいプラットフォームです。動的なコンテンツ(アプリケーション)に特化していて、Pages に比べてはるかに柔軟なアプリケーションを作成可能です。
+	- 従来の動的なPagesに代わる、新しいプラットフォームです。動的なコンテンツ(アプリケーション)に特化していて、Pagesに比べてはるかに柔軟なアプリケーションを作成可能です。
 
 ### Changes
-
 #### For server admins
-
 - Node.js 18.x or later is required
 - PostgreSQL 15.x is required
-  - Misskey not using 15 specific features at 13.0.0, but may do so in the future.
-  - Docker 環境で PostgreSQL のアップデートを行う際のガイドはこちら: https://github.com/misskey-dev/misskey/pull/9641#issue-1536336620
-- Elasticsearch のサポートが削除されました
-  - 代わりに今後任意の検索プロバイダを設定できる仕組みを構想しています。その仕組みを使えば今まで通り Elasticsearch も利用できます
-- Yarn から pnpm に移行されました
-  corepack の有効化を推奨します: `sudo corepack enable`
+	- Misskey not using 15 specific features at 13.0.0, but may do so in the future.
+	- Docker環境でPostgreSQLのアップデートを行う際のガイドはこちら: https://github.com/misskey-dev/misskey/pull/9641#issue-1536336620
+- Elasticsearchのサポートが削除されました
+	- 代わりに今後任意の検索プロバイダを設定できる仕組みを構想しています。その仕組みを使えば今まで通りElasticsearchも利用できます
+- Yarnからpnpmに移行されました
+  corepackの有効化を推奨します: `sudo corepack enable`
 - インスタンスブロックはサブドメインにも適用されるようになります
 - ロールの導入に伴い、いくつかの機能がロールと統合されました
-  - モデレーターはロールに統合されました。今までのモデレーター情報は失われるため、予めモデレーター一覧を記録しておき、アップデート後にモデレーターロールを作りアサインし直してください。
-  - サイレンスはロールに統合されました。今までのユーザーは恩赦されるため、予めサイレンス一覧を記録しておくのをおすすめします。
-  - ユーザーごとのドライブ容量設定はロールに統合されました。
-  - インスタンスデフォルトのドライブ容量設定はロールに統合されました。アップデート後、ベースロールもしくはコンディショナルロールでドライブ容量を編集してください。
-  - LTL/GTL の解放状態はロールに統合されました。
-- Docker の実行を root で行わないようにしました。Docker かつオブジェクトストレージを使用していない場合は`chown -hR 991.991 ./files`を実行してください。
+	- モデレーターはロールに統合されました。今までのモデレーター情報は失われるため、予めモデレーター一覧を記録しておき、アップデート後にモデレーターロールを作りアサインし直してください。
+	- サイレンスはロールに統合されました。今までのユーザーは恩赦されるため、予めサイレンス一覧を記録しておくのをおすすめします。
+	- ユーザーごとのドライブ容量設定はロールに統合されました。
+	- インスタンスデフォルトのドライブ容量設定はロールに統合されました。アップデート後、ベースロールもしくはコンディショナルロールでドライブ容量を編集してください。
+	- LTL/GTLの解放状態はロールに統合されました。
+- Dockerの実行をrootで行わないようにしました。Dockerかつオブジェクトストレージを使用していない場合は`chown -hR 991.991 ./files`を実行してください。
   https://github.com/misskey-dev/misskey/pull/9560
 
 #### For users
-
 - ノートのウォッチ機能が削除されました
 - アンケートに投票された際に通知が作成されなくなりました
 - ノートの数式埋め込みが削除されました
-- 新たに動的な Pages を作ることはできなくなりました
-  - 代わりに AiScript を用いてより柔軟に動的なコンテンツを作成できる Misskey Play 機能が実装されています。
-- AiScript が 0.12.2 にアップデートされました
-  - 0.12.x の変更点についてはこちら https://github.com/syuilo/aiscript/blob/master/CHANGELOG.md#0120
-  - 0.12.x 未満のプラグインは読み込むことはできません
-- iOS15 以下のデバイスはサポートされなくなりました
-- Firefox110 以下はサポートされなくなりました
-  - 109 でも ContainerQueries のフラグを有効にする事で問題なく使用できます
+- 新たに動的なPagesを作ることはできなくなりました
+	- 代わりにAiScriptを用いてより柔軟に動的なコンテンツを作成できるMisskey Play機能が実装されています。
+- AiScriptが0.12.2にアップデートされました
+	- 0.12.xの変更点についてはこちら https://github.com/syuilo/aiscript/blob/master/CHANGELOG.md#0120
+	- 0.12.x未満のプラグインは読み込むことはできません
+- iOS15以下のデバイスはサポートされなくなりました
+- Firefox110以下はサポートされなくなりました
+  - 109でもContainerQueriesのフラグを有効にする事で問題なく使用できます
 
 #### For app developers
-
-- API: meta のレスポンスに`emojis`プロパティが含まれなくなりました
-  - カスタム絵文字一覧情報を取得するには、`emojis`エンドポイントにリクエストします
+- API: metaのレスポンスに`emojis`プロパティが含まれなくなりました
+	- カスタム絵文字一覧情報を取得するには、`emojis`エンドポイントにリクエストします
 - API: カスタム絵文字エンティティに`url`プロパティが含まれなくなりました
-  - 絵文字画像を表示するには、`<instance host>/emoji/<emoji name>.webp`にリクエストすると画像が返ります。
-  - e.g. `https://p1.a9z.dev/emoji/misskey.webp`
-  - remote: `https://p1.a9z.dev/emoji/syuilo_birth_present@mk.f72u.net.webp`
+	- 絵文字画像を表示するには、`<instance host>/emoji/<emoji name>.webp`にリクエストすると画像が返ります。
+	- e.g. `https://p1.a9z.dev/emoji/misskey.webp`
+	- remote: `https://p1.a9z.dev/emoji/syuilo_birth_present@mk.f72u.net.webp`
 - API: `user`および`note`エンティティに`emojis`プロパティが含まれなくなりました
 - API: `user`エンティティに`avatarColor`および`bannerColor`プロパティが含まれなくなりました
 - API: `instance`エンティティに`latestStatus`、`lastCommunicatedAt`、`latestRequestSentAt`プロパティが含まれなくなりました
 - API: `instance`エンティティの`caughtAt`は`firstRetrievedAt`に名前が変わりました
 
 ### Improvements
-
 - Role system @syuilo
 - Misskey Play @syuilo
 - Introduce retention-rate aggregation @syuilo
@@ -898,7 +785,7 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - クリップおよびクリップ内のノートの作成可能数を設定可能に @syuilo
 - ユーザーリストおよびユーザーリスト内のユーザーの作成可能数を設定可能に @syuilo
 - ハードワードミュートの最大文字数を設定可能に @syuilo
-- Webhook の作成可能数を設定可能に @syuilo
+- Webhookの作成可能数を設定可能に @syuilo
 - ノートをピン留めできる数を設定可能に @syuilo
 - Server: signToActivityPubGet is set to true by default @syuilo
 - Server: improve syslog performance @syuilo
@@ -941,25 +828,24 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - Client: add new mfm function (position, fg, bg) @syuilo
 - Client: show fireworks when visit user who today is birthday @syuilo
 - Client: show bot warning on screen when logged in as bot account @syuilo
-- Client: AiScript からカスタム絵文字一覧を参照できるように @syuilo
+- Client: AiScriptからカスタム絵文字一覧を参照できるように @syuilo
 - Client: improve overall performance of client @syuilo
 - Client: ui tweaks @syuilo
 - Client: clicker game @syuilo
 
 ### Bugfixes
-
 - Server: Fix @tensorflow/tfjs-core's MODULE_NOT_FOUND error @ikuradon
-- Server: 引用内の文章が nyaize されてしまう問題を修正 @kabo2468
+- Server: 引用内の文章がnyaizeされてしまう問題を修正 @kabo2468
 - Server: Bug fix for Pinned Users lookup on instance @squidicuzz
 - Server: Fix peers API returning suspended instances @ineffyble
 - Server: trim long text of note from ap @syuilo
-- Server: Ap inbox の最大ペイロードサイズを 64kb に制限 @syuilo
+- Server: Ap inboxの最大ペイロードサイズを64kbに制限 @syuilo
 - Server: アンテナの作成数上限を追加 @syuilo
-- Server: pages/like のエラー ID が重複しているのを修正 @syuilo
-- Server: pages/update のパラメータによっては summary の値が更新されないのを修正 @syuilo
+- Server: pages/likeのエラーIDが重複しているのを修正 @syuilo
+- Server: pages/updateのパラメータによってはsummaryの値が更新されないのを修正 @syuilo
 - Server: Escape SQL LIKE @mei23
-- Server: 特定の PNG 画像のアップロードに失敗する問題を修正 @usbharu
-- Server: 非公開のクリップの URL で OGP レンダリングされる問題を修正 @syuilo
+- Server: 特定のPNG画像のアップロードに失敗する問題を修正 @usbharu
+- Server: 非公開のクリップのURLでOGPレンダリングされる問題を修正 @syuilo
 - Server: アンテナタイムライン（ストリーミング）が、フォローしていないユーザーの鍵投稿も拾ってしまう @syuilo
 - Server: follow request list api pagination @sim1222
 - Server: ドライブ容量超過時のエラーが適切にレスポンスされない問題を修正 @syuilo
@@ -967,36 +853,31 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 - Client: 日付形式の文字列などがカスタム絵文字として表示されるのを修正 @syuilo
 - Client: case insensitive emoji search @saschanaz
 - Client: 画面の幅が狭いとウィジェットドロワーを閉じる手段がなくなるのを修正 @syuilo
-- Client: InApp ウィンドウが操作できなくなることがあるのを修正 @tamaina
+- Client: InAppウィンドウが操作できなくなることがあるのを修正 @tamaina
 - Client: use proxied image for instance icon @syuilo
-- Client: Webhook の編集画面で、内容を保存することができない問題を修正 @m-hayabusa
-- Client: Page 編集でブロックの移動が行えない問題を修正 @syuilo
+- Client: Webhookの編集画面で、内容を保存することができない問題を修正 @m-hayabusa
+- Client: Page編集でブロックの移動が行えない問題を修正 @syuilo
 - Client: update emoji picker immediately on all input @saschanaz
 - Client: チャートのツールチップが画面に残ることがあるのを修正 @syuilo
 - Client: fix wrong link in tutorial @syuilo
 
 ### Special thanks
-
 - All contributors
 - All who have created instances for the beta test
 - All who participated in the beta test
 
 ## 12.119.1 (2022/12/03)
-
 ### Bugfixes
-
 - Server: Mitigate AP reference chain DoS vector @skehmatics
 
 ## 12.119.0 (2022/09/10)
 
 ### Improvements
-
 - Client: Add following badge to user preview popup @nvisser
 - Client: mobile twitter url can be used as widget @caipira113
 - Client: Improve clock widget @syuilo
 
 ### Bugfixes
-
 - マイグレーションに失敗する問題を修正
 - Server: 他人の通知を既読にできる可能性があるのを修正 @syuilo
 - Client: アクセストークン管理画面、アカウント管理画面表示できないのを修正 @futchitwo
@@ -1004,123 +885,103 @@ Meilisearch の設定に`index`が必要になりました。値は Misskey サ�
 ## 12.118.1 (2022/08/08)
 
 ### Bugfixes
-
 - Client: can not show some setting pages @syuilo
 
 ## 12.118.0 (2022/08/07)
 
 ### Improvements
-
 - Client: 設定のバックアップ/リストア機能
 - Client: Add vi-VN language support
 - Client: Add unix time widget @syuilo
 
 ### Bugfixes
-
 - Server: リモートユーザーを正しくブロックできるように修正する @xianonn
-- Client: 一度作った webhook の設定画面を開こうとするとページがフリーズする @syuilo
-- Client: MiAuth 認証ページが機能していない @syuilo
+- Client: 一度作ったwebhookの設定画面を開こうとするとページがフリーズする @syuilo
+- Client: MiAuth認証ページが機能していない @syuilo
 - Client: 一部のアプリからファイルを投稿フォームへドロップできない場合がある問題を修正 @m-hayabusa
 
 ## 12.117.1 (2022/07/19)
 
 ### Improvements
-
-- Client: UI のブラッシュアップ @syuilo
+- Client: UIのブラッシュアップ @syuilo
 
 ### Bugfixes
-
 - Server: ファイルのアップロードに失敗することがある問題を修正 @acid-chicken
 - Client: リアクションピッカーがアプリ内ウィンドウの後ろに表示されてしまう問題を修正 @syuilo
 - Client: ユーザー情報の取得の再試行を修正 @xianonn
-- Client: MFM チートシートの挙動を修正 @syuilo
+- Client: MFMチートシートの挙動を修正 @syuilo
 - Client: 「インスタンスからのお知らせを受け取る」の設定を変更できない問題を修正 @syuilo
 
 ## 12.117.0 (2022/07/18)
 
 ### Improvements
-
 - Client: ウィンドウを最大化できるように @syuilo
-- Client: Shift キーを押した状態でリンクをクリックするとアプリ内ウィンドウで開くように @syuilo
-- Client: デッキを使用している際、Ctrl キーを押した状態でリンクをクリックするとページ遷移を強制できるように @syuilo
-- Client: UI のブラッシュアップ @syuilo
+- Client: Shiftキーを押した状態でリンクをクリックするとアプリ内ウィンドウで開くように @syuilo
+- Client: デッキを使用している際、Ctrlキーを押した状態でリンクをクリックするとページ遷移を強制できるように @syuilo
+- Client: UIのブラッシュアップ @syuilo
 
 ## 12.116.1 (2022/07/17)
 
 ### Bugfixes
-
-- Client: デッキ UI 時に ページで表示 ボタンが機能しない問題を修正 @syuilo
+- Client: デッキUI時に ページで表示 ボタンが機能しない問題を修正 @syuilo
 - Error During Migration Run to 12.111.x
 
 ## 12.116.0 (2022/07/16)
 
 ### Improvements
-
 - Client: registry editor @syuilo
-- Client: UI のブラッシュアップ @syuilo
+- Client: UIのブラッシュアップ @syuilo
 
 ### Bugfixes
-
 - Error During Migration Run to 12.111.x
 - Server: TypeError: Cannot convert undefined or null to object @syuilo
 
 ## 12.115.0 (2022/07/16)
 
 ### Improvements
-
-- Client: Deck のプロファイル切り替えを簡単に @syuilo
-- Client: UI のブラッシュアップ @syuilo
+- Client: Deckのプロファイル切り替えを簡単に @syuilo
+- Client: UIのブラッシュアップ @syuilo
 
 ## 12.114.0 (2022/07/15)
 
 ### Improvements
-
-- RSS ティッカーで表示順序をシャッフルできるように @syuilo
+- RSSティッカーで表示順序をシャッフルできるように @syuilo
 
 ### Bugfixes
-
 - クライアントが起動しなくなることがある問題を修正 @syuilo
 
 ## 12.113.0 (2022/07/13)
 
 ### Improvements
-
 - Support <plain> syntax for MFM
 
 ### Bugfixes
-
 - Server: Fix crash at startup if TensorFlow is not supported @mei23
-- Client: URL エンコードされたルーティングを修正
+- Client: URLエンコードされたルーティングを修正
 
 ## 12.112.3 (2022/07/09)
 
 ### Improvements
-
 - Make active email validation configurable
 
 ### Bugfixes
-
 - Server: Fix Attempts to update all notifications @mei23
 
 ## 12.112.2 (2022/07/08)
 
 ### Bugfixes
-
 - Fix Docker doesn't work @mei23
   Still not working on arm64 environment. (See 12.112.0)
 
 ## 12.112.1 (2022/07/07)
-
 same as 12.112.0
 
 ## 12.112.0 (2022/07/07)
 
 ### Known issues
-
-- 現在 arm64 環境ではインストールに失敗します。これは次のバージョンで修正される予定です。
+- 現在arm64環境ではインストールに失敗します。これは次のバージョンで修正される予定です。
 
 ### Changes
-
 - ハイライトがみつけるに統合されました
 - カスタム絵文字ページはインスタンス情報ページに統合されました
 - 連合ページはインスタンス情報ページに統合されました
@@ -1130,7 +991,6 @@ same as 12.112.0
 - メニューからリストタイムラインを表示する方法は廃止され、タイムライン上部のアイコンからアクセスするようになりました
 
 ### Improvements
-
 - Server: Allow GET method for some endpoints @syuilo
 - Server: Auto NSFW detection @syuilo
 - Server: Add rate limit to i/notifications @tamaina
@@ -1158,7 +1018,6 @@ same as 12.112.0
 - Add additional drive capacity change support @CyberRex0
 
 ### Bugfixes
-
 - Server: Fix GenerateVideoThumbnail failed @mei23
 - Server: Ensure temp directory cleanup @Johann150
 - favicons of federated instances not showing @syuilo
@@ -1171,31 +1030,27 @@ same as 12.112.0
 ## 12.111.1 (2022/06/13)
 
 ### Bugfixes
-
 - some fixes of multiple notification read @tamaina
 - some GenerateVideoThumbnail failed @Johann150
 - Client: デッキでウィジェットの情報が保存されない問題を修正 @syuilo
 - Client: ギャラリーの投稿を開こうとすると編集画面が表示される @futchitwo
 
 ## 12.111.0 (2022/06/11)
-
 ### Note
-
 - Node.js 16.15.0 or later is required
 
 ### Improvements
-
 - Supports Unicode Emoji 14.0 @mei23
 - プッシュ通知を複数アカウント対応に #7667 @tamaina
-- プッシュ通知にクリックや action を設定 #7667 @tamaina
-- ドライブに画像ファイルをアップロードするときオリジナル画像を破棄して webpublic のみ保持するオプション @tamaina
+- プッシュ通知にクリックやactionを設定 #7667 @tamaina
+- ドライブに画像ファイルをアップロードするときオリジナル画像を破棄してwebpublicのみ保持するオプション @tamaina
 - Server: always remove completed tasks of job queue @Johann150
 - Client: アバターの設定で画像をクロップできるように @syuilo
 - Client: make emoji stand out more on reaction button @Johann150
 - Client: display URL of QR code for TOTP registration @tamaina
 - Client: render quote renote CWs as MFM @pixeldesu
-- API: notifications/read は配列でも受け付けるように #7667 @tamaina
-- API: ユーザー検索で、クエリが username の条件を満たす場合は username も LIKE 検索するように @tamaina
+- API: notifications/readは配列でも受け付けるように #7667 @tamaina
+- API: ユーザー検索で、クエリがusernameの条件を満たす場合はusernameもLIKE検索するように @tamaina
 - MFM: Allow speed changes in all animated MFMs @Johann150
 - The theme color is now better validated. @Johann150
   Your own theme color may be unset if it was in an invalid format.
@@ -1205,7 +1060,6 @@ same as 12.112.0
   Admins should make sure the reverse proxy sets the `X-Forwarded-For` header to the original address.
 
 ### Bugfixes
-
 - Server: keep file order of note attachement @Johann150
 - Server: fix missing foreign key for reports leading to reports page being unusable @Johann150
 - Server: fix internal in-memory caching @Johann150
@@ -1233,42 +1087,36 @@ same as 12.112.0
 ## 12.110.1 (2022/04/23)
 
 ### Bugfixes
-
 - Fix GOP rendering @syuilo
 - Improve performance of antenna, clip, and list @xianonn
 
 ## 12.110.0 (2022/04/11)
 
 ### Improvements
-
 - Improve webhook @syuilo
 - Client: Show loading icon on splash screen @syuilo
 
 ### Bugfixes
-
 - API: parameter validation of users/show was wrong
 - Federation: リモートインスタンスへのダイレクト投稿が届かない問題を修正 @syuilo
 
 ## 12.109.2 (2022/04/03)
 
 ### Bugfixes
-
 - API: admin/update-meta was not working @syuilo
-- Client: テーマを切り替えたり読み込んだりすると meta[name="theme-color"]の content が undefined になる問題を修正 @tamaina
+- Client: テーマを切り替えたり読み込んだりするとmeta[name="theme-color"]のcontentがundefinedになる問題を修正 @tamaina
 
 ## 12.109.1 (2022/04/02)
 
 ### Bugfixes
-
-- API: Renote が行えない問題を修正
+- API: Renoteが行えない問題を修正
 
 ## 12.109.0 (2022/04/02)
 
 ### Improvements
-
 - Webhooks @syuilo
-- Bull Dashboard を組み込み、ジョブキューの確認や操作を行えるように @syuilo
-  - Bull Dashboard を開くには、最初だけ一旦ログアウトしてから再度管理者権限を持つアカウントでログインする必要があります
+- Bull Dashboardを組み込み、ジョブキューの確認や操作を行えるように @syuilo
+  - Bull Dashboardを開くには、最初だけ一旦ログアウトしてから再度管理者権限を持つアカウントでログインする必要があります
 - Check that installed Node.js version fulfills version requirement @ThatOneCalculator
 - Server: overall performance improvements @syuilo
 - Federation: avoid duplicate activity delivery @Johann150
@@ -1276,68 +1124,60 @@ same as 12.112.0
 - Client: タッチパッド・タッチスクリーンでのデッキの操作性を向上 @tamaina
 
 ### Bugfixes
-
 - email address validation was not working @ybw2016v
 - API: fix endpoint endpoint @Johann150
 - API: fix admin/meta endpoint @syuilo
 - API: improved validation and documentation for endpoints that accept different variants of input @Johann150
 - API: `notes/create`: The `mediaIds` property is now deprecated. @Johann150
   - Use `fileIds` instead, it has the same behaviour.
-- Client: URI エンコーディングが異常で decodeURIComponent が失敗すると URL が表示できなくなる問題を修正 @tamaina
+- Client: URIエンコーディングが異常でdecodeURIComponentが失敗するとURLが表示できなくなる問題を修正 @tamaina
 
 ## 12.108.1 (2022/03/12)
 
 ### Bugfixes
-
 - リレーが動作しない問題を修正 @xianonn
-- ulid を使用していると動作しない問題を修正 @syuilo
-- 外部から OGP が正しく取得できない問題を修正 @syuilo
+- ulidを使用していると動作しない問題を修正 @syuilo
+- 外部からOGPが正しく取得できない問題を修正 @syuilo
 - instance can not get the files from other instance when there are items in allowedPrivateNetworks in .config/default.yml @ybw2016v
 
 ## 12.108.0 (2022/03/09)
 
 ### NOTE
-
-このバージョンから Node v16.14.0 以降が必要です
+このバージョンからNode v16.14.0以降が必要です
 
 ### Changes
-
-- ノートの最大文字数を設定できる機能が廃止され、デフォルトで一律 3000 文字になりました @syuilo
+- ノートの最大文字数を設定できる機能が廃止され、デフォルトで一律3000文字になりました @syuilo
 - Misskey can no longer terminate HTTPS connections. @Johann150
   - If you did not use a reverse proxy (e.g. nginx) before, you will probably need to adjust
     your configuration file and set up a reverse proxy. The `https` configuration key is no
     longer recognized!
 
 ### Improvements
-
 - インスタンスデフォルトテーマを設定できるように @syuilo
 - ミュートに期限を設定できるように @syuilo
 - アンケートが終了したときに通知が作成されるように @syuilo
-- プロフィールの追加情報を最大 16 まで保存できるように @syuilo
-- 連合チャートに Pub&Sub を追加 @syuilo
-- 連合チャートに Active を追加 @syuilo
-- デフォルトで 10 秒以上時間がかかるデータベースへのクエリは中断されるように @syuilo
-  - 設定ファイルの`db.extra`に`statement_timeout`を設定することでタイムアウト時間を変更できます
+- プロフィールの追加情報を最大16まで保存できるように @syuilo
+- 連合チャートにPub&Subを追加 @syuilo
+- 連合チャートにActiveを追加 @syuilo
+- デフォルトで10秒以上時間がかかるデータベースへのクエリは中断されるように @syuilo
+	- 設定ファイルの`db.extra`に`statement_timeout`を設定することでタイムアウト時間を変更できます
 - Client: スプラッシュスクリーンにインスタンスのアイコンを表示するように @syuilo
 
 ### Bugfixes
-
 - Client: リアクションピッカーの高さが低くなったまま戻らないことがあるのを修正 @syuilo
 - Client: ユーザー名オートコンプリートが正しく動作しない問題を修正 @syuilo
 - Client: タッチ操作だとウィジェットの編集がしにくいのを修正 @xianonn
 - Client: register_note_view_interruptor()が動かないのを修正 @syuilo
-- Client: iPhone X 以降(?)でページの内容が全て表示しきれないのを修正 @tamaina
+- Client: iPhone X以降(?)でページの内容が全て表示しきれないのを修正 @tamaina
 - Client: fix image caption on mobile @nullobsi
 
 ## 12.107.0 (2022/02/12)
 
 ### Improvements
-
 - クライアント: テーマを追加 @syuilo
 
 ### Bugfixes
-
-- API: stats API で内部エラーが発生する問題を修正 @syuilo
+- API: stats APIで内部エラーが発生する問題を修正 @syuilo
 - クライアント: ソフトミュートですべてがマッチしてしまう場合があるのを修正 @tamaina
 - クライアント: デバイスのスクリーンのセーフエリアを考慮するように @syuilo
 - クライアント: 一部環境でサイドバーの投稿ボタンが表示されない問題を修正 @syuilo
@@ -1345,17 +1185,14 @@ same as 12.112.0
 ## 12.106.3 (2022/02/11)
 
 ### Improvements
-
 - クライアント: スマートフォンでの余白を調整 @syuilo
 
 ### Bugfixes
-
 - クライアント: ノートの詳細が表示されない問題を修正 @syuilo
 
 ## 12.106.2 (2022/02/11)
 
 ### Bugfixes
-
 - クライアント: 削除したノートがタイムラインから自動で消えない問題を修正 @syuilo
 - クライアント: リアクション数が正しくないことがある問題を修正 @syuilo
 - 一部環境でマイグレーションが動作しない問題を修正 @syuilo
@@ -1363,13 +1200,11 @@ same as 12.112.0
 ## 12.106.1 (2022/02/11)
 
 ### Bugfixes
-
 - クライアント: ワードミュートが保存できない問題を修正 @syuilo
 
 ## 12.106.0 (2022/02/11)
 
 ### Improvements
-
 - Improve federation chart @syuilo
 - クライアント: リアクションピッカーのサイズを設定できるように @syuilo
 - クライアント: リアクションピッカーの幅、高さ制限を緩和 @syuilo
@@ -1377,47 +1212,41 @@ same as 12.112.0
 - Update dependencies
 
 ### Bugfixes
-
 - validate regular expressions in word mutes @Johann150
 
 ## 12.105.0 (2022/02/09)
 
 ### Improvements
-
 - インスタンスのテーマカラーを設定できるように @syuilo
 
 ### Bugfixes
-
 - 一部環境でマイグレーションが失敗する問題を修正 @syuilo
 
 ## 12.104.0 (2022/02/09)
 
 ### Note
-
 ビルドする前に`yarn clean`を実行してください。
 
 このリリースはマイグレーションの規模が大きいため、インスタンスによってはマイグレーションに時間がかかる可能性があります。
 マイグレーションが終わらない場合は、チャートの情報はリセットされてしまいますが`__chart__`で始まるテーブルの**レコード**を全て削除(テーブル自体は消さないでください)してから再度試す方法もあります。
 
 ### Improvements
-
 - チャートエンジンの強化 @syuilo
-  - テーブルサイズの削減
-  - notes/instance/perUserNotes チャートに添付ファイル付きノートの数を追加
-  - activeUsers チャートに新しい項目を追加
-  - federation チャートに新しい項目を追加
-  - apRequest チャートを追加
-  - network チャート廃止
+	- テーブルサイズの削減
+	- notes/instance/perUserNotesチャートに添付ファイル付きノートの数を追加
+	- activeUsersチャートに新しい項目を追加
+	- federationチャートに新しい項目を追加
+	- apRequestチャートを追加
+	- networkチャート廃止
 - クライアント: 自インスタンス情報ページでチャートを見れるように @syuilo
 - クライアント: デバイスの種類を手動指定できるように @syuilo
-- クライアント: UI のアイコンを更新 @syuilo
-- クライアント: UI のアイコンをセルフホスティングするように @syuilo
+- クライアント: UIのアイコンを更新 @syuilo
+- クライアント: UIのアイコンをセルフホスティングするように @syuilo
 - NodeInfo のユーザー数と投稿数の内容を見直す @xianonn
 
 ### Bugfixes
-
 - Client: タイムライン種別を切り替えると「新しいノートがあります」の表示が残留してしまうのを修正 @tamaina
-- Client: UI のサイズがおかしくなる問題の修正 @tamaina
+- Client: UIのサイズがおかしくなる問題の修正 @tamaina
 - Client: Setting instance information of notes to always show breaks the timeline @Johann150
 - Client: 環境に依っては返信する際のカーソル位置が正しくない問題を修正 @syuilo
 - Client: コントロールパネルのユーザー、ファイルにて、インスタンスの表示範囲切り替えが機能しない問題を修正 @syuilo
@@ -1425,28 +1254,25 @@ same as 12.112.0
 - Client: Follows/Followers Visibility changes won't be saved unless clicking on an other checkbox @Johann150
 - API: Fix API cast @mei23
 - add instance favicon where it's missing @solfisher
-- チャートの定期 resync が動作していない問題を修正 @syuilo
+- チャートの定期resyncが動作していない問題を修正 @syuilo
 
 ## 12.103.1 (2022/02/02)
 
 ### Bugfixes
-
 - クライアント: ツールチップの表示位置が正しくない問題を修正
 
 ## 12.103.0 (2022/02/02)
 
 ### Improvements
-
 - クライアント: 連合インスタンスページからインスタンス情報再取得を行えるように
 
 ### Bugfixes
-
-- クライアント: 投稿の NSFW 画像を表示したあとにリアクションが更新されると画像が非表示になる問題を修正
+- クライアント: 投稿のNSFW画像を表示したあとにリアクションが更新されると画像が非表示になる問題を修正
 - クライアント: 「クリップ」ページが開かない問題を修正
 - クライアント: トレンドウィジェットが動作しないのを修正
 - クライアント: フェデレーションウィジェットが動作しないのを修正
 - クライアント: リアクション設定で絵文字ピッカーが開かないのを修正
-- クライアント: DM ページでメンションが含まれる問題を修正
+- クライアント: DMページでメンションが含まれる問題を修正
 - クライアント: 投稿フォームのハッシュタグ保持フィールドが動作しない問題を修正
 - クライアント: サイドビューが動かないのを修正
 - クライアント: ensure that specified users does not get duplicates
@@ -1454,30 +1280,25 @@ same as 12.112.0
   files and media proxy
 
 ## 12.102.1 (2022/01/27)
-
 ### Bugfixes
-
 - チャットが表示できない問題を修正
 
 ## 12.102.0 (2022/01/27)
 
 ### NOTE
-
 アップデート後、一部カスタム絵文字が表示できなくなる場合があります。その場合、一旦絵文字管理ページから絵文字を一括エクスポートし、再度コントロールパネルから一括インポートすると直ります。
-⚠ 12.102.0 以前にエクスポートされた zip とは互換性がありません。アップデートしてからエクスポートを行なってください。
+⚠ 12.102.0以前にエクスポートされたzipとは互換性がありません。アップデートしてからエクスポートを行なってください。
 
 ### Changes
-
-- Room 機能が削除されました
+- Room機能が削除されました
   - 後日別リポジトリとして復活予定です
 - リバーシ機能が削除されました
   - 後日別リポジトリとして復活予定です
-- Chat UI が削除されました
-- ノートに添付できるファイルの数が 16 に増えました
-- カスタム絵文字に SVG を指定した場合、PNG に変換されて表示されるようになりました
+- Chat UIが削除されました
+- ノートに添付できるファイルの数が16に増えました
+- カスタム絵文字にSVGを指定した場合、PNGに変換されて表示されるようになりました
 
 ### Improvements
-
 - カスタム絵文字一括編集機能
 - カスタム絵文字一括インポート
 - 投稿フォームで一時的に投稿するアカウントを切り替えられるように
@@ -1486,58 +1307,48 @@ same as 12.112.0
 - セキュリティの向上
 
 ### Bugfixes
-
 - アップロードエラー時の処理を修正
 
 ## 12.101.1 (2021/12/29)
 
 ### Bugfixes
-
-- SVG 絵文字が表示できないのを修正
-- エクスポートした絵文字の拡張子が false になることがあるのを修正
+- SVG絵文字が表示できないのを修正
+- エクスポートした絵文字の拡張子がfalseになることがあるのを修正
 
 ## 12.101.0 (2021/12/29)
 
 ### Improvements
-
 - クライアント: ノートプレビューの精度を改善
-- クライアント: MFM sparkle エフェクトの改善
+- クライアント: MFM sparkleエフェクトの改善
 - クライアント: デザインの調整
 - セキュリティの向上
 
 ### Bugfixes
-
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 - fix html blockquote conversion
 
 ## 12.100.2 (2021/12/18)
 
 ### Bugfixes
-
-- クライアント: Deck カラムの増減がページをリロードするまで正しく反映されない問題を修正
+- クライアント: Deckカラムの増減がページをリロードするまで正しく反映されない問題を修正
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 - クライアント: カスタム絵文字一覧ページの負荷が高いのを修正
 
 ## 12.100.1 (2021/12/17)
 
 ### Bugfixes
-
 - クライアント: デザインの調整
 
 ## 12.100.0 (2021/12/17)
 
 ### Improvements
-
 - クライアント: モバイルでの各種メニュー、リアクションピッカーの表示を改善
 
 ### Bugfixes
-
 - クライアント: 一部のコンポーネントが裏に隠れるのを修正
 
 ## 12.99.3 (2021/12/14)
-
 ### Bugfixes
-
 - クライアント: オートコンプリートがダイアログの裏に隠れる問題を修正
 
 ## 12.99.2 (2021/12/14)
@@ -1547,7 +1358,6 @@ same as 12.112.0
 ## 12.99.0 (2021/12/14)
 
 ### Improvements
-
 - Added a user-level instance mute in user settings
 - フォローエクスポートでミュートしているユーザーを含めないオプションを追加
 - フォローエクスポートで使われていないアカウントを含めないオプションを追加
@@ -1556,7 +1366,6 @@ same as 12.112.0
 - グループから抜けられるように
 
 ### Bugfixes
-
 - クライアント: タッチ機能付きディスプレイを使っていてマウス操作をしている場合に一部機能が動作しない問題を修正
 - クライアント: クリップの設定を編集できない問題を修正
 - クライアント: メニューなどがウィンドウの裏に隠れる問題を修正
@@ -1564,19 +1373,17 @@ same as 12.112.0
 ## 12.98.0 (2021/12/03)
 
 ### Improvements
-
 - API: /antennas/notes API で日付による絞り込みができるように
 - クライアント: アンケートに投票する際に確認ダイアログを出すように
-- クライアント: Renote なノート詳細ページから元のノートページに遷移できるように
+- クライアント: Renoteなノート詳細ページから元のノートページに遷移できるように
 - クライアント: 画像ポップアップでクリックで閉じられるように
 - クライアント: デザインの調整
 - フォロワーを解除できる機能
 
 ### Bugfixes
-
-- クライアント: LTL や GTL が無効になっている場合でも UI 上にタブが表示される問題を修正
+- クライアント: LTLやGTLが無効になっている場合でもUI上にタブが表示される問題を修正
 - クライアント: ログインにおいてパスワードが誤っている際のエラーメッセージが正しく表示されない問題を修正
-- クライアント: リアクションツールチップ、Renote ツールチップのユーザーの並び順を修正
+- クライアント: リアクションツールチップ、Renoteツールチップのユーザーの並び順を修正
 - クライアント: サウンドのマスターボリュームが正しく保存されない問題を修正
 - クライアント: 一部環境において通知が表示されると操作不能になる問題を修正
 - クライアント: モバイルでタップしたときにツールチップが表示される問題を修正
@@ -1585,43 +1392,36 @@ same as 12.112.0
 - API: ユーザーを取得時に条件によっては内部エラーになる問題を修正
 
 ### Changes
-
 - クライアント: ノートにモデレーターバッジを表示するのを廃止
 
 ## 12.97.0 (2021/11/19)
 
 ### Improvements
-
-- クライアント: 返信先や Renote に対しても自動折りたたみされるように
+- クライアント: 返信先やRenoteに対しても自動折りたたみされるように
 - クライアント: 長いスレッドの表示を改善
-- クライアント: 翻訳にも MFM を適用し、元の文章の改行などを保持するように
+- クライアント: 翻訳にもMFMを適用し、元の文章の改行などを保持するように
 - クライアント: アカウント削除に確認ダイアログを出すように
 
 ### Bugfixes
-
 - クライアント: ユーザー検索の「全て」が動作しない問題を修正
-- クライアント: リアクション一覧、Renote 一覧ツールチップのスタイルを修正
+- クライアント: リアクション一覧、Renote一覧ツールチップのスタイルを修正
 
 ## 12.96.1 (2021/11/13)
-
 ### Improvements
-
-- npm script の互換性を向上
+- npm scriptの互換性を向上
 
 ## 12.96.0 (2021/11/13)
 
 ### Improvements
-
 - フォロー/フォロワーを非公開にできるように
 - インスタンスプロフィールレンダリング ready
 - 通知のリアクションアイコンをホバーで拡大できるように
-- Renote ボタンをホバーで Renote したユーザー一覧を表示するように
+- RenoteボタンをホバーでRenoteしたユーザー一覧を表示するように
 - 返信の際にメンションを含めるように
-- 通報があったときに管理者へ E メールで通知されるように
+- 通報があったときに管理者へEメールで通知されるように
 - メールアドレスのバリデーションを強化
 
 ### Bugfixes
-
 - アカウント削除処理があると高負荷になる問題を修正
 - クライアント: 長いメニューが画面からはみ出す問題を修正
 - クライアント: コントロールパネルのジョブキューに個々のジョブが表示されないのを修正
@@ -1629,18 +1429,15 @@ same as 12.112.0
 - fix html conversion issue with code blocks
 
 ### Changes
-
 - ノートにモバイルからの投稿か否かの情報を含めないように
 
 ## 12.95.0 (2021/10/31)
 
 ### Improvements
-
 - スレッドミュート機能
 
 ### Bugfixes
-
-- リレー向けの Activity が一部実装で除外されてしまうことがあるのを修正
+- リレー向けのActivityが一部実装で除外されてしまうことがあるのを修正
 - 削除したノートやユーザーがリモートから参照されると復活することがあるのを修正
 - クライアント: ページ編集時のドロップダウンメニューなどが動作しない問題を修正
 - クライアント: コントロールパネルのカスタム絵文字タブが切り替わらないように見える問題を修正
@@ -1651,45 +1448,38 @@ same as 12.112.0
 ### Improvements
 
 ### Bugfixes
-
 - クライアント: ユーザーページのナビゲーションが失敗する問題を修正
 
 ## 12.94.0 (2021/10/25)
 
 ### Improvements
-
 - クライアント: 画像ビューアを強化
 - クライアント: メンションにユーザーのアバターを表示するように
 - クライアント: デザインの調整
-- クライアント: twemoji をセルフホスティングするように
+- クライアント: twemojiをセルフホスティングするように
 
 ### Bugfixes
-
-- クライアント: CW で画像が隠されたとき、画像の高さがおかしいことになる問題を修正
+- クライアント: CWで画像が隠されたとき、画像の高さがおかしいことになる問題を修正
 
 ### NOTE
-
-- このバージョンから、iOS 15 未満のサポートがされなくなります。対象のバージョンをお使いの方は、iOS のバージョンアップを行ってください。
+- このバージョンから、iOS 15未満のサポートがされなくなります。対象のバージョンをお使いの方は、iOSのバージョンアップを行ってください。
 
 ## 12.93.2 (2021/10/23)
 
 ### Bugfixes
-
 - クライアント: ウィジェットを追加できない問題を修正
 
 ## 12.93.1 (2021/10/23)
 
 ### Bugfixes
-
 - クライアント: 通知上でローカルのリアクションが表示されないのを修正
 
 ## 12.93.0 (2021/10/23)
 
 ### Improvements
-
 - クライアント: コントロールパネルのパフォーマンスを改善
 - クライアント: 自分のリアクション一覧を見れるように
-  - 設定により、リアクション一覧を全員に公開することも可能
+	- 設定により、リアクション一覧を全員に公開することも可能
 - クライアント: ユーザー検索の精度を強化
 - クライアント: 新しいライトテーマを追加
 - クライアント: 新しいダークテーマを追加
@@ -1697,200 +1487,178 @@ same as 12.112.0
 - API: users/search および users/search-by-username-and-host を強化
 - ミュート及びブロックのインポートを行えるように
 - クライアント: /share のクエリでリプライやファイル等の情報を渡せるように
-- チャートの sync を毎日 0 時に自動で行うように
+- チャートのsyncを毎日0時に自動で行うように
 
 ### Bugfixes
-
 - クライアント: テーマの管理が行えない問題を修正
 - API: アプリケーション通知が取得できない問題を修正
 - クライアント: リモートノートで意図せずローカルカスタム絵文字が使われてしまうことがあるのを修正
-- ActivityPub: not reacted な Undo.Like が inbox に滞留するのを修正
+- ActivityPub: not reacted な Undo.Like がinboxに滞留するのを修正
 
 ### Changes
-
 - 連合の考慮に問題があることなどが分かったため、モデレーターをブロックできない仕様を廃止しました
 - データベースにログを保存しないようになりました
-  - ログを永続化したい場合は syslog を利用してください
+	- ログを永続化したい場合はsyslogを利用してください
 
 ## 12.92.0 (2021/10/16)
 
 ### Improvements
-
 - アカウント登録にメールアドレスの設定を必須にするオプション
-- クライアント: 全体的な UI のブラッシュアップ
-- クライアント: MFM 関数構文のサジェストを実装
+- クライアント: 全体的なUIのブラッシュアップ
+- クライアント: MFM関数構文のサジェストを実装
 - クライアント: ノート本文を投稿フォーム内でプレビューできるように
 - クライアント: 未読の通知のみ表示する機能
 - クライアント: 通知ページで通知の種類によるフィルタ
 - クライアント: アニメーションを減らす設定の適用範囲を拡充
 - クライアント: 新しいダークテーマを追加
 - クライアント: テーマコンパイラに hue と saturate 関数を追加
-- ActivityPub: HTML -> MFM の変換を強化
+- ActivityPub: HTML -> MFMの変換を強化
 - API: グループから抜ける users/groups/leave エンドポイントを実装
 - API: i/notifications に unreadOnly オプションを追加
-- API: ap 系のエンドポイントをログイン必須化+レートリミット追加
+- API: ap系のエンドポイントをログイン必須化+レートリミット追加
 - MFM: Add tag syntaxes of bold <b></b> and strikethrough <s></s>
 
 ### Bugfixes
-
 - Fix createDeleteAccountJob
 - admin inbox queue does not show individual jobs
 - クライアント: ヘッダーのタブが折り返される問題を修正
 - クライアント: ヘッダーにタブが表示されている状態でタイトルをクリックしたときにタブ選択が表示されるのを修正
 - クライアント: ユーザーページのタブが機能していない問題を修正
 - クライアント: ピン留めユーザーの設定項目がない問題を修正
-- クライアント: Deck UI において、重ねたカラムの片方を畳んだ状態で右に出すと表示が壊れる問題を修正
+- クライアント: Deck UIにおいて、重ねたカラムの片方を畳んだ状態で右に出すと表示が壊れる問題を修正
 - API: 管理者およびモデレーターをブロックできてしまう問題を修正
 - MFM: Mentions in the link label are parsed as text
 - MFM: Add a property to the URL node indicating whether it was enclosed in <>
 - MFM: Disallows < and > in hashtags
 
 ### Changes
-
-- 保守性やユーザビリティの観点から、Misskey のコマンドラインオプションが削除されました。
-  - 必要であれば、代わりに環境変数で設定することができます
+- 保守性やユーザビリティの観点から、Misskeyのコマンドラインオプションが削除されました。
+	- 必要であれば、代わりに環境変数で設定することができます
 - MFM: パフォーマンス、保守性、構文誤認識抑制の観点から、旧関数構文のサポートが削除されました。
-  - 旧構文(`[foo bar]`)を使用せず、現行の構文(`$[foo bar]`)を使用してください。
+	- 旧構文(`[foo bar]`)を使用せず、現行の構文(`$[foo bar]`)を使用してください。
 
 ## 12.91.0 (2021/09/22)
 
 ### Improvements
-
-- ActivityPub: リモートユーザーの Delete アクティビティに対応
+- ActivityPub: リモートユーザーのDeleteアクティビティに対応
 - ActivityPub: add resolver check for blocked instance
-- ActivityPub: deliver キューのメモリ使用量を削減
-- API: 管理者用アカウント削除 API を実装(/admin/accounts/delete)
-  - リモートユーザーの削除も可能に
+- ActivityPub: deliverキューのメモリ使用量を削減
+- API: 管理者用アカウント削除APIを実装(/admin/accounts/delete)
+	- リモートユーザーの削除も可能に
 - アカウントが凍結された場合に、凍結された旨を表示してからログアウトするように
 - 凍結されたアカウントにログインしようとしたときに、凍結されている旨を表示するように
 - リスト、アンテナタイムラインを個別ページとして分割
-- UI の改善
-- MFM に sparkles エフェクトを追加
+- UIの改善
+- MFMにsparklesエフェクトを追加
 - 非ログイン自は更新ダイアログを出さないように
 - クライアント起動時、アップデートが利用可能な場合エラー表示およびダイアログ表示しないように
 
 ### Bugfixes
-
 - アカウントデータのエクスポート/インポート処理ができない問題を修正
 - アンテナの既読が付かない問題を修正
-- popup で設定ページを表示すると、アカウントの削除ページにアクセスすることができない問題を修正
-- "問題が発生しました"ウィンドウを開くと ☓ ボタンがなくて閉じれない問題を修正
+- popupで設定ページを表示すると、アカウントの削除ページにアクセスすることができない問題を修正
+- "問題が発生しました"ウィンドウを開くと☓ボタンがなくて閉じれない問題を修正
 
 ## 12.90.1 (2021/09/05)
 
 ### Bugfixes
-
-- Dockerfile を修正
+- Dockerfileを修正
 - ノート翻訳時に公開範囲が考慮されていない問題を修正
 
 ## 12.90.0 (2021/09/04)
 
 ### Improvements
-
 - 藍モード、および藍ウィジェット
-  - クライアントに藍ちゃんを召喚することができるようになりました。
-- URL からのアップロード, AP の添付ファイル, 外部ファイルのプロキシ等では、Private アドレス等へのリクエストは拒否されるようになりました。
-  - development で動作している場合は、この制限は適用されません。
-  - Proxy 使用時には、この制限は適用されません。
-    Proxy 使用時に同等の制限を行いたい場合は、Proxy 側で設定を行う必要があります。
-  - `default.yml`にて`allowedPrivateNetworks`に CIDR を追加することにより、宛先ネットワークを指定してこの制限から除外することが出来ます。
-- アップロード, ダウンロード出来るファイルサイズにハードリミットが適用されるようになりました。(約 250MB)
-  - `default.yml`にて`maxFileSize`を変更することにより、制限値を変更することが出来ます。
+	- クライアントに藍ちゃんを召喚することができるようになりました。
+- URLからのアップロード, APの添付ファイル, 外部ファイルのプロキシ等では、Privateアドレス等へのリクエストは拒否されるようになりました。
+	- developmentで動作している場合は、この制限は適用されません。
+	- Proxy使用時には、この制限は適用されません。
+		Proxy使用時に同等の制限を行いたい場合は、Proxy側で設定を行う必要があります。
+	- `default.yml`にて`allowedPrivateNetworks`にCIDRを追加することにより、宛先ネットワークを指定してこの制限から除外することが出来ます。
+- アップロード, ダウンロード出来るファイルサイズにハードリミットが適用されるようになりました。(約250MB)
+	- `default.yml`にて`maxFileSize`を変更することにより、制限値を変更することが出来ます。
 
 ### Bugfixes
-
 - 管理者が最初にサインアップするページでログインされないのを修正
-- CW を維持する設定を復活
+- CWを維持する設定を復活
 - クライアントの表示を修正
 
 ## 12.89.2 (2021/08/24)
 
 ### Bugfixes
-
-- カスタム CSS を有効にしているとエラーになる問題を修正
+- カスタムCSSを有効にしているとエラーになる問題を修正
 
 ## 12.89.1 (2021/08/24)
 
 ### Improvements
-
 - クライアントのデザインの調整
 
 ### Bugfixes
-
-- 翻訳で DeepL の Pro アカウントに対応していない問題を修正
-- インスタンス設定で DeepL の Auth Key が空で表示される問題を修正
+- 翻訳でDeepLのProアカウントに対応していない問題を修正
+- インスタンス設定でDeepLのAuth Keyが空で表示される問題を修正
 - セキュリティの向上
 
 ## 12.89.0 (2021/08/21)
 
 ### Improvements
-
 - アカウント削除の安定性を向上
 - 絵文字オートコンプリートの挙動を改修
-- localStorage の accounts は indexedDB で保持するように
+- localStorageのaccountsはindexedDBで保持するように
 - ActivityPub: ジョブキューの試行タイミングを調整 (#7635)
-- API: sw/unregister を追加
+- API: sw/unregisterを追加
 - ワードミュートのドキュメントを追加
 - クライアントのデザインの調整
 - 依存関係の更新
 
 ### Bugfixes
-
 - チャンネルを作成しているとアカウントを削除できないのを修正
 - ノートの「削除して編集」をするとアンケートの選択肢が[object Object]になる問題を修正
 
 ## 12.88.0 (2021/08/17)
 
 ### Features
-
 - ノートの翻訳機能を追加
-  - 有効にするには、サーバー管理者が DeepL の無料アカウントを登録し、取得した認証キーを「インスタンス設定 > その他 > DeepL Auth Key」に設定する必要があります。
-- Misskey 更新時にダイアログを表示するように
+  - 有効にするには、サーバー管理者がDeepLの無料アカウントを登録し、取得した認証キーを「インスタンス設定 > その他 > DeepL Auth Key」に設定する必要があります。
+- Misskey更新時にダイアログを表示するように
 - ジョブキューウィジェットに警報音を鳴らす設定を追加
 
 ### Improvements
-
 - ブロックの挙動を改修
-  - ブロックされたユーザーがブロックしたユーザーに対してアクション出来ないようになりました。詳細はドキュメントをご確認ください。
-- UI デザインの調整
+	- ブロックされたユーザーがブロックしたユーザーに対してアクション出来ないようになりました。詳細はドキュメントをご確認ください。
+- UIデザインの調整
 - データベースのインデックスを最適化
-- Proxy 使用時に Keep-Alive をサポート
-- DNS キャッシュでネガティブキャッシュをサポート
+- Proxy使用時にKeep-Aliveをサポート
+- DNSキャッシュでネガティブキャッシュをサポート
 - 依存関係の更新
 
 ### Bugfixes
-
 - タッチ操作でウィンドウを閉じることができない問題を修正
-- Renote された時刻が投稿された時刻のように表示される問題を修正
+- Renoteされた時刻が投稿された時刻のように表示される問題を修正
 - コントロールパネルでファイルを削除した際の表示を修正
 - ActivityPub: 長いユーザーの名前や自己紹介の対応
 
 ## 12.87.0 (2021/08/12)
 
 ### Improvements
-
 - 絵文字オートコンプリートで一文字目は最近使った絵文字をサジェストするように
 - 絵文字オートコンプリートのパフォーマンスを改善
-- about-misskey ページにドキュメントへのリンクを追加
-- Docker: Node.js を 16.6.2 に
+- about-misskeyページにドキュメントへのリンクを追加
+- Docker: Node.jsを16.6.2に
 - 依存関係の更新
 - 翻訳の更新
 
 ### Bugfixes
-
-- Misskey 更新時、テーマキャッシュの影響でスタイルがおかしくなる問題を修正
+- Misskey更新時、テーマキャッシュの影響でスタイルがおかしくなる問題を修正
 
 ## 12.86.0 (2021/08/11)
 
 ### Improvements
-
 - ドキュメントの更新
-  - ドキュメントに changelog を追加
+	- ドキュメントにchangelogを追加
 - ぼかし効果のオプションを追加
-- Vue を 3.2.1 に更新
-- UI の調整
+- Vueを3.2.1に更新
+- UIの調整
 
 ### Bugfixes
-
 - ハッシュタグ入力が空のときに#が付くのを修正
-- フォローリクエストの E メール通知を修正
+- フォローリクエストのEメール通知を修正

--- a/packages/frontend/src/components/MkFollowButton.vue
+++ b/packages/frontend/src/components/MkFollowButton.vue
@@ -131,8 +131,7 @@ onBeforeUnmount(() => {
 	position: relative;
 	display: inline-block;
 	font-weight: bold;
-	color: var(--accent);
-	background: transparent;
+	color: var(--fgOnWhite);
 	border: solid 1px var(--accent);
 	padding: 0;
 	height: 31px;

--- a/packages/frontend/src/themes/_dark.json5
+++ b/packages/frontend/src/themes/_dark.json5
@@ -21,6 +21,7 @@
 		fgTransparent: ':alpha<0.5<@fg',
 		fgHighlighted: ':lighten<3<@fg',
 		fgOnAccent: '#fff',
+		fgOnWhite: '#333',
 		divider: 'rgba(255, 255, 255, 0.1)',
 		indicator: '@accent',
 		panel: ':lighten<3<@bg',

--- a/packages/frontend/src/themes/_light.json5
+++ b/packages/frontend/src/themes/_light.json5
@@ -21,6 +21,7 @@
 		fgTransparent: ':alpha<0.5<@fg',
 		fgHighlighted: ':darken<3<@fg',
 		fgOnAccent: '#fff',
+		fgOnWhite: '#333',
 		divider: 'rgba(0, 0, 0, 0.1)',
 		indicator: '@accent',
 		panel: ':lighten<3<@bg',

--- a/packages/frontend/src/themes/d-astro.json5
+++ b/packages/frontend/src/themes/d-astro.json5
@@ -53,6 +53,7 @@
 		panelHeaderBg: ':lighten<3<@panel',
 		panelHeaderFg: '@fg',
 		htmlThemeColor: '@bg',
+		fgOnWhite: '@accent',
 		panelHighlight: ':lighten<3<@panel',
 		listItemHoverBg: 'rgba(255, 255, 255, 0.03)',
 		scrollbarHandle: 'rgba(255, 255, 255, 0.2)',

--- a/packages/frontend/src/themes/d-botanical.json5
+++ b/packages/frontend/src/themes/d-botanical.json5
@@ -11,6 +11,7 @@
 		bg: 'rgb(37, 38, 36)',
 		fg: 'rgb(216, 212, 199)',
 		fgHighlighted: '#fff',
+		fgOnWhite: '@accent',
 		divider: 'rgba(255, 255, 255, 0.14)',
 		panel: 'rgb(47, 47, 44)',
 		panelHeaderDivider: 'rgba(0, 0, 0, 0)',

--- a/packages/frontend/src/themes/d-cherry.json5
+++ b/packages/frontend/src/themes/d-cherry.json5
@@ -10,6 +10,7 @@
 		accent: 'rgb(255, 89, 117)',
 		bg: 'rgb(28, 28, 37)',
 		fg: 'rgb(236, 239, 244)',
+		fgOnWhite: '@accent',
 		panel: 'rgb(35, 35, 47)',
 		renote: '@accent',
 		link: '@accent',

--- a/packages/frontend/src/themes/d-dark.json5
+++ b/packages/frontend/src/themes/d-dark.json5
@@ -11,6 +11,7 @@
 		bg: '#232323',
 		fg: 'rgb(199, 209, 216)',
 		fgHighlighted: '#fff',
+		fgOnWhite: '@accent',
 		divider: 'rgba(255, 255, 255, 0.14)',
 		panel: '#2d2d2d',
 		panelHeaderDivider: 'rgba(0, 0, 0, 0)',

--- a/packages/frontend/src/themes/d-future.json5
+++ b/packages/frontend/src/themes/d-future.json5
@@ -12,6 +12,7 @@
 		fg: '#D5D5D6',
 		fgHighlighted: '#fff',
 		fgOnAccent: '#000',
+		fgOnWhite: '@accent',
 		divider: 'rgba(255, 255, 255, 0.1)',
 		panel: '#18181c',
 		panelHeaderDivider: 'rgba(0, 0, 0, 0)',

--- a/packages/frontend/src/themes/d-green-lime.json5
+++ b/packages/frontend/src/themes/d-green-lime.json5
@@ -12,6 +12,7 @@
 		fg: '#dee7e4',
 		fgHighlighted: '#fff',
 		fgOnAccent: '#192320',
+		fgOnWhite: '@accent',
 		divider: '#e7fffb24',
 		panel: '#192320',
 		panelHeaderDivider: 'rgba(0, 0, 0, 0)',

--- a/packages/frontend/src/themes/d-green-orange.json5
+++ b/packages/frontend/src/themes/d-green-orange.json5
@@ -12,6 +12,7 @@
 		fg: '#dee7e4',
 		fgHighlighted: '#fff',
 		fgOnAccent: '#192320',
+		fgOnWhite: '@accent',
 		divider: '#e7fffb24',
 		panel: '#192320',
 		panelHeaderDivider: 'rgba(0, 0, 0, 0)',

--- a/packages/frontend/src/themes/d-ice.json5
+++ b/packages/frontend/src/themes/d-ice.json5
@@ -8,6 +8,7 @@
 
 	props: {
 		accent: '#47BFE8',
+		fgOnWhite: '@accent',
 		bg: '#212526',
 	},
 }

--- a/packages/frontend/src/themes/d-persimmon.json5
+++ b/packages/frontend/src/themes/d-persimmon.json5
@@ -11,6 +11,7 @@
 		bg: 'rgb(31, 33, 31)',
 		fg: '#cdd8c7',
 		fgHighlighted: '#fff',
+		fgOnWhite: '@accent',
 		divider: 'rgba(255, 255, 255, 0.14)',
 		panel: 'rgb(41, 43, 41)',
 		infoFg: '@fg',

--- a/packages/frontend/src/themes/d-u0.json5
+++ b/packages/frontend/src/themes/d-u0.json5
@@ -55,6 +55,7 @@
 		codeNumber: '#cfff9e',
 		codeString: '#ffb675',
 		fgOnAccent: '#fff',
+		fgOnWhite: '@accent',
 		infoWarnBg: '#42321c',
 		infoWarnFg: '#ffbd3e',
 		navHoverFg: ':lighten<17<@fg',

--- a/packages/frontend/src/themes/l-apricot.json5
+++ b/packages/frontend/src/themes/l-apricot.json5
@@ -10,6 +10,7 @@
 		accent: 'rgb(234, 154, 82)',
 		bg: '#e6e5e2',
 		fg: 'rgb(149, 143, 139)',
+		fgOnWhite: '@accent',
 		panel: '#EEECE8',
 		renote: '@accent',
 		link: '@accent',

--- a/packages/frontend/src/themes/l-botanical.json5
+++ b/packages/frontend/src/themes/l-botanical.json5
@@ -11,6 +11,7 @@
 		bg: 'e2deda',
 		fg: '#3d3d3d',
 		fgHighlighted: '#6bc9a0',
+		fgOnWhite: '@accent',
 		divider: '#cfcfcf',
 		panel: '@X14',
 		panelHeaderBg: '@panel',

--- a/packages/frontend/src/themes/l-cherry.json5
+++ b/packages/frontend/src/themes/l-cherry.json5
@@ -10,6 +10,7 @@
 		accent: 'rgb(219, 96, 114)',
 		bg: 'rgb(254, 248, 249)',
 		fg: 'rgb(152, 13, 26)',
+		fgOnWhite: '@accent',
 		panel: 'rgb(255, 255, 255)',
 		renote: '@accent',
 		link: 'rgb(156, 187, 5)',

--- a/packages/frontend/src/themes/l-coffee.json5
+++ b/packages/frontend/src/themes/l-coffee.json5
@@ -10,6 +10,7 @@
 		accent: '#9f8989',
 		bg: '#f5f3f3',
 		fg: '#7f6666',
+		fgOnWhite: '@accent',
 		panel: '#fff',
 		divider: 'rgba(87, 68, 68, 0.1)',
 		renote: 'rgb(160, 172, 125)',

--- a/packages/frontend/src/themes/l-light.json5
+++ b/packages/frontend/src/themes/l-light.json5
@@ -10,6 +10,7 @@
 	props: {
 		bg: '#f9f9f9',
 		fg: '#676767',
+		fgOnWhite: '@accent',
 		divider: '#e8e8e8',
 		header: ':alpha<0.7<@panel',
 		navBg: '#fff',

--- a/packages/frontend/src/themes/l-rainy.json5
+++ b/packages/frontend/src/themes/l-rainy.json5
@@ -10,6 +10,7 @@
 		accent: '#5db0da',
 		bg: 'rgb(246 248 249)',
 		fg: '#636b71',
+		fgOnWhite: '@accent',
 		panel: '#fff',
 		divider: 'rgb(230 233 234)',
 		panelHeaderDivider: '@divider',

--- a/packages/frontend/src/themes/l-sushi.json5
+++ b/packages/frontend/src/themes/l-sushi.json5
@@ -10,6 +10,7 @@
 		accent: '#e36749',
 		bg: '#f0eee9',
 		fg: '#5f5f5f',
+		fgOnWhite: '@accent',
 		renote: '@accent',
 		link: '@accent',
 		mention: '@accent',

--- a/packages/frontend/src/themes/l-u0.json5
+++ b/packages/frontend/src/themes/l-u0.json5
@@ -55,6 +55,7 @@
 		codeNumber: '#cfff9e',
 		codeString: '#ffb675',
 		fgOnAccent: '#fff',
+		fgOnWhite: '@accent',
 		infoWarnBg: '#42321c',
 		infoWarnFg: '#ffbd3e',
 		navHoverFg: ':lighten<17<@fg',

--- a/packages/frontend/src/themes/l-vivid.json5
+++ b/packages/frontend/src/themes/l-vivid.json5
@@ -52,6 +52,7 @@
 		driveFolderBg: ':alpha<0.3<@accent',
 		fgHighlighted: ':darken<3<@fg',
 		fgTransparent: ':alpha<0.5<@fg',
+		fgOnWhite: '@accent',
 		panelHeaderBg: ':lighten<3<@panel',
 		panelHeaderFg: '@fg',
 		htmlThemeColor: '@bg',


### PR DESCRIPTION
## What
#10672 に関連して、フォローボタンが「フォロー」として表示されている際のスタイルを調整しました。
(#10674 が現状のブランチと乖離しているのでPRし直したモノです。)
- backgroundが二重に指定されていたため白に固定
- 白の背景に `@accent` が使われた際、視認性が著しく下がる場合があるため、白の背景に利用できるプロパティ `fgOnWhite` を追加
- 上記に伴い、ベースとなるテーマに `fgOnWhite` を `#333` で追加
- 同様にプリインストールテーマに対して `fgOnWhite` を `@accent` で追加

## Why
- 過剰なbackground指定の削除
- テーマの自由度を確保しながら、視認性を確保できるようにするため（元の状態では文字が読めなくなる場合があった）


## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
