### PR TITLE
Export notes with file detail

### DIFF
--- a/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
@@ -14,6 +14,8 @@ import { bindThis } from '@/decorators.js';
 import { QueueLoggerService } from '../QueueLoggerService.js';
 import type * as Bull from 'bullmq';
 import type { DbJobDataWithUser } from '../types.js';
+import { DriveFileEntityService } from '@/core/entities/DriveFileEntityService.js';
+import { Packed } from '@/misc/json-schema.js';
 
 @Injectable()
 export class ExportNotesProcessorService {
@@ -34,6 +36,8 @@ export class ExportNotesProcessorService {
 
 		private driveService: DriveService,
 		private queueLoggerService: QueueLoggerService,
+
+		private driveFileEntityService: DriveFileEntityService,
 	) {
 		this.logger = this.queueLoggerService.logger.createSubLogger('export-notes');
 	}
@@ -97,7 +101,8 @@ export class ExportNotesProcessorService {
 					if (note.hasPoll) {
 						poll = await this.pollsRepository.findOneByOrFail({ noteId: note.id });
 					}
-					const content = JSON.stringify(serialize(note, poll));
+					const files = await this.driveFileEntityService.packManyByIds(note.fileIds);
+					const content = JSON.stringify(serialize(note, poll, files));
 					const isFirst = exportedNotesCount === 0;
 					await write(isFirst ? content : ',\n' + content);
 					exportedNotesCount++;
@@ -125,12 +130,13 @@ export class ExportNotesProcessorService {
 	}
 }
 
-function serialize(note: Note, poll: Poll | null = null): Record<string, unknown> {
+function serialize(note: Note, poll: Poll | null = null, files: Map<Packed<'DriveFile'>['id'], Packed<'DriveFile'>>): Record<string, unknown> {
 	return {
 		id: note.id,
 		text: note.text,
 		createdAt: note.createdAt,
 		fileIds: note.fileIds,
+		files: files,
 		replyId: note.replyId,
 		renoteId: note.renoteId,
 		poll: poll,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Add file field to the export notes like in "show" endpoint, so user can follow the url to extract file later.


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Current export feature only contains fileid not the actual file nor url, its hard for import later and archiving.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
