### PR TITLE
enhance(backend): 一人のリモートユーザーが複数の公開鍵を持つコーナーケースを処理

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -183,13 +183,16 @@ export class ApPersonService implements OnModuleInit {
 		}
 
 		if (x.publicKey) {
-			if (typeof x.publicKey.id !== 'string') {
-				throw new Error('invalid Actor: publicKey.id is not a string');
-			}
+			const publicKeys = Array.isArray(x.publicKey) ? x.publicKey : [x.publicKey];
+			for (const publicKey of publicKeys) {
+				if (typeof publicKey.id !== 'string') {
+					throw new Error('invalid Actor: publicKey.id is not a string');
+				}
 
-			const publicKeyIdHost = this.punyHost(x.publicKey.id);
-			if (publicKeyIdHost !== expectHost) {
-				throw new Error('invalid Actor: publicKey.id has different host');
+				const publicKeyIdHost = this.punyHost(publicKey.id);
+				if (publicKeyIdHost !== expectHost) {
+					throw new Error('invalid Actor: publicKey.id has different host');
+				}
 			}
 		}
 
@@ -356,10 +359,13 @@ export class ApPersonService implements OnModuleInit {
 				}));
 
 				if (person.publicKey) {
+					// TODO: 一人のユーザが複数の公開鍵を持っている場合があるので、MiUserPublicKeyの主キーもuserIdから(userId, keyId)に変更する必要があるかも…？
+					// As a user can have multiple public keys, it might be better to change MiUserPublicKey's primary key from userId to (userId, keyId).
+					const publicKey = Array.isArray(person.publicKey) ? person.publicKey[0] : person.publicKey;
 					await transactionalEntityManager.save(new MiUserPublickey({
 						userId: user.id,
-						keyId: person.publicKey.id,
-						keyPem: person.publicKey.publicKeyPem,
+						keyId: publicKey.id,
+						keyPem: publicKey.publicKeyPem,
 					}));
 				}
 			});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

一人のリモートユーザーが複数の公開鍵を持つコーナーケースを処理します.

This patch handles the corner case where a remote user has multiple public keys.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

理論上、アクターの`publicKey`は複数の公開鍵を含む配列にすることができます。Mastodonもこのケースを処理しています。

In theory, an actor's `publicKey` could be an array containing multiple public keys.  Mastodon also already handles this case.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

現在は`MiUserPublicKey`の主キーが`userId`なので、一人のユーザが複数の公開鍵を持っている場合、最初の鍵だけを保存するように実装しました。将来的には`MiUserPublicKey`の主キーを`(userId, keyId)`に変える方が良いかもしれません。

For now, the primary key of `MiUserPublicKey` is userId, so my implementation only stores the first key if a user has multiple public keys.  In the future, it might be better to change the primary key of `MiUserPublicKey` to `(userId, keyId)`.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
