### PR TITLE
feat: Mk:api()の第三引数にnullを渡せるように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Enhance: タイムラインでリスト/アンテナ選択時のパフォーマンスを改善
 - Enhance: 「Moderation note」、「Add moderation note」をローカライズできるように
 - Enhance: 細かなデザインの調整
+- Enhance: Mk:apiの第三引数に`null`を渡せるように
 - Fix: サーバー情報画面(`/instance-info/{domain}`)でブロックができないのを修正
 - Fix: 未読のお知らせの「わかった」をクリック・タップしてもその場で「わかった」が消えない問題を修正
 - Fix: iOSで画面を回転させるとテキストサイズが変わる問題を修正

--- a/packages/frontend/src/scripts/aiscript/api.ts
+++ b/packages/frontend/src/scripts/aiscript/api.ts
@@ -35,11 +35,13 @@ export function createAiScriptEnv(opts) {
 		}),
 		'Mk:api': values.FN_NATIVE(async ([ep, param, token]) => {
 			if (token) {
-				utils.assertString(token);
-				// バグがあればundefinedもあり得るため念のため
-				if (typeof token.value !== 'string') throw new Error('invalid token');
+				if (token.type !== 'null') {
+					utils.assertString(token);
+					// バグがあればundefinedもあり得るため念のため
+					if (typeof token.value !== 'string') throw new Error('invalid token');
+				}
 			}
-			return os.api(ep.value, utils.valToJs(param), token ? token.value : (opts.token ?? null)).then(res => {
+			return os.api(ep.value, utils.valToJs(param), (token ? token.value : opts.token) ?? null).then(res => {
 				return utils.jsToVal(res);
 			}, err => {
 				return values.ERROR('request_failed', utils.jsToVal(err));


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Mk:api()の第三引数にnullを渡すことが出来るようにしました。
これにより、トークン無しでエンドポイントを叩けるようになり、リモートサーバーのAPIを利用する際に便利です。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Close #11495 

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
AiScript側のutils( https://github.com/syuilo/aiscript/blob/06d9c4f67a5231d06d64654a4647a0047585cf94/src/interpreter/util.ts )でnullを許容したままタイプチェックする方法が無さそうでしたので、とりあえずMisskey側で中身がnullかどうか確認し、nullでない場合には従来通り`utils.assertString()`が呼び出されるように実装しています。
そのため、実際にはnullを許容するにも関わらず、nullやstring以外の値が渡された場合の例外文は`Expect string, but got~`となってしまいます。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
