### PR TITLE
fix(backend): 1702718871541-ffVisibility.jsのdownが壊れている

### DIFF
--- a/packages/backend/migration/1702718871541-ffVisibility.js
+++ b/packages/backend/migration/1702718871541-ffVisibility.js
@@ -24,9 +24,11 @@ export class ffVisibility1702718871541 {
 	async down(queryRunner) {
 		await queryRunner.query(`CREATE TYPE "public"."user_profile_ffvisibility_enum" AS ENUM('public', 'followers', 'private')`);
 		await queryRunner.query(`ALTER TABLE "user_profile" ADD "ffVisibility" "public"."user_profile_ffvisibility_enum" NOT NULL DEFAULT 'public'`);
+
 		await queryRunner.query(`CREATE CAST ("public"."user_profile_followingvisibility_enum" AS "public"."user_profile_ffvisibility_enum") WITH INOUT AS ASSIGNMENT`);
-		await queryRunner.query(`UPDATE "user_profile" SET ffVisibility = "user_profile"."followingVisibility"`);
+		await queryRunner.query(`UPDATE "user_profile" SET "ffVisibility" = "followingVisibility"`);
 		await queryRunner.query(`DROP CAST ("public"."user_profile_followingvisibility_enum" AS "public"."user_profile_ffvisibility_enum")`);
+
 		await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "followersVisibility"`);
 		await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "followingVisibility"`);
 		await queryRunner.query(`DROP TYPE "public"."user_profile_followersVisibility_enum"`);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
掲題の現象を修正しました。
これにより、`pmpm revert`が成功するようになります。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
2023.12.0への更新に失敗した時など、前のバージョンまで巻き戻したいケースがあると考えます。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ローカルにて`pnpm migrate`と`pnpm revert`を繰り返し実行し、いずれもエラーとならないこと、`user_profile.ffVisibility`の値が壊れずに引き継がれることを確認しています。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ※別途相談したいです
- [ ] (If possible) Add tests
