### PR TITLE
Fix: #10955 TypeError: JSON5.parse is not a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ## 13.13.1 (unreleased)
 
 ### Server
-- Fix: api/metaで`TypeError: JSON5.parse is not a function`エラーになる問題を修正
+- Fix: api/metaで`TypeError: JSON5.parse is not a function`エラーが発生する問題を修正
 
 ## 13.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 -->
 
+## 13.13.1 (unreleased)
+
+### Server
+- Fix: api/metaで`TypeError: JSON5.parse is not a function`エラーになる問題を修正
+
 ## 13.13.0
 
 ### General

--- a/packages/backend/src/server/api/endpoints/meta.ts
+++ b/packages/backend/src/server/api/endpoints/meta.ts
@@ -1,6 +1,6 @@
 import { IsNull, LessThanOrEqual, MoreThan } from 'typeorm';
 import { Inject, Injectable } from '@nestjs/common';
-import * as JSON5 from 'json5';
+import JSON5 from 'json5';
 import type { AdsRepository, UsersRepository } from '@/models/index.js';
 import { MAX_NOTE_TEXT_LENGTH } from '@/const.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';


### PR DESCRIPTION
## What
Fix: #10955 `TypeError: JSON5.parse is not a function` 

## Why
v13.13.0にアップデート後、ページが表示されない問題がある。
サーバー側のログでは、`TypeError: JSON5.parse is not a function` と出ているので、怪しい部分を修正。 

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [X] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
