### PR TITLE
fix(frontend): ユーザー名が長い場合に、フォローボタンを折り返して表示させる

### DIFF
--- a/packages/frontend/src/pages/gallery/post.vue
+++ b/packages/frontend/src/pages/gallery/post.vue
@@ -236,6 +236,7 @@ definePageMetadata(computed(() => post ? {
 			border-top: solid 0.5px var(--divider);
 			display: flex;
 			align-items: center;
+			flex-wrap: wrap;
 
 			> .avatar {
 				width: 52px;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- 以下のIssueのフォローアップです。
  - https://github.com/misskey-dev/misskey/issues/11325
- フォローボタンの表示幅が足りない場合、折り返して表示するように修正

|対応前|対応後|
|---|---|
|<img width="387" alt="スクリーンショット 2023-07-19 23 50 45" src="https://github.com/misskey-dev/misskey/assets/39184410/25abb62e-b757-4eb9-b383-3e0d18186c2f">|<img width="396" alt="スクリーンショット 2023-07-19 23 51 34" src="https://github.com/misskey-dev/misskey/assets/39184410/283444c1-03a0-471e-8f57-55e5e576843b">|

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

- フォローボタンの表示領域が少ない場合のデザイン崩れを防止するため。


## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- 回り込んだ後の位置は、既存踏襲の右寄せにしています。 (違和感をなくすため)
  - 位置に関して問題あれば、レビュワー担当者様と相談の上修正したいです。



## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
