### PR TITLE
fix(frontend): Recieve Unrenote on streaming

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -232,6 +232,7 @@ const keymap = {
 useNoteCapture({
 	rootEl: el,
 	note: $$(appearNote),
+	pureNote: $$(note),
 	isDeletedRef: isDeleted,
 });
 

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -296,6 +296,7 @@ const reactionsPagination = $computed(() => ({
 useNoteCapture({
 	rootEl: el,
 	note: $$(appearNote),
+	pureNote: $$(note),
 	isDeletedRef: isDeleted,
 });
 

--- a/packages/frontend/src/scripts/use-note-capture.ts
+++ b/packages/frontend/src/scripts/use-note-capture.ts
@@ -84,7 +84,7 @@ export function useNoteCapture(props: {
 		if (connection) {
 			// TODO: このノートがストリーミング経由で流れてきた場合のみ sr する
 			connection.send(document.body.contains(props.rootEl.value) ? 'sr' : 's', { id: note.value.id });
-			if (pureNote.value.id != note.value.id) connection.send('s', { id: pureNote.value.id });
+			if (pureNote.value.id !== note.value.id) connection.send('s', { id: pureNote.value.id });
 			if (withHandler) connection.on('noteUpdated', onStreamNoteUpdated);
 		}
 	}

--- a/packages/frontend/src/scripts/use-note-capture.ts
+++ b/packages/frontend/src/scripts/use-note-capture.ts
@@ -11,15 +11,17 @@ import { $i } from '@/account.js';
 export function useNoteCapture(props: {
 	rootEl: Ref<HTMLElement>;
 	note: Ref<Misskey.entities.Note>;
+	pureNote: Ref<Misskey.entities.Note>;
 	isDeletedRef: Ref<boolean>;
 }) {
 	const note = props.note;
+	const pureNote = props.pureNote;
 	const connection = $i ? useStream() : null;
 
 	function onStreamNoteUpdated(noteData): void {
 		const { type, id, body } = noteData;
 
-		if (id !== note.value.id) return;
+		if ((id !== note.value.id) && (id !== pureNote.value.id)) return;
 
 		switch (type) {
 			case 'reacted': {
@@ -82,6 +84,7 @@ export function useNoteCapture(props: {
 		if (connection) {
 			// TODO: このノートがストリーミング経由で流れてきた場合のみ sr する
 			connection.send(document.body.contains(props.rootEl.value) ? 'sr' : 's', { id: note.value.id });
+			if (pureNote.value.id != note.value.id) connection.send('s', { id: pureNote.value.id });
 			if (withHandler) connection.on('noteUpdated', onStreamNoteUpdated);
 		}
 	}

--- a/packages/frontend/src/scripts/use-note-capture.ts
+++ b/packages/frontend/src/scripts/use-note-capture.ts
@@ -94,6 +94,11 @@ export function useNoteCapture(props: {
 			connection.send('un', {
 				id: note.value.id,
 			});
+			if (pureNote.value.id !== note.value.id) {
+				connection.send('un', {
+					id: pureNote.value.id,
+				});
+			}
 			if (withHandler) connection.off('noteUpdated', onStreamNoteUpdated);
 		}
 	}


### PR DESCRIPTION
表示しているリノートがリノート解除されたらストリーミングで受信してすぐに消えるようにする

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
`useNoteCapture`で見て`sr`もしくは`s`してるのが`appearNote`のみで
ほとんどはこれで問題がないが
リノート解除の場合は`pureNote`を`s`していないと受信して反映ができない
そのため`appearNote`と`pureNote`が違う場合のみ`s`する
おそらく`pureNote`対象に流れてくるのは`deleted`のみなはずだが
クライアントの表示件数のみストリームに接続するので許容してほしい

## Why
Resolve https://github.com/misskey-dev/misskey/issues/12078

## Additional info (optional)
ローカル環境とテスト環境で確認済み
## 📌 Environment
Misskey v12.119.2
Misskey 2023.10.2-beta.2
### 💻 Frontend
* Model and OS of the device(s):
macOS Sonoma
iOS 15.7.1
* Browser:
Firefox 115.3.1esr (64-bit)
Firefox Focus 118.0
* Server URL:
Our Misskey Test Environment
* Misskey:
Misskey 12.119.2
Misskey 2023.10.2-beta.2

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
