### PR TITLE
2段階認証のバックアップコード一覧をテキストファイルでダウンロード可能に

### DIFF
--- a/packages/frontend/src/pages/settings/2fa.qrdialog.vue
+++ b/packages/frontend/src/pages/settings/2fa.qrdialog.vue
@@ -83,6 +83,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 											<template #value><code class="_monospace">{{ code }}</code></template>
 										</MkKeyValue>
 									</div>
+
+									<MkButton primary rounded gradate @click="downloadBackupCodes"><i class="ti ti-download"></i> {{ i18n.ts.download }}</MkButton>
 								</div>
 							</MkFolder>
 						</div>
@@ -108,6 +110,7 @@ import * as os from '@/os.js';
 import MkFolder from '@/components/MkFolder.vue';
 import MkInfo from '@/components/MkInfo.vue';
 import { confetti } from '@/scripts/confetti.js';
+import { $i } from '@/account.js';
 
 defineProps<{
 	twoFactorData: {
@@ -141,6 +144,16 @@ async function tokenDone() {
 	confetti({
 		duration: 1000 * 3,
 	});
+}
+
+function downloadBackupCodes() {
+	if (backupCodes.value !== undefined) {
+		const txtBlob = new Blob([backupCodes.value.join('\n')], { type: 'text/plain' });
+		const dummya = document.createElement('a');
+		dummya.href = URL.createObjectURL(txtBlob);
+		dummya.download = `${$i?.username}-2fa-backup-codes.txt`;
+		dummya.click();
+	}
 }
 
 function allDone() {


### PR DESCRIPTION
## What
2段階認証のセットアップ完了時に発行されるバックアップコードを一覧にしたテキストファイルをダウンロードできるようにする。
<img src="https://github.com/misskey-dev/misskey/assets/26585194/c33677b0-56b3-4d57-9f19-0cc7fdd7b648" width="320">

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
