### PR TITLE
redisForTimelineに入っていない古い投稿を見れるようにする

### DIFF
--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -874,7 +874,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 			});
 
 			// TODO: あまりにも数が多いと redisPipeline.exec に失敗する(理由は不明)ため、3万件程度を目安に分割して実行するようにする
-			for (const following of [...followings, note.userId]) {
+			for (const following in [...Object.keys(followings), note.userId]) {
 				// 自分自身以外への返信
 				if (note.replyId && note.replyUserId !== note.userId) {
 					if (!following.withReplies) continue;

--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -874,7 +874,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 			});
 
 			// TODO: あまりにも数が多いと redisPipeline.exec に失敗する(理由は不明)ため、3万件程度を目安に分割して実行するようにする
-			for (const following in [...Object.keys(followings), note.userId]) {
+			for (const following of followings) {
 				// 自分自身以外への返信
 				if (note.replyId && note.replyUserId !== note.userId) {
 					if (!following.withReplies) continue;

--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -874,7 +874,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 			});
 
 			// TODO: あまりにも数が多いと redisPipeline.exec に失敗する(理由は不明)ため、3万件程度を目安に分割して実行するようにする
-			for (const following of followings) {
+			for (const following of [...followings, note.userId]) {
 				// 自分自身以外への返信
 				if (note.replyId && note.replyUserId !== note.userId) {
 					if (!following.withReplies) continue;

--- a/packages/backend/src/core/QueryService.ts
+++ b/packages/backend/src/core/QueryService.ts
@@ -106,6 +106,28 @@ export class QueryService {
 	}
 
 	@bindThis
+	public generateChannelQuery(q: SelectQueryBuilder<any>, me?: { id: MiUser['id'] } | null): void {
+		if (me == null) {
+			q.andWhere('note.channelId IS NULL');
+		} else {
+			q.leftJoinAndSelect('note.channel', 'channel');
+
+			const channelFollowingQuery = this.channelFollowingsRepository.createQueryBuilder('channelFollowing')
+				.select('channelFollowing.followeeId')
+				.where('channelFollowing.followerId = :followerId', { followerId: me.id });
+
+			q.andWhere(new Brackets(qb => { qb
+				// チャンネルのノートではない
+				.where('note.channelId IS NULL')
+				// または自分がフォローしているチャンネルのノート
+				.orWhere(`note.channelId IN (${ channelFollowingQuery.getQuery() })`);
+			}));
+
+			q.setParameters(channelFollowingQuery.getParameters());
+		}
+	}
+
+	@bindThis
 	public generateMutedNoteThreadQuery(q: SelectQueryBuilder<any>, me: { id: MiUser['id'] }): void {
 		const mutedQuery = this.noteThreadMutingsRepository.createQueryBuilder('threadMuted')
 			.select('threadMuted.threadId')
@@ -174,6 +196,32 @@ export class QueryService {
 		q.andWhere(`user.id NOT IN (${ mutingQuery.getQuery() })`);
 
 		q.setParameters(mutingQuery.getParameters());
+	}
+
+	@bindThis
+	public generateRepliesQuery(q: SelectQueryBuilder<any>, withReplies: boolean, me?: Pick<MiUser, 'id'> | null): void {
+		if (me == null) {
+			q.andWhere(new Brackets(qb => { qb
+				.where('note.replyId IS NULL') // 返信ではない
+				.orWhere(new Brackets(qb => { qb // 返信だけど投稿者自身への返信
+					.where('note.replyId IS NOT NULL')
+					.andWhere('note.replyUserId = note.userId');
+				}));
+			}));
+		} else if (!withReplies) {
+			q.andWhere(new Brackets(qb => { qb
+				.where('note.replyId IS NULL') // 返信ではない
+				.orWhere('note.replyUserId = :meId', { meId: me.id }) // 返信だけど自分のノートへの返信
+				.orWhere(new Brackets(qb => { qb // 返信だけど自分の行った返信
+					.where('note.replyId IS NOT NULL')
+					.andWhere('note.userId = :meId', { meId: me.id });
+				}))
+				.orWhere(new Brackets(qb => { qb // 返信だけど投稿者自身への返信
+					.where('note.replyId IS NOT NULL')
+					.andWhere('note.replyUserId = note.userId');
+				}));
+			}));
+		}
 	}
 
 	@bindThis

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -59,6 +59,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private notesRepository: NotesRepository,
 
 		private noteEntityService: NoteEntityService,
+		private queryService: QueryService,
 		private activeUsersChart: ActiveUsersChart,
 		private idService: IdService,
 		private cacheService: CacheService,

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -110,7 +110,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				this.queryService.generateMutedUserQuery(query, me);
 				this.queryService.generateBlockedUserQuery(query, me);
 				this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
-				let ids = await query.limit(limit - noteIds.length).getMany();
+				const ids = await query.limit(limit - noteIds.length).getMany();
 				noteIds = noteIds.concat(ids.map(note => note.id));
 			}
 


### PR DESCRIPTION
## What
https://github.com/misskey-dev/misskey/issues/11958
redisForTimelineに入っていない古い投稿を見れるようにする Get older posts not stored in redisForTimeline

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
・とりあえずホームタイムラインのみ実装
・タイムラインを200件以上さかのぼった場合、DBにアクセスしノートが取得できることを確認した

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
