### PR TITLE
feat(frontend): Note translate language

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1162,6 +1162,8 @@ useGroupedNotifications: "Display grouped notifications"
 signupPendingError: "There was a problem verifying the email address. The link may have expired."
 cwNotationRequired: "If \"Hide content\" is enabled, a description must be provided."
 doReaction: "Add reaction"
+translateLanguage: "Note translate language"
+useUILanguageAsTranslateLanguage: "Use UI language"
 _announcement:
   forExistingUsers: "Existing users only"
   forExistingUsersDescription: "This announcement will only be shown to users existing at the point of publishment if enabled. If disabled, those newly signing up after it has been posted will also see it."

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -1169,6 +1169,8 @@ export interface Locale {
     "signupPendingError": string;
     "cwNotationRequired": string;
     "doReaction": string;
+    "translateLanguage": string;
+    "useUILanguageAsTranslateLanguage": string;
     "_announcement": {
         "forExistingUsers": string;
         "forExistingUsersDescription": string;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1166,6 +1166,8 @@ useGroupedNotifications: "通知をグルーピングして表示する"
 signupPendingError: "メールアドレスの確認中に問題が発生しました。リンクの有効期限が切れている可能性があります。"
 cwNotationRequired: "「内容を隠す」がオンの場合は注釈の記述が必要です。"
 doReaction: "リアクションする"
+translateLanguage: "投稿翻訳に使用する言語"
+useUILanguageAsTranslateLanguage: "UI言語を使用する"
 
 _announcement:
   forExistingUsers: "既存ユーザーのみ"

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -1158,6 +1158,8 @@ useGroupedNotifications: "알림을 그룹화하고 표시"
 signupPendingError: "메일 주소 확인중에 문제가 발생했습니다. 링크의 유효기간이 지났을 가능성이 있습니다."
 cwNotationRequired: "'내용을 숨기기'를 체크한 경우 주석을 써야 합니다."
 doReaction: "리액션 추가"
+translateLanguage: "게시물 번역 언어"
+useUILanguageAsTranslateLanguage: "UI 표시 언어를 사용"
 _announcement:
   forExistingUsers: "기존 유저에게만 알림"
   forExistingUsersDescription: "활성화하면 이 공지사항을 게시한 시점에서 이미 가입한 유저에게만 표시합니다. 비활성화하면 게시 후에 가입한 유저에게도 표시합니다."

--- a/packages/frontend/src/pages/settings/general.vue
+++ b/packages/frontend/src/pages/settings/general.vue
@@ -16,6 +16,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</I18n>
 		</template>
 	</MkSelect>
+	<MkSelect v-model="overridedTranslateLanguage">
+		<template #label>{{ i18n.ts.translateLanguage }}</template>
+		<p>{{ i18n.ts.useUILanguageAsTranslateLanguage }}</p>
+		<option :key="i18n.ts.useUILanguageAsTranslateLanguage" :value="null">{{ i18n.ts.useUILanguageAsTranslateLanguage }}</option>
+		<option v-for="x in translateLanguages" :key="x.name" :value="x.language">{{ x.name }}</option>
+	</MkSelect>
 
 	<MkRadios v-model="overridedDeviceKind">
 		<template #label>{{ i18n.ts.overridedDeviceKind }}</template>
@@ -207,6 +213,7 @@ import { definePageMetadata } from '@/scripts/page-metadata.js';
 import { miLocalStorage } from '@/local-storage.js';
 import { globalEvents } from '@/events.js';
 import { claimAchievement } from '@/scripts/achievements.js';
+import translateLanguages from '@/translate-language.json';
 
 const lang = ref(miLocalStorage.getItem('lang'));
 const fontSize = ref(miLocalStorage.getItem('fontSize'));
@@ -258,6 +265,7 @@ const notificationStackAxis = computed(defaultStore.makeGetterSetter('notificati
 const keepScreenOn = computed(defaultStore.makeGetterSetter('keepScreenOn'));
 const disableStreamingTimeline = computed(defaultStore.makeGetterSetter('disableStreamingTimeline'));
 const useGroupedNotifications = computed(defaultStore.makeGetterSetter('useGroupedNotifications'));
+const overridedTranslateLanguage = computed(defaultStore.makeGetterSetter('overridedTranslateLanguage'));
 
 watch(lang, () => {
 	miLocalStorage.setItem('lang', lang.value as string);

--- a/packages/frontend/src/scripts/get-note-menu.ts
+++ b/packages/frontend/src/scripts/get-note-menu.ts
@@ -244,7 +244,7 @@ export function getNoteMenu(props: {
 		props.translating.value = true;
 		const res = await os.api('notes/translate', {
 			noteId: appearNote.id,
-			targetLang: miLocalStorage.getItem('lang') ?? navigator.language,
+			targetLang: defaultStore.state.overridedTranslateLanguage ?? miLocalStorage.getItem('lang') ?? navigator.language,
 		});
 		props.translating.value = false;
 		props.translation.value = res;

--- a/packages/frontend/src/store.ts
+++ b/packages/frontend/src/store.ts
@@ -191,6 +191,10 @@ export const defaultStore = markRaw(new Storage('base', {
 		where: 'device',
 		default: null as null | 'smartphone' | 'tablet' | 'desktop',
 	},
+	overridedTranslateLanguage: {
+		where: 'device',
+		default: null as null | string,
+	},
 	serverDisconnectedBehavior: {
 		where: 'device',
 		default: 'quiet' as 'quiet' | 'reload' | 'dialog',

--- a/packages/frontend/src/translate-language.json
+++ b/packages/frontend/src/translate-language.json
@@ -1,0 +1,157 @@
+[
+	{
+		"language": "BG",
+		"name": "Bulgarian",
+		"supports_formality": false
+	},
+	{
+		"language": "CS",
+		"name": "Czech",
+		"supports_formality": false
+	},
+	{
+		"language": "DA",
+		"name": "Danish",
+		"supports_formality": false
+	},
+	{
+		"language": "DE",
+		"name": "German",
+		"supports_formality": true
+	},
+	{
+		"language": "EL",
+		"name": "Greek",
+		"supports_formality": false
+	},
+	{
+		"language": "EN-GB",
+		"name": "English (British)",
+		"supports_formality": false
+	},
+	{
+		"language": "EN-US",
+		"name": "English (American)",
+		"supports_formality": false
+	},
+	{
+		"language": "ES",
+		"name": "Spanish",
+		"supports_formality": true
+	},
+	{
+		"language": "ET",
+		"name": "Estonian",
+		"supports_formality": false
+	},
+	{
+		"language": "FI",
+		"name": "Finnish",
+		"supports_formality": false
+	},
+	{
+		"language": "FR",
+		"name": "French",
+		"supports_formality": true
+	},
+	{
+		"language": "HU",
+		"name": "Hungarian",
+		"supports_formality": false
+	},
+	{
+		"language": "ID",
+		"name": "Indonesian",
+		"supports_formality": false
+	},
+	{
+		"language": "IT",
+		"name": "Italian",
+		"supports_formality": true
+	},
+	{
+		"language": "JA",
+		"name": "Japanese",
+		"supports_formality": true
+	},
+	{
+		"language": "KO",
+		"name": "Korean",
+		"supports_formality": false
+	},
+	{
+		"language": "LT",
+		"name": "Lithuanian",
+		"supports_formality": false
+	},
+	{
+		"language": "LV",
+		"name": "Latvian",
+		"supports_formality": false
+	},
+	{
+		"language": "NB",
+		"name": "Norwegian",
+		"supports_formality": false
+	},
+	{
+		"language": "NL",
+		"name": "Dutch",
+		"supports_formality": true
+	},
+	{
+		"language": "PL",
+		"name": "Polish",
+		"supports_formality": true
+	},
+	{
+		"language": "PT-BR",
+		"name": "Portuguese (Brazilian)",
+		"supports_formality": true
+	},
+	{
+		"language": "PT-PT",
+		"name": "Portuguese (European)",
+		"supports_formality": true
+	},
+	{
+		"language": "RO",
+		"name": "Romanian",
+		"supports_formality": false
+	},
+	{
+		"language": "RU",
+		"name": "Russian",
+		"supports_formality": true
+	},
+	{
+		"language": "SK",
+		"name": "Slovak",
+		"supports_formality": false
+	},
+	{
+		"language": "SL",
+		"name": "Slovenian",
+		"supports_formality": false
+	},
+	{
+		"language": "SV",
+		"name": "Swedish",
+		"supports_formality": false
+	},
+	{
+		"language": "TR",
+		"name": "Turkish",
+		"supports_formality": false
+	},
+	{
+		"language": "UK",
+		"name": "Ukrainian",
+		"supports_formality": false
+	},
+	{
+		"language": "ZH",
+		"name": "Chinese (simplified)",
+		"supports_formality": false
+	}
+]


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
![image](https://github.com/misskey-dev/misskey/assets/46598063/73179c66-6ee9-4a53-8c3b-cc96c28738ad)

![image](https://github.com/misskey-dev/misskey/assets/46598063/97161d78-ecc3-456d-8fb7-99f71b32b776)

Allow users to choose which language to use for note translation

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
1. Even if your language is not exist on UI languages, you can translate note with your one if deepl supports it.
2. You can set UI language and note translate language separately

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
packages/frontend/src/translate-language.json is output of
```sh
curl -X GET 'https://api-free.deepl.com/v2/languages?type=target' --header 'Authorization: DeepL-Auth-Key [APIKEY]'
```
when deelp updates there supporting language, you can update list of language by paste result of api
 

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
