### PR TITLE
Use generate-api-json for api.json diff GitHub comment

### DIFF
--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -8,7 +8,7 @@ on:
       - develop
 
 jobs:
-  get-base:
+  get-from-misskey:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,12 +16,20 @@ jobs:
     strategy:
       matrix:
         node-version: [20.5.1]
+        api-json-name: [api-base.json, api-head.json]
+        include:
+          - api-json-name: api-base.json
+            repo-name: ${{ github.event.pull_request.base.repo.full_name }}
+            ref: ${{ github.base_ref }}
+          - api-json-name: api-head.json
+            repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+            ref: ${{ github.head_ref }}
 
     steps:
     - uses: actions/checkout@v4.1.1
       with:
-        repository: ${{ github.event.pull_request.base.repo.full_name }}
-        ref: ${{ github.base_ref }}
+        repository: ${{ matrix.repo-name }}
+        ref: ${{ matrix.ref }}
         submodules: true
     - name: Install pnpm
       uses: pnpm/action-setup@v2
@@ -44,55 +52,12 @@ jobs:
     - name: Generate API JSON
       run: pnpm --filter backend generate-api-json
     - name: Copy API.json
-      run: cp packages/backend/built/api.json api-base.json
+      run: cp packages/backend/built/api.json ${{ matrix.api-json-name }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         name: api-artifact
-        path: api-base.json
-
-  get-head:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    strategy:
-      matrix:
-        node-version: [20.5.1]
-
-    steps:
-    - uses: actions/checkout@v4.1.1
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{ github.head_ref }}
-        submodules: true
-    - name: Install pnpm
-      uses: pnpm/action-setup@v2
-      with:
-        version: 8
-        run_install: false
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4.0.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    - run: corepack enable
-    - run: pnpm i --frozen-lockfile
-    - name: Check pnpm-lock.yaml
-      run: git diff --exit-code pnpm-lock.yaml
-    - name: Copy Configure
-      run: cp .config/example.yml .config/default.yml
-    - name: Build
-      run: pnpm build
-    - name: Generate API JSON
-      run: pnpm --filter backend generate-api-json
-    - name: Copy API.json
-      run: cp packages/backend/built/api.json api-head.json
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: api-artifact
-        path: api-head.json
+        path: ${{ matrix.api-json-name }}
 
   save-pr-number:
     runs-on: ubuntu-latest

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -17,21 +17,6 @@ jobs:
       matrix:
         node-version: [20.5.1]
 
-    services:
-      db:
-        image: postgres:13
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_DB: misskey
-          POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_USER: example-misskey-user
-          POSTGRESS_PASS: example-misskey-pass
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-
     steps:
     - uses: actions/checkout@v4.1.1
       with:
@@ -52,43 +37,17 @@ jobs:
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
-    - name: Copy Configure
-      run: cp .config/example.yml .config/default.yml
     - name: Build
       run: pnpm build
-    - name : Migrate
-      run: pnpm migrate
-    - name: Launch misskey
-      run: |
-        screen -S misskey -dm pnpm run dev
-        sleep 30s
-    - name: Wait for Misskey to be ready
-      run: |
-        MAX_RETRIES=12
-        RETRY_DELAY=5
-        count=0
-        until $(curl --output /dev/null --silent --head --fail http://localhost:3000) || [[ $count -eq $MAX_RETRIES ]]; do
-          printf '.'
-          sleep $RETRY_DELAY
-          count=$((count + 1))
-        done
-
-        if [[ $count -eq $MAX_RETRIES ]]; then
-          echo "Failed to connect to Misskey after $MAX_RETRIES attempts."
-          exit 1
-        fi
-    - id: fetch
-      name: Get api.json from Misskey
-      run: |
-        RESULT=$(curl --retry 5 --retry-delay 5 --retry-max-time 60 http://localhost:3000/api.json)
-        echo $RESULT > api-base.json
+    - name: Generate API JSON
+      run: pnpm --filter backend generate-api-json
+    - name: Copy API.json
+      run: cp packages/backend/built/api.json api-base.json
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         name: api-artifact
         path: api-base.json
-    - name: Kill Misskey Job
-      run: screen -S misskey -X quit
 
   get-head:
     runs-on: ubuntu-latest
@@ -98,21 +57,6 @@ jobs:
     strategy:
       matrix:
         node-version: [20.5.1]
-
-    services:
-      db:
-        image: postgres:13
-        ports:
-          - 5432:5432
-        env:
-          POSTGRES_DB: misskey
-          POSTGRES_HOST_AUTH_METHOD: trust
-          POSTGRES_USER: example-misskey-user
-          POSTGRESS_PASS: example-misskey-pass
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
 
     steps:
     - uses: actions/checkout@v4.1.1
@@ -134,43 +78,17 @@ jobs:
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
-    - name: Copy Configure
-      run: cp .config/example.yml .config/default.yml
     - name: Build
       run: pnpm build
-    - name : Migrate
-      run: pnpm migrate
-    - name: Launch misskey
-      run: |
-        screen -S misskey -dm pnpm run dev
-        sleep 30s
-    - name: Wait for Misskey to be ready
-      run: |
-        MAX_RETRIES=12
-        RETRY_DELAY=5
-        count=0
-        until $(curl --output /dev/null --silent --head --fail http://localhost:3000) || [[ $count -eq $MAX_RETRIES ]]; do
-          printf '.'
-          sleep $RETRY_DELAY
-          count=$((count + 1))
-        done
-
-        if [[ $count -eq $MAX_RETRIES ]]; then
-          echo "Failed to connect to Misskey after $MAX_RETRIES attempts."
-          exit 1
-        fi
-    - id: fetch
-      name: Get api.json from Misskey
-      run: |
-        RESULT=$(curl --retry 5 --retry-delay 5 --retry-max-time 60 http://localhost:3000/api.json)
-        echo $RESULT > api-head.json
+    - name: Generate API JSON
+      run: pnpm --filter backend generate-api-json
+    - name: Copy API.json
+      run: cp packages/backend/built/api.json api-head.json
     - name: Upload Artifact
       uses: actions/upload-artifact@v3
       with:
         name: api-artifact
         path: api-head.json
-    - name: Kill Misskey Job
-      run: screen -S misskey -X quit
 
   save-pr-number:
     runs-on: ubuntu-latest

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -37,6 +37,8 @@ jobs:
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
+    - name: Copy Configure
+      run: cp .config/example.yml .config/default.yml
     - name: Build
       run: pnpm build
     - name: Generate API JSON
@@ -78,6 +80,8 @@ jobs:
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
+    - name: Copy Configure
+      run: cp .config/example.yml .config/default.yml
     - name: Build
       run: pnpm build
     - name: Generate API JSON

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
       - develop
+    paths:
+      - packages/backend/**
+      - .github/workflows/get-api-diff.yml
 
 jobs:
   get-from-misskey:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
githubのprへのコメントで使用するapi.jsonを #12402 で追加された`generate-api-json`で生成するようにしました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

- 過去に何度かmisskeyの起動時間が長いことで落ちたことが何度かあるため
- misskeyの起動を待たなくて良いためパフォーマンスが良くなる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

`get-api-diff.yml`は`pull_request`イベントで発火するため、pull requestのheadの`get-api-diff.yml`が使われるはずなため、`generate-api-json`コマンドがなくてエラーになることはないはずです。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
