### PR TITLE
fix(backend): ハッシュタグのランキングの問い合わせ結果がないときのエラー修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix: 自分のフォローしているユーザーの自分のフォローしていないユーザーの visibility: followers な投稿への返信がストリーミングで流れてくる問題を修正
 - Fix: RedisへのTLキャッシュが有効の場合にHTL/LTL/STLが空になることがある問題を修正
 - Fix: STLでフォローしていないチャンネルが取得される問題を修正
+- Fix: `hashtags/trend`にてRedisからトレンドの情報が取得できない際にInternal Server Errorになる問題を修正
 
 ## 2023.10.2
 

--- a/packages/backend/src/core/FeaturedService.ts
+++ b/packages/backend/src/core/FeaturedService.ts
@@ -52,7 +52,7 @@ export class FeaturedService {
 			`${name}:${currentWindow}`, 0, threshold, 'REV', 'WITHSCORES');
 		redisPipeline.zrange(
 			`${name}:${previousWindow}`, 0, threshold, 'REV', 'WITHSCORES');
-		const [currentRankingResult, previousRankingResult] = await redisPipeline.exec().then(result => result ? result.map(r => r[1] as string[]) : [[], []]);
+		const [currentRankingResult, previousRankingResult] = await redisPipeline.exec().then(result => result ? result.map(r => (r[1] || []) as string[]) : [[], []]);
 
 		const ranking = new Map<string, number>();
 		for (let i = 0; i < currentRankingResult.length; i += 2) {

--- a/packages/backend/src/core/FeaturedService.ts
+++ b/packages/backend/src/core/FeaturedService.ts
@@ -52,7 +52,7 @@ export class FeaturedService {
 			`${name}:${currentWindow}`, 0, threshold, 'REV', 'WITHSCORES');
 		redisPipeline.zrange(
 			`${name}:${previousWindow}`, 0, threshold, 'REV', 'WITHSCORES');
-		const [currentRankingResult, previousRankingResult] = await redisPipeline.exec().then(result => result ? result.map(r => (r[1] || []) as string[]) : [[], []]);
+		const [currentRankingResult, previousRankingResult] = await redisPipeline.exec().then(result => result ? result.map(r => (r[1] ?? []) as string[]) : [[], []]);
 
 		const ranking = new Map<string, number>();
 		for (let i = 0; i < currentRankingResult.length; i += 2) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

resultがないときにundefinedになりlengthが取得できないエラーが起きるので配列になるように直した
## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix: https://github.com/misskey-dev/misskey/issues/12144
## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
