### PR TITLE
Enhance: 連合向けのノート配信を軽量化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Fix: properly handle cc followers
 - Fix: ジョブに関する設定の名前を修正 relashionshipJobPerSec -> relationshipJobPerSec
 - Fix: コントロールパネル->モデレーション->「誰でも新規登録できるようにする」の初期値をONからOFFに変更 #13122
+- Enhance: 連合向けのノート配信を軽量化
 
 ### Service Worker
 - Enhance: オフライン表示のデザインを改善・多言語対応

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
 - Fix: properly handle cc followers
 - Fix: ジョブに関する設定の名前を修正 relashionshipJobPerSec -> relationshipJobPerSec
 - Fix: コントロールパネル->モデレーション->「誰でも新規登録できるようにする」の初期値をONからOFFに変更 #13122
-- Enhance: 連合向けのノート配信を軽量化
+- Enhance: 連合向けのノート配信を軽量化 #13192
 
 ### Service Worker
 - Enhance: オフライン表示のデザインを改善・多言語対応

--- a/packages/backend/src/core/MfmService.ts
+++ b/packages/backend/src/core/MfmService.ts
@@ -419,6 +419,10 @@ export class MfmService {
 			},
 
 			text: (node) => {
+				if (!node.props.text.match(/[\r\n]/)) {
+					return doc.createTextNode(node.props.text);
+				}
+
 				const el = doc.createElement('span');
 				const nodes = node.props.text.split(/\r\n|\r|\n/).map(x => doc.createTextNode(x));
 

--- a/packages/backend/src/core/activitypub/ApMfmService.ts
+++ b/packages/backend/src/core/activitypub/ApMfmService.ts
@@ -25,8 +25,21 @@ export class ApMfmService {
 	}
 
 	@bindThis
-	public getNoteHtml(note: MiNote): string | null {
-		if (!note.text) return '';
-		return this.mfmService.toHtml(mfm.parse(note.text), JSON.parse(note.mentionedRemoteUsers));
+	public getNoteHtml(note: MiNote, apAppend?: string) {
+		let noMisskeyContent = false;
+		const srcMfm = (note.text ?? '') + (apAppend ?? '');
+
+		const parsed = mfm.parse(srcMfm);
+
+		if (!apAppend && parsed?.every(n => ['text', 'unicodeEmoji','emojiCode', 'mention', 'hashtag', 'url'].includes(n.type))) {
+			noMisskeyContent = true;
+		}
+
+		const content = this.mfmService.toHtml(parsed, JSON.parse(note.mentionedRemoteUsers));
+
+		return {
+			content,
+			noMisskeyContent,
+		};
 	}
 }

--- a/packages/backend/src/core/activitypub/ApMfmService.ts
+++ b/packages/backend/src/core/activitypub/ApMfmService.ts
@@ -31,7 +31,7 @@ export class ApMfmService {
 
 		const parsed = mfm.parse(srcMfm);
 
-		if (!apAppend && parsed?.every(n => ['text', 'unicodeEmoji','emojiCode', 'mention', 'hashtag', 'url'].includes(n.type))) {
+		if (!apAppend && parsed?.every(n => ['text', 'unicodeEmoji', 'emojiCode', 'mention', 'hashtag', 'url'].includes(n.type))) {
 			noMisskeyContent = true;
 		}
 

--- a/packages/backend/src/core/activitypub/ApRendererService.ts
+++ b/packages/backend/src/core/activitypub/ApRendererService.ts
@@ -389,17 +389,15 @@ export class ApRendererService {
 			poll = await this.pollsRepository.findOneBy({ noteId: note.id });
 		}
 
-		let apText = text;
+		let apAppend = '';
 
 		if (quote) {
-			apText += `\n\nRE: ${quote}`;
+			apAppend += `\n\nRE: ${quote}`;
 		}
 
 		const summary = note.cw === '' ? String.fromCharCode(0x200B) : note.cw;
 
-		const content = this.apMfmService.getNoteHtml(Object.assign({}, note, {
-			text: apText,
-		}));
+		const { content, noMisskeyContent } = this.apMfmService.getNoteHtml(note, apAppend);
 
 		const emojis = await this.getEmojis(note.emojis);
 		const apemojis = emojis.filter(emoji => !emoji.localOnly).map(emoji => this.renderEmoji(emoji));
@@ -412,9 +410,6 @@ export class ApRendererService {
 
 		const asPoll = poll ? {
 			type: 'Question',
-			content: this.apMfmService.getNoteHtml(Object.assign({}, note, {
-				text: text,
-			})),
 			[poll.expiresAt && poll.expiresAt < new Date() ? 'closed' : 'endTime']: poll.expiresAt,
 			[poll.multiple ? 'anyOf' : 'oneOf']: poll.choices.map((text, i) => ({
 				type: 'Note',
@@ -432,11 +427,13 @@ export class ApRendererService {
 			attributedTo,
 			summary: summary ?? undefined,
 			content: content ?? undefined,
-			_misskey_content: text,
-			source: {
-				content: text,
-				mediaType: 'text/x.misskeymarkdown',
-			},
+			...(noMisskeyContent ? {} : {
+				_misskey_content: text,
+				source: {
+					content: text,
+					mediaType: 'text/x.misskeymarkdown',
+				},
+			}),
 			_misskey_quote: quote,
 			quoteUrl: quote,
 			published: this.idService.parse(note.id).date.toISOString(),

--- a/packages/backend/test/unit/ApMfmService.ts
+++ b/packages/backend/test/unit/ApMfmService.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import { Test } from '@nestjs/testing';
+
+import { CoreModule } from '@/core/CoreModule.js';
+import { ApMfmService } from '@/core/activitypub/ApMfmService.js';
+import { GlobalModule } from '@/GlobalModule.js';
+import { MiNote } from '@/models/Note.js';
+
+describe('ApMfmService', () => {
+	let apMfmService: ApMfmService;
+
+	beforeAll(async () => {
+		const app = await Test.createTestingModule({
+			imports: [GlobalModule, CoreModule],
+		}).compile();
+		apMfmService = app.get<ApMfmService>(ApMfmService);
+	});
+
+	describe('getNoteHtml', () => {
+		test('Do not provide _misskey_content for simple text', () => {
+			const note: MiNote = {
+				text: 'テキスト #タグ @mention 🍊 :emoji: https://example.com',
+				mentionedRemoteUsers: '[]',
+			} as any;
+
+			const { content, noMisskeyContent } = apMfmService.getNoteHtml(note);
+
+			assert.equal(noMisskeyContent, true, 'noMisskeyContent');
+			assert.equal(content, '<p>テキスト <a href="http://misskey.local/tags/タグ" rel="tag">#タグ</a> <a href="http://misskey.local/@mention" class="u-url mention">@mention</a> 🍊 ​:emoji:​ <a href="https://example.com">https://example.com</a></p>', 'content');
+		});
+
+		test('Provide _misskey_content for MFM', () => {
+			const note: MiNote = {
+				text: '$[tada foo]',
+				mentionedRemoteUsers: '[]',
+			} as any;
+
+			const { content, noMisskeyContent } = apMfmService.getNoteHtml(note);
+
+			assert.equal(noMisskeyContent, false, 'noMisskeyContent');
+			assert.equal(content, '<p><i>foo</i></p>', 'content');
+		});
+	});
+});

--- a/packages/backend/test/unit/MfmService.ts
+++ b/packages/backend/test/unit/MfmService.ts
@@ -33,6 +33,12 @@ describe('MfmService', () => {
 			const output = '<p><span>foo<br>bar<br>baz</span></p>';
 			assert.equal(mfmService.toHtml(mfm.parse(input)), output);
 		});
+
+		test('Do not generate unnecessary span', () => {
+			const input = 'foo $[tada bar]';
+			const output = '<p>foo <i>bar</i></p>';
+			assert.equal(mfmService.toHtml(mfm.parse(input)), output);
+		});
 	});
 
 	describe('fromHtml', () => {


### PR DESCRIPTION
## What
Resolve #13191

連合向けのノート配信を軽量化しています

### 不要な場合はMisskey生表現を使用しない
現状AP標準HTML (content) の他に、_misskey_content 等のMisskey生表現も添付していますが
テキスト, タグ, 絵文字, URL, メンション などの基本的な表現であれば、AP標準HTMLのみでやりとり可能なので
不要な場合は添付しないようにしています。もちろんそれ以外のMFMを含む場合は現状通りです。

※ ロジック的には、MFMの最上位ASTが全て [テキスト, タグ, 絵文字, URL, メンション] (これは子要素を持たない) のいずれかで構成されていれば間違いなくMisskey生表現は省略可能とみなして省略しています。
それ以下の子要素を探索して省略の可能性を探ることはコスパ的にやってません。

### 無駄なspanを減らす
基本的に改行を含まないMFM textノードではspanを生成しないようにしています。
改行を含むMFM textノードは依然としてspanを生成しますが (eg: `<span>1行目<br>2行目</span>`) 
これを改善しようとするとロジックをいじくらないといけないので触ってません。

### サンプル
```
  content: '<p><span>テキスト </span><a href="https://example.com/tags/タグ" rel="tag">#タグ</a><span> </span><a href="https://example.com/">https://example.com/</a><span> </span>🍊<span> </span>​:emoji:​<span> </span><a href="https://example.com/@b" class="u-url mention">@b</a></p>',
  _misskey_content: 'テキスト #タグ https://example.com/ 🍊 :emoji: @b',
  source: {
    content: 'テキスト #タグ https://example.com/ 🍊 :emoji: @b',
    mediaType: 'text/x.misskeymarkdown'
  },
```
↓
```
  content: '<p>テキスト <a href="https://example.com/tags/タグ" rel="tag">#タグ</a> <a href="https://example.com/">https://example.com/</a> 🍊 ​:emoji:​ <a href="https://example.com/@b" class="u-url mention">@b</a></p>',
```

## Why
Resolve #13191 
長いテキストはネットワークトラフィックの他に署名等の付加も増えるので可能なら減らしたい
また、なんとなくダサい

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
