### PR TITLE
devcontainer で、 node_modules を volume 化して高速化＋パーミッション問題回避 + git submodule update 時にローカルに submodule があっても問題が起こらないようにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 		"ghcr.io/devcontainers-contrib/features/corepack:1": {}
 	},
 	"forwardPorts": [3000],
-	"postCreateCommand": "sudo chmod 755 .devcontainer/init.sh && .devcontainer/init.sh",
+	"postCreateCommand": "/bin/bash .devcontainer/init.sh",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
 
     volumes:
       - ../:/workspace:cached
+      - node_modules:/workspace/node_modules
 
     command: sleep infinity
 
@@ -46,6 +47,7 @@ services:
 volumes:
   postgres-data:
   redis-data:
+  node_modules:
 
 networks:
   internal_network:

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -2,7 +2,8 @@
 
 set -xe
 
-sudo chown -R node /workspace
+sudo chown node node_modules
+git config --global --add safe.directory /workspace
 git submodule update --init
 corepack install
 corepack enable


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

- devcontainer において、 node_modules を Docker 側のボリュームとして独立させる（ Volume Trick ）。
- devcontainer 内のワークスペースフォルダを git の safe.directory に指定する。

## Why
現在の devcontainer は、git clone してすぐに起動する分には特に問題なく起動するのですが、ローカルで環境を作った後に devcontainer を起動させようとすると、（少なくとも手元の Mac + Docker 環境では）パーミッションの問題でエラーになります。

`sudo chown -R node /workspace` はそれを解決しようとして指定しているのかもしれませんが、そこまで広範囲に所有権を変更する必要はなく、またこれによって

- git submodule
- node_modules

がローカルで作られている場合にエラーが発生するので、この操作は除外しました。

node_modules はローカルと同期すると（特に Mac 環境では）とても遅いのと、アーキテクチャが違ってローカルとは共用できないので、volume 指定することにより除外しました。またこの際、マウント直後は所有者が root になるので chown しています。これによりローカルからの同期がなくなるためパーミッション問題も同時に解決します。

git submodule は https://github.com/misskey-dev/misskey/issues/11492 で報告されている内容ですが、 `chown -R` をやめると手元では `fatal: detected dubious ownership in repository at '/workspace'` となってしまうため、 `safe.directory` 指定を追加しました。コンテナ内だけなのでおそらく問題になることは少ないと思いますが、リスクがないとは言い切れないため、不適切だと判断される場合はここは除外してください。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
