### PR TITLE
feat(backend): MasterプロセスのPIDを書き出せるように

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -30,7 +30,7 @@ url: https://example.tld/
 # The port that your Misskey server should listen on.
 port: 3000
 
-# You can also use UNIX domain socket. 
+# You can also use UNIX domain socket.
 # socket: /path/to/misskey.sock
 # chmodSocket: '777'
 
@@ -60,17 +60,17 @@ dbReplications: false
 # You can configure any number of replicas here
 #dbSlaves:
 #  -
-#    host: 
-#    port: 
-#    db: 
-#    user: 
-#    pass: 
+#    host:
+#    port:
+#    db:
+#    user:
+#    pass:
 #  -
-#    host: 
-#    port: 
-#    db: 
-#    user: 
-#    pass: 
+#    host:
+#    port:
+#    db:
+#    user:
+#    pass:
 
 #   ┌─────────────────────┐
 #───┘ Redis configuration └─────────────────────────────────────
@@ -206,3 +206,6 @@ signToActivityPubGet: true
 
 # Upload or download file size limits (bytes)
 #maxFileSize: 262144000
+
+# PID File of master process
+#pidFile: /tmp/misskey.pid

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -63,6 +63,7 @@ export async function masterMain() {
 		showNodejsVersion();
 		config = loadConfigBoot();
 		//await connectDb();
+		if (config.pidFile) fs.writeFileSync(config.pidFile, process.pid.toString());
 	} catch (e) {
 		bootLogger.error('Fatal error occurred during initialization', null, true);
 		process.exit(1);

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -89,6 +89,7 @@ type Source = {
 	perChannelMaxNoteCacheCount?: number;
 	perUserNotificationsMaxCount?: number;
 	deactivateAntennaThreshold?: number;
+	pidFile: string;
 };
 
 export type Config = {
@@ -163,6 +164,7 @@ export type Config = {
 	perChannelMaxNoteCacheCount: number;
 	perUserNotificationsMaxCount: number;
 	deactivateAntennaThreshold: number;
+	pidFile: string;
 };
 
 const _filename = fileURLToPath(import.meta.url);
@@ -255,6 +257,7 @@ export function loadConfig(): Config {
 		perChannelMaxNoteCacheCount: config.perChannelMaxNoteCacheCount ?? 1000,
 		perUserNotificationsMaxCount: config.perUserNotificationsMaxCount ?? 300,
 		deactivateAntennaThreshold: config.deactivateAntennaThreshold ?? (1000 * 60 * 60 * 24 * 7),
+		pidFile: config.pidFile,
 	};
 }
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
config.pidFileの設定に基づき、masterプロセスのPIDを書き出せるようにする。
#11734 の代替案でもある。

## Why
systemdなどにおいてプロセスの生存確認、確実に停止したりすることなどに有用なため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
