### PR TITLE
エスケープせずにDescriptionを出力、Update info-card.pug

### DIFF
--- a/packages/backend/src/server/web/views/info-card.pug
+++ b/packages/backend/src/server/web/views/info-card.pug
@@ -47,4 +47,4 @@ html
 			header#banner(style=`background-image: url(${meta.bannerUrl})`)
 				div#title= meta.name || host
 		div#content
-			div#description= meta.description
+			div#description!= meta.description


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
HTMLのタグがエスケープされず、HTMLelementとして表示されるように。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
HTMLのタグがエスケープされ、
misskey-hub.netのサーバー一覧で、iframeで読み込む際にタグがそのまま出力される状況が発生していた。 
eg
```plain
Misskey.io は、Misskey HQが運営する地球で生まれた分散マイクロブログSNSです。Fediverse（様々なSNSで構成される宇宙）の中に存在するため、他のSNSと相互に繋がっています。 <br> 暫し都会の喧騒から離れて、新しいインターネットにダイブしてみませんか。<br> <br> <strong>現在、新規登録時に利用できないユーザー名で登録しようとするとメール認証をした後に失敗する不具合が確認されています。お手数ですが、「始める」を押す前にユーザー名の下に「利用できます」と表示されていることをご確認ください。</strong><br> <br> <a href="https://go.misskey.io/support" target="_blank">お問い合わせはこちら<br>https://go.misskey.io/support</a><br> <br> <br> &copy; 2023 MisskeyHQ<br> Powered by Misskey
```
pugにおける仕様に則り、!=に変更、エスケープを行わないように。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
部分的な修正ですので、issueにおけるreviewはスキップさせて頂きました。


## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
<!-- - [] (If needed) Add story of storybook
- [] (If needed) Update CHANGELOG.md
- [] (If possible) Add tests -->