### PR TITLE
fix(backend): change character limits to allow for long instance domains

### DIFF
--- a/packages/backend/migration/1692374635734-IncreaseHostCharLimit.js
+++ b/packages/backend/migration/1692374635734-IncreaseHostCharLimit.js
@@ -1,0 +1,47 @@
+export class IncreaseHostCharLimit1692374635734 {
+		name = 'IncreaseHostCharLimit1692374635734'
+
+		async up(queryRunner) {
+				await queryRunner.query(`ALTER TABLE "drive_file" ALTER COLUMN "userHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "host" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "userHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "user_publickey" ALTER COLUMN "keyId" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "emoji" ALTER COLUMN "host" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "userHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "replyUserHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "renoteUserHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "host" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "iconUrl" TYPE character varying(4096)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "faviconUrl" TYPE character varying(4096)`);
+
+				await queryRunner.query(`ALTER TABLE "poll" ALTER COLUMN "userHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "abuse_user_report" ALTER COLUMN "targetUserHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "abuse_user_report" ALTER COLUMN "reporterHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "following" ALTER COLUMN "followeeHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "following" ALTER COLUMN "followerHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "follow_request" ALTER COLUMN "followeeHost" TYPE character varying(512)`);
+				await queryRunner.query(`ALTER TABLE "follow_request" ALTER COLUMN "followerHost" TYPE character varying(512)`);
+		}
+
+		async down(queryRunner) {
+				await queryRunner.query(`ALTER TABLE "drive_file" ALTER COLUMN "userHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "user" ALTER COLUMN "host" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "user_profile" ALTER COLUMN "userHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "user_publickey" ALTER COLUMN "keyId" TYPE character varying(256)`);
+				await queryRunner.query(`ALTER TABLE "emoji" ALTER COLUMN "host" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "userHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "replyUserHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "note" ALTER COLUMN "renoteUserHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "host" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "iconUrl" TYPE character varying(256)`);
+				await queryRunner.query(`ALTER TABLE "instance" ALTER COLUMN "faviconUrl" TYPE character varying(256)`);
+
+				await queryRunner.query(`ALTER TABLE "poll" ALTER COLUMN "userHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "abuse_user_report" ALTER COLUMN "targetUserHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "abuse_user_report" ALTER COLUMN "reporterHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "following" ALTER COLUMN "followeeHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "following" ALTER COLUMN "followerHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "follow_request" ALTER COLUMN "followeeHost" TYPE character varying(128)`);
+				await queryRunner.query(`ALTER TABLE "follow_request" ALTER COLUMN "followerHost" TYPE character varying(128)`);
+		}
+}

--- a/packages/backend/src/models/entities/AbuseUserReport.ts
+++ b/packages/backend/src/models/entities/AbuseUserReport.ts
@@ -69,14 +69,14 @@ export class MiAbuseUserReport {
 	//#region Denormalized fields
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public targetUserHost: string | null;
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public reporterHost: string | null;

--- a/packages/backend/src/models/entities/DriveFile.ts
+++ b/packages/backend/src/models/entities/DriveFile.ts
@@ -36,7 +36,7 @@ export class MiDriveFile {
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: 'The host of owner. It will be null if the user in local.',
 	})
 	public userHost: string | null;

--- a/packages/backend/src/models/entities/Emoji.ts
+++ b/packages/backend/src/models/entities/Emoji.ts
@@ -25,7 +25,7 @@ export class MiEmoji {
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 	})
 	public host: string | null;
 

--- a/packages/backend/src/models/entities/Following.ts
+++ b/packages/backend/src/models/entities/Following.ts
@@ -48,7 +48,7 @@ export class MiFollowing {
 	//#region Denormalized fields
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public followerHost: string | null;
@@ -67,7 +67,7 @@ export class MiFollowing {
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public followeeHost: string | null;

--- a/packages/backend/src/models/entities/Instance.ts
+++ b/packages/backend/src/models/entities/Instance.ts
@@ -25,7 +25,7 @@ export class MiInstance {
 	 */
 	@Index({ unique: true })
 	@Column('varchar', {
-		length: 128,
+		length: 512,
 		comment: 'The host of the Instance.',
 	})
 	public host: string;
@@ -126,12 +126,12 @@ export class MiInstance {
 	public maintainerEmail: string | null;
 
 	@Column('varchar', {
-		length: 256, nullable: true,
+		length: 4096, nullable: true,
 	})
 	public iconUrl: string | null;
 
 	@Column('varchar', {
-		length: 256, nullable: true,
+		length: 4096, nullable: true,
 	})
 	public faviconUrl: string | null;
 

--- a/packages/backend/src/models/entities/Note.ts
+++ b/packages/backend/src/models/entities/Note.ts
@@ -204,7 +204,7 @@ export class MiNote {
 	//#region Denormalized fields
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public userHost: string | null;
@@ -217,7 +217,7 @@ export class MiNote {
 	public replyUserId: MiUser['id'] | null;
 
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public replyUserHost: string | null;
@@ -230,7 +230,7 @@ export class MiNote {
 	public renoteUserId: MiUser['id'] | null;
 
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public renoteUserHost: string | null;

--- a/packages/backend/src/models/entities/Poll.ts
+++ b/packages/backend/src/models/entities/Poll.ts
@@ -54,7 +54,7 @@ export class MiPoll {
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public userHost: string | null;

--- a/packages/backend/src/models/entities/User.ts
+++ b/packages/backend/src/models/entities/User.ts
@@ -201,7 +201,7 @@ export class MiUser {
 
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: 'The host of the User. It will be null if the origin of the user is local.',
 	})
 	public host: string | null;

--- a/packages/backend/src/models/entities/UserProfile.ts
+++ b/packages/backend/src/models/entities/UserProfile.ts
@@ -238,7 +238,7 @@ export class MiUserProfile {
 	//#region Denormalized fields
 	@Index()
 	@Column('varchar', {
-		length: 128, nullable: true,
+		length: 512, nullable: true,
 		comment: '[Denormalized]',
 	})
 	public userHost: string | null;

--- a/packages/backend/src/models/entities/UserPublickey.ts
+++ b/packages/backend/src/models/entities/UserPublickey.ts
@@ -20,7 +20,7 @@ export class MiUserPublickey {
 
 	@Index({ unique: true })
 	@Column('varchar', {
-		length: 256,
+		length: 512,
 	})
 	public keyId: string;
 


### PR DESCRIPTION
## What
This PR changes the max length for hosts of various entities to 512 characters, and the max length of favicon and icon URLs for instances to 4096 characters, to allow federation to work properly with instances that have long domains.

## Why
Federation with instances with large domains such as [this one](https://helloeverybodymynameismarkiplierandwelcometofivenightsatfreddys.anindiehorrorgamethatyouguyssuggestedenmasseandisawthatyamimash.playeditandhesaidthatitwasreallyreallygoodsoimveryeagertoseewha.tisupandthatisaterrifyinganimatronicbear.fnaf.stream) is broken due to database fields having too short of a character limit

## Additional info (optional)
There's probably a better way to do this, but i've tested this and it works fine. I'm open to suggestions if there's a better way to fix this.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
