### PR TITLE
fix: 12528の巻き戻し

### DIFF
--- a/packages/frontend/src/scripts/theme.ts
+++ b/packages/frontend/src/scripts/theme.ts
@@ -44,7 +44,7 @@ export const getBuiltinThemes = () => Promise.all(
 		'd-cherry',
 		'd-ice',
 		'd-u0',
-	].map(name => import(`${__dirname}/../themes/${name}.json5`).then(({ default: _default }): Theme => _default)),
+	].map(name => import(`../themes/${name}.json5`).then(({ default: _default }): Theme => _default)),
 );
 
 export const getBuiltinThemesRef = () => {


### PR DESCRIPTION
This reverts commit a5f0b5ec74940b0c53242dfc64c322139c91e362.

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
#12547 の対応です。
#12528 の対応内容がマズくて、テーマの設定画面が出なくなっています。

revetなので、#12528の内容が再び起こります。…が、現状よりはマシかと考えました
確認不足でした、申し訳ないです 🙇‍♂️

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
テーマの設定画面が出ない

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
pnpm startで設定画面が出ることを確認

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
