### PR TITLE
fix(backend): explicitly set query runner on insertOne

### DIFF
--- a/packages/backend/src/models/_.ts
+++ b/packages/backend/src/models/_.ts
@@ -80,6 +80,14 @@ interface AsyncDisposableReference<T> extends AsyncDisposable {
 	readonly value: T;
 }
 
+// SEEALSO: <https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html#using-declarations-and-explicit-resource-management>
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+Symbol.dispose ??= Symbol('Symbol.dispose');
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
+
 export interface MiRepository<T extends ObjectLiteral> {
 	createTableColumnNames(this: Repository<T> & MiRepository<T>, queryBuilder: InsertQueryBuilder<T>): string[];
 	createTableColumnNamesWithPrimaryKey(this: Repository<T> & MiRepository<T>, queryBuilder: InsertQueryBuilder<T>): string[];

--- a/packages/backend/test/jest.setup.ts
+++ b/packages/backend/test/jest.setup.ts
@@ -5,6 +5,13 @@
 
 import { initTestDb, sendEnvResetRequest } from './utils.js';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+Symbol.dispose ??= Symbol('Symbol.dispose');
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
+
 beforeAll(async () => {
 	await Promise.all([
 		initTestDb(false),

--- a/packages/backend/test/jest.setup.ts
+++ b/packages/backend/test/jest.setup.ts
@@ -6,13 +6,6 @@
 import { initTestDb, sendEnvResetRequest } from './utils.js';
 
 beforeAll(async () => {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-expect-error
-	Symbol.dispose ??= Symbol('Symbol.dispose');
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-expect-error
-	Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
-
 	await Promise.all([
 		initTestDb(false),
 		sendEnvResetRequest(),

--- a/packages/backend/test/jest.setup.ts
+++ b/packages/backend/test/jest.setup.ts
@@ -5,14 +5,14 @@
 
 import { initTestDb, sendEnvResetRequest } from './utils.js';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
-Symbol.dispose ??= Symbol('Symbol.dispose');
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
-Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
-
 beforeAll(async () => {
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-expect-error
+	Symbol.dispose ??= Symbol('Symbol.dispose');
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-expect-error
+	Symbol.asyncDispose ??= Symbol('Symbol.asyncDispose');
+
 	await Promise.all([
 		initTestDb(false),
 		sendEnvResetRequest(),


### PR DESCRIPTION
## What

insertOne 問い合わせ時 TypeORM が選択している QueryRunner が不適切な可能性があるので明示的に指定する

## Why

May fix #13921

## Additional info (optional)

wip

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
