### PR TITLE
fix: correctly check the sensitivity flag

### DIFF
--- a/packages/backend/src/server/web/views/note.pug
+++ b/packages/backend/src/server/web/views/note.pug
@@ -5,8 +5,8 @@ block vars
 	- const title = user.name ? `${user.name} (@${user.username})` : `@${user.username}`;
 	- const url = `${config.url}/notes/${note.id}`;
 	- const isRenote = note.renote && note.text == null && note.fileIds.length == 0 && note.poll == null;
-	- const image = (note.files || []).find(file => file.type.startsWith('image/') && !file.type.isSensitive)
-	- const video = (note.files || []).find(file => file.type.startsWith('video/') && !file.type.isSensitive)
+	- const image = (note.files || []).find(file => file.type.startsWith('image/') && !file.isSensitive)
+	- const video = (note.files || []).find(file => file.type.startsWith('video/') && !file.isSensitive)
 
 block title
 	= `${title} | ${instanceName}`


### PR DESCRIPTION
## What
#10862 apparently tried to filter out images marked as sensitive but it's [not actually working](https://github.com/misskey-dev/misskey/issues/5964#issuecomment-1583719736) due to a typo.

## Why
It fixes a typo since `isSensitive` should be laid directly under the `file` object.

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
