### PR TITLE
fix(build): `locales/index.d.ts`生成時にexport defaultを生成するように

### DIFF
--- a/locales/generateDTS.js
+++ b/locales/generateDTS.js
@@ -51,11 +51,7 @@ export default function generateDTS() {
 				ts.NodeFlags.Const | ts.NodeFlags.Ambient | ts.NodeFlags.ContextFlags,
 			),
 		),
-		ts.factory.createExportAssignment(
-			undefined,
-			true,
-			ts.factory.createIdentifier('locales'),
-		),
+		ts.factory.createExportDefault(ts.factory.createIdentifier('locales')),
 	];
 	const printed = ts.createPrinter({
 		newLine: ts.NewLineKind.LineFeed,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`locales/index.d.ts`生成時にexport defaultを生成するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`generateDTS.js`が実行されるたびにdiffが作られる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
