### PR TITLE
fix(ci): Get api.json from Misskey （get-api-diff）が死んでいるのを修正

### DIFF
--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: api-artifact-${{ matrix.runs-on }}
+        name: api-artifact-${{ matrix.api-json-name }}
         path: ${{ matrix.api-json-name }}
 
   save-pr-number:

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: api-artifact
+        name: api-artifact-${{ matrix.runs-on }}
         path: ${{ matrix.api-json-name }}
 
   save-pr-number:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Get api.json from Misskeyが死んでいるのを修正しました。
バージョンアップ時の対応漏れ？

参考：https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
CIが役目を果たさないため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
