### PR TITLE
fix: Refetch user keys when HTTP Signature validation fails

### DIFF
--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -164,6 +164,19 @@ export class ApDbResolverService implements OnApplicationShutdown {
 		};
 	}
 
+	/**
+	 * Miskey User -> Refetched Key
+	 */
+	@bindThis
+	public async refetchPublicKeyForApId(user: MiRemoteUser): Promise<MiUserPublickey | null> {
+		await this.apPersonService.updatePerson(user.uri!);
+		const key = this.userPublickeysRepository.findOneBy({ userId: user.id });
+		if (key != null) {
+			await this.publicKeyByUserIdCache.set(user.id, key);
+		}
+		return key;
+	}
+
 	@bindThis
 	public dispose(): void {
 		this.publicKeyCache.dispose();

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -104,7 +104,18 @@ export class InboxProcessorService {
 		}
 
 		// HTTP-Signatureの検証
-		const httpSignatureValidated = httpSignature.verifySignature(signature, authUser.key.keyPem);
+		let httpSignatureValidated = httpSignature.verifySignature(signature, authUser.key.keyPem);
+
+		// If signature validation failed, try refetching the actor
+		if (!httpSignatureValidated) {
+			authUser.key = await this.apDbResolverService.refetchPublicKeyForApId(authUser.user);
+
+			if (authUser.key == null) {
+				throw new Bull.UnrecoverableError('skip: failed to re-resolve user publicKey');
+			}
+
+			httpSignatureValidated = httpSignature.verifySignature(signature, authUser.key.keyPem);
+		}
 
 		// また、signatureのsignerは、activity.actorと一致する必要がある
 		if (!httpSignatureValidated || authUser.user.uri !== activity.actor) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
If a user has had a key rotation, and nobody on this server follows that user, we will not receive the Update activity with the new key

Therefore, when we encounter key validation errors we should check for an up-to-date key.

## Why
Currently, federation will break with accounts on remote servers which have no local followers as the key update activity will not be received

This can happen if, for example, a Mastodon admin runs `tootctl accounts rotate`

## Additional info (optional)
Behaviour mirrors other implementations:

 * [Mastodon](https://github.com/mastodon/mastodon/blob/fc9ab61448af94513524f14f5fd287d2a26ceeab/app/controllers/concerns/signature_verification.rb#L96)
 * [Akkoma](https://akkoma.dev/AkkomaGang/http_signatures/src/branch/main/lib/http_signatures/http_signatures.ex#L46)

This is a port of [Iceshrimp PR 327](https://iceshrimp.dev/iceshrimp/iceshrimp/pulls/327), and has been verified as resolving federation issues there

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
