### PR TITLE
fix(backend): "誰でも新規登録できるようにする"の初期値をOFFにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - Fix: ipv4とipv6の両方が利用可能な環境でallowedPrivateNetworksが設定されていた場合プライベートipの検証ができていなかった問題を修正
 - Fix: properly handle cc followers
 - Fix: ジョブに関する設定の名前を修正 relashionshipJobPerSec -> relationshipJobPerSec
+- Fix: コントロールパネル->モデレーション->「誰でも新規登録できるようにする」の初期値をONからOFFに変更 #13122
 
 ### Service Worker
 - Enhance: オフライン表示のデザインを改善・多言語対応

--- a/packages/backend/migration/1706791962000-fix-meta-disableRegistration.js
+++ b/packages/backend/migration/1706791962000-fix-meta-disableRegistration.js
@@ -7,10 +7,10 @@ export class FixMetaDisableRegistration1706791962000 {
     name = 'FixMetaDisableRegistration1706791962000'
 
     async up(queryRunner) {
-        await queryRunner.query(`alter table meta	alter column "disableRegistration" set default true;`);
+        await queryRunner.query(`alter table meta alter column "disableRegistration" set default true;`);
     }
 
     async down(queryRunner) {
-        await queryRunner.query(`alter table meta	alter column "disableRegistration" set default false;`);
+        await queryRunner.query(`alter table meta alter column "disableRegistration" set default false;`);
     }
 }

--- a/packages/backend/migration/1706791962000-fix-meta-disableRegistration.js
+++ b/packages/backend/migration/1706791962000-fix-meta-disableRegistration.js
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and other misskey contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class FixMetaDisableRegistration1706791962000 {
+    name = 'FixMetaDisableRegistration1706791962000'
+
+    async up(queryRunner) {
+        await queryRunner.query(`alter table meta	alter column "disableRegistration" set default true;`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`alter table meta	alter column "disableRegistration" set default false;`);
+    }
+}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
#13122 の対応です。
これにより、コントロールパネル->モデレーションにある「誰でも新規登録できるようにする」の初期値がOFFになります。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
fix #13122

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
以下を確認済みです
- pnpm migrateでmeta.disableRegistrationのデフォルト値がtrueとして設定されること
- pnpm revertでmeta.disableRegistrationのデフォルト値がfalseに戻ること
- イチからMisskeyをセットアップした後に「誰でも新規登録できるようにする」の初期値を確認し、OFFであること

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
