### PR TITLE
fix(backend): リモートサーバーの情報が更新できなくなっていた問題を修正

### DIFF
--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -73,13 +73,14 @@ export class FetchInstanceMetadataService {
 	public async fetchInstanceMetadata(instance: MiInstance, force = false): Promise<void> {
 		const host = instance.host;
 
+		// unlockされてしまうのでtry内でロックチェックをしない
+		if (!force && await this.tryLock(host) === '1') {
+			// 1が返ってきていたらロックされているという意味なので、何もしない
+			return;
+		}
+
 		try {
 			if (!force) {
-				if (await this.tryLock(host) === '1') {
-					// 1が返ってきていたらロックされている = 何もしない
-					return;
-				}
-
 				const _instance = await this.federatedInstanceService.fetch(host);
 				const now = Date.now();
 				if (_instance && _instance.infoUpdatedAt && (now - _instance.infoUpdatedAt.getTime() < 1000 * 60 * 60 * 24)) {

--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -51,7 +51,8 @@ export class FetchInstanceMetadataService {
 	}
 
 	@bindThis
-	private async tryLock(host: string): Promise<string | null> {
+	// public for test
+	public async tryLock(host: string): Promise<string | null> {
 		// TODO: マイグレーションなのであとで消す (2024.3.1)
 		this.redisClient.del(`fetchInstanceMetadata:mutex:${host}`);
 
@@ -63,7 +64,8 @@ export class FetchInstanceMetadataService {
 	}
 
 	@bindThis
-	private unlock(host: string): Promise<number> {
+	// public for test
+	public unlock(host: string): Promise<number> {
 		return this.redisClient.del(`fetchInstanceMetadata:mutex:v2:${host}`);
 	}
 

--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -74,6 +74,7 @@ export class FetchInstanceMetadataService {
 		const host = instance.host;
 
 		// finallyでunlockされてしまうのでtry内でロックチェックをしない
+		// （returnであってもfinallyは実行される）
 		if (!force && await this.tryLock(host) === '1') {
 			// 1が返ってきていたらロックされているという意味なので、何もしない
 			return;

--- a/packages/backend/src/core/FetchInstanceMetadataService.ts
+++ b/packages/backend/src/core/FetchInstanceMetadataService.ts
@@ -73,7 +73,7 @@ export class FetchInstanceMetadataService {
 	public async fetchInstanceMetadata(instance: MiInstance, force = false): Promise<void> {
 		const host = instance.host;
 
-		// unlockされてしまうのでtry内でロックチェックをしない
+		// finallyでunlockされてしまうのでtry内でロックチェックをしない
 		if (!force && await this.tryLock(host) === '1') {
 			// 1が返ってきていたらロックされているという意味なので、何もしない
 			return;


### PR DESCRIPTION
Fix #13506

## What
fetchInstanceMetadataのLockにおいて、サーバーの強制終了などでunlockがされないことで永久にロックされたままになる問題を修正

- `fetchInstanceMetadata:mutex:v2:${host}`を使うように
- EXを設定(30秒)
- unlockはdelに
- リファクタ

Reference: https://github.com/MisskeyIO/misskey/pull/191

## Why
Fix #13506

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
