### PR TITLE
Fix(frontend): role users/timeline visiable ui

### DIFF
--- a/packages/frontend/src/pages/role.vue
+++ b/packages/frontend/src/pages/role.vue
@@ -18,11 +18,19 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<MkSpacer v-else-if="tab === 'users'" :contentMax="1200">
 		<div class="_gaps_s">
 			<div v-if="role">{{ role.description }}</div>
-			<MkUserList :pagination="users" :extractor="(item) => item.user"/>
+			<MkUserList v-if="visiable" :pagination="users" :extractor="(item) => item.user"/>
+			<div v-else-if="!visiable" class="_fullinfo">
+				<img :src="infoImageUrl" class="_ghost"/>
+				<div>{{ i18n.ts.nothing }}</div>
+			</div>
 		</div>
 	</MkSpacer>
 	<MkSpacer v-else-if="tab === 'timeline'" :contentMax="700">
-		<MkTimeline ref="timeline" src="role" :role="props.role"/>
+		<MkTimeline v-if="visiable" ref="timeline" src="role" :role="props.role"/>
+		<div v-else-if="!visiable" class="_fullinfo">
+			<img :src="infoImageUrl" class="_ghost"/>
+			<div>{{ i18n.ts.nothing }}</div>
+		</div>
 	</MkSpacer>
 </MkStickyContainer>
 </template>
@@ -35,7 +43,7 @@ import { definePageMetadata } from '@/scripts/page-metadata.js';
 import { i18n } from '@/i18n.js';
 import MkTimeline from '@/components/MkTimeline.vue';
 import { instanceName } from '@/config.js';
-import { serverErrorImageUrl } from '@/instance.js';
+import { serverErrorImageUrl, infoImageUrl } from '@/instance.js';
 
 const props = withDefaults(defineProps<{
 	role: string;
@@ -47,6 +55,7 @@ const props = withDefaults(defineProps<{
 let tab = $ref(props.initialTab);
 let role = $ref();
 let error = $ref();
+let visiable = $ref(false);
 
 watch(() => props.role, () => {
 	os.api('roles/show', {
@@ -54,6 +63,7 @@ watch(() => props.role, () => {
 	}).then(res => {
 		role = res;
 		document.title = `${role?.name} | ${instanceName}`;
+		visiable = res.isExplorable && res.isPublic;
 	}).catch((err) => {
 		if (err.code === 'NO_SUCH_ROLE') {
 			error = i18n.ts.noRole;


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

ロールのユーザーリスト・タイムラインが公開されてない場合に
ロール情報を開いた段階で`roles/show`
ロールユーザーリスト・タイムラインが公開されないことが取得できているので
`roles/users` `roles/notes`はAPIコールしないで
Nothingページを返す

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: https://github.com/misskey-dev/misskey/issues/12304

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカル環境でテスト済み
もしあとでロールユーザーリスト・タイムラインの閲覧条件を変える場合
（例えば管理者のみは見られるとかにするとき）
ここの条件式
`visiable = res.isExplorable && res.isPublic;`
を変えてください

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
