### PR TITLE
fix(backend): メール配信機能が無効ならばメールを送ることのないように

### DIFF
--- a/packages/backend/src/core/EmailService.ts
+++ b/packages/backend/src/core/EmailService.ts
@@ -40,6 +40,8 @@ export class EmailService {
 	public async sendEmail(to: string, subject: string, html: string, text: string) {
 		const meta = await this.metaService.fetch(true);
 
+		if (!meta.enableEmail) return;
+
 		const iconUrl = `${this.config.url}/static-assets/mi-white.png`;
 		const emailSettingUrl = `${this.config.url}/settings/email`;
 


### PR DESCRIPTION
メール配信機能が無効ならばメールを送ることのないようにする
`packages/backend/src/core/EmailService.ts`の`sendEmail`で`meta`を取得するので
その直後で`return`することで関数を終了させる

Fix: https://github.com/misskey-dev/misskey/issues/13151

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
メール配信機能が無効ならばメールを送ることのないようにする

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix: https://github.com/misskey-dev/misskey/issues/13151

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
tested on our developing environment

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
