### PR TITLE
feat: ユーザースキーマの改善

### DIFF
--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -698,6 +698,23 @@ export const packedMeDetailedOnlySchema = {
 			items: {
 				type: 'object',
 				nullable: false, optional: false,
+				properties: {
+					id: {
+						type: 'string',
+						nullable: false, optional: false,
+						format: 'id',
+						example: 'xxxxxxxxxx',
+					},
+					name: {
+						type: 'string',
+						nullable: false, optional: false,
+					},
+					lastUsed: {
+						type: 'string',
+						nullable: false, optional: false,
+						format: 'date-time',
+					},
+				},
 			},
 		},
 		//#endregion

--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -9,11 +9,11 @@ const notificationRecieveConfig = {
 	properties: {
 		type: {
 			type: 'string',
-			enum: ['all', 'following', 'follower', 'mutualFollow', 'list', 'never'],
 			nullable: false, optional: false,
+			enum: ['all', 'following', 'follower', 'mutualFollow', 'list', 'never'],
 		},
 	},
-};
+} as const;
 
 export const packedUserLiteSchema = {
 	type: 'object',

--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -398,6 +398,7 @@ export const packedUserDetailedNotMeOnlySchema = {
 		notify: {
 			type: 'string',
 			nullable: false, optional: true,
+			enum: ['normal', 'none'],
 		},
 		withReplies: {
 			type: 'boolean',

--- a/packages/backend/src/models/json-schema/user.ts
+++ b/packages/backend/src/models/json-schema/user.ts
@@ -3,6 +3,18 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+const notificationRecieveConfig = {
+	type: 'object',
+	nullable: false, optional: true,
+	properties: {
+		type: {
+			type: 'string',
+			enum: ['all', 'following', 'follower', 'mutualFollow', 'list', 'never'],
+			nullable: false, optional: false,
+		},
+	},
+};
+
 export const packedUserLiteSchema = {
 	type: 'object',
 	properties: {
@@ -554,6 +566,19 @@ export const packedMeDetailedOnlySchema = {
 		notificationRecieveConfig: {
 			type: 'object',
 			nullable: false, optional: false,
+			properties: {
+				app: notificationRecieveConfig,
+				quote: notificationRecieveConfig,
+				reply: notificationRecieveConfig,
+				follow: notificationRecieveConfig,
+				renote: notificationRecieveConfig,
+				mention: notificationRecieveConfig,
+				reaction: notificationRecieveConfig,
+				pollEnded: notificationRecieveConfig,
+				achievementEarned: notificationRecieveConfig,
+				receiveFollowRequest: notificationRecieveConfig,
+				followRequestAccepted: notificationRecieveConfig,
+			},
 		},
 		emailNotificationTypes: {
 			type: 'array',

--- a/packages/misskey-js/src/autogen/endpoint.ts
+++ b/packages/misskey-js/src/autogen/endpoint.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-04T05:05:14.934Z
+ * generatedAt: 2023-12-04T07:13:58.541Z
  */
 
 import type {

--- a/packages/misskey-js/src/autogen/endpoint.ts
+++ b/packages/misskey-js/src/autogen/endpoint.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-03T02:04:45.058Z
+ * generatedAt: 2023-12-04T05:05:14.934Z
  */
 
 import type {

--- a/packages/misskey-js/src/autogen/entities.ts
+++ b/packages/misskey-js/src/autogen/entities.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-04T05:05:14.929Z
+ * generatedAt: 2023-12-04T07:13:58.538Z
  */
 
 import { operations } from './types.js';

--- a/packages/misskey-js/src/autogen/entities.ts
+++ b/packages/misskey-js/src/autogen/entities.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-03T02:04:45.053Z
+ * generatedAt: 2023-12-04T05:05:14.929Z
  */
 
 import { operations } from './types.js';

--- a/packages/misskey-js/src/autogen/models.ts
+++ b/packages/misskey-js/src/autogen/models.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-04T05:05:14.926Z
+ * generatedAt: 2023-12-04T07:13:58.535Z
  */
 
 import { components } from './types.js';

--- a/packages/misskey-js/src/autogen/models.ts
+++ b/packages/misskey-js/src/autogen/models.ts
@@ -1,6 +1,6 @@
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-03T02:04:45.051Z
+ * generatedAt: 2023-12-04T05:05:14.926Z
  */
 
 import { components } from './types.js';

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -3,7 +3,7 @@
 
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-03T02:04:44.864Z
+ * generatedAt: 2023-12-04T05:05:14.780Z
  */
 
 /**
@@ -3218,7 +3218,8 @@ export type components = {
       isBlocked?: boolean;
       isMuted?: boolean;
       isRenoteMuted?: boolean;
-      notify?: string;
+      /** @enum {string} */
+      notify?: 'normal' | 'none';
       withReplies?: boolean;
     };
     MeDetailedOnly: {
@@ -3287,7 +3288,12 @@ export type components = {
       };
       email?: string | null;
       emailVerified?: boolean | null;
-      securityKeysList?: Record<string, never>[];
+      securityKeysList?: {
+          id: string;
+          name: string;
+          /** Format: date-time */
+          lastUsed: string;
+        }[];
     };
     UserDetailedNotMe: components['schemas']['UserLite'] & components['schemas']['UserDetailedNotMeOnly'];
     MeDetailed: components['schemas']['UserLite'] & components['schemas']['UserDetailedNotMeOnly'] & components['schemas']['MeDetailedOnly'];

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -3,7 +3,7 @@
 
 /*
  * version: 2023.12.0-beta.1
- * generatedAt: 2023-12-04T05:05:14.780Z
+ * generatedAt: 2023-12-04T07:13:58.362Z
  */
 
 /**
@@ -3254,7 +3254,52 @@ export type components = {
       mutedWords: string[][];
       hardMutedWords: string[][];
       mutedInstances: string[] | null;
-      notificationRecieveConfig: Record<string, never>;
+      notificationRecieveConfig: {
+        app?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        quote?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        reply?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        follow?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        renote?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        mention?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        reaction?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        pollEnded?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        achievementEarned?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        receiveFollowRequest?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+        followRequestAccepted?: {
+          /** @enum {string} */
+          type: 'all' | 'following' | 'follower' | 'mutualFollow' | 'list' | 'never';
+        };
+      };
       emailNotificationTypes: string[];
       achievements: {
           name: string;
@@ -3289,6 +3334,10 @@ export type components = {
       email?: string | null;
       emailVerified?: boolean | null;
       securityKeysList?: {
+          /**
+           * Format: id
+           * @example xxxxxxxxxx
+           */
           id: string;
           name: string;
           /** Format: date-time */


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

- `packedUserDetailedNotMeOnlySchema.notify` に `enum` を追加しました
- `packedMeDetailedOnlySchema.securityKeysList` に `properties` を定義しました

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

現状だとドキュメントから `securityKeysList` は `object` であることしか知ることが出来ない為。また、`notify` にはどのような文字列が入るのか明確にするため

## Additional info (optional)

現状は何も手を加えていませんが `notificationRecieveConfig` にも `properties` を定義したいと考えています。愚直に記述すると量がとても多いため、部分的に別の変数に分けてそれを使うようにしたいのですが、大丈夫でしょうか?
以下がやりたい物になるので、大丈夫そうでしたらこちらもコミットしようと思います

```ts
const notificationRecieveConfig = {
	type: 'object',
	nullable: false, optional: true,
	properties: {
		type: {
			type: 'string',
			enum: ['all', 'following', 'follower', 'mutualFollow', 'list', 'never'],
			nullable: false, optional: false,
		}
	}
}

export const packedMeDetailedOnlySchema = {
	type: 'object',
	properties: {
		// ...
		notificationRecieveConfig: {
			type: 'object',
			nullable: false, optional: false,
			properties: {
				app: notificationRecieveConfig,
				quote: notificationRecieveConfig,
				reply: notificationRecieveConfig,
				follow: notificationRecieveConfig,
				renote: notificationRecieveConfig,
				mention: notificationRecieveConfig,
				reaction: notificationRecieveConfig,
				pollEnded: notificationRecieveConfig,
				achievementEarned: notificationRecieveConfig,
				receiveFollowRequest: notificationRecieveConfig,
				followRequestAccepted: notificationRecieveConfig,
			},
		},
		// ...
	},
} as const;
```

<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
