### PR TITLE
enhance(backend): Add address bind config option

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -159,6 +159,9 @@ id: 'aid'
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 
+# Local address used for outgoing requests
+#outgoingAddress: 127.0.0.1
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 ### Server
 - Fix: APIのオフセットが壊れていたせいで「もっと見る」でもっと見れない問題を修正
 - Fix: 外部サーバーの投稿がタイムラインに表示されないことがある問題を修正
+- Enhance: Add address bind config option (outgoingAddress)
 
 ## 13.14.1
 

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -76,6 +76,7 @@ export type Source = {
 
 	id: string;
 
+	outgoingAddress?: string;
 	outgoingAddressFamily?: 'ipv4' | 'ipv6' | 'dual';
 
 	deliverJobConcurrency?: number;

--- a/packages/backend/src/core/HttpRequestService.ts
+++ b/packages/backend/src/core/HttpRequestService.ts
@@ -53,12 +53,14 @@ export class HttpRequestService {
 			keepAlive: true,
 			keepAliveMsecs: 30 * 1000,
 			lookup: cache.lookup as unknown as net.LookupFunction,
+			localAddress: config.outgoingAddress,
 		});
 
 		this.https = new https.Agent({
 			keepAlive: true,
 			keepAliveMsecs: 30 * 1000,
 			lookup: cache.lookup as unknown as net.LookupFunction,
+			localAddress: config.outgoingAddress,
 		});
 
 		const maxSockets = Math.max(256, config.deliverJobConcurrency ?? 128);
@@ -71,6 +73,7 @@ export class HttpRequestService {
 				maxFreeSockets: 256,
 				scheduling: 'lifo',
 				proxy: config.proxy,
+				localAddress: config.outgoingAddress,
 			})
 			: this.http;
 
@@ -82,6 +85,7 @@ export class HttpRequestService {
 				maxFreeSockets: 256,
 				scheduling: 'lifo',
 				proxy: config.proxy,
+				localAddress: config.outgoingAddress,
 			})
 			: this.https;
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
This adds a new config option, `outgoingAddress`, which lets the instance admin manually provide an IP address to bind to for outgoing fetch requests.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fixes #11406, which is caused when deploying Misskey in environments where requests are proxied by creating a new network interface, e.g. when using Wireguard or Tailscale.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
