### PR TITLE
fix(backend): より多くの人に使われているハッシュタグが検索結果上位に来るように

### DIFF
--- a/packages/backend/src/server/api/endpoints/hashtags/search.ts
+++ b/packages/backend/src/server/api/endpoints/hashtags/search.ts
@@ -43,7 +43,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		super(meta, paramDef, async (ps, me) => {
 			const hashtags = await this.hashtagsRepository.createQueryBuilder('tag')
 				.where('tag.name like :q', { q: sqlLikeEscape(ps.query.toLowerCase()) + '%' })
-				.orderBy('tag.count', 'DESC')
+				.orderBy('tag.mentionedLocalUsersCount', 'DESC')
 				.groupBy('tag.id')
 				.limit(ps.limit)
 				.offset(ps.offset)


### PR DESCRIPTION
（PR作り直しました。すみません）

## What

このPRではIssue #11498 を解決します。

`/api/hashtags/search`でのハッシュタグの検索において、`mentionedLocalUsersCount`の降順ソートを行うようにしました。

## Why

`/api/hashtags/search`は投稿するノートのテキストを編集しているときに、ハッシュタグのサジェスト候補を取得するために使われるAPIです。現在のMisskeyではこの候補は正しい並び替えがされていないため、あまり使われていないハッシュタグがサジェスト候補上位に来てしまうというUX上の問題があります。

このPRでは、結果として得られるハッシュタグの配列が、そのハッシュタグを使用したローカルユーザーの数が多いものから順番に並ぶように変更しました。これにより上記の問題が解決します。

## Additional info (optional)

これまでのコードには`count`というカラムで降順ソートをするように書かれていましたが、そのようなカラムは存在しないはずです。

この変更により、たくさんのハッシュタグがデータベースに登録されているような大規模なサーバーではパフォーマンスが問題になるかもしれません。（ただ、目当てのハッシュタグがサジェストされるまでにかかるAPI呼び出し回数は多くのシチュエーションで減るはずです。）

`MiHashtag`には`mentionedLocalUsersCount`の他に`mentionedUsersCount`（ローカル・リモート問わずそのハッシュタグを使用したユーザーの数）や`mentionedRemoteUsersCount`（リモートユーザーのみ）といったカラムもあり、そちらで並び替えることもできますが、とりあえずローカルユーザーの数で並び替えるようにしてみました。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
