### PR TITLE
fix(frontend): Android環境で通知音量を0にしても音が鳴っているかのように振る舞う問題の修正

### DIFF
--- a/packages/frontend/src/scripts/sound.ts
+++ b/packages/frontend/src/scripts/sound.ts
@@ -132,9 +132,7 @@ export function play(type: 'noteMy' | 'note' | 'antenna' | 'channel' | 'notifica
 }
 
 export function playFile(file: string, volume: number) {
-	const masterVolume = soundConfigStore.state.sound_masterVolume;
-	if (masterVolume === 0) return;
-
 	const audio = setVolume(getAudio(file), volume);
+	if (audio.volume === 0) return;
 	audio.play();
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
https://github.com/misskey-dev/misskey/issues/6096
Android 環境で通知音量を0にしても音が鳴っているかのように振る舞う問題の修正

MasterVolumeが0の時だけでなく各通知音の音量設定が0のときも、HTMLAudioElement.playが実行されないように変更
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
Youtubeをバックグラウンド再生しながらmisskeyを使っていたら再現できた
下記の状況で新しいNoteが投稿されるとYoutubeの音量が一時的に(１秒程度）下がる
- MasterVolume > 0
- NoteVolume == 0

`audio.play()`時にvolumeが0であってもAndroidの音声フォーカスがYoutubeからMisskeyに移ることが原因なのではないかと推測される
https://developer.android.com/guide/topics/media-apps/audio-focus?hl=ja

<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
手元のAndroid環境では上記の状況で音声フォーカスを取られなくなってそう。
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
