### PR TITLE
Fix: enhance: タイムラインにフォロイーの行った他人へのリプライを含めるかどうかの設定をアカウントに保存するのをやめるように

### DIFF
--- a/packages/frontend/src/pages/settings/profile.vue
+++ b/packages/frontend/src/pages/settings/profile.vue
@@ -127,7 +127,6 @@ const profile = reactive({
 	lang: $i.lang,
 	isBot: $i.isBot,
 	isCat: $i.isCat,
-	showTimelineReplies: $i.showTimelineReplies,
 });
 
 watch(() => profile, () => {
@@ -151,7 +150,7 @@ while (fields.value.length < 4) {
 	addField();
 }
 
-function deleteField(index: number) { 
+function deleteField(index: number) {
 	fields.value.splice(index, 1);
 }
 
@@ -176,7 +175,6 @@ function save() {
 		lang: profile.lang || null,
 		isBot: !!profile.isBot,
 		isCat: !!profile.isCat,
-		showTimelineReplies: !!profile.showTimelineReplies,
 	});
 	claimAchievement('profileFilled');
 	if (profile.name === 'syuilo' || profile.name === 'しゅいろ') {


### PR DESCRIPTION
## What
Fix: enhance: タイムラインにフォロイーの行った他人へのリプライを含めるかどうかの設定をアカウントに保存するのをやめるように
消し忘れにより`i/update`が動かないので
```
Endpoint: i/update
Info: {"e":{"message":"Property \"showTimelineReplies\" was not found in \"User\". Make sure your query is correct.","code":"EntityPropertyNotFoundError","id":"xxxxxxxxxxxxxxxxxx"}}
```


## Why
Resolve https://github.com/misskey-dev/misskey/issues/10646

## Additional info (optional)
ローカル環境で問題なし

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
