### PR TITLE
fix(backend): Remove @types/node-fetch

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -207,7 +207,6 @@
 		"@types/mime-types": "2.1.4",
 		"@types/ms": "0.7.34",
 		"@types/node": "20.12.7",
-		"@types/node-fetch": "3.0.3",
 		"@types/nodemailer": "6.4.15",
 		"@types/oauth": "0.9.4",
 		"@types/oauth2orize": "1.11.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,9 +586,6 @@ importers:
       '@types/node':
         specifier: 20.12.7
         version: 20.12.7
-      '@types/node-fetch':
-        specifier: 3.0.3
-        version: 3.0.3
       '@types/nodemailer':
         specifier: 6.4.15
         version: 6.4.15
@@ -4618,10 +4615,6 @@ packages:
 
   '@types/node-fetch@2.6.4':
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
-
-  '@types/node-fetch@3.0.3':
-    resolution: {integrity: sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==}
-    deprecated: This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.
 
   '@types/node@18.17.15':
     resolution: {integrity: sha512-2yrWpBk32tvV/JAd3HNHWuZn/VDN1P+72hWirHnvsvTGSqbANi+kSeuQR9yAHnbvaBvHDsoTdXV0Fe+iRtHLKA==}
@@ -16018,10 +16011,6 @@ snapshots:
     dependencies:
       '@types/node': 20.12.7
       form-data: 3.0.1
-
-  '@types/node-fetch@3.0.3':
-    dependencies:
-      node-fetch: 3.3.2
 
   '@types/node@18.17.15': {}
 


### PR DESCRIPTION
## What
@types/node-fetchを消して `pnpm install` するときに出る警告を解決します。

## Why
> Since `3.x` types are bundled with `node-fetch`, so you don't need to install any additional packages.
https://github.com/node-fetch/node-fetch?tab=readme-ov-file#typescript

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
