### PR TITLE
feat(backend): add /healthz endpoint

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 PORT=$(grep '^port:' /misskey/.config/default.yml | awk 'NR==1{print $2; exit}')
-curl -s -S -o /dev/null "http://localhost:${PORT}"
+curl -Sfso /dev/null "http://localhost:${PORT}/healthz"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 PORT=$(grep '^port:' /misskey/.config/default.yml | awk 'NR==1{print $2; exit}')
-curl -Sfso /dev/null "http://localhost:${PORT}/healthz"
+curl -Sfso/dev/null "http://localhost:${PORT}/healthz"

--- a/packages/backend/src/boot/entry.ts
+++ b/packages/backend/src/boot/entry.ts
@@ -15,6 +15,7 @@ import Logger from '@/logger.js';
 import { envOption } from '../env.js';
 import { masterMain } from './master.js';
 import { workerMain } from './worker.js';
+import { readyRef } from './ready.js';
 
 import 'reflect-metadata';
 
@@ -78,6 +79,8 @@ if (cluster.isPrimary || envOption.disableClustering) {
 if (cluster.isWorker || envOption.disableClustering) {
 	await workerMain();
 }
+
+readyRef.value = true;
 
 // ユニットテスト時にMisskeyが子プロセスで起動された時のため
 // それ以外のときは process.send は使えないので弾く

--- a/packages/backend/src/boot/ready.ts
+++ b/packages/backend/src/boot/ready.ts
@@ -1,0 +1,1 @@
+export const readyRef = { value: false };

--- a/packages/backend/src/boot/ready.ts
+++ b/packages/backend/src/boot/ready.ts
@@ -1,1 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 export const readyRef = { value: false };

--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import { Inject, Injectable } from '@nestjs/common';
 import * as Redis from 'ioredis';
 import { DataSource } from 'typeorm';

--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -1,0 +1,43 @@
+import { Inject, Injectable } from '@nestjs/common';
+import * as Redis from 'ioredis';
+import { DataSource } from 'typeorm';
+import { bindThis } from '@/decorators.js';
+import { DI } from '@/di-symbols.js';
+import { readyRef } from '@/boot/ready.js';
+import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
+
+@Injectable()
+export class HealthServerService {
+	constructor(
+		@Inject(DI.redis)
+		private redis: Redis.Redis,
+
+		@Inject(DI.redisForPub)
+		private redisForPub: Redis.Redis,
+
+		@Inject(DI.redisForSub)
+		private redisForSub: Redis.Redis,
+
+		@Inject(DI.redisForTimelines)
+		private redisForTimelines: Redis.Redis,
+
+		@Inject(DI.db)
+		private db: DataSource,
+	) {}
+
+	@bindThis
+	public createServer(fastify: FastifyInstance, options: FastifyPluginOptions, done: (err?: Error) => void) {
+		fastify.get('/', async (request, reply) => {
+			reply.code(await Promise.all([
+				new Promise<void>((resolve, reject) => readyRef.value ? resolve() : reject()),
+				this.redis.ping(),
+				this.redisForPub.ping(),
+				this.redisForSub.ping(),
+				this.redisForTimelines.ping(),
+				this.db.query('SELECT 1'),
+			]).then(() => 200, () => 503));
+		});
+
+		done();
+	}
+}

--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -46,6 +46,7 @@ export class HealthServerService {
 				this.db.query('SELECT 1'),
 				...(this.meilisearch ? [this.meilisearch.health()] : []),
 			]).then(() => 200, () => 503));
+			reply.header('Cache-Control', 'no-store');
 		});
 
 		done();

--- a/packages/backend/src/server/HealthServerService.ts
+++ b/packages/backend/src/server/HealthServerService.ts
@@ -5,6 +5,7 @@ import { bindThis } from '@/decorators.js';
 import { DI } from '@/di-symbols.js';
 import { readyRef } from '@/boot/ready.js';
 import type { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import type { MeiliSearch } from 'meilisearch';
 
 @Injectable()
 export class HealthServerService {
@@ -23,6 +24,9 @@ export class HealthServerService {
 
 		@Inject(DI.db)
 		private db: DataSource,
+
+		@Inject(DI.meilisearch)
+		private meilisearch: MeiliSearch | null,
 	) {}
 
 	@bindThis
@@ -35,6 +39,7 @@ export class HealthServerService {
 				this.redisForSub.ping(),
 				this.redisForTimelines.ping(),
 				this.db.query('SELECT 1'),
+				...(this.meilisearch ? [this.meilisearch.health()] : []),
 			]).then(() => 200, () => 503));
 		});
 

--- a/packages/backend/src/server/ServerModule.ts
+++ b/packages/backend/src/server/ServerModule.ts
@@ -8,6 +8,7 @@ import { EndpointsModule } from '@/server/api/EndpointsModule.js';
 import { CoreModule } from '@/core/CoreModule.js';
 import { ApiCallService } from './api/ApiCallService.js';
 import { FileServerService } from './FileServerService.js';
+import { HealthServerService } from './HealthServerService.js';
 import { NodeinfoServerService } from './NodeinfoServerService.js';
 import { ServerService } from './ServerService.js';
 import { WellKnownServerService } from './WellKnownServerService.js';
@@ -55,6 +56,7 @@ import { ReversiGameChannelService } from './api/stream/channels/reversi-game.js
 		ClientServerService,
 		ClientLoggerService,
 		FeedService,
+		HealthServerService,
 		UrlPreviewService,
 		ActivityPubServerService,
 		FileServerService,

--- a/packages/backend/src/server/ServerService.ts
+++ b/packages/backend/src/server/ServerService.ts
@@ -28,6 +28,7 @@ import { ApiServerService } from './api/ApiServerService.js';
 import { StreamingApiServerService } from './api/StreamingApiServerService.js';
 import { WellKnownServerService } from './WellKnownServerService.js';
 import { FileServerService } from './FileServerService.js';
+import { HealthServerService } from './HealthServerService.js';
 import { ClientServerService } from './web/ClientServerService.js';
 import { OpenApiServerService } from './api/openapi/OpenApiServerService.js';
 import { OAuth2ProviderService } from './oauth/OAuth2ProviderService.js';
@@ -61,6 +62,7 @@ export class ServerService implements OnApplicationShutdown {
 		private wellKnownServerService: WellKnownServerService,
 		private nodeinfoServerService: NodeinfoServerService,
 		private fileServerService: FileServerService,
+		private healthServerService: HealthServerService,
 		private clientServerService: ClientServerService,
 		private globalEventService: GlobalEventService,
 		private loggerService: LoggerService,
@@ -108,6 +110,7 @@ export class ServerService implements OnApplicationShutdown {
 		fastify.register(this.wellKnownServerService.createServer);
 		fastify.register(this.oauth2ProviderService.createServer, { prefix: '/oauth' });
 		fastify.register(this.oauth2ProviderService.createTokenServer, { prefix: '/oauth/token' });
+		fastify.register(this.healthServerService.createServer, { prefix: '/healthz' });
 
 		fastify.get<{ Params: { path: string }; Querystring: { static?: any; badge?: any; }; }>('/emoji/:path(.*)', async (request, reply) => {
 			const path = request.params.path;


### PR DESCRIPTION
## What

`GET /healthz` でヘルスチェックできるようにする

## Why

e.g.

```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 3000
readinessProbe:
  httpGet:
    path: /healthz
    port: 3000
  failureThreshold: 1
  periodSeconds: 1
startupProbe:
  httpGet:
    path: /healthz
    port: 3000
  failureThreshold: 30
  periodSeconds: 1
```

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
