### PR TITLE
fix(misskey-js): fix ESLint error in generator due to `operationId` change

### DIFF
--- a/packages/misskey-js/generator/src/generator.ts
+++ b/packages/misskey-js/generator/src/generator.ts
@@ -98,6 +98,8 @@ async function generateEndpoints(
 
 	const entitiesOutputLine: string[] = [];
 
+	entitiesOutputLine.push('/* eslint @typescript-eslint/naming-convention: 0 */');
+
 	entitiesOutputLine.push(`import { operations } from '${toImportPath(typeFileName)}';`);
 	entitiesOutputLine.push('');
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
https://github.com/misskey-dev/misskey/commit/3db26f2b94af6cc981f1305ddd4da20401aa2910 により、`develop` 最新で
```sh
pnpm --filter backend generate-api-json
cp ./packages/backend/built/api.json ./packages/misskey-js/generator/api.json
pnpm --filter misskey-js-type-generator generate
```
すると落ちてしまうのを修正します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Check Misskey JS autogen ワークフローが落ちてしまうので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
