### PR TITLE
fix: devcontaner.jsonで定義されているpnpmのバージョンが古いため、DevContainerビルド後のパッケージインストールのタイミングでコケる問題を修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"workspaceFolder": "/workspace",
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/pnpm:2": {
-			"version": "8.9.2"
+			"version": "9.0.6"
 		},
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "20.12.2"


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
devcontaner.jsonで定義されているpnpmのバージョンが古いため、DevContainerの立ち上げ時にコケてしまっていました。
このPRでは、package.jsonをもとにDevContainerにインストールするpnpmのバージョンを9.0.6に変更します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
#13818

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
