### PR TITLE
enhance(server): Improve user block (Renote Part)

### DIFF
--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -56,6 +56,7 @@ import { SearchService } from '@/core/SearchService.js';
 import { FeaturedService } from '@/core/FeaturedService.js';
 import { FunoutTimelineService } from '@/core/FunoutTimelineService.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import { UserBlockingService } from '@/core/UserBlockingService.js';
 
 type NotificationType = 'reply' | 'renote' | 'quote' | 'mention';
 
@@ -216,6 +217,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 		private activeUsersChart: ActiveUsersChart,
 		private instanceChart: InstanceChart,
 		private utilityService: UtilityService,
+		private userBlockingService: UserBlockingService,
 	) { }
 
 	@bindThis
@@ -289,6 +291,18 @@ export class NoteCreateService implements OnApplicationShutdown {
 				case 'specified':
 					// specified / direct noteはreject
 					throw new Error('Renote target is not public or home');
+			}
+		}
+
+		// Check blocking
+		if (data.renote && data.text == null && data.poll == null && (data.files == null || data.files.length === 0)) {
+			if (data.renote.userHost === null) {
+				if (data.renote.userId !== user.id) {
+					const blocked = await this.userBlockingService.checkBlocked(data.renote.userId, user.id);
+					if (blocked) {
+						throw new Error('blocked');
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
## What
When you try to Renote, do not create a renote if you are blocked by the original note author of the renote.
リノートするとき、リノートのオリジナルノート投稿者にブロックされている場合、リノートを作成しないようにします

## Why
Resolve https://github.com/misskey-dev/misskey/issues/9395
現在は当時と違ってBlockingをCacheでDBに負荷かけずに
取得できるようになっていて処理しやすくなっているので
Currently, unlike when the issue was created, blocking information can be retrieved without loading the DB by using Cache.

## Additional info (optional)
ローカル環境とテスト環境で確認済み
現状Renoteのみを処理する
Quoteならばブロックの判定が再帰的になる可能性があるためここでは検査しない
`data.renote.userHost`が`null`じゃない場合に検査するのは
リモート→ローカルのブロックか
リモート→リモートのブロックであり
リモート→ローカルのブロックはローカルのAPIレベルでリノートを禁止しており
リモート→リモートのブロック情報は保持していないから
検査する意味がないのでここでは検査しない

* Model and OS of the device(s):
macOS Sonoma
* Browser:
Firefox 115.3.1esr (64-bit)
* Server URL:
Our Misskey Test Environment
* Misskey:
Misskey 2023.10.2-beta.2

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
