### PR TITLE
fix: headerActionにPC以外で空のボタンが出てしまうバグの修正

### DIFF
--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -141,40 +141,40 @@ function focus(): void {
 }
 
 const headerActions = $computed(() => {
-  const tmp = [
-    {
-      icon: 'ti ti-dots',
-      text: i18n.ts.options,
-      handler: (ev) => {
-        os.popupMenu([{
-          type: 'switch',
-          text: i18n.ts.showRenotes,
-          icon: 'ti ti-repeat',
-          ref: $$(withRenotes),
-        }, src === 'local' || src === 'social' ? {
-          type: 'switch',
-          text: i18n.ts.showRepliesToOthersInTimeline,
-          ref: $$(withReplies),
-        } : undefined, {
-          type: 'switch',
-          text: i18n.ts.fileAttachedOnly,
-          icon: 'ti ti-photo',
-          ref: $$(onlyFiles),
-        }], ev.currentTarget ?? ev.target);
-      },
-    }
-  ]
-  if (deviceKind === "desktop") {
-    tmp.unshift({
-      icon: "ti ti-refresh",
-      text: i18n.ts.reload,
-      handler: (ev: Event) => {
-        console.log("called");
-        tlComponent.reloadTimeline();
-      },
-    });
-  }
-  return tmp
+	const tmp = [
+		{
+			icon: 'ti ti-dots',
+			text: i18n.ts.options,
+			handler: (ev) => {
+				os.popupMenu([{
+					type: 'switch',
+					text: i18n.ts.showRenotes,
+					icon: 'ti ti-repeat',
+					ref: $$(withRenotes),
+				}, src === 'local' || src === 'social' ? {
+					type: 'switch',
+					text: i18n.ts.showRepliesToOthersInTimeline,
+					ref: $$(withReplies),
+				} : undefined, {
+					type: 'switch',
+					text: i18n.ts.fileAttachedOnly,
+					icon: 'ti ti-photo',
+					ref: $$(onlyFiles),
+				}], ev.currentTarget ?? ev.target);
+			},
+		},
+	];
+	if (deviceKind === 'desktop') {
+		tmp.unshift({
+			icon: 'ti ti-refresh',
+			text: i18n.ts.reload,
+			handler: (ev: Event) => {
+				console.log('called');
+				tlComponent.reloadTimeline();
+			},
+		});
+	}
+	return tmp;
 });
 
 const headerTabs = $computed(() => [...(defaultStore.reactiveState.pinnedUserLists.value.map(l => ({

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -140,36 +140,42 @@ function focus(): void {
 	tlComponent.focus();
 }
 
-const headerActions = $computed(() => [
-	...[deviceKind === 'desktop' ? {
-		icon: 'ti ti-refresh',
-		text: i18n.ts.reload,
-		handler: (ev) => {
-			console.log('called');
-			tlComponent.reloadTimeline();
-		},
-	} : {}], {
-		icon: 'ti ti-dots',
-		text: i18n.ts.options,
-		handler: (ev) => {
-			os.popupMenu([{
-				type: 'switch',
-				text: i18n.ts.showRenotes,
-				icon: 'ti ti-repeat',
-				ref: $$(withRenotes),
-			}, src === 'local' || src === 'social' ? {
-				type: 'switch',
-				text: i18n.ts.showRepliesToOthersInTimeline,
-				ref: $$(withReplies),
-			} : undefined, {
-				type: 'switch',
-				text: i18n.ts.fileAttachedOnly,
-				icon: 'ti ti-photo',
-				ref: $$(onlyFiles),
-			}], ev.currentTarget ?? ev.target);
-		},
-	}
-]);
+const headerActions = $computed(() => {
+  const tmp = [
+    {
+      icon: 'ti ti-dots',
+      text: i18n.ts.options,
+      handler: (ev) => {
+        os.popupMenu([{
+          type: 'switch',
+          text: i18n.ts.showRenotes,
+          icon: 'ti ti-repeat',
+          ref: $$(withRenotes),
+        }, src === 'local' || src === 'social' ? {
+          type: 'switch',
+          text: i18n.ts.showRepliesToOthersInTimeline,
+          ref: $$(withReplies),
+        } : undefined, {
+          type: 'switch',
+          text: i18n.ts.fileAttachedOnly,
+          icon: 'ti ti-photo',
+          ref: $$(onlyFiles),
+        }], ev.currentTarget ?? ev.target);
+      },
+    }
+  ]
+  if (deviceKind === "desktop") {
+    tmp.unshift({
+      icon: "ti ti-refresh",
+      text: i18n.ts.reload,
+      handler: (ev: Event) => {
+        console.log("called");
+        tlComponent.reloadTimeline();
+      },
+    });
+  }
+  return tmp
+});
 
 const headerTabs = $computed(() => [...(defaultStore.reactiveState.pinnedUserLists.value.map(l => ({
 	key: 'list:' + l.id,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->


![スクリーンショット 2023-10-31 13 19 11](https://github.com/misskey-dev/misskey/assets/18308639/bb7881ea-7fa3-4db0-9e62-a96e54dd000d)
![スクリーンショット 2023-10-31 13 19 15](https://github.com/misskey-dev/misskey/assets/18308639/0a18382b-6514-4061-b3ad-eb9daae28a15)
引張りリロードとデスクトップ用の更新ボタンが配置されましたが、この更新ボタンはデスクトップ以外では空白として存在します。（配列にからのオブジェクトとして存在しているので）
これを削除します



![スクリーンショット 2023-10-31 13 30 16](https://github.com/misskey-dev/misskey/assets/18308639/50cbd0ae-bedb-4f12-aa0c-5c1dc9743fda)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

スクリーンサイズの小さいスマートフォンでは、ヘッダーの謎の空白はより気になります

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
