### PR TITLE
URL取得方法を関数に変更 #11392

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Client
 - リストTLで、ユーザーが追加・削除されてもTLを初期化しないように
+- URL取得変数を関数に変更　CURRENT_URL -> Mk:url()
 - Fix: モバイル表示のときページ下部がナビゲーションバーに隠れる問題を修正
 - Fix: 一部モーダルダイアログでスクロールできない問題を修正
 - Fix: Selecting all emojis in Custom emoji is impossible

--- a/packages/frontend/src/scripts/aiscript/api.ts
+++ b/packages/frontend/src/scripts/aiscript/api.ts
@@ -11,7 +11,6 @@ export function createAiScriptEnv(opts) {
 		USER_NAME: $i ? values.STR($i.name) : values.NULL,
 		USER_USERNAME: $i ? values.STR($i.username) : values.NULL,
 		CUSTOM_EMOJIS: utils.jsToVal(customEmojis.value),
-		CURRENT_URL: values.STR(window.location.href),
 		'Mk:dialog': values.FN_NATIVE(async ([title, text, type]) => {
 			await os.alert({
 				type: type ? type.value : 'info',
@@ -47,6 +46,9 @@ export function createAiScriptEnv(opts) {
 		'Mk:load': values.FN_NATIVE(([key]) => {
 			utils.assertString(key);
 			return utils.jsToVal(JSON.parse(miLocalStorage.getItem(`aiscript:${opts.storageKey}:${key.value}`)));
+		}),
+		'Mk:url': values.FN_NATIVE(() => {
+			return values.STR(window.location.href);
 		}),
 	};
 }


### PR DESCRIPTION
## What
現在表示中のURLを取得する方法を関数呼び出しに変更した

## Why
以前、表示中のURLを取得するために環境変数を追加したが、目的の画面で一度ユーザが再読み込みしなければならず、使い勝手が良くなかったため
関数呼び出しに変更することで、aiscript側が任意のタイミングでURLを取得できる

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
