### PR TITLE
Fix: DB CONSTRAINT of RenoteMuting

### DIFF
--- a/packages/backend/migration/1665091090561-add-renote-muting.js
+++ b/packages/backend/migration/1665091090561-add-renote-muting.js
@@ -16,5 +16,9 @@ export class addRenoteMuting1665091090561 {
 	}
 
 	async down(queryRunner) {
+		await queryRunner.query(`DROP INDEX "IDX_renote_muting_muterId"`);
+		await queryRunner.query(`DROP INDEX "IDX_renote_muting_muteeId"`);
+		await queryRunner.query(`DROP INDEX "IDX_renote_muting_createdAt"`);
+		await queryRunner.query(`DROP TABLE "renote_muting"`);
 	}
 }

--- a/packages/backend/migration/1690417561185-fix-renote-muting.js
+++ b/packages/backend/migration/1690417561185-fix-renote-muting.js
@@ -1,5 +1,5 @@
-export class FixRenoteMuting1692060074749 {
-    name = 'FixRenoteMuting1692060074749'
+export class FixRenoteMuting1690417561185 {
+    name = 'FixRenoteMuting1690417561185'
 
     async up(queryRunner) {
       await queryRunner.query(`DELETE FROM "renote_muting" WHERE "muteeId" NOT IN (SELECT "id" FROM "user")`);

--- a/packages/backend/migration/1692060074749-fix-renote-muting.js
+++ b/packages/backend/migration/1692060074749-fix-renote-muting.js
@@ -1,0 +1,12 @@
+export class FixRenoteMuting1692060074749 {
+    name = 'FixRenoteMuting1692060074749'
+
+    async up(queryRunner) {
+      await queryRunner.query(`DELETE FROM "renote_muting" WHERE "muteeId" NOT IN (SELECT "id" FROM "user")`);
+      await queryRunner.query(`DELETE FROM "renote_muting" WHERE "muterId" NOT IN (SELECT "id" FROM "user")`);
+    }
+
+    async down(queryRunner) {
+
+    }
+}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fix: DB CONSTRAINT of RenoteMuting
リノートミュートしているユーザーが削除されてもリノートミュートが壊れないようにします。
現在リノートミュートが導入されていますが、ユーザーIDに対する外部キー制約を設定されていなかったため、リノートミュートされているユーザーが消された場合に、リノートミュートがうまく動かなくなります。
https://github.com/misskey-dev/misskey/pull/11398 にて外部キー制約が設定されましたが、以前古いレコードは残ったままであり、このままリリースしてしまうとマイグレーションがエラーとなり通らなくなります。
そのためこのPRにて、外部キー制約を導入するために、事前に該当レコードを削除します。
サブクエリは重くなる可能性がありますが、該当PRのマイグレーションを通すためにはやむを得ません。
またこれは新しいマイグレーションファイルとして用意される必要があります。
なぜならすでにマイグレーションを完了しているインスタンスには同じマイグレーションを適用することはできないからです。

今回と直接関係はないですがリノートミュートのdownメソッドが定義されませんでしたので、これは元のマイグレーションファイルに追記します。

## Why
Fix: https://github.com/misskey-dev/misskey/issues/11343
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Misskey v13.14.2 以降の開発ブランチの開発環境で問題なし
<img width="734" alt="Screenshot 2023-08-15 at 10 31 49" src="https://github.com/misskey-dev/misskey/assets/83960488/d610fa30-aec3-4b79-9d9f-3f005e00f3b0">

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
