### PR TITLE
perf: early return users/notes and users/featured-notes if me is blocked by requesting user

### DIFF
--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -86,6 +86,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			if (ps.withReplies && ps.withFiles) throw new ApiError(meta.errors.bothWithRepliesAndWithFiles);
 
+			// early return if me is blocked by requesting user
+			if (me != null) {
+				const userIdsWhoBlockingMe = await this.cacheService.userBlockedCache.fetch(me.id);
+				if (userIdsWhoBlockingMe.has(ps.userId)) {
+					return [];
+				}
+			}
+
 			if (!serverSettings.enableFanoutTimeline) {
 				const timeline = await this.getFromDb({
 					untilId,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

> しかしそのようにするのであればそもそもredisに問い合わせる前にblockされてるか確認して[]をearly returnするべきだと思います

https://github.com/misskey-dev/misskey/pull/12511#discussion_r1414187559

を実装します。
ブロックされてる場合にはノートが一切表示されない仕様なためearly returnします

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

DBにアクセスしなくなって多分パフォーマンスが上がる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
