### PR TITLE
fix(frontend): WebKitブラウザー上でも「デバイスの画面を常にオンにする」機能が効くように

### DIFF
--- a/packages/frontend/src/boot/common.ts
+++ b/packages/frontend/src/boot/common.ts
@@ -202,20 +202,22 @@ export async function common(createVue: () => App<Element>) {
 		}
 	}, { immediate: true });
 
-	if (defaultStore.state.keepScreenOn) {
-		if ('wakeLock' in navigator) {
-			navigator.wakeLock.request('screen')
-			.then(() => {
-				document.addEventListener('visibilitychange', async () => {
-					if (document.visibilityState === 'visible') {
-						navigator.wakeLock.request('screen');
-					}
-				});
-			})
-			.catch(() => {
-				// If Permission fails on an AppleDevice such as Safari
-			});
+	// Keep screen on
+	const onVisibilityChange = () => document.addEventListener('visibilitychange', () => {
+		if (document.visibilityState === 'visible') {
+			navigator.wakeLock.request('screen');
 		}
+	});
+	if (defaultStore.state.keepScreenOn && 'wakeLock' in navigator) {
+		navigator.wakeLock.request('screen')
+			.then(onVisibilityChange)
+			.catch(() => {
+				document.addEventListener(
+					'click',
+					() => navigator.wakeLock.request('screen').then(onVisibilityChange),
+					{ once: true },
+				);
+			});
 	}
 
 	//#region Fetch user

--- a/packages/frontend/src/boot/common.ts
+++ b/packages/frontend/src/boot/common.ts
@@ -212,6 +212,8 @@ export async function common(createVue: () => App<Element>) {
 		navigator.wakeLock.request('screen')
 			.then(onVisibilityChange)
 			.catch(() => {
+				// On WebKit-based browsers, user activation is required to send wake lock request
+				// https://webkit.org/blog/13862/the-user-activation-api/
 				document.addEventListener(
 					'click',
 					() => navigator.wakeLock.request('screen').then(onVisibilityChange),


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
WebKit ベースのブラウザー上でも「デバイスの画面を常にオンにする」機能が効くようにしました。

WebKit 以外のブラウザーは今まで通りの挙動となりますが、WebKit ブラウザー環境の場合は（妥協案として）ユーザーによるクリックイベントがあったときに初めて機能を有効化するようにしました[^1]。この方法は些か hacky な気がするので、もっと良い方法があれば close のほどお願いします。

[^1]: すなわち、アクセス後にクリックイベントが一切なければこの機能は動作しないということですが、Misskey を使う上でクリックを一切しないということはまずないでしょう

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: #12462（読み込めなくなる問題自体は #12464 で既に解決されています）

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
macOS 14.0 上の Safari 17.0 で正常に機能することを確認しています。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests