### PR TITLE
Respond .well-known/host-meta.json with application/json

### DIFF
--- a/packages/backend/src/server/WellKnownServerService.ts
+++ b/packages/backend/src/server/WellKnownServerService.ts
@@ -73,7 +73,7 @@ export class WellKnownServerService {
 		});
 
 		fastify.get('/.well-known/host-meta.json', async (request, reply) => {
-			reply.header('Content-Type', jrd);
+			reply.header('Content-Type', 'application/json');
 			return {
 				links: [{
 					rel: 'lrdd',


### PR DESCRIPTION
According to RFC 6415 appendix-A.
>   The server
   MUST include the HTTP "Content-Type" response header field with a
   value of "application/json".  Any other "Content-Type" value (or lack
   thereof) indicates that the server does not support the JRD format.

`application/jrd+json` is only used by WebFinger (RFC 7033)
