### PR TITLE
perf(backend): createPersonでキャッシュに保存する, DBのトランザクション回数を減らす

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -361,6 +361,11 @@ export class ApPersonService implements OnModuleInit {
 			}
 		});
 
+		this.usersChart.update(user, true);
+
+		// ハッシュタグ更新
+		this.hashtagService.updateUsertags(user, tags);
+
 		//#region アバターとヘッダー画像をフェッチ
 		try {
 			const updates = await this.resolveAvatarAndBanner(user, person.icon, person.image);
@@ -373,11 +378,6 @@ export class ApPersonService implements OnModuleInit {
 			this.logger.error('error occured while fetching user avatar/banner', { stack: err });
 		}
 		//#endregion
-
-		this.usersChart.update(user, true);
-
-		// ハッシュタグ更新
-		this.hashtagService.updateUsertags(user, tags);
 
 		await this.updateFeatured(user.id, resolver).catch(err => this.logger.error(err));
 

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -352,6 +352,15 @@ export class ApPersonService implements OnModuleInit {
 		// Register to the cache
 		this.cacheService.uriPersonCache.set(user.uri, user);
 
+		// Register host
+		this.federatedInstanceService.fetch(host).then(async i => {
+			this.instancesRepository.increment({ id: i.id }, 'usersCount', 1);
+			this.fetchInstanceMetadataService.fetchInstanceMetadata(i);
+			if ((await this.metaService.fetch()).enableChartsForFederatedInstances) {
+				this.instanceChart.newUser(i.host);
+			}
+		});
+
 		//#region アバターとヘッダー画像をフェッチ
 		try {
 			const updates = await this.resolveAvatarAndBanner(user, person.icon, person.image);
@@ -364,15 +373,6 @@ export class ApPersonService implements OnModuleInit {
 			this.logger.error('error occured while fetching user avatar/banner', { stack: err });
 		}
 		//#endregion
-
-		// Register host
-		this.federatedInstanceService.fetch(host).then(async i => {
-			this.instancesRepository.increment({ id: i.id }, 'usersCount', 1);
-			this.fetchInstanceMetadataService.fetchInstanceMetadata(i);
-			if ((await this.metaService.fetch()).enableChartsForFederatedInstances) {
-				this.instanceChart.newUser(i.host);
-			}
-		});
 
 		this.usersChart.update(user, true);
 

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -43,8 +43,6 @@ import type { ApLoggerService } from '../ApLoggerService.js';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { ApImageService } from './ApImageService.js';
 import type { IActor, IObject } from '../type.js';
-import { ca } from 'date-fns/locale';
-import { users } from 'systeminformation';
 
 const nameLength = 128;
 const summaryLength = 2048;

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -291,6 +291,8 @@ export class ApPersonService implements OnModuleInit {
 			await this.db.transaction(async transactionalEntityManager => {
 				user = await transactionalEntityManager.save(new User({
 					id: this.idService.genId(),
+					avatarId: null,
+					bannerId: null,
 					createdAt: new Date(),
 					lastFetchedAt: new Date(),
 					name: truncate(person.name, nameLength),

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -270,8 +270,8 @@ export class ApPersonService implements OnModuleInit {
 			emojis: [],
 		};
 
+		//#region アバターとヘッダー画像をフェッチ
 		try {
-			//#region アバターとヘッダー画像をフェッチ
 			const [avatar, banner] = await Promise.all([person.icon, person.image].map(img => {
 				if (img == null) return null;
 				if (user == null) throw new Error('failed to create user: user is null');
@@ -284,10 +284,10 @@ export class ApPersonService implements OnModuleInit {
 			userAdditionalInfo.bannerUrl = banner ? this.driveFileEntityService.getPublicUrl(banner) : null;
 			userAdditionalInfo.avatarBlurhash = avatar?.blurhash ?? null;
 			userAdditionalInfo.bannerBlurhash = banner?.blurhash ?? null;
-			//#endregion
 		} catch (err) {
 			this.logger.error('error occured while fetching user avatar/banner', { stack: err });
 		}
+		//#endregion
 
 		//#region カスタム絵文字取得
 		userAdditionalInfo.emojis = await this.apNoteService.extractEmojis(person.tag ?? [], host)


### PR DESCRIPTION
## What
ApPersonService.createPersonで

- キャッシュにユーザーを保存する
- ~~アバター、ヘッダー画像、~~ 絵文字一覧をあとで挿入するのではなく最初に保存する

## Why
ユーザー作成時のトランザクション回数を減らす

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
