### PR TITLE
Keep using open-sourced Redis v7.2

### DIFF
--- a/docker-compose_example.yml
+++ b/docker-compose_example.yml
@@ -25,7 +25,7 @@ services:
 
   redis:
     restart: always
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     networks:
       - internal_network
     volumes:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Changed example docker-compose.yml file to keep Redis version at v7.2

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
As mentioned in discussion #13612 , Redis changed their license and version starting from v7.4 is no longer considered open source. I think as an open-source project, we should be using the open-sourced version.
## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
Redis v7.2 has EOL of August 31, 2025. Maybe consider move to an alternative before this date.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
