### PR TITLE
Fix(frontend): プロフィール編集後にプロフィール画面に行ってもリロードをしないと編集内容が反映されない。

### DIFF
--- a/packages/frontend/src/pages/user/index.vue
+++ b/packages/frontend/src/pages/user/index.vue
@@ -74,9 +74,16 @@ function fetchUser(): void {
 	});
 }
 
-watch(() => props.acct, fetchUser, {
-	immediate: true,
-});
+watch(
+	[() => props.acct, () => $i],
+	() => {
+		fetchUser();
+	},
+	{
+		immediate: true,
+		deep: true,
+	},
+);
 
 const headerActions = computed(() => []);
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
バグ修正です。
プロフィール編集後にプロフィール画面に行ってもリロードをしないと編集内容が反映されない問題を修正しました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
本バグが存在するとユーザーはプロフィール編集をしたのに、反映がされていないように感じてしまう。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
https://github.com/misskey-dev/misskey/issues/13078

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
