### PR TITLE
fix(backend): timeout when querying mentions

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/mentions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/mentions.ts
@@ -63,6 +63,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					.where(`'{"${me.id}"}' <@ note.mentions`)
 					.orWhere(`'{"${me.id}"}' <@ note.visibleUserIds`);
 				}))
+				// Avoid scanning primary key index
+				.orderBy('CONCAT(note.id)', 'DESC')
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('note.reply', 'reply')
 				.leftJoinAndSelect('note.renote', 'renote')


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
I use a trick to avoid using primary key to solve a slow query problem. Is there any other better way?

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
For queries like this, postgresql sometimes decides to scan the primary key instead of using the index on "visibleUserIds" field
```SQL
EXPLAIN
SELECT
	"note"."id" AS "note_id"
FROM
	"note" "note"
WHERE
	'{"01GWCS86KKFQX39VH79KMD48JS"}' <@"note"."visibleUserIds"
ORDER BY
	"note"."id" DESC
LIMIT 10
```
However, postgresql doesn't know that sometimes users' data distribution is very uneven, which is the reason for the timeout problems some people have.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Expected to be fast, actually very slow :
<img width="706" alt="image" src="https://github.com/misskey-dev/misskey/assets/80657402/9a0f131c-80ce-4d60-98fd-bce2d625dd41">

Satisfactory speed :
<img width="652" alt="image" src="https://github.com/misskey-dev/misskey/assets/80657402/39b2fcf2-fec1-49aa-a991-a084aa83c60c">



## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
