### PR TITLE
fix: report progress out of 100% in CleanRemoteFilesProcessorService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Enhance: misskey-dev/summaly@5.1.0の取り込み（プレビュー生成処理の効率化）
 - Fix: フォローリクエストを作成する際に既存のものは削除するように  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/440)
+- Fix: CleanRemoteFilesProcessorService report progress from 100% (#13632)
 
 ## 2024.3.1
 

--- a/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
@@ -63,7 +63,7 @@ export class CleanRemoteFilesProcessorService {
 				isLink: false,
 			});
 
-			job.updateProgress(deletedCount / total);
+			job.updateProgress(100 / total * deletedCount);
 		}
 
 		this.logger.succ('All cached remote files has been deleted.');


### PR DESCRIPTION
## What
I changed the reported progress from being measured as out of 1 to being measured out of 100%.

## Why
Closes issue #13632

## Additional info (optional)
I tested the changed code isolated as that was much easier than testing within misskey.

<img width="258" alt="image" src="https://github.com/misskey-dev/misskey/assets/43315617/aa78f552-7a4c-44cc-a3b8-d285c5a87229">


## Checklist
- [X] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [X] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [X] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
