### PR TITLE
Make role tag clickable on user pages

### DIFF
--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -44,8 +44,10 @@
 					</div>
 					<div v-if="user.roles.length > 0" class="roles">
 						<span v-for="role in user.roles" :key="role.id" v-tooltip="role.description" class="role" :style="{ '--color': role.color }">
-							<img v-if="role.iconUrl" style="height: 1.3em; vertical-align: -22%;" :src="role.iconUrl"/>
-							{{ role.name }}
+							<MkA v-adaptive-bg :to="`/roles/${role.id}`">
+								<img v-if="role.iconUrl" style="height: 1.3em; vertical-align: -22%;" :src="role.iconUrl"/>
+								{{ role.name }}
+							</MkA>
 						</span>
 					</div>
 					<div v-if="iAmModerator" class="moderationNote">


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
Fixes #11018
ユーザーページ(`https://misskey.example.com/@user_name`) にある、そのユーザーが所属するロール一覧をロールのページ(`https://misskey.example.com/roles/********`) へのリンクにする。

## Why
一般ユーザーは、自分の所属していないロールのロールタイムラインにきわめてアクセスしずらい。（私はAPIをたたいてロールIDを取得することでURLをみつけている…）
したがって、新規登録用のユーザーのロールのタイムラインを有効にしていても、交流を促す効果が低い。
ユーザーのロールタグをクリック可能にすることで、ユーザーがロールタイムラインの機能の存在を認識しやすくなり、またアクセスしやすくなる。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
