### PR TITLE
enhance(misskey-js): metaの型定義をパラメータで分岐できるように

### DIFF
--- a/packages/misskey-js/etc/misskey-js.api.md
+++ b/packages/misskey-js/etc/misskey-js.api.md
@@ -398,6 +398,13 @@ class APIClient {
     // (undocumented)
     fetch: FetchLike;
     // (undocumented)
+    getMiAuthURL(options: {
+        name?: string;
+        icon?: string;
+        callback?: string;
+        permission?: typeof permissions_2[number][];
+    }, sessionId?: string): string;
+    // (undocumented)
     origin: string;
 }
 
@@ -1085,6 +1092,22 @@ export type Endpoints = Overwrite<Endpoints_2, {
             };
         };
     };
+    'meta': {
+        req: MetaRequest;
+        res: {
+            $switch: {
+                $cases: [
+                [
+                    {
+                    detail: true;
+                },
+                MetaDetailed
+                ]
+                ];
+                $default: MetaLite;
+            };
+        };
+    };
     'signup': {
         req: SignupRequest;
         res: SignupResponse;
@@ -1096,6 +1119,10 @@ export type Endpoints = Overwrite<Endpoints_2, {
     'signin': {
         req: SigninRequest;
         res: SigninResponse;
+    };
+    'miauth/placeholder/check': {
+        req: EmptyRequest;
+        res: MiAuthCheckResponse;
     };
 }>;
 
@@ -1122,6 +1149,7 @@ declare namespace entities {
         SignupPendingResponse,
         SigninRequest,
         SigninResponse,
+        MiAuthCheckResponse,
         EmptyRequest,
         EmptyResponse,
         AdminMetaResponse,
@@ -2249,6 +2277,12 @@ type MetaRequest = operations['meta']['requestBody']['content']['application/jso
 type MetaResponse = operations['meta']['responses']['200']['content']['application/json'];
 
 // @public (undocumented)
+type MiAuthCheckResponse = {
+    token: string;
+    user: UserDetailedNotMe;
+};
+
+// @public (undocumented)
 type MiauthGenTokenRequest = operations['miauth___gen-token']['requestBody']['content']['application/json'];
 
 // @public (undocumented)
@@ -3110,6 +3144,7 @@ type UsersUpdateMemoRequest = operations['users___update-memo']['requestBody']['
 
 // Warnings were encountered during analysis:
 //
+// src/api.ts:90:3 - (ae-forgotten-export) The symbol "permissions_2" needs to be exported by the entry point index.d.ts
 // src/entities.ts:25:2 - (ae-forgotten-export) The symbol "ModerationLogPayloads" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/misskey-js/src/api.types.ts
+++ b/packages/misskey-js/src/api.types.ts
@@ -70,10 +70,10 @@ export type Endpoints = Overwrite<
 				$switch: {
 					$cases: [[
 						{
-							detail: true;
-						}, MetaDetailed,
+							detail: false;
+						}, MetaLite,
 					]];
-					$default: MetaLite;
+					$default: MetaDetailed;
 				}
 			}
 		},

--- a/packages/misskey-js/src/api.types.ts
+++ b/packages/misskey-js/src/api.types.ts
@@ -1,6 +1,6 @@
 import { Endpoints as Gen } from './autogen/endpoint.js';
-import { UserDetailed } from './autogen/models.js';
-import { UsersShowRequest } from './autogen/entities.js';
+import { MetaDetailed, MetaLite, UserDetailed } from './autogen/models.js';
+import { MetaRequest, UsersShowRequest } from './autogen/entities.js';
 import {
 	SigninRequest,
 	SigninResponse,
@@ -63,6 +63,19 @@ export type Endpoints = Overwrite<
 					$default: UserDetailed;
 				};
 			};
+		},
+		'meta': {
+			req: MetaRequest;
+			res: {
+				$switch: {
+					$cases: [[
+						{
+							detail: true;
+						}, MetaDetailed,
+					]];
+					$default: MetaLite;
+				}
+			}
 		},
 		// api.jsonには載せないものなのでここで定義
 		'signup': {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
misskeyApiでmetaを呼び出す際に、パラメータの`detail`がtrue/falseで動的に型をスイッチできるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
うれしいため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
