### PR TITLE
refactor(backend): `ReactionService.prototype.convertLegacyReactions`

### DIFF
--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -346,11 +346,12 @@ export class ReactionService {
 				return acc;
 			}, {});
 
-		const _reactions2: Record<string, number> = {};
-
-		for (const reaction of Object.keys(_reactions)) {
-			_reactions2[this.decodeReaction(reaction).reaction] = _reactions[reaction];
-		}
+		const _reactions2 = Object.entries(_reactions)
+			.reduce<Record<string, number>>((acc, [reaction, count]) => {
+				const key = this.decodeReaction(reaction).reaction;
+				acc[key] = count;
+				return acc;
+			}, {});
 
 		return _reactions2;
 	}

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -326,23 +326,23 @@ export class ReactionService {
 	public convertLegacyReactions(reactions: Record<string, number>) {
 		const _reactions: Record<string, number> = {};
 
-		for (const reaction of Object.keys(reactions)) {
-			if (reactions[reaction] <= 0) continue;
+		for (const [reaction, count] of Object.entries(reactions)) {
+			if (count <= 0) continue;
 
 			// unchecked indexed access
 			const convertedReaction = legacies[reaction] as string | undefined;
 
 			if (convertedReaction !== undefined) {
 				if (_reactions[convertedReaction]) {
-					_reactions[convertedReaction] += reactions[reaction];
+					_reactions[convertedReaction] += count;
 				} else {
-					_reactions[convertedReaction] = reactions[reaction];
+					_reactions[convertedReaction] = count;
 				}
 			} else {
 				if (_reactions[reaction]) {
-					_reactions[reaction] += reactions[reaction];
+					_reactions[reaction] += count;
 				} else {
-					_reactions[reaction] = reactions[reaction];
+					_reactions[reaction] = count;
 				}
 			}
 		}

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -324,7 +324,7 @@ export class ReactionService {
 
 	@bindThis
 	public convertLegacyReactions(reactions: Record<string, number>) {
-		const _reactions = {} as Record<string, number>;
+		const _reactions: Record<string, number> = {};
 
 		for (const reaction of Object.keys(reactions)) {
 			if (reactions[reaction] <= 0) continue;
@@ -344,7 +344,7 @@ export class ReactionService {
 			}
 		}
 
-		const _reactions2 = {} as Record<string, number>;
+		const _reactions2: Record<string, number> = {};
 
 		for (const reaction of Object.keys(_reactions)) {
 			_reactions2[this.decodeReaction(reaction).reaction] = _reactions[reaction];

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -329,11 +329,14 @@ export class ReactionService {
 		for (const reaction of Object.keys(reactions)) {
 			if (reactions[reaction] <= 0) continue;
 
-			if (Object.keys(legacies).includes(reaction)) {
-				if (_reactions[legacies[reaction]]) {
-					_reactions[legacies[reaction]] += reactions[reaction];
+			// unchecked indexed access
+			const convertedReaction = legacies[reaction] as string | undefined;
+
+			if (convertedReaction !== undefined) {
+				if (_reactions[convertedReaction]) {
+					_reactions[convertedReaction] += reactions[reaction];
 				} else {
-					_reactions[legacies[reaction]] = reactions[reaction];
+					_reactions[convertedReaction] = reactions[reaction];
 				}
 			} else {
 				if (_reactions[reaction]) {

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -322,8 +322,12 @@ export class ReactionService {
 		//#endregion
 	}
 
+	/**
+	 * 文字列タイプのレガシーな形式のリアクションを現在の形式に変換しつつ、
+	 * データベース上には存在する「0個のリアクションがついている」という情報を削除する。
+	 */
 	@bindThis
-	public convertLegacyReactions(reactions: Record<string, number>) {
+	public convertLegacyReactions(reactions: MiNote['reactions']): MiNote['reactions'] {
 		return Object.entries(reactions)
 			.filter(([, count]) => {
 				// `ReactionService.prototype.delete`ではリアクション削除時に、
@@ -340,7 +344,7 @@ export class ReactionService {
 
 				return [key, count] as const;
 			})
-			.reduce<Record<string, number>>((acc, [key, count]) => {
+			.reduce<MiNote['reactions']>((acc, [key, count]) => {
 				// unchecked indexed access
 				const prevCount = acc[key] as number | undefined;
 

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -332,19 +332,12 @@ export class ReactionService {
 			// unchecked indexed access
 			const convertedReaction = legacies[reaction] as string | undefined;
 
-			if (convertedReaction !== undefined) {
-				if (_reactions[convertedReaction]) {
-					_reactions[convertedReaction] += count;
-				} else {
-					_reactions[convertedReaction] = count;
-				}
-			} else {
-				if (_reactions[reaction]) {
-					_reactions[reaction] += count;
-				} else {
-					_reactions[reaction] = count;
-				}
-			}
+			const key = convertedReaction ?? reaction;
+
+			// unchecked indexed access
+			const prevCount = _reactions[key] as number | undefined;
+
+			_reactions[key] = (prevCount ?? 0) + count;
 		}
 
 		const _reactions2: Record<string, number> = {};

--- a/packages/backend/test/unit/ReactionService.ts
+++ b/packages/backend/test/unit/ReactionService.ts
@@ -124,5 +124,11 @@ describe('ReactionService', () => {
 			const output = {};
 			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), output);
 		});
+
+		test('host部分の有無によりデコードすると同じ表記になるカスタム絵文字リアクションの個数情報を正しく足し合わせる', () => {
+			const input = { ':custom_emoji:': 1, ':custom_emoji@.:': 2 };
+			const output = { ':custom_emoji@.:': 3 };
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), output);
+		});
 	});
 });

--- a/packages/backend/test/unit/ReactionService.ts
+++ b/packages/backend/test/unit/ReactionService.ts
@@ -90,4 +90,39 @@ describe('ReactionService', () => {
 			assert.strictEqual(await reactionService.normalize('unknown'), '❤');
 		});
 	});
+
+	describe('convertLegacyReactions', () => {
+		test('空の入力に対しては何もしない', () => {
+			const input = {};
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), input);
+		});
+
+		test('Unicode絵文字リアクションを変換してしまわない', () => {
+			const input = { '👍': 1, '🍮': 2 };
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), input);
+		});
+
+		test('カスタム絵文字リアクションを変換してしまわない', () => {
+			const input = { ':like@.:': 1, ':pudding@example.tld:': 2 };
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), input);
+		});
+
+		test('文字列によるレガシーなリアクションを変換する', () => {
+			const input = { 'like': 1, 'pudding': 2 };
+			const output = { '👍': 1, '🍮': 2 };
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), output);
+		});
+
+		test('host部分が省略されたレガシーなカスタム絵文字リアクションを変換する', () => {
+			const input = { ':custom_emoji:': 1 };
+			const output = { ':custom_emoji@.:': 1 };
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), output);
+		});
+
+		test('「0個のリアクション」情報を削除する', () => {
+			const input = { 'angry': 0 };
+			const output = {};
+			assert.deepStrictEqual(reactionService.convertLegacyReactions(input), output);
+		});
+	});
 });


### PR DESCRIPTION
## What

`ReactionService.prototype.convertLegacyReactions`をリファクタリングしました。

## Why

可読性が低かったため。

## Additional info (optional)

単体テストも追加しました。

---

カスタム絵文字を文字列として表記した場合の`host`部分の有無により、`ReactionService.prototype.decode`でデコードすると同じ表記になってしまうカスタム絵文字リアクションの個数情報について、これまでの実装では後ろにあるもので上書きされていました。この挙動はおそらくバグだろうと判断し、このPRでの実装では上書きではなく加算するように変更しました。とはいえこの変更が実際に影響してくるシチュエーションはほぼないと思います。

```
// 引数として入力する値
{ ':custom_emoji:': 1, ':custom_emoji@.:': 2 }

// これまでの実装での返り値
{ ':custom_emoji@.:': 2 }

// このPRの実装での返り値
{ ':custom_emoji@.:': 3 }
```

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
