### PR TITLE
Enhance(frontend): MkCustomEmojiDetailedDialogを調整

### DIFF
--- a/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
+++ b/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
@@ -10,9 +10,9 @@ SPDX-License-Identifier: AGPL-3.0-only
       <MkSpacer>
         <div style="display: flex; flex-direction: column; gap: 1em;">
           <div :class="$style.emojiImgWrapper">
-            <MkCustomEmoji :name="emoji.name" :normal="true" style="height: 100%;"></MkCustomEmoji>
+            <MkCustomEmoji :name="emoji.name" :normal="true" :useOriginalSize="true" style="height: 100%;"></MkCustomEmoji>
           </div>
-          <MkKeyValue>
+          <MkKeyValue :copy="`:${emoji.name}:`">
             <template #key>{{ i18n.ts.name }}</template>
             <template #value>{{ emoji.name }}</template>
           </MkKeyValue>
@@ -94,6 +94,7 @@ const cancel = () => {
 
 .alias {
   display: inline-block;
+  word-break: break-all;
   padding: 3px 10px;
   background-color: var(--X5);
   border: solid 1px var(--divider);

--- a/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
+++ b/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
@@ -41,7 +41,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           </MkKeyValue>
           <MkKeyValue>
             <template #key>{{ i18n.ts.license }}</template>
-            <template #value>{{ emoji.license ?? i18n.ts.none }}</template>
+            <template #value><Mfm :text="emoji.license ?? i18n.ts.none" /></template>
           </MkKeyValue>
           <MkKeyValue :copy="emoji.url">
             <template #key>{{ i18n.ts.emojiUrl }}</template>

--- a/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
+++ b/packages/frontend/src/components/MkCustomEmojiDetailedDialog.vue
@@ -46,7 +46,7 @@ SPDX-License-Identifier: AGPL-3.0-only
           <MkKeyValue :copy="emoji.url">
             <template #key>{{ i18n.ts.emojiUrl }}</template>
             <template #value>
-              <a :href="emoji.url" target="_blank">{{ emoji.url }}</a>
+              <MkLink :url="emoji.url" target="_blank">{{ emoji.url }}</MkLink>
             </template>
           </MkKeyValue>
         </div>
@@ -61,6 +61,7 @@ import { defineProps, shallowRef } from 'vue';
 import { i18n } from '@/i18n.js';
 import MkModalWindow from '@/components/MkModalWindow.vue';
 import MkKeyValue from '@/components/MkKeyValue.vue';
+import MkLink from './MkLink.vue';
 const props = defineProps<{
   emoji: Misskey.entities.EmojiDetailed,
 }>();

--- a/packages/frontend/src/pages/emoji-edit-dialog.vue
+++ b/packages/frontend/src/pages/emoji-edit-dialog.vue
@@ -44,7 +44,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 						{{ i18n.ts.setMultipleBySeparatingWithSpace }}
 					</template>
 				</MkInput>
-				<MkInput v-model="license">
+				<MkInput v-model="license" :mfmAutocomplete="true">
 					<template #label>{{ i18n.ts.license }}</template>
 				</MkInput>
 				<MkFolder>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
MkCustomEmojiDetailedDialogまわりを調整しました。(それぞれの粒度が小さいので1つのPRにまとめました)
- 絵文字の画像にオリジナル画質を使うように
  - ガビガビになってしまうため
- :絵文字名:をコピーできるように
  - コピーできたほうが便利なため
- ライセンスにMFMが使えるように
  - URLをクリック可能にするため
- 画像URLに`<a>`ではなく`<MkLink>`を使うように
  - `<a>`だと色が通常テキストと変わらずリンクだということが分かりにくいため
- エイリアスに長い単語を入れた場合改行されずはみ出てしまう問題を修正
  - はみ出ると見た目が悪いため

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
同上

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
