### PR TITLE
fix(backend): correctFilename changes dll to exe

### DIFF
--- a/packages/backend/src/misc/correct-filename.ts
+++ b/packages/backend/src/misc/correct-filename.ts
@@ -43,6 +43,8 @@ export function correctFilename(filename: string, ext: string | null) {
 		// jpeg, tiffを同一視
 		dotExt === '.jpg' && filenameExt === '.jpeg' ||
 		dotExt === '.tif' && filenameExt === '.tiff' ||
+		// dllもexeもportable executableなので判定が正しく行われない
+		dotExt === '.exe' && filenameExt === '.dll' ||
 
 		// 圧縮形式っぽければ下手に拡張子を変えない
 		// https://github.com/misskey-dev/misskey/issues/11482


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`.dll`が`.exe`になるので`.dll`のままにする

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
実行ファイルじゃないのが実行ファイル扱いを受けるので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

changelogは`ファイルアップロード時等にファイル名の拡張子を修正する関数(correctFilename)の挙動を改善`に含められると思ったため更新してません

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
