### PR TITLE
fix: add suuport Japanese message of errors.

### DIFF
--- a/packages/backend/src/misc/is-duplicate-key-value-error.ts
+++ b/packages/backend/src/misc/is-duplicate-key-value-error.ts
@@ -1,5 +1,5 @@
-import { QueryFailedError } from "typeorm";
+import { QueryFailedError } from 'typeorm';
 
 export function isDuplicateKeyValueError(e: unknown | Error): boolean {
-	return e instanceof QueryFailedError && e.driverError.code === "23505";
+	return e instanceof QueryFailedError && e.driverError.code === '23505';
 }

--- a/packages/backend/src/misc/is-duplicate-key-value-error.ts
+++ b/packages/backend/src/misc/is-duplicate-key-value-error.ts
@@ -1,3 +1,7 @@
 export function isDuplicateKeyValueError(e: unknown | Error): boolean {
-	return (e as any).message && (e as Error).message.startsWith('duplicate key value');
+	return (
+		(e as any).message &&
+		((e as Error).message.startsWith("duplicate key value") ||
+			(e as Error).message.startsWith("重複したキー値"))
+	);
 }

--- a/packages/backend/src/misc/is-duplicate-key-value-error.ts
+++ b/packages/backend/src/misc/is-duplicate-key-value-error.ts
@@ -1,7 +1,5 @@
+import { QueryFailedError } from "typeorm";
+
 export function isDuplicateKeyValueError(e: unknown | Error): boolean {
-	return (
-		(e as any).message &&
-		((e as Error).message.startsWith("duplicate key value") ||
-			(e as Error).message.startsWith("重複したキー値"))
-	);
+	return e instanceof QueryFailedError && e.driverError.code === "23505";
 }


### PR DESCRIPTION
## What
#11133 の対応

## Why
日本語でエラー文が流れた際にRedisに大量にDelayedが蓄積され、適切にDelayedになっているものとの混在で混乱を招くため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
