### PR TITLE
AP Key の JSON-LD 表現を修正

### DIFF
--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -625,6 +625,7 @@ export class ApRendererService {
 				'https://www.w3.org/ns/activitystreams',
 				'https://w3id.org/security/v1',
 				{
+					Key: 'sec:Key',
 					// as non-standards
 					manuallyApprovesFollowers: 'as:manuallyApprovesFollowers',
 					sensitive: 'as:sensitive',


### PR DESCRIPTION
## What
AP Key の JSON-LD 表現を修正

`Person.publicKey`, `/publickey` などの、`"type": "Key"` が `https://w3id.org/security#Key` として完全名で解決されるようになります

https://github.com/misskey-dev/misskey/issues/13169 の Expected Behavior になる

## Why
Fix https://github.com/misskey-dev/misskey/issues/13169

ほぼ実影響はないと思われるが、変ではあるらしい。

## Additional info (optional)
https://github.com/misskey-dev/misskey/issues/13169 の Steps to Reproduce などに従って検証すると良さそう。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
