### PR TITLE
UserLite.nameにnullが入りうるのを型で明示

### DIFF
--- a/packages/misskey-js/etc/misskey-js.api.md
+++ b/packages/misskey-js/etc/misskey-js.api.md
@@ -2961,7 +2961,7 @@ type UserLite = {
     id: ID;
     username: string;
     host: string | null;
-    name: string;
+    name: string | null;
     onlineStatus: 'online' | 'active' | 'offline' | 'unknown';
     avatarUrl: string;
     avatarBlurhash: string;

--- a/packages/misskey-js/src/entities.ts
+++ b/packages/misskey-js/src/entities.ts
@@ -12,7 +12,7 @@ export type UserLite = {
 	id: ID;
 	username: string;
 	host: string | null;
-	name: string;
+	name: string | null;
 	onlineStatus: 'online' | 'active' | 'offline' | 'unknown';
 	avatarUrl: string;
 	avatarBlurhash: string;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
型の修正です。
- UserLite.nameにnullが入りうるのを型で明示しました
具体的には、新規登録後のユーザーで名前が未設定の場合にnullになります。
<img width="626" alt="image" src="https://github.com/misskey-dev/misskey/assets/49822810/f7fa0d61-b65c-4b66-8649-b7275c4951ee">

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
例えばi18n周りで不正な引数が渡ることになり、フォールバックとしてキーが表示される状態になります。
![image](https://github.com/misskey-dev/misskey/assets/49822810/315aaacd-59f3-4191-be7e-1e1deefe16aa)
![image](https://github.com/misskey-dev/misskey/assets/49822810/d21cdd14-97a3-4400-8b1d-858517ccb22f)

注) 下記画像の変更はPRに含みません
![image](https://github.com/misskey-dev/misskey/assets/49822810/58dae546-8fa9-41c7-ad03-bd80ea398a77)



## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
