### PR TITLE
fix(frontend): Add missing styles

### DIFF
--- a/packages/frontend/src/pages/announcement.vue
+++ b/packages/frontend/src/pages/announcement.vue
@@ -109,6 +109,15 @@ definePageMetadata(() => ({
 </script>
 
 <style lang="scss" module>
+.fadeEnterActive,
+.fadeLeaveActive {
+	transition: opacity 0.125s ease;
+}
+.fadeEnterFrom,
+.fadeLeaveTo {
+	opacity: 0;
+}
+
 .announcement {
 	padding: 16px;
 }


### PR DESCRIPTION
## What

存在しないスタイルが使われているので追加します。内容は[既存の同名のスタイル](https://github.com/misskey-dev/misskey/blob/379ce0145b9d0b74334b35fa57f2ef87366388f2/packages/frontend/src/pages/page.vue#L265-L272)と同じです。

## Why

期待した動作になっていないと思われるため。

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
