### PR TITLE
refactor(backend): ノート削除時の`findCascadingNotes`の処理を整理

### DIFF
--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -121,10 +121,8 @@ export class NoteDeleteService {
 	}
 
 	@bindThis
-	private async findCascadingNotes(note: Note) {
-		const cascadingNotes: Note[] = [];
-
-		const recursive = async (noteId: string) => {
+	private async findCascadingNotes(note: Note): Promise<Note[]> {
+		const recursive = async (noteId: string): Promise<Note[]> => {
 			const query = this.notesRepository.createQueryBuilder('note')
 				.where('note.replyId = :noteId', { noteId })
 				.orWhere(new Brackets(q => {
@@ -133,12 +131,14 @@ export class NoteDeleteService {
 				}))
 				.leftJoinAndSelect('note.user', 'user');
 			const replies = await query.getMany();
-			for (const reply of replies) {
-				cascadingNotes.push(reply);
-				await recursive(reply.id);
-			}
+
+			return [
+				replies,
+				...await Promise.all(replies.map(async reply => await recursive(reply.id))),
+			].flat();
 		};
-		await recursive(note.id);
+
+		const cascadingNotes: Note[] = await recursive(note.id);
 
 		return cascadingNotes.filter(note => note.userHost === null); // filter out non-local users
 	}

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -134,7 +134,7 @@ export class NoteDeleteService {
 
 			return [
 				replies,
-				...await Promise.all(replies.map(async reply => await recursive(reply.id))),
+				...await Promise.all(replies.map(reply => recursive(reply.id))),
 			].flat();
 		};
 


### PR DESCRIPTION
## What
ノートが削除されるときにはそのノートと連なったノートに関しても削除され、削除アクティビティがdeliverされます。このPRでは削除アクティビティをdeliverするために「連なったノート」を探す処理をリファクタリングしました。

## Why
現時点では特に何かに困っているわけではありません。強いて挙げるなら、現時点では`Promise.all`を使っていないため並列では処理されなくなってしまっていると思われます。が、これによってどういった影響が出ているのかについては不明です。

## Additional info (optional)
このPRでリファクタリングしたのは #5812 で追加された処理です。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
