### PR TITLE
fix(frontend): federation settings glitch when the grid has more tha…

### DIFF
--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -46,7 +46,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 import { computed, ComputedRef, isRef, nextTick, onActivated, onBeforeUnmount, onDeactivated, onMounted, ref, watch } from 'vue';
 import * as Misskey from 'misskey-js';
 import * as os from '@/os.js';
-import { onScrollTop, isTopVisible, getBodyScrollHeight, getScrollContainer, onScrollBottom, scrollToBottom, scroll, isBottomVisible } from '@/scripts/scroll.js';
+import { onScrollTop, isTopVisible, getBodyScrollHeight, getScrollContainer, onScrollBottom, scrollToBottom, scroll, isBottomVisible, onScrollDownOnce, onScrollUpOnce } from '@/scripts/scroll.js';
 import { useDocumentVisibility } from '@/scripts/use-document-visibility.js';
 import MkButton from '@/components/MkButton.vue';
 import { defaultStore } from '@/store.js';
@@ -95,8 +95,11 @@ const props = withDefaults(defineProps<{
 	pagination: Paging;
 	disableAutoLoad?: boolean;
 	displayLimit?: number;
+	disableObserver?: boolean;
+	tolerance?: number;
 }>(), {
 	displayLimit: 20,
+	tolerance: TOLERANCE,
 });
 
 const emit = defineEmits<{
@@ -106,7 +109,7 @@ const emit = defineEmits<{
 let rootEl = $shallowRef<HTMLElement>();
 
 // 遡り中かどうか
-let backed = $ref(false);
+let backed = $ref(true);
 
 let scrollRemove = $ref<(() => void) | null>(null);
 
@@ -151,11 +154,13 @@ const BACKGROUND_PAUSE_WAIT_SEC = 10;
 
 // 先頭が表示されているかどうかを検出
 // https://qiita.com/mkataigi/items/0154aefd2223ce23398e
-let scrollObserver = $ref<IntersectionObserver>();
+let scrollObserver = $ref<IntersectionObserver | null>(null);
 
-watch([() => props.pagination.reversed, $$(scrollableElement)], () => {
-	if (scrollObserver) scrollObserver.disconnect();
-
+const createScrollObserver = () => {
+	if (scrollObserver) {
+		scrollObserver.disconnect();
+		scrollObserver = null;
+	}
 	scrollObserver = new IntersectionObserver(entries => {
 		backed = entries[0].isIntersecting;
 	}, {
@@ -163,6 +168,16 @@ watch([() => props.pagination.reversed, $$(scrollableElement)], () => {
 		rootMargin: props.pagination.reversed ? '-100% 0px 100% 0px' : '100% 0px -100% 0px',
 		threshold: 0.01,
 	});
+};
+
+let initialScrollCleaner: () => void | undefined;
+
+watch([() => props.pagination.reversed, $$(scrollableElement)], () => {
+	if (props.disableObserver) {
+		initialScrollCleaner?.();
+	} else {
+		createScrollObserver();
+	}
 }, { immediate: true });
 
 watch($$(rootEl), () => {
@@ -175,8 +190,7 @@ watch($$(rootEl), () => {
 watch([$$(backed), $$(contentEl)], () => {
 	if (!backed) {
 		if (!contentEl) return;
-
-		scrollRemove = (props.pagination.reversed ? onScrollBottom : onScrollTop)(contentEl, executeQueue, TOLERANCE);
+		scrollRemove = (props.pagination.reversed ? onScrollBottom : onScrollTop)(contentEl, executeQueue, props.tolerance, false, !props.disableObserver);
 	} else {
 		if (scrollRemove) scrollRemove();
 		scrollRemove = null;
@@ -201,9 +215,15 @@ async function init(): Promise<void> {
 		...params,
 		limit: props.pagination.limit ?? 10,
 	}).then(res => {
-		for (let i = 0; i < res.length; i++) {
+		for (let i = 0; i < res.length; i += 3) {
 			const item = res[i];
-			if (i === 3) item._shouldInsertAd_ = true;
+			if (!item) {
+				continue;
+			}
+			if (i === 3) {
+				item._shouldInsertAd_ = true;
+				break;
+			}
 		}
 
 		if (res.length === 0 || props.pagination.noPaging) {
@@ -241,9 +261,9 @@ const fetchMore = async (): Promise<void> => {
 			untilId: Array.from(items.value.keys()).at(-1),
 		}),
 	}).then(res => {
-		for (let i = 0; i < res.length; i++) {
-			const item = res[i];
-			if (i === 10) item._shouldInsertAd_ = true;
+		for (let i = 0; i < res.length; i += 10) {
+			if (!res[i]) continue;
+			res[i]._shouldInsertAd_ = true;
 		}
 
 		const reverseConcat = _res => {
@@ -388,9 +408,11 @@ const prepend = (item: MisskeyEntity): void => {
  */
 function unshiftItems(newItems: MisskeyEntity[]) {
 	const length = newItems.length + items.value.size;
-	items.value = new Map([...arrayToEntries(newItems), ...items.value].slice(0, props.displayLimit));
+	const mapEntries = [...arrayToEntries(newItems), ...items.value].slice(0, props.displayLimit);
+	items.value = new Map(mapEntries);
 
 	if (length >= props.displayLimit) more.value = true;
+	offset.value = mapEntries.length;
 }
 
 /**
@@ -399,9 +421,11 @@ function unshiftItems(newItems: MisskeyEntity[]) {
  */
 function concatItems(oldItems: MisskeyEntity[]) {
 	const length = oldItems.length + items.value.size;
-	items.value = new Map([...items.value, ...arrayToEntries(oldItems)].slice(0, props.displayLimit));
+	const mapEntries = [...items.value, ...arrayToEntries(oldItems)].slice(0, props.displayLimit);
+	items.value = new Map(mapEntries);
 
 	if (length >= props.displayLimit) more.value = true;
+	offset.value = mapEntries.length;
 }
 
 function executeQueue() {
@@ -447,17 +471,52 @@ function toBottom() {
 	scrollToBottom(contentEl!);
 }
 
+const createInitialScrollListener = () => {
+	if (!props.disableObserver || !contentEl) {
+		return;
+	}
+	setTimeout(() => {
+		initialScrollCleaner = (props.pagination.reversed ? onScrollUpOnce : onScrollDownOnce)(contentEl, () => {
+			backed = false;
+			nextTick(() => {
+				const cleaner = (props.pagination.reversed ? onScrollBottom : onScrollTop)(contentEl, () => {
+					setTimeout(() => {
+						backed = true;
+						createInitialScrollListener();
+					});
+				}, props.tolerance, true, false);
+				if (cleaner) initialScrollCleaner = cleaner;
+			});
+		});
+	});
+}
+
+watch($$(contentEl), () => {
+	if (props.disableObserver) {
+		createInitialScrollListener();
+	}
+});
+
 onMounted(() => {
 	inited.then(() => {
 		if (props.pagination.reversed) {
 			nextTick(() => {
-				setTimeout(toBottom, 800);
+				setTimeout(() => {
+					toBottom();
+					setTimeout(() => {
+						createInitialScrollListener();
+					});
+				}, 800);
 
 				// scrollToBottomでmoreFetchingボタンが画面外まで出るまで
 				// more = trueを遅らせる
 				setTimeout(() => {
 					moreFetching.value = false;
 				}, 2000);
+			});
+		} else {
+			nextTick(() => {
+				createInitialScrollListener();
 			});
 		}
 	});

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -489,7 +489,7 @@ const createInitialScrollListener = () => {
 			});
 		});
 	});
-}
+};
 
 watch($$(contentEl), () => {
 	if (props.disableObserver) {

--- a/packages/frontend/src/pages/admin/federation.vue
+++ b/packages/frontend/src/pages/admin/federation.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<template #header><XHeader :actions="headerActions"/></template>
 		<MkSpacer :contentMax="900">
 			<div class="_gaps">
-				<div ref="form">
+				<div>
 					<MkInput v-model="host" :debounce="true" class="">
 						<template #prefix><i class="ti ti-search"></i></template>
 						<template #label>{{ i18n.ts.host }}</template>

--- a/packages/frontend/src/pages/admin/federation.vue
+++ b/packages/frontend/src/pages/admin/federation.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<template #header><XHeader :actions="headerActions"/></template>
 		<MkSpacer :contentMax="900">
 			<div class="_gaps">
-				<div>
+				<div ref="form">
 					<MkInput v-model="host" :debounce="true" class="">
 						<template #prefix><i class="ti ti-search"></i></template>
 						<template #label>{{ i18n.ts.host }}</template>
@@ -42,8 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						</MkSelect>
 					</FormSplit>
 				</div>
-
-				<MkPagination v-slot="{items}" ref="instances" :key="host + state" :pagination="pagination">
+				<MkPagination v-slot="{items}" ref="instances" :key="host + state" :pagination="pagination" :tolerance="1" disable-observer>
 					<div :class="$style.instances">
 						<MkA v-for="instance in items" :key="instance.id" v-tooltip.mfm="`Status: ${getStatus(instance)}`" :class="$style.instance" :to="`/instance-info/${instance.host}`">
 							<MkInstanceCardMini :instance="instance"/>
@@ -70,13 +69,14 @@ import { definePageMetadata } from '@/scripts/page-metadata.js';
 let host = $ref('');
 let state = $ref('federating');
 let sort = $ref('+pubSub');
+
 const pagination = {
 	endpoint: 'federation/instances' as const,
-	limit: 10,
+	limit: 30,
 	offsetMode: true,
 	params: computed(() => ({
 		sort: sort,
-		host: host !== '' ? host : null,
+		host: host || null,
 		...(
 			state === 'federating' ? { federating: true } :
 			state === 'subscribing' ? { subscribing: true } :

--- a/packages/frontend/src/pages/admin/federation.vue
+++ b/packages/frontend/src/pages/admin/federation.vue
@@ -42,7 +42,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						</MkSelect>
 					</FormSplit>
 				</div>
-				<MkPagination v-slot="{items}" ref="instances" :key="host + state" :pagination="pagination" :tolerance="1" disable-observer>
+				<MkPagination v-slot="{items}" ref="instances" :key="host + state" :pagination="pagination" :tolerance="1" disableObserver>
 					<div :class="$style.instances">
 						<MkA v-for="instance in items" :key="instance.id" v-tooltip.mfm="`Status: ${getStatus(instance)}`" :class="$style.instance" :to="`/instance-info/${instance.host}`">
 							<MkInstanceCardMini :instance="instance"/>

--- a/packages/frontend/src/scripts/scroll.ts
+++ b/packages/frontend/src/scripts/scroll.ts
@@ -137,10 +137,10 @@ export function onScrollDownOnce(el: HTMLElement, cb: () => unknown): () => void
 	const containerEl = getScrollContainer(el);
 	const targetEl = containerEl ?? window;
 
-	let initialScrollTop = containerEl?.scrollTop || 0;
+	const initialScrollTop = containerEl?.scrollTop ?? 0;
 
 	const listener = () => {
-		if ((containerEl?.scrollTop || 0) > initialScrollTop) {
+		if ((containerEl?.scrollTop ?? 0) > initialScrollTop) {
 			cb();
 			targetEl.removeEventListener('scroll', listener);
 		}
@@ -157,10 +157,10 @@ export function onScrollUpOnce(el: HTMLElement, cb: () => unknown): () => void {
 	const containerEl = getScrollContainer(el);
 	const targetEl = containerEl ?? window;
 
-	let initialScrollTop = containerEl?.scrollTop || 0;
+	const initialScrollTop = containerEl?.scrollTop ?? 0;
 
 	const listener = () => {
-		if ((containerEl?.scrollTop || 0) < initialScrollTop) {
+		if ((containerEl?.scrollTop ?? 0) < initialScrollTop) {
 			cb();
 			targetEl.removeEventListener('scroll', listener);
 		}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR add a new property called `disableObserver` to `MKPagination`, it will disable the internal `IntersectionObserver` in the `MKPagination` and replace it with scroll listener chained methods to keep the `executeQueue` method working.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

### Bug: Federation page glitching when the grid has three columns

The `MKPagination` contains an IntersectionObserver which will observe the `rootEl` in `MKPagination`, which works well in the timeline. But in `admin/federation`, the IntersectionObserver will cause a glitch, because the `rootMargin` is actually the container shift up in 100% of its height, and the `MKPagination` will never be intersected with the scrollable container with shifted rect.

Related code:

```ts
scrollObserver = new IntersectionObserver(entries => {
  backed = entries[0].isIntersecting;
}, {
  root: scrollableElement,
  rootMargin: getObserverRootMargin(),
  threshold: 0.01,
});
```

Because the `entries[0].isIntersecting` will be `false` constantly, in the next lines, the `scrollRemove` method will be called.

```ts
scrollRemove = (props.pagination.reversed ? onScrollBottom : onScrollTop)(contentEl, executeQueue, TOLERANCE);
```

That will cause the existed items be removed, and cause glitch on the page.

#### Bug Replication

1. Navigate to `/admin/federation`, when there's 2/3 columns, scrolling down the page.
2. The new items disappeared suddenly and just disappeared.

### Bug: incorrect offset value

There's another wrong implementation in `MKPagination`, the `offset` value won't be reset when the `scrollRemove` has been called, it will cause the disappeared items cannot be loaded again until the user refresh the whole page.

This issue has been fixed in this PR.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

### About new property

New features will not be enabled until the `disableObserver` has been set to `true`, if some other scenarios have same issue, enable this property might be helpful.

The new method to detect whether the element back to the top/bottom is use a scroll listener to detect the scroll behaviour, it determine whether the user has left the top/bottom, then set `backed` to `false` (I modified the default value to `true` because the element should be the top/bottom of the container in this case, as for the original function, the `IntersectionObserver` will update the correct value to `backed` and trigger the watcher to setup the listener for `executeQueue`).

Then I using another `onScrollTop` and `onScrollBottom` (which disabled the first check when listener just setup) to detect if the user backed to top or bottom. 

### About the federation page

Because of the initial query limit is way below than the max count that the screen can display, if `executeQueue` refresh the items in `MKPagination`, to users, there's still a small glitch (last items disappeared suddenly). In my opinion, to call `executeQueue` to refresh items in this page in not that meaningful, if this step can be bypassed, the experience in this page will be better. 

### About the quality of this PR (Important)

**Because the default value of `backed` has been modified to `true`, it might cause some unexpected side effects to the original functions due to the `MKPagination` is a common component, so there should be more tests before officially publish. Currently I do not have that much time to test all the scenarios that used `MKPagination`, so this PR might be harmful to some functions.**

A harmless way to solve the issue is **just disable the `IntersectionObserver`**, if choose this way to solve the issue, you can close this PR and simply fix with another patch.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
