### PR TITLE
fix(ci): `misskey-js` のバージョンチェックをトリガーする条件の修正

### DIFF
--- a/.github/workflows/check-misskey-js-version.yml
+++ b/.github/workflows/check-misskey-js-version.yml
@@ -1,0 +1,28 @@
+name: Check Misskey JS version
+
+on:
+  push:
+    branches: [ develop ]
+    paths:
+      - packages/misskey-js/package.json
+      - package.json
+  pull_request:
+    branches: [ develop ]
+    paths:
+      - packages/misskey-js/package.json
+      - package.json
+
+jobs:
+  check-version:
+    # ルートの package.json と packages/misskey-js/package.json のバージョンが一致しているかを確認する
+    name: Check version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Check version
+        run: |
+          if [ "$(jq -r '.version' package.json)" != "$(jq -r '.version' packages/misskey-js/package.json)" ]; then
+            echo "Version mismatch!"
+            exit 1
+          fi

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -54,17 +54,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./packages/misskey-js/coverage/coverage-final.json
-
-  check-version:
-    # ルートの package.json と packages/misskey-js/package.json のバージョンが一致しているかを確認する
-    name: Check version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4.1.1
-      - name: Check version
-        run: |
-          if [ "$(jq -r '.version' package.json)" != "$(jq -r '.version' packages/misskey-js/package.json)" ]; then
-            echo "Version mismatch!"
-            exit 1
-          fi

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2024.2.0-beta.7",
+	"version": "2024.2.0-beta.8",
 	"description": "Misskey SDK for JavaScript",
 	"types": "./built/dts/index.d.ts",
 	"exports": {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`misskey-js` のバージョンチェックをトリガーする条件を修正しました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
現状 `packages/misskey-js` ディレクトリ内に変更があったときしかチェックが走らないため、直下の `package.json` を変更した際にチェックが機能しない問題があります。これを修正します。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
