### PR TITLE
fix(backend): withChannelNotesとwithFilesを同時に指定したときの考慮

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -113,6 +113,9 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				redisTimelines,
 				useDbFallback: true,
 				noteFilter: note => {
+					if (ps.withFiles && note.fileIds.length === 0) {
+						return false;
+					}
 					if (me && isUserRelated(note, userIdsWhoMeMuting, true)) return false;
 
 					if (note.renoteId) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

#12549 を修正

## Why
Redisから取得した場合とPostgreSQLから取得した場合で結果を同一にするため、またサードパーティでチャンネルのノートを含むファイルつきノートを取得できるようにするため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
