### PR TITLE
Condensedlines reflow once

### DIFF
--- a/packages/frontend/src/components/global/MkCondensedLine.vue
+++ b/packages/frontend/src/components/global/MkCondensedLine.vue
@@ -13,13 +13,17 @@ interface Props {
 
 const contentSymbol = Symbol();
 const observer = new ResizeObserver((entries) => {
+  const results = [];
 	for (const entry of entries) {
 		const content = (entry.target[contentSymbol] ? entry.target : entry.target.firstElementChild) as HTMLSpanElement;
 		const props: Required<Props> = content[contentSymbol];
 		const container = content.parentElement as HTMLSpanElement;
 		const contentWidth = content.getBoundingClientRect().width;
 		const containerWidth = container.getBoundingClientRect().width;
-		container.style.transform = `scaleX(${Math.max(props.minScale, Math.min(1, containerWidth / contentWidth))})`;
+		results.append({container, minScale: props.minScale, containerWidth, contentWidth});
+	}
+	for (const result in results) {
+		result.container.style.transform = `scaleX(${Math.max(result.minScale, Math.min(1, result.containerWidth / result.contentWidth))})`;
 	}
 });
 </script>

--- a/packages/frontend/src/components/global/MkCondensedLine.vue
+++ b/packages/frontend/src/components/global/MkCondensedLine.vue
@@ -20,9 +20,9 @@ const observer = new ResizeObserver((entries) => {
 		const container = content.parentElement as HTMLSpanElement;
 		const contentWidth = content.getBoundingClientRect().width;
 		const containerWidth = container.getBoundingClientRect().width;
-		results.append({container, minScale: props.minScale, containerWidth, contentWidth});
+		results.push({container, minScale: props.minScale, containerWidth, contentWidth});
 	}
-	for (const result in results) {
+	for (const result of results) {
 		result.container.style.transform = `scaleX(${Math.max(result.minScale, Math.min(1, result.containerWidth / result.contentWidth))})`;
 	}
 });

--- a/packages/frontend/src/components/global/MkCondensedLine.vue
+++ b/packages/frontend/src/components/global/MkCondensedLine.vue
@@ -20,7 +20,7 @@ const observer = new ResizeObserver((entries) => {
 		const container = content.parentElement as HTMLSpanElement;
 		const contentWidth = content.getBoundingClientRect().width;
 		const containerWidth = container.getBoundingClientRect().width;
-		results.push({container, minScale: props.minScale, containerWidth, contentWidth});
+		results.push({ container, minScale: props.minScale, containerWidth, contentWidth });
 	}
 	for (const result of results) {
 		result.container.style.transform = `scaleX(${Math.max(result.minScale, Math.min(1, result.containerWidth / result.contentWidth))})`;

--- a/packages/frontend/src/components/global/MkCondensedLine.vue
+++ b/packages/frontend/src/components/global/MkCondensedLine.vue
@@ -23,10 +23,10 @@ const observer = new ResizeObserver((entries) => {
 		const container = content.parentElement as HTMLSpanElement;
 		const contentWidth = content.getBoundingClientRect().width;
 		const containerWidth = container.getBoundingClientRect().width;
-		results.push({ container, minScale: props.minScale, containerWidth, contentWidth });
+		results.push({ container, transform: `scaleX(${Math.max(props.minScale, Math.min(1, containerWidth / contentWidth))})` });
 	}
 	for (const result of results) {
-		result.container.style.transform = `scaleX(${Math.max(result.minScale, Math.min(1, result.containerWidth / result.contentWidth))})`;
+		result.container.style.transform = result.transform;
 	}
 });
 </script>

--- a/packages/frontend/src/components/global/MkCondensedLine.vue
+++ b/packages/frontend/src/components/global/MkCondensedLine.vue
@@ -13,7 +13,10 @@ interface Props {
 
 const contentSymbol = Symbol();
 const observer = new ResizeObserver((entries) => {
-  const results = [];
+  const results: {
+    container: HTMLSpanElement;
+    transform: string;
+  }[] = [];
 	for (const entry of entries) {
 		const content = (entry.target[contentSymbol] ? entry.target : entry.target.firstElementChild) as HTMLSpanElement;
 		const props: Required<Props> = content[contentSymbol];


### PR DESCRIPTION
## What
Fixes #10927
全てのMkCondensedLineオブジェクトでgetBoundingClientRectの読み出しが完了してからスタイルを書き換える

## Why
better performance on page load / read more

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
