### PR TITLE
chore: 以前の開発環境（backendにアクセスする方式）を立ち上げられるように

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,19 @@ command.
 If you have not changed it from the default, it will be "http://localhost:3000".
 If "port" in .config/default.yml is set to something other than 3000, you need to change the proxy settings in packages/frontend/vite.config.local-dev.ts.
 
+### `MK_DEV_PREFER=backend pnpm dev`
+pnpm dev has another mode with `MK_DEV_PREFER=backend`.
+
+```
+MK_DEV_PREFER=backend pnpm dev
+```
+
+- This mode is closer to the production environment than the default mode.
+- Vite runs behind the backend (the backend will proxy Vite at /vite).
+- You can see Misskey by accessing `http://localhost:3000` (Replace `3000` with the port configured with `port` in .config/default.yml).
+- To change the port of Vite, specify with `VITE_PORT` environment variable.
+- HMR may not work in some environments such as Windows.
+
 ### Dev Container
 Instead of running `pnpm` locally, you can use Dev Container to set up your development environment.
 To use Dev Container, open the project directory on VSCode with Dev Containers installed.  

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -64,7 +64,7 @@ execa('pnpm', ['--filter', 'backend', 'dev'], {
 	stderr: process.stderr,
 });
 
-execa('pnpm', ['--filter', 'frontend', process.env.MK_DEV_PRFER === 'backend' ? 'dev' : 'watch'], {
+execa('pnpm', ['--filter', 'frontend', process.env.MK_DEV_PREFER === 'backend' ? 'dev' : 'watch'], {
 	cwd: _dirname + '/../',
 	stdout: process.stdout,
 	stderr: process.stderr,

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -64,7 +64,7 @@ execa('pnpm', ['--filter', 'backend', 'dev'], {
 	stderr: process.stderr,
 });
 
-execa('pnpm', ['--filter', 'frontend', 'dev'], {
+execa('pnpm', ['--filter', 'frontend', process.env.MK_DEV_PRFER === 'backend' ? 'dev' : 'watch'], {
 	cwd: _dirname + '/../',
 	stdout: process.stdout,
 	stderr: process.stderr,


### PR DESCRIPTION
## What
`MK_DEV_PREFER=backend` を指定することで、#12593 で変更される前の開発環境（backendがviteをプロキシし開発者はbackendにアクセスする本番環境に近いモード）を利用できるようにします。

## Why
- 本番環境に近い方が良い
- 同一ポートでpnpm start/pnpm devへアクセス可能

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
