### PR TITLE
fix(drop-and-fusion): バブルゲームのリトライボタンでリトライができない問題を修正

### DIFF
--- a/packages/frontend/src/pages/drop-and-fusion.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.vue
@@ -153,7 +153,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</div>
 			<div :class="$style.frame">
 				<div :class="$style.frameInner">
-					<MkButton danger @click="surrender">Retry</MkButton>
+					<MkButton v-if="!isGameOver && !replaying" full danger @click="surrender">Surrender</MkButton>
+					<MkButton v-else full @click="retry">Retry</MkButton>
 				</div>
 			</div>
 		</div>
@@ -483,15 +484,22 @@ async function surrender() {
 	game.surrender();
 }
 
+async function retry() {
+	end();
+	await start();
+}
+
 function end() {
 	game.dispose();
 	isGameOver.value = false;
+	replaying.value = false;
 	currentPick.value = null;
 	dropReady.value = true;
 	stock.value = [];
 	score.value = 0;
 	combo.value = 0;
 	comboPrev.value = 0;
+	maxCombo.value = 0;
 	bgmNodes?.soundSource.stop();
 	gameStarted.value = false;
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ゲーム中なら諦める、ゲームオーバー画面の表示中はリスタートになるように
一部の値がゲーム終了時初期化されていないのも直した

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
リトライって書いてあるボタンを押すとゲームオーバー画面になるだけなのでユーザーの期待通りの動きではなくなっている

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ioではすでに適用済み
https://github.com/MisskeyIO/misskey/pull/350

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
