### PR TITLE
chore: Use pnpm@8.8.0 on DevContainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"features": {
-		"ghcr.io/devcontainers-contrib/features/pnpm:2": {},
+		"ghcr.io/devcontainers-contrib/features/pnpm:2": {
+			"version": "8.8.0"
+		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "20.5.1"
 		}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
DevContainer環境で使うpnpmのバージョンをlatestから8.8.0に固定する

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

DevContainerではデフォルトのpnpmは(なぜか)7.28.0がインストールされるが、このバージョンではpnpm installが正しく動かない。
おそらく原因はpnpmのバグ https://github.com/pnpm/pnpm/issues/6424 で 8.3.1 で修正されている。
8.8.0を使えば問題なくpnpm iできる。

```
node ➜ /workspace (develop) $ pnpm install --frozen-lockfile
Scope: all 5 workspace projects
Lockfile is up to date, resolution step is skipped
 WARN  GET https://codeload.github.com/misskey-dev/storybook-addon-misskey-theme/tar.gz/cf583db098365b2ccc81a82f63ca9c93bc32b640 error (ERR_INVALID_THIS). Will retry in 10 seconds. 2 retries left.
Packages: +1
+
 WARN  GET https://codeload.github.com/misskey-dev/storybook-addon-misskey-theme/tar.gz/cf583db098365b2ccc81a82f63ca9c93bc32b640 error (ERR_INVALID_THIS). Will retry in 1 minute. 1 retries left.
 ERR_INVALID_THIS  Value of "this" must be of type URLSearchParams

pnpm [ERR_INVALID_THIS]: Value of "this" must be of type URLSearchParams
    at new NodeError (node:internal/errors:405:5)
    at Proxy.getAll (node:internal/url:527:13)
    at Proxy.<anonymous> (/usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59406:55)
    at /usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59468:31
    at Array.reduce (<anonymous>)
    at Proxy.raw (/usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59467:33)
    at new Headers (/usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59352:28)
    at getNodeRequestOptions (/usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59701:23)
    at /usr/local/share/npm-global/lib/node_modules/pnpm/dist/pnpm.cjs:59758:25
    at new Promise (<anonymous>)
Progress: resolved 1, reused 0, downloaded 0, added 0
node ➜ /workspace (develop) $ 
```

また、 package.jsonには ac19b055c7fa44c88d91c7fba6c76027a577a021 で `"packageManager": "pnpm@8.8.0"` が明記されているので一致させておいたほうがよい。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

*    DevContainerをRebuildしてpnpmのバージョンが上がっていること。
*   pnpm startしてdevサーバーが立ち上がること

Before
```
node ➜ /workspace (develop) $ pnpm -v
7.28.0
```

After
```
node ➜ /workspace (chore/set-pnpm-version-on-devcontainer) $ pnpm -v
8.8.0
```

環境:
* Windows 10 Pro 22H2
* Docker Desktop 4.24.1
* VSCode 1.83.0

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
