### PR TITLE
fix(frontend): Fix type checking

### DIFF
--- a/packages/frontend/src/account.ts
+++ b/packages/frontend/src/account.ts
@@ -120,7 +120,7 @@ function fetchAccount(token: string, id?: string, forceShowDialog?: boolean): Pr
 				res.json().then(done2, fail2);
 			}))
 			.then(async res => {
-				if (res.error) {
+				if ('error' in res) {
 					if (res.error.id === 'a8c724b3-6e9c-4b46-b1a8-bc3ed6258370') {
 						// SUSPENDED
 						if (forceShowDialog || $i && (token === $i.token || id === $i.id)) {


### PR DESCRIPTION
## What

型チェックを修正します。

## Why

次のTypeScriptエラーを解決するため：

```
src/account.ts(123,13): error TS2339: Property 'error' does not exist on type 'Account | { error: Record<string, any>; }'.
  Property 'error' does not exist on type 'Account'.
src/account.ts(124,14): error TS2339: Property 'error' does not exist on type 'Account | { error: Record<string, any>; }'.
  Property 'error' does not exist on type 'Account'.
src/account.ts(129,21): error TS2339: Property 'error' does not exist on type 'Account | { error: Record<string, any>; }'.
  Property 'error' does not exist on type 'Account'.
src/account.ts(139,21): error TS2339: Property 'error' does not exist on type 'Account | { error: Record<string, any>; }'.
  Property 'error' does not exist on type 'Account'.
src/account.ts(153,33): error TS2339: Property 'error' does not exist on type 'Account | { error: Record<string, any>; }'.
  Property 'error' does not exist on type 'Account'.
```

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
