### PR TITLE
fix(backend): moderation_logテーブルのuserテーブルへのFK制約をon delete set null に変更する

### DIFF
--- a/packages/backend/migration/1712469608832-ModerationLogDoNotCascadeOnDelete.js
+++ b/packages/backend/migration/1712469608832-ModerationLogDoNotCascadeOnDelete.js
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class ModerationLogDoNotCascadeOnDelete1712469608832 {
+
+		name = 'ModerationLogDoNotCascadeOnDelete1712469608832'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "moderation_log" DROP CONSTRAINT "FK_a08ad074601d204e0f69da9a954"`)
+        await queryRunner.query(`ALTER TABLE "moderation_log" ADD CONSTRAINT "FK_a08ad074601d204e0f69da9a954" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE NO ACTION`);
+    }
+
+    async down(queryRunner) {
+			await queryRunner.query(`ALTER TABLE "moderation_log" DROP CONSTRAINT "FK_a08ad074601d204e0f69da9a954"`)
+			await queryRunner.query(`ALTER TABLE "moderation_log" ADD CONSTRAINT "FK_a08ad074601d204e0f69da9a954" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+}

--- a/packages/backend/src/models/ModerationLog.ts
+++ b/packages/backend/src/models/ModerationLog.ts
@@ -17,7 +17,7 @@ export class MiModerationLog {
 	public userId: MiUser['id'];
 
 	@ManyToOne(type => MiUser, {
-		onDelete: 'CASCADE',
+		onDelete: 'SET NULL',
 	})
 	@JoinColumn()
 	public user: MiUser | null;


### PR DESCRIPTION
## What
Fix of https://github.com/misskey-dev/misskey/issues/12388
（修正案1 

## Why
モデレーター以上の権限を持ったユーザーが行ったモデレーション操作が、
そのユーザーが削除された時にモデレーションログ事削除されてしまって、ログが後追い出来ないため、
テーブルのFK制約を変更して解決しました。

修正案2は→ https://github.com/misskey-dev/misskey/pull/13673

1, 2 どちらか良さそうな案（あるいは第三の案があれば）を採用していただけると助かります。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
