### PR TITLE
refactor(backend): Use `request.routeOptions.url` instead of `request.routerPath` to supress FSTDEP017

### DIFF
--- a/packages/backend/src/server/web/ClientServerService.ts
+++ b/packages/backend/src/server/web/ClientServerService.ts
@@ -188,7 +188,7 @@ export class ClientServerService {
 		// Authenticate
 		fastify.addHook('onRequest', async (request, reply) => {
 			// %71ueueとかでリクエストされたら困るため
-			const url = decodeURI(request.routerPath);
+			const url = decodeURI(request.routeOptions.url);
 			if (url === bullBoardPath || url.startsWith(bullBoardPath + '/')) {
 				const token = request.cookies.token;
 				if (token == null) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
- close #11934
- fastifyの`request.routerPath`が使われているところを`request.routeOptions.url`に書きかえています
  (一箇所だけでしたが……)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- issueにもある通り、`request.routerPath`はFastifyの次のメジャーアップデートで削除される予定の非推奨プロパティです。
- 早急に変える必要は認められないといえばそうなのですが、
  このせいで警告FSTDEP017がリクエストごとにログに出てきて少し邪魔です……

<br />

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
