### PR TITLE
(fix) デフォルト表示時のヘッダにあるチャンネルボタンが反応しない現象の修正

### DIFF
--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -132,7 +132,7 @@ async function chooseChannel(ev: MouseEvent): Promise<void> {
 			indicate: channel.hasUnreadNote,
 			to: `/channels/${channel.id}`,
 		})),
-		(channels.length === 0 ? undefined : null),
+		(channels.length === 0 ? undefined : { type: 'divider' }),
 		{
 			type: 'link' as const,
 			icon: 'ti ti-plus',

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -125,7 +125,7 @@ async function chooseChannel(ev: MouseEvent): Promise<void> {
 	const channels = await os.api('channels/my-favorites', {
 		limit: 100,
 	});
-	const items = [
+	const items: MenuItem[] = [
 		...channels.map(channel => ({
 			type: 'link' as const,
 			text: channel.name,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

#12647 の対応です。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix #12647

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカルで以下を確認
- お気に入りチャンネルありのとき、チャンネル名と新規追加メニューの間に区切り線があること
- お気に入りチャンネルなしのとき、チャンネル名と区切り線が表示されず、新規追加メニューのみが表示されること

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ※ごく最近のコミットに対する修正なので記載していません
- [ ] (If possible) Add tests
