### PR TITLE
fix(frontend): fix `shapeFlag` error in admin announcements

### DIFF
--- a/packages/frontend/src/pages/admin/announcements.vue
+++ b/packages/frontend/src/pages/admin/announcements.vue
@@ -63,7 +63,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { } from 'vue';
+import { ref } from 'vue';
 import XHeader from './_header_.vue';
 import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
@@ -91,8 +91,8 @@ function add() {
 		imageUrl: null,
 		icon: 'info',
 		display: 'normal',
-		forExistingUsers: false,
-		needConfirmationToRead: false,
+		forExistingUsers: ref(false),
+		needConfirmationToRead: ref(false),
 	});
 }
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
- `packages/frontend/src/pages/admin/announcements.vue` line 94~95
    - `false` to `ref(false)`

## Why
- it causes `Cannot read properties of null (reading 'shapeFlag') at setVarsOnVNode` error

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
