### PR TITLE
Fix: judge domain block and silence by endsWith (federation/instances)

### DIFF
--- a/packages/backend/src/server/api/endpoints/federation/instances.ts
+++ b/packages/backend/src/server/api/endpoints/federation/instances.ts
@@ -101,9 +101,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			if (typeof ps.blocked === 'boolean') {
 				const meta = await this.metaService.fetch(true);
 				if (ps.blocked) {
-					query.andWhere(meta.blockedHosts.length === 0 ? '1=0' : 'instance.host IN (:...blocks)', { blocks: meta.blockedHosts });
+					query.andWhere(meta.blockedHosts.length === 0 ? '1=0' : 'instance.host ILIKE ANY(ARRAY[:...blocks])', { blocks: meta.blockedHosts.flatMap(x => [x, `%.${x}`]) });
 				} else {
-					query.andWhere(meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT IN (:...blocks)', { blocks: meta.blockedHosts });
+					query.andWhere(meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT ILIKE ALL(ARRAY[:...blocks])', { blocks: meta.blockedHosts.flatMap(x => [x, `%.${x}`]) });
 				}
 			}
 
@@ -130,12 +130,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					if (meta.silencedHosts.length === 0) {
 						return [];
 					}
-					query.andWhere('instance.host IN (:...silences)', {
-						silences: meta.silencedHosts,
+					query.andWhere('instance.host ILIKE ANY(ARRAY[:...silences])', {
+						silences: meta.silencedHosts.flatMap(x => [x, `%.${x}`]),
 					});
 				} else if (meta.silencedHosts.length > 0) {
-					query.andWhere('instance.host NOT IN (:...silences)', {
-						silences: meta.silencedHosts,
+					query.andWhere('instance.host NOT ILIKE ALL(ARRAY[:...silences])', {
+						silences: meta.silencedHosts.flatMap(x => [x, `%.${x}`]),
 					});
 				}
 			}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
ドメインブロックとサーバーサイレンスを`endsWith`で評価しているが
現状完全一致したものしか一覧には表示されないので整合性が取れてないため
`federation/instances`を`endsWith`に対応させる
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: https://github.com/misskey-dev/misskey/pull/9263
Fix: https://github.com/misskey-dev/misskey/pull/12031

## Additional info (optional)
tested on our developing environment

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
