### PR TITLE
Fix: properly handle cc followers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Fix: `notes/create`で、`text`が空白文字のみで構成されているか`null`であって、かつ`text`だけであるリクエストに対するレスポンスが400になるように変更
 - Fix: `notes/create`で、`text`が空白文字のみで構成されていてかつリノート、ファイルまたは投票を含んでいるリクエストに対するレスポンスの`text`が`""`から`null`になるように変更
 - Fix: ipv4とipv6の両方が利用可能な環境でallowedPrivateNetworksが設定されていた場合プライベートipの検証ができていなかった問題を修正
+- Fix: properly handle cc followers
 
 ## 2023.12.2
 

--- a/packages/backend/src/core/activitypub/ApAudienceService.ts
+++ b/packages/backend/src/core/activitypub/ApAudienceService.ts
@@ -58,7 +58,7 @@ export class ApAudienceService {
 			};
 		}
 
-		if (toGroups.followers.length > 0 or ccGroups.followers.length > 0) {
+		if (toGroups.followers.length > 0 || ccGroups.followers.length > 0) {
 			return {
 				visibility: 'followers',
 				mentionedUsers,

--- a/packages/backend/src/core/activitypub/ApAudienceService.ts
+++ b/packages/backend/src/core/activitypub/ApAudienceService.ts
@@ -58,7 +58,7 @@ export class ApAudienceService {
 			};
 		}
 
-		if (toGroups.followers.length > 0) {
+		if (toGroups.followers.length > 0 or ccGroups.followers.length > 0) {
 			return {
 				visibility: 'followers',
 				mentionedUsers,


### PR DESCRIPTION
Fix #13001

## What

Check for cc:followers, not just to:followers

## Why

When encountering a post with no `to` and only `cc: <followers>`, it now gets parsed correctly as a followers-only post

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
