### PR TITLE
[enhance] Use background image on Misskey - Update style.scss

### DIFF
--- a/packages/frontend/src/style.scss
+++ b/packages/frontend/src/style.scss
@@ -23,6 +23,10 @@
 
 html {
 	background-color: var(--bg);
+	background-size: var(--bg-size, cover);
+	background-repeat: var(--bg-repeat, no-repeat);
+	background-position: var(--bg-position, center center);
+
 	color: var(--fg);
 	accent-color: var(--accent);
 	overflow: auto;


### PR DESCRIPTION
## What
Add default background image styles.

For better show an image as centered, cover size, and no repeat.

And can be modified by CSS vars.

## Why

By default, if we setup an image as background for Misskey, it will just do not show it at all. When process with style settings and found that the background image was not fit to the page viewpoint.

So I create this patch for better usage of bit images as background, and also can be controlled by CSS vars as other styles.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
