### PR TITLE
ci(test-frontend): Cypressのテストの失敗時、永遠に止まらない問題を回避

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -115,6 +115,7 @@ jobs:
       run: pnpm exec cypress install
     - name: Cypress run
       uses: cypress-io/github-action@v6
+      timeout-minutes: 15
       with:
         install: false
         start: pnpm start:test

--- a/cypress/e2e/basic.cy.js
+++ b/cypress/e2e/basic.cy.js
@@ -162,12 +162,12 @@ describe('After user signed in', () => {
 
   it('successfully loads', () => {
 		// 表示に時間がかかるのでデフォルト秒数だとタイムアウトする
-		cy.get('[data-cy-user-setup-continue]', { timeout: 12000 }).should('be.visible');
+		cy.get('[data-cy-user-setup-continue]', { timeout: 30000 }).should('be.visible');
   });
 
 	it('account setup wizard', () => {
 		// 表示に時間がかかるのでデフォルト秒数だとタイムアウトする
-		cy.get('[data-cy-user-setup-continue]', { timeout: 12000 }).click();
+		cy.get('[data-cy-user-setup-continue]', { timeout: 30000 }).click();
 
 		cy.get('[data-cy-user-setup-user-name] input').type('ありす');
 		cy.get('[data-cy-user-setup-user-description] textarea').type('ほげ');
@@ -205,7 +205,7 @@ describe('After user setup', () => {
 
 		// アカウント初期設定ウィザード
 		// 表示に時間がかかるのでデフォルト秒数だとタイムアウトする
-		cy.get('[data-cy-user-setup] [data-cy-modal-window-close]', { timeout: 12000 }).click();
+		cy.get('[data-cy-user-setup] [data-cy-modal-window-close]', { timeout: 30000 }).click();
 		cy.get('[data-cy-modal-dialog-ok]').click();
 	});
 

--- a/cypress/e2e/router.cy.js
+++ b/cypress/e2e/router.cy.js
@@ -14,7 +14,7 @@ describe('Router transition', () => {
 
 			// アカウント初期設定ウィザード
 			// 表示に時間がかかるのでデフォルト秒数だとタイムアウトする
-			cy.get('[data-cy-user-setup] [data-cy-modal-window-close]', { timeout: 12000 }).click();
+			cy.get('[data-cy-user-setup] [data-cy-modal-window-close]', { timeout: 30000 }).click();
 			cy.wait(500);
 			cy.get('[data-cy-modal-dialog-ok]').click();
 		});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Cherry-picked from MisskeyIO#434

失敗しないようタイムアウトの延長・15分で止まるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
タイムアウトが12秒になっているが、
成功してる時も11秒で完了したり、
タイムアウトを長くして確認すると27秒も掛かったりするので、12秒だと短い

低確率ではあるがテストに失敗するとそのまま固まって
GitHub ActionsのStepのデフォルトのタイムアウト時間である6時間ずっと回りっぱなしになったりもするため
Stepの実行時間を15分に制限する

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
