### PR TITLE
fix(frontend): Misskeyプラグインをインストールする際のAiScriptバージョンのチェックが0.14.0以降に対応していない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - Fix: iOSで画面を回転させるとテキストサイズが変わる問題を修正
 - Fix: word mute for sub note is not applied
 - Fix: タイムラインを下にスクロールしてノート画面に移動して再び戻ったら以前のスクロール位置を失う問題を修正
-- Fix: Misskeyプラグインをインストールする際のAiScriptバージョンのチェックが0.14.0以降に対応していない問題を修正 https://github.com/misskey-dev/misskey/issues/11420
+- Fix: Misskeyプラグインをインストールする際のAiScriptバージョンのチェックが0.14.0以降に対応していない問題を修正
 
 ### Server
 - cacheRemoteFilesの初期値はfalseになりました

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix: iOSで画面を回転させるとテキストサイズが変わる問題を修正
 - Fix: word mute for sub note is not applied
 - Fix: タイムラインを下にスクロールしてノート画面に移動して再び戻ったら以前のスクロール位置を失う問題を修正
+- Fix: Misskeyプラグインをインストールする際のAiScriptバージョンのチェックが0.14.0以降に対応していない問題を修正 https://github.com/misskey-dev/misskey/issues/11420
 
 ### Server
 - cacheRemoteFilesの初期値はfalseになりました

--- a/packages/frontend/src/pages/settings/plugin.install.vue
+++ b/packages/frontend/src/pages/settings/plugin.install.vue
@@ -19,6 +19,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import { defineAsyncComponent, nextTick, ref } from 'vue';
+import { compareVersions } from 'compare-versions';
 import { Interpreter, Parser, utils } from '@syuilo/aiscript';
 import { v4 as uuid } from 'uuid';
 import MkTextarea from '@/components/MkTextarea.vue';
@@ -54,7 +55,7 @@ async function install() {
 			text: 'No language version annotation found :(',
 		});
 		return;
-	} else if (!(lv.startsWith('0.12.') || lv.startsWith('0.13.'))) {
+	} else if (compareVersions(lv, '0.12.0') < 0) {
 		os.alert({
 			type: 'error',
 			text: `aiscript version '${lv}' is not supported :(`,

--- a/packages/frontend/src/pages/settings/plugin.install.vue
+++ b/packages/frontend/src/pages/settings/plugin.install.vue
@@ -45,6 +45,14 @@ function installPlugin({ id, meta, src, token }) {
 	}));
 }
 
+function isSupportedAiScriptVersion(version: string): boolean {
+	try {
+		return (compareVersions(version, '0.12.0') >= 0);
+	} catch (err) {
+		return false;
+	}
+}
+
 async function install() {
 	if (code.value == null) return;
 
@@ -55,7 +63,7 @@ async function install() {
 			text: 'No language version annotation found :(',
 		});
 		return;
-	} else if (compareVersions(lv, '0.12.0') < 0) {
+	} else if (!isSupportedAiScriptVersion(lv)) {
 		os.alert({
 			type: 'error',
 			text: `aiscript version '${lv}' is not supported :(`,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
https://github.com/misskey-dev/misskey/blob/792622aeadf3e36d50cddec3c64b2ff0105ea927/packages/frontend/src/boot/common.ts#L82 で利用されている`compareVersions`を使って、AiScript0.12.0以降の全てのバージョンに対応させます。
Close #11420 

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- 0.14.0以降のバージョン表記がある場合にプラグインがインストール出来ないため。
- `0.12.`や`0.13.`が含まれているかどうかという判別方法では、条件が無限に増えていってしまうため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
