### PR TITLE
[For #13464] Use hint for getAuthUserFromApId

### DIFF
--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -35,7 +35,6 @@ export type UriParseResult = {
 
 @Injectable()
 export class ApDbResolverService implements OnApplicationShutdown {
-	private publicKeyCache: MemoryKVCache<MiUserPublickey | null>;
 	private publicKeyByUserIdCache: MemoryKVCache<MiUserPublickey[] | null>;
 
 	constructor(
@@ -54,7 +53,6 @@ export class ApDbResolverService implements OnApplicationShutdown {
 		private cacheService: CacheService,
 		private apPersonService: ApPersonService,
 	) {
-		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(1e3 * 60 * 20); // 20分
 		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey[] | null>(1e3 * 60 * 20); // 20分
 	}
 
@@ -117,36 +115,6 @@ export class ApDbResolverService implements OnApplicationShutdown {
 	}
 
 	/**
-	 * AP KeyId => Misskey User and Key
-	 */
-	@bindThis
-	public async getAuthUserFromKeyId(keyId: string): Promise<{
-		user: MiRemoteUser;
-		key: MiUserPublickey;
-	} | null> {
-		const key = await this.publicKeyCache.fetch(keyId, async () => {
-			const key = await this.userPublickeysRepository.findOneBy({
-				keyId,
-			});
-
-			if (key == null) return null;
-
-			return key;
-		}, key => key != null);
-
-		if (key == null) return null;
-
-		const user = await this.cacheService.findUserById(key.userId).catch(() => null) as MiRemoteUser | null;
-		if (user == null) return null;
-		if (user.isDeleted) return null;
-
-		return {
-			user,
-			key,
-		};
-	}
-
-	/**
 	 * AP Actor id => Misskey User and Key
 	 */
 	@bindThis
@@ -194,16 +162,10 @@ export class ApDbResolverService implements OnApplicationShutdown {
 	@bindThis
 	public refreshCacheByUserId(userId: MiUser['id']): void {
 		this.publicKeyByUserIdCache.delete(userId);
-		for (const [k, v] of this.publicKeyCache.cache.entries()) {
-			if (v.value?.userId === userId) {
-				this.publicKeyCache.delete(k);
-			}
-		}
 	}
 
 	@bindThis
 	public dispose(): void {
-		this.publicKeyCache.dispose();
 		this.publicKeyByUserIdCache.dispose();
 	}
 

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -150,7 +150,7 @@ export class ApDbResolverService implements OnApplicationShutdown {
 	 * AP Actor id => Misskey User and Key
 	 */
 	@bindThis
-	public async getAuthUserFromApId(uri: string): Promise<{
+	public async getAuthUserFromApId(uri: string, keyId?: string): Promise<{
 		user: MiRemoteUser;
 		key: MiUserPublickey | null;
 	} | null> {
@@ -170,6 +170,7 @@ export class ApDbResolverService implements OnApplicationShutdown {
 			keys[0] :
 			keys.find(x => {
 				try {
+					if (x.keyId === keyId) return true;
 					const url = new URL(x.keyId);
 					const path = url.pathname.split('/').pop()?.toLowerCase();
 					if (url.hash) {

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -77,20 +77,18 @@ export class InboxProcessorService {
 		let authUser: {
 			user: MiRemoteUser;
 			key: MiUserPublickey | null;
-		} | null = await this.apDbResolverService.getAuthUserFromKeyId(signature.keyId);
+		} | null = null;
 
 		// keyIdでわからなければ、activity.actorを元にDBから取得 || activity.actorを元にリモートから取得
-		if (authUser == null) {
-			try {
-				authUser = await this.apDbResolverService.getAuthUserFromApId(getApId(activity.actor), signature.keyId);
-			} catch (err) {
-				// 対象が4xxならスキップ
-				if (err instanceof StatusError) {
-					if (!err.isRetryable) {
-						throw new Bull.UnrecoverableError(`skip: Ignored deleted actors on both ends ${activity.actor} - ${err.statusCode}`);
-					}
-					throw new Error(`Error in actor ${activity.actor} - ${err.statusCode}`);
+		try {
+			authUser = await this.apDbResolverService.getAuthUserFromApId(getApId(activity.actor), signature.keyId);
+		} catch (err) {
+			// 対象が4xxならスキップ
+			if (err instanceof StatusError) {
+				if (!err.isRetryable) {
+					throw new Bull.UnrecoverableError(`skip: Ignored deleted actors on both ends ${activity.actor} - ${err.statusCode}`);
 				}
+				throw new Error(`Error in actor ${activity.actor} - ${err.statusCode}`);
 			}
 		}
 

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -82,7 +82,7 @@ export class InboxProcessorService {
 		// keyIdでわからなければ、activity.actorを元にDBから取得 || activity.actorを元にリモートから取得
 		if (authUser == null) {
 			try {
-				authUser = await this.apDbResolverService.getAuthUserFromApId(getApId(activity.actor));
+				authUser = await this.apDbResolverService.getAuthUserFromApId(getApId(activity.actor), signature.keyId);
 			} catch (err) {
 				// 対象が4xxならスキップ
 				if (err instanceof StatusError) {


### PR DESCRIPTION
## What
プルリクエスト perf(federation): EdDSA署名に対応する #13464 用

> 厄介な処理: 

1. 初見ユーザーがいきなりadditionalKeysなed25519で来た時に、keyIdからユーザーを引っ張るけどここではDB見るだけでリモート解決はされず
https://github.com/misskey-dev/misskey/blob/59ae73516976da0f1d34dd320a2bb76f6df14d69/packages/backend/src/queue/processors/InboxProcessorService.ts#L80

2. ここで初めてリモート解決されてるけど、ここで返される鍵はmainぽい鍵優先なので
https://github.com/misskey-dev/misskey/blob/59ae73516976da0f1d34dd320a2bb76f6df14d69/packages/backend/src/queue/processors/InboxProcessorService.ts#L85

3. 署名検証は来たkeyIdに関係なく2で返されたmainぽい鍵を使うので失敗しそう
https://github.com/misskey-dev/misskey/blob/59ae73516976da0f1d34dd320a2bb76f6df14d69/packages/backend/src/queue/processors/InboxProcessorService.ts#L108

2でkeyIdをヒントをあげて鍵を選択すればいいんじゃないかと



<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
