### PR TITLE
feat: nodeinfo 2.1

### DIFF
--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -73,7 +73,8 @@ export class NodeinfoServerService {
 
 			const basePolicies = { ...DEFAULT_POLICIES, ...meta.policies };
 
-			let document: any = {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const document: any = {
 				software: {
 					name: 'misskey',
 					version: this.config.version,
@@ -113,7 +114,7 @@ export class NodeinfoServerService {
 					themeColor: meta.themeColor ?? '#86b300',
 				},
 			};
-			if(version >= 21) {
+			if (version >= 21) {
 				document.software.repository = meta.repositoryUrl;
 				document.software.homepage = meta.repositoryUrl;
 			}

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -125,7 +125,11 @@ export class NodeinfoServerService {
 		fastify.get(nodeinfo2_1path, async (request, reply) => {
 			const base = await cache.fetch(() => nodeinfo2(21));
 
-			reply.header('Cache-Control', 'public, max-age=600');
+			reply
+				.type(
+					'application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.1#"',
+				)
+				.header('Cache-Control', 'public, max-age=600');
 			return { version: '2.1', ...base };
 		});
 
@@ -134,7 +138,11 @@ export class NodeinfoServerService {
 
 			delete (base as any).software.repository;
 
-			reply.header('Cache-Control', 'public, max-age=600');
+			reply
+				.type(
+					'application/json; profile="http://nodeinfo.diaspora.software/ns/schema/2.0#"',
+				)
+				.header('Cache-Control', 'public, max-age=600');
 			return { version: '2.0', ...base };
 		});
 

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -35,10 +35,10 @@ export class NodeinfoServerService {
 
 	@bindThis
 	public getLinks() {
-		return [/* (awaiting release) {
-			rel: 'http://nodeinfo.diaspora.software/ns/schema/2.1',
-			href: config.url + nodeinfo2_1path
-		}, */{
+		return [{
+				rel: 'http://nodeinfo.diaspora.software/ns/schema/2.1',
+				href: this.config.url + nodeinfo2_1path
+			}, {
 				rel: 'http://nodeinfo.diaspora.software/ns/schema/2.0',
 				href: this.config.url + nodeinfo2_0path,
 			}];

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -115,6 +115,7 @@ export class NodeinfoServerService {
 			};
 			if(version >= 21) {
 				document.software.repository = meta.repositoryUrl;
+				document.software.homepage = meta.repositoryUrl;
 			}
 			return document;
 		};


### PR DESCRIPTION
Since 9dd06a7621d1745b30ed1c2b1d94d34143dd638e, nodeinfo 2.1 has been released.

<https://github.com/jhass/nodeinfo/releases/tag/2.1>

```diff
3,4c3,4
<   "id": "http://nodeinfo.diaspora.software/ns/schema/2.0#",
<   "description": "NodeInfo schema version 2.0.",
---
>   "id": "http://nodeinfo.diaspora.software/ns/schema/2.1#",
>   "description": "NodeInfo schema version 2.1.",
18c18
<       "description": "The schema version, must be 2.0.",
---
>       "description": "The schema version, must be 2.1.",
20c20
<         "2.0"
---
>         "2.1"
38a39,46
>           "type": "string"
>         },
>         "repository": {
>           "description": "The url of the source code repository of this server software.",
>           "type": "string"
>         },
>         "homepage": {
>           "description": "The url of the homepage of this server software.",
```