### PR TITLE
fix: nullable ref is not a valid OpenAPI definition

### DIFF
--- a/packages/backend/src/server/api/openapi/schemas.ts
+++ b/packages/backend/src/server/api/openapi/schemas.ts
@@ -26,7 +26,12 @@ export function convertSchemaToOpenApiSchema(schema: Schema) {
 	if (schema.allOf) res.allOf = schema.allOf.map(convertSchemaToOpenApiSchema);
 
 	if (schema.ref) {
-		res.$ref = `#/components/schemas/${schema.ref}`;
+		const $ref = `#/components/schemas/${schema.ref}`;
+		if (schema.nullable || schema.optional) {
+			res.allOf = [{ $ref }];
+		} else {
+			res.$ref = $ref;
+		}
 	}
 
 	return res;


### PR DESCRIPTION
## What

`nullable` や `optional` なオブジェクトで `$ref` を使う場合は `allOf` でラップするように

## Why

`nullable` や `optional` キーワードと `$ref` の併用は OpenAPI 3.0 の定義として invalid なので

## Additional info (optional)


## Checklist

- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
