### PR TITLE
enhance(frontend): federated instance icon with proxy (welcome entrance)

### DIFF
--- a/packages/frontend/src/pages/welcome.entrance.a.vue
+++ b/packages/frontend/src/pages/welcome.entrance.a.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<MarqueeText :duration="40">
 			<MkA v-for="instance in instances" :key="instance.id" :class="$style.federationInstance" :to="`/instance-info/${instance.host}`" behavior="window">
 				<!--<MkInstanceCardMini :instance="instance"/>-->
-				<img v-if="instance.iconUrl" class="icon" :src="instance.iconUrl" alt=""/>
+				<img v-if="instance.iconUrl" class="icon" :src="getInstanceIcon(instance)" alt=""/>
 				<span class="name _monospace">{{ instance.host }}</span>
 			</MkA>
 		</MarqueeText>
@@ -46,9 +46,14 @@ import { instance } from '@/instance.js';
 import number from '@/filters/number.js';
 import MkNumber from '@/components/MkNumber.vue';
 import MkVisitorDashboard from '@/components/MkVisitorDashboard.vue';
+import { getProxiedImageUrl } from '@/scripts/media-proxy.js';
 
 let meta = $ref<Misskey.entities.Instance>();
 let instances = $ref<any[]>();
+
+function getInstanceIcon(instance): string {
+  return getProxiedImageUrl(instance.iconUrl, 'preview');
+}
 
 os.api('meta', { detail: true }).then(_meta => {
 	meta = _meta;


### PR DESCRIPTION
## What
Proxy the federated instance icon that appears on the welcome entrance.

## Why
1. Loading a URL directly can expose the user's request data to the other server.
2. It will depend on your environment, but in severe cases it will increase the time of all other requests. ▼
<img width="862" alt="image" src="https://github.com/misskey-dev/misskey/assets/54402969/bd50906b-5124-410d-9f7e-8a0542cfd8cf">
<img width="293" alt="image" src="https://github.com/misskey-dev/misskey/assets/54402969/d2b3b40e-c4a7-4b70-adf1-f55404d9643a">

## Additional info (optional)
None.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
