### PR TITLE
fix(backend): ユーザーテーブルを物理削除しない

### DIFF
--- a/packages/backend/src/core/DeleteAccountService.ts
+++ b/packages/backend/src/core/DeleteAccountService.ts
@@ -35,7 +35,7 @@ export class DeleteAccountService {
 		await this.userSuspendService.doPostSuspend(user).catch(e => {});
 
 		this.queueService.createDeleteAccountJob(user, {
-			soft: false,
+			soft: true,
 		});
 
 		await this.usersRepository.update(user.id, {

--- a/packages/backend/src/server/api/endpoints/admin/accounts/delete.ts
+++ b/packages/backend/src/server/api/endpoints/admin/accounts/delete.ts
@@ -53,7 +53,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				await this.userSuspendService.doPostSuspend(user).catch(err => {});
 
 				this.queueService.createDeleteAccountJob(user, {
-					soft: false,
+					soft: true,
 				});
 			} else {
 				this.queueService.createDeleteAccountJob(user, {


### PR DESCRIPTION
## What

Fix of https://github.com/misskey-dev/misskey/issues/12388
（修正案2


## Why

モデレーター以上の権限を持ったユーザーが行ったモデレーション操作が、
そのユーザーが削除された時にモデレーションログ事削除されてしまって、ログが後追い出来ないため、

こちらの案では、そもそもユーザーをハードデリートしないように修正しています。

修正案1は→https://github.com/misskey-dev/misskey/pull/13672

1, 2 どちらか良さそうな案（あるいは第三の案があれば）を採用していただけると助かります。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
