### PR TITLE
fix: clear queue endpoint error with redis script

### DIFF
--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -400,11 +400,11 @@ export class QueueService {
 		this.deliverQueue.once('cleaned', (jobs, status) => {
 			//deliverLogger.succ(`Cleaned ${jobs.length} ${status} jobs`);
 		});
-		this.deliverQueue.clean(0, Infinity, 'delayed');
+		this.deliverQueue.clean(0, 0, 'delayed');
 
 		this.inboxQueue.once('cleaned', (jobs, status) => {
 			//inboxLogger.succ(`Cleaned ${jobs.length} ${status} jobs`);
 		});
-		this.inboxQueue.clean(0, Infinity, 'delayed');
+		this.inboxQueue.clean(0, 0, 'delayed');
 	}
 }


### PR DESCRIPTION
Error message:
```
ReplyError: ERR value is not an integer or out of range script: 720d973b3877f92b4fb3285ced83c97cdd204979, on @user_script:209.
```

The whole error can be tracked back to one of the arguments, which is `Infinity` in the codebase, but it has to be a number.

The documentation in bullmq says `0` is unlimited[^1], and bullmq tries to parse the argument with `tonumber` which returns with `-9223372036854775808` if the argument is `"Infinity"` which is out of bound.

```
127.0.0.1:6379> eval 'return tonumber(ARGV[3])' '2' 'slippy.xyz:queue:inbox:inbox:delayed' 'slippy.xyz:queue:inbox:inbox:events' 'slippy.xyz:queue:inbox:inbox:' '1687183763944' Infinity 'delayed'
(integer) -9223372036854775808
127.0.0.1:6379>
```

[^1]: https://github.com/taskforcesh/bullmq/blob/master/src/commands/cleanJobsInSet-2.lua#L10