### PR TITLE
ci: Get api.json from Misskeyでupload-artifact@v4で同名artifactでエラーになるのを修正

### DIFF
--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: api-artifact
+        name: api-artifact-${{ matrix.api-json-name }}
         path: ${{ matrix.api-json-name }}
 
   save-pr-number:
@@ -69,5 +69,5 @@ jobs:
           echo "$PR_NUMBER" > ./pr_number
       - uses: actions/upload-artifact@v4
         with:
-          name: api-artifact
+          name: api-artifact-pr-number
           path: pr_number

--- a/.github/workflows/report-api-diff.yml
+++ b/.github/workflows/report-api-diff.yml
@@ -19,24 +19,28 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
             let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: context.payload.workflow_run.id,
             });
-            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "api-artifact"
-            })[0];
-            let download = await github.rest.actions.downloadArtifact({
-               owner: context.repo.owner,
-               repo: context.repo.repo,
-               artifact_id: matchArtifact.id,
-               archive_format: 'zip',
+            let matchArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name.startsWith("api-artifact-")
             });
-            let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/api-artifact.zip`, Buffer.from(download.data));
-      - name: Extract artifact
-        run: unzip api-artifact.zip -d artifacts
+            await Promise.all(matchArtifacts.map(async (artifact) => {
+              let download = await github.rest.actions.downloadArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+                archive_format: 'zip',
+              });
+              await fs.promises.writeFile(`${process.env.GITHUB_WORKSPACE}/${artifact.name}.zip`, Buffer.from(download.data));
+            }));
+      - name: Extract all artifacts
+        run: |
+          find . -mindepth 1 -maxdepth 1 -type f -name '*.zip' -exec unzip {} -d artifacts ';'
+          ls -la
       - name: Load PR Number
         id: load-pr-num
         run: echo "pr-number=$(cat artifacts/pr_number)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/report-api-diff.yml
+++ b/.github/workflows/report-api-diff.yml
@@ -26,7 +26,7 @@ jobs:
                run_id: context.payload.workflow_run.id,
             });
             let matchArtifacts = allArtifacts.data.artifacts.filter((artifact) => {
-              return artifact.name.startsWith("api-artifact-")
+              return artifact.name.startsWith("api-artifact-") || artifact.name == "api-artifact"
             });
             await Promise.all(matchArtifacts.map(async (artifact) => {
               let download = await github.rest.actions.downloadArtifact({

--- a/.github/workflows/report-api-diff.yml
+++ b/.github/workflows/report-api-diff.yml
@@ -87,3 +87,11 @@ jobs:
           pr_number: ${{ steps.load-pr-num.outputs.pr-number }}
           comment_tag: show_diff
           filePath: ./output.md
+      - name: Tell error to PR
+        uses: thollander/actions-comment-pull-request@v2
+        if: failure() && steps.load-pr-num.outputs.pr-number
+        with:
+          pr_number: ${{ steps.load-pr-num.outputs.pr-number }}
+          comment_tag: show_diff_error
+          message: |
+            api.jsonの差分作成中にエラーが発生しました。詳細は[Workflowのログ](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})を確認してください。


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
#12768 と同じです。

Regression in #12670

また、レポートの方でエラーになったときに何もエラーにならなかったので、エラーをプルリクに投げるようにしました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

普通の動作確認: anatawa12/misskey#10
upload-artifact@v3時代との互換性確認: anatawa12/misskey#11
report-api-diff内でのエラーの確認: anatawa12/misskey#12 (取得自体を無効化してます)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
