### PR TITLE
refactor(`ApDbResolverService.ts`): URLを扱う複雑な正規表現をURLインターフェイスで置き換え

### DIFF
--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -60,7 +60,7 @@ export class ApDbResolverService implements OnApplicationShutdown {
 		const uri = new URL(getApId(value));
 		if (uri.origin !== this.config.url) return { local: false, uri: uri.href };
 
-		const [type, id, ...rest] = uri.pathname.split(separator);
+		const [, type, id, ...rest] = uri.pathname.split(separator);
 		return {
 			local: true,
 			type,

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
-import escapeRegexp from 'escape-regexp';
 import { DI } from '@/di-symbols.js';
 import type { NotesRepository, UserPublickeysRepository, UsersRepository } from '@/models/index.js';
 import type { Config } from '@/config.js';
@@ -56,25 +55,18 @@ export class ApDbResolverService implements OnApplicationShutdown {
 
 	@bindThis
 	public parseUri(value: string | IObject): UriParseResult {
-		const uri = getApId(value);
-	
-		// the host part of a URL is case insensitive, so use the 'i' flag.
-		const localRegex = new RegExp('^' + escapeRegexp(this.config.url) + '/(\\w+)/(\\w+)(?:\/(.+))?', 'i');
-		const matchLocal = uri.match(localRegex);
-	
-		if (matchLocal) {
-			return {
-				local: true,
-				type: matchLocal[1],
-				id: matchLocal[2],
-				rest: matchLocal[3],
-			};
-		} else {
-			return {
-				local: false,
-				uri,
-			};
-		}
+		const separator = '/';
+
+		const uri = new URL(getApId(value));
+		if (uri.origin !== this.config.url) return { local: false, uri: uri.href };
+
+		const [type, id, ...rest] = uri.pathname.split(separator);
+		return {
+			local: true,
+			type,
+			id,
+			rest: rest.length === 0 ? undefined : rest.join(separator),
+		};
 	}
 
 	/**


### PR DESCRIPTION
## What
URL文字列を正規表現で扱っていた部分をURLインターフェイスを使うように書き換えました。

## Why
可読性が低かったため。

## Additional info (optional)
これまでの実装ではURLに含まれる文字列として`/\w/`を使っていたようですが、これは十分ではありません。`/\w/`は`[A-Za-z0-9_]`ですが[^1]、URLでは`-`や`.`も認められるはずです[^2]。

[^1]: https://developer.mozilla.org/ja/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes
[^2]: https://url.spec.whatwg.org/#url-code-points

この正規表現の定義の誤りにより、これまで`matchLocal`がFalsyとなっていた場面においても、`local: false`にすべきではなかった場面があると考えられます。具体的にどのような場面においてどのような形で問題になるのかはまだ調べきれていませんが、もしかすると #11122 と関連しているかもしれません。（どうやらそのIssueの場面では`-`を含むURLを扱っているようであるため。）

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
