### PR TITLE
タイムラインの「リノートを表示」のトグルスイッチが反応しない問題を直す

### DIFF
--- a/packages/frontend/src/components/MkMenu.vue
+++ b/packages/frontend/src/components/MkMenu.vue
@@ -202,7 +202,7 @@ function focusDown() {
 }
 
 function switchItem(item: MenuSwitch & { ref: any }) {
-	if (typeof item.disabled === 'boolean' ? item.disabled : item.disabled.value) return;
+	if (item.disabled !== undefined && (typeof item.disabled === 'boolean' ? item.disabled : item.disabled.value)) return;
 	item.ref = !item.ref;
 }
 

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -158,6 +158,7 @@ const headerActions = $computed(() => {
 					type: 'switch',
 					text: i18n.ts.showRenotes,
 					ref: $$(withRenotes),
+					disabled: false,
 				}, src === 'local' || src === 'social' ? {
 					type: 'switch',
 					text: i18n.ts.showRepliesToOthersInTimeline,

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -158,7 +158,6 @@ const headerActions = $computed(() => {
 					type: 'switch',
 					text: i18n.ts.showRenotes,
 					ref: $$(withRenotes),
-					disabled: false,
 				}, src === 'local' || src === 'social' ? {
 					type: 'switch',
 					text: i18n.ts.showRepliesToOthersInTimeline,


### PR DESCRIPTION
## What
「リノートを表示」トグルスイッチの disabled 属性に false を指定する
## Why
トグルスイッチの disabled に boolean の値を指定しないと、value属性を参照しようとするため。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
