### PR TITLE
fix(backend): nginx経由で/files/にRangeリクエストされた場合に正しく応答できないのを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Fix: リプライのみの引用リノートと、CWのみの引用リノートが純粋なリノートとして誤って扱われてしまう問題を修正
 - Fix: 登録にメール認証が必須になっている場合、登録されているメールアドレスを削除できないように  
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/606)
+- Fix: nginx経由で/files/にRangeリクエストされた場合に正しく応答できないのを修正
 
 ## 2024.3.1
 

--- a/packages/backend/src/server/FileServerService.ts
+++ b/packages/backend/src/server/FileServerService.ts
@@ -214,6 +214,8 @@ export class FileServerService {
 				}
 
 				reply.header('Content-Type', FILE_TYPE_BROWSERSAFE.includes(image.type) ? image.type : 'application/octet-stream');
+				reply.header('Content-Length', file.file.size);
+				reply.header('Cache-Control', 'max-age=31536000, immutable');
 				reply.header('Content-Disposition',
 					contentDisposition(
 						'inline',
@@ -256,6 +258,7 @@ export class FileServerService {
 				return fs.createReadStream(file.path);
 			} else {
 				reply.header('Content-Type', FILE_TYPE_BROWSERSAFE.includes(file.file.type) ? file.file.type : 'application/octet-stream');
+				reply.header('Content-Length', file.file.size);
 				reply.header('Cache-Control', 'max-age=31536000, immutable');
 				reply.header('Content-Disposition', contentDisposition('inline', file.filename));
 
@@ -530,9 +533,7 @@ export class FileServerService {
 		if (!file.storedInternal) {
 			if (!(file.isLink && file.uri)) return '204';
 			const result = await this.downloadAndDetectTypeFromUrl(file.uri);
-			if (!file.size) {
-				file.size = (await fs.promises.stat(result.path)).size;
-			}
+			file.size = (await fs.promises.stat(result.path)).size;	// DB file.sizeは正確とは限らないので
 			return {
 				...result,
 				url: file.uri,


### PR DESCRIPTION
## What
Fix https://github.com/misskey-dev/misskey/issues/12881
nginx経由で/files/にRangeリクエストされた場合に正しく応答出来るようにしています。

## Why
以下で、Rangeリクエストに対応したり修正してたりしているものの
https://github.com/misskey-dev/misskey/pull/12925
https://github.com/misskey-dev/misskey/pull/13701
Misskeyのnginxサンプルにあるようにcache付き構成で動かすとうまく動かずに、nginxは常に200で返してしまうようです。

nginxでcacheありの場合には、通常Rangeリクエストを投げてこないようです。
ですので、Misskey側でRangeに対応してもほとんどの運用環境では効果がなさそうです。

Misskey側でRangeリクエストに対応しなくても、nginxで`proxy_force_ranges on;`を設定していればRangeリクエストに対応してくれるはずですが、Misskeyが`/files/`で`Content-Length`を返さないためnginxがRangeリクエストに対応できません。
(上の修正では非Rangeリクエストでは`Content-Length`を返すように修正してないようです)

非Rangeでのドライブファイルの応答で`Contet-Length`を返すようにしてこれを修正しています。
また、Cache-Controlの設定漏れでキャッシュしてくれないことがあるようなので修正しています。

## Additional info (optional)
cache有効nginx経由でのリクエスト結果

リモート動画
```
curl -i -X GET -H "range: bytes=1-8" https://mi13.m213.xyz/files/webpublic-066a6ebd-22d2-4232-83c6-0f5f2a855701
HTTP/2 206
server: nginx/1.22.1
date: Sun, 14 Apr 2024 07:26:33 GMT
content-type: video/mp4
content-length: 8
strict-transport-security: max-age=15552000; preload
content-security-policy: default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'
cache-control: max-age=31536000, immutable
content-disposition: inline; filename="2016.mp4"
x-cache: HIT
content-range: bytes 1-8/3191293
```

ローカル動画 (ファイルシステム格納)
```
curl -i -X GET -H "range: bytes=1-8" https://mi13.m213.xyz/files/be0f722c-0ac2-45cd-93cd-bf19d86f2d90
HTTP/2 206
server: nginx/1.22.1
date: Sun, 14 Apr 2024 07:28:20 GMT
content-type: video/mp4
content-length: 8
strict-transport-security: max-age=15552000; preload
content-security-policy: default-src 'none'; img-src 'self'; media-src 'self'; style-src 'unsafe-inline'
cache-control: max-age=31536000, immutable
content-disposition: inline; filename="2016.mp4"
x-cache: HIT
content-range: bytes 1-8/3191293
```

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
