### PR TITLE
ci: use refs/pull/*/merge to get head api.json

### DIFF
--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -22,16 +22,13 @@ jobs:
         api-json-name: [api-base.json, api-head.json]
         include:
           - api-json-name: api-base.json
-            repo-name: ${{ github.event.pull_request.base.repo.full_name }}
             ref: ${{ github.base_ref }}
           - api-json-name: api-head.json
-            repo-name: ${{ github.event.pull_request.head.repo.full_name }}
-            ref: ${{ github.head_ref }}
+            ref: refs/pull/${{ github.event.number }}/merge
 
     steps:
     - uses: actions/checkout@v4.1.1
       with:
-        repository: ${{ matrix.repo-name }}
         ref: ${{ matrix.ref }}
         submodules: true
     - name: Install pnpm


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

API.jsonを取得するときにrefs/pull/*/mergeを使用するようにします。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

baseの変更に起因するapi.jsonのdiffが発生しなく(しづらく)なります。

baseの変更に起因するapi.jsonの例: https://github.com/misskey-dev/misskey/pull/12507#issuecomment-1831981435

developとの分岐点を #12507 と同じところにしたので多分二つで比較できると思います

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
