### PR TITLE
プロフィールのURL認証をrel=meで可能に

### DIFF
--- a/packages/backend/src/server/api/endpoints/i/update.ts
+++ b/packages/backend/src/server/api/endpoints/i/update.ts
@@ -421,9 +421,13 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 		const myLink = `${this.config.url}/@${user.username}`;
 
-		const includesMyLink = Array.from(doc.getElementsByTagName('a')).some(a => a.href === myLink);
+		const aEls = Array.from(doc.getElementsByTagName('a'));
+		const linkEls = Array.from(doc.getElementsByTagName('link'));
 
-		if (includesMyLink) {
+		const includesMyLink = aEls.some(a => a.href === myLink);
+		const includesRelMeLinks = [...aEls, ...linkEls].some(link => link.rel === 'me' && link.href === myLink);
+
+		if (includesMyLink || includesRelMeLinks) {
 			await this.userProfilesRepository.createQueryBuilder('profile').update()
 				.where('userId = :userId', { userId: user.id })
 				.set({


### PR DESCRIPTION
## What
Resolve #11860 

## Why
MastodonユーザーなどがMisskeyを使う際にウェブサイトの変更無しにURL認証をできるようにするため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
