### PR TITLE
refactor: forkでデフォルトのノート文字数を変更した場合、E2Eテストが落ちる問題を修正する

### DIFF
--- a/packages/backend/test/e2e/note.ts
+++ b/packages/backend/test/e2e/note.ts
@@ -165,7 +165,7 @@ describe('Note', () => {
 
 	test('文字数ぎりぎりで怒られない', async () => {
 		const post = {
-			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH),
+			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH), // 3000文字
 		};
 		const res = await api('/notes/create', post, alice);
 		assert.strictEqual(res.status, 200);
@@ -173,7 +173,7 @@ describe('Note', () => {
 
 	test('文字数オーバーで怒られる', async () => {
 		const post = {
-			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH + 1),
+			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH + 1), // 3001文字
 		};
 		const res = await api('/notes/create', post, alice);
 		assert.strictEqual(res.status, 400);

--- a/packages/backend/test/e2e/note.ts
+++ b/packages/backend/test/e2e/note.ts
@@ -5,6 +5,7 @@ import { Note } from '@/models/entities/Note.js';
 import { signup, post, uploadUrl, startServer, initTestDb, api, uploadFile } from '../utils.js';
 import type { INestApplicationContext } from '@nestjs/common';
 import type * as misskey from 'misskey-js';
+import { MAX_NOTE_TEXT_LENGTH } from '@/const.js';
 
 describe('Note', () => {
 	let app: INestApplicationContext;
@@ -164,7 +165,7 @@ describe('Note', () => {
 
 	test('文字数ぎりぎりで怒られない', async () => {
 		const post = {
-			text: '!'.repeat(3000),
+			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH),
 		};
 		const res = await api('/notes/create', post, alice);
 		assert.strictEqual(res.status, 200);
@@ -172,7 +173,7 @@ describe('Note', () => {
 
 	test('文字数オーバーで怒られる', async () => {
 		const post = {
-			text: '!'.repeat(3001),
+			text: '!'.repeat(MAX_NOTE_TEXT_LENGTH + 1),
 		};
 		const res = await api('/notes/create', post, alice);
 		assert.strictEqual(res.status, 400);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
デフォルトのノート文字数を変更した場合、文字数のチェックのテストが通らない箇所を修正します

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`packages/backend/src/const.ts` に定義されているデフォルトの投稿可能文字数から文字数を変更した場合、CIが落ちるようになっています。
forkなどでデフォルト文字数が変更されていた場合に文字数のチェックがうまくいかない状態になります。
forkの事情ではありますが、CIが落ちている状態をよしとすることはできないと思うので、変更可能な定数の箇所であることを踏まえ、テストにべた書きをしないようにしました。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
E2Eテストを動かす方法についてコントリビューションガイドのドキュメントになかったのですが、github actionsで動かして確認しています。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
