### PR TITLE
fix(backend): Set comment to `NULL` instead of `Denormalized`

### DIFF
--- a/packages/backend/migration/1716129964060-ChannelIdDenormalizedForMiPoll.js
+++ b/packages/backend/migration/1716129964060-ChannelIdDenormalizedForMiPoll.js
@@ -15,7 +15,7 @@ export class ChannelIdDenormalizedForMiPoll1716129964060 {
 
     async down(queryRunner) {
         await queryRunner.query(`DROP INDEX "public"."IDX_c1240fcc9675946ea5d6c2860e"`);
-        await queryRunner.query(`COMMENT ON COLUMN "poll"."channelId" IS '[Denormalized]'`);
+        await queryRunner.query(`COMMENT ON COLUMN "poll"."channelId" IS NULL`);
         await queryRunner.query(`ALTER TABLE "poll" DROP COLUMN "channelId"`);
     }
 }


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
The DROP migration listed setting the comment on the channelId column to the same as the UP migration which is invalid.

It should be `NULL` instead to clear out the comment

Initial concern about this was raised here https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/537#note_3712

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
(Look at the text above)

## Checklist
- [X] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [X] Test working in a local environment
