### PR TITLE
Fix: word mute did not apply to quote notes

### DIFF
--- a/packages/frontend/src/components/MkNoteSimple.vue
+++ b/packages/frontend/src/components/MkNoteSimple.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div :class="$style.root">
+<div v-if="!muted" :class="$style.root">
 	<MkAvatar :class="$style.avatar" :user="note.user" link preview/>
 	<div :class="$style.main">
 		<MkNoteHeader :class="$style.header" :note="note" :mini="true"/>
@@ -19,21 +19,37 @@ SPDX-License-Identifier: AGPL-3.0-only
 		</div>
 	</div>
 </div>
+<div v-else :class="$style.muted" @click="muted = false">
+	<I18n :src="i18n.ts.userSaysSomething" tag="small">
+		<template #name>
+			<MkA v-user-preview="note.userId" :to="userPage(note.user)">
+				<MkUserName :user="note.user"/>
+			</MkA>
+		</template>
+	</I18n>
+</div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
 import * as Misskey from 'misskey-js';
+import { i18n } from '@/i18n.js';
 import MkNoteHeader from '@/components/MkNoteHeader.vue';
 import MkSubNoteContent from '@/components/MkSubNoteContent.vue';
 import MkCwButton from '@/components/MkCwButton.vue';
 import { $i } from '@/account.js';
+import { checkWordMute } from '@/scripts/check-word-mute.js';
+import { deepClone } from '@/scripts/clone.js';
+import { userPage } from '@/filters/user.js';
 
 const props = defineProps<{
 	note: Misskey.entities.Note;
 }>();
 
 const showContent = ref(false);
+
+let note = ref(deepClone(props.note));
+const muted = ref(checkWordMute(note, $i, $i?.mutedWords));
 </script>
 
 <style lang="scss" module>
@@ -77,6 +93,12 @@ const showContent = ref(false);
 	cursor: default;
 	margin: 0;
 	padding: 0;
+}
+
+.muted {
+	padding: 8px;
+	text-align: center;
+	opacity: 0.7;
 }
 
 @container (min-width: 250px) {

--- a/packages/frontend/src/components/MkNoteSimple.vue
+++ b/packages/frontend/src/components/MkNoteSimple.vue
@@ -39,17 +39,24 @@ import MkSubNoteContent from '@/components/MkSubNoteContent.vue';
 import MkCwButton from '@/components/MkCwButton.vue';
 import { $i } from '@/account.js';
 import { checkWordMute } from '@/scripts/check-word-mute.js';
-import { deepClone } from '@/scripts/clone.js';
 import { userPage } from '@/filters/user.js';
+import { deepClone } from '@/scripts/clone.js';
 
 const props = defineProps<{
 	note: Misskey.entities.Note;
 }>();
 
-const showContent = ref(false);
+const note = ref(deepClone(props.note));
 
-let note = ref(deepClone(props.note));
-const muted = ref(checkWordMute(note, $i, $i?.mutedWords));
+const showContent = ref(false);
+const muted = ref(checkMute(note.value, $i?.mutedWords));
+
+function checkMute(note: Misskey.entities.Note, mutedWords: Array<string | string[]> | undefined | null): boolean {
+	if (mutedWords == null) return false;
+
+	if (checkWordMute(note, $i, mutedWords)) return true;
+	return false;
+}
 </script>
 
 <style lang="scss" module>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
![image](https://github.com/misskey-dev/misskey/assets/46598063/41a2426e-cd6d-4f1c-9cc2-1088cd9634d7)
Apply word mute on quoted note like replied note to ensure consistency

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Unlike replied note, word mute is not affect on quoted note
![image](https://github.com/misskey-dev/misskey/assets/46598063/08e11777-6c30-45ac-a022-4dc55587c37b)

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
