### PR TITLE
fix(frontend): Use opening quote in notifications

### DIFF
--- a/packages/frontend/src/components/MkNotification.vue
+++ b/packages/frontend/src/components/MkNotification.vue
@@ -283,6 +283,12 @@ useTooltip(reactionRef, (showing) => {
 
 .quote:first-child {
 	margin-right: 4px;
+	position: relative;
+
+	&:before {
+		position: absolute;
+		transform: rotate(180deg);
+	}
 }
 
 .quote:last-child {


### PR DESCRIPTION
## What
Changed left quote on notifications to opening quote.

## Why
Closes #12071 

## Additional info (optional)
<img width="1084" alt="image" src="https://github.com/misskey-dev/misskey/assets/12772118/4b9ca471-fac2-4fae-bf36-62983c7ae7b8">

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
