### PR TITLE
(dev) index.htmlにmeta[name=viewport]がなかったので追加＆足りてないCSP追加

### DIFF
--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -17,12 +17,14 @@
 	<meta
 		http-equiv="Content-Security-Policy"
 		content="default-src 'self';
-		  script-src 'self';
-		  style-src 'self' 'unsafe-inline';
-		  img-src 'self' data: www.google.com xn--931a.moe localhost:3000 localhost:5173 127.0.0.1:5173 127.0.0.1:3000;
+			worker-src 'self';
+			script-src 'self';
+			style-src 'self' 'unsafe-inline';
+			img-src 'self' data: www.google.com xn--931a.moe localhost:3000 localhost:5173 127.0.0.1:5173 127.0.0.1:3000;
 			media-src 'self' localhost:3000 localhost:5173 127.0.0.1:5173 127.0.0.1:3000;"
 	/>
 	<meta property="og:site_name" content="[DEV BUILD] Misskey" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>

--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -24,7 +24,7 @@
 			media-src 'self' localhost:3000 localhost:5173 127.0.0.1:5173 127.0.0.1:3000;"
 	/>
 	<meta property="og:site_name" content="[DEV BUILD] Misskey" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 
 <body>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
pnpm dev向けの対応です。
devモードでのみ使用するindex.htmlにmetaタグが不足しており、モバイル表示ができない状態になっていました。
また、コンソールにCSPの警告が出ていたので、それについても修正しています。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
devモードでモバイル表示を確認したい

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
devモードでモバイル表示とPC表示を行い、コンソールに警告が出ないこと、TLが表示されることを確認

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
