### PR TITLE
Fix offscreencanvas undefined

### DIFF
--- a/packages/frontend/src/workers/test-webgl2.ts
+++ b/packages/frontend/src/workers/test-webgl2.ts
@@ -1,13 +1,7 @@
-try {
-    // throw ReferenceError in Safari <= 16.3
-    const canvas = new OffscreenCanvas(1, 1);
-    const gl = canvas.getContext('webgl2');
-    if (gl) {
-        postMessage({ result: true });
-    } else {
-        postMessage({ result: false });
-    }
-} catch (err) {
-    // assert(e instanceof ReferenceError)
+const canvas = globalThis.OffscreenCanvas && new OffscreenCanvas(1, 1);
+const gl = canvas?.getContext('webgl2');
+if (gl) {
+    postMessage({ result: true });
+} else {
     postMessage({ result: false });
 }

--- a/packages/frontend/src/workers/test-webgl2.ts
+++ b/packages/frontend/src/workers/test-webgl2.ts
@@ -1,3 +1,7 @@
+if (!OffscreenCanvas) {
+    postMessage({ result: false });
+    return;
+}
 const canvas = new OffscreenCanvas(1, 1);
 const gl = canvas.getContext('webgl2');
 if (gl) {

--- a/packages/frontend/src/workers/test-webgl2.ts
+++ b/packages/frontend/src/workers/test-webgl2.ts
@@ -1,11 +1,11 @@
-if (!OffscreenCanvas) {
-    postMessage({ result: false });
-    return;
-}
-const canvas = new OffscreenCanvas(1, 1);
-const gl = canvas.getContext('webgl2');
-if (gl) {
-    postMessage({ result: true });
+if (window.OffscreenCanvas) {
+    const canvas = new OffscreenCanvas(1, 1);
+    const gl = canvas.getContext('webgl2');
+    if (gl) {
+        postMessage({ result: true });
+    } else {
+        postMessage({ result: false });
+    }
 } else {
     postMessage({ result: false });
 }

--- a/packages/frontend/src/workers/test-webgl2.ts
+++ b/packages/frontend/src/workers/test-webgl2.ts
@@ -1,4 +1,5 @@
-if (window.OffscreenCanvas) {
+try {
+    // throw ReferenceError in Safari <= 16.3
     const canvas = new OffscreenCanvas(1, 1);
     const gl = canvas.getContext('webgl2');
     if (gl) {
@@ -6,6 +7,7 @@ if (window.OffscreenCanvas) {
     } else {
         postMessage({ result: false });
     }
-} else {
+} catch (e) {
+    // assert(e instanceof ReferenceError)
     postMessage({ result: false });
 }

--- a/packages/frontend/src/workers/test-webgl2.ts
+++ b/packages/frontend/src/workers/test-webgl2.ts
@@ -7,7 +7,7 @@ try {
     } else {
         postMessage({ result: false });
     }
-} catch (e) {
+} catch (err) {
     // assert(e instanceof ReferenceError)
     postMessage({ result: false });
 }


### PR DESCRIPTION
## What
Fixes #11016
burahaで描画時にブラウザがOffscreenCanvasに対応していない場合に、エラーをcatchして未対応と報告する

## Why


## Additional info (optional)
iOSやMac端末を持っていないので、Chromeからの閲覧でエラーが生じないことのみチェックしています。

## Checklist
- [ x ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ x ] Test working in a local environment (_partially_)
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
