### PR TITLE
fix: アンテナ新規作成/編集時のバリデーションを修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/antennas/create.ts
+++ b/packages/backend/src/server/api/endpoints/antennas/create.ts
@@ -86,8 +86,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 		private globalEventService: GlobalEventService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
-			if ((ps.keywords.length === 0) || ps.keywords[0].every(x => x === '')) {
-				throw new Error('invalid param');
+			if (ps.keywords.flat().every(x => x === '') && ps.excludeKeywords.flat().every(x => x === '')) {
+				throw new Error('either keywords or excludeKeywords is required.');
 			}
 
 			const currentAntennasCount = await this.antennasRepository.countBy({

--- a/packages/backend/src/server/api/endpoints/antennas/update.ts
+++ b/packages/backend/src/server/api/endpoints/antennas/update.ts
@@ -83,6 +83,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 		private globalEventService: GlobalEventService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			if (ps.keywords.flat().every(x => x === '') && ps.excludeKeywords.flat().every(x => x === '')) {
+				throw new Error('either keywords or excludeKeywords is required.');
+			}
 			// Fetch the antenna
 			const antenna = await this.antennasRepository.findOneBy({
 				id: ps.antennaId,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

closes: #11446

## What
アンテナの新規作成時と編集時のバリデーションを変更して
- keywords/excludeKeywordsの両方が指定されていない場合に限りエラーとする
- `invalid param`ではなく意味のあるエラーメッセージを返す
- 2つの操作で同一基準のバリデーションを行う

を実現しました
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
既存の実装では
1. アンテナの新規作成時にはkeywordsが存在しないとエラーとしているが、アンテナの設定変更時には同等のチェックを行っていない
1. keywordsが存在しない場合のエラーとして`invalid param`というエラーの発生原因がわからないメッセージを返す

といった問題点がありました
少なくとも1.に関して解決をしたいという意図で行った変更です

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

この変更がMisskeyの仕様(または思想)に合致しているのかという点を図れていないため、私の実装がそれに反するものであれば再度変更いたします
具体的には
- アンテナのバリデーション基準(keywords無しでexcludeKeywordsのみのアンテナの存在を許してよいのか)
- エラーメッセージ(詳細なメッセージを返すことによるデメリットは存在しないか)

という点が気になっていますので、問題があればコメントいただけますと嬉しいです

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
