### PR TITLE
fix(frontend): Fix type annotations

### DIFF
--- a/packages/frontend/src/filters/user.ts
+++ b/packages/frontend/src/filters/user.ts
@@ -6,7 +6,7 @@
 import * as Misskey from 'misskey-js';
 import { url } from '@/config.js';
 
-export const acct = (user: misskey.Acct) => {
+export const acct = (user: Misskey.Acct) => {
 	return Misskey.acct.toString(user);
 };
 
@@ -14,6 +14,6 @@ export const userName = (user: Misskey.entities.User) => {
 	return user.name || user.username;
 };
 
-export const userPage = (user: misskey.Acct, path?, absolute = false) => {
+export const userPage = (user: Misskey.Acct, path?: string, absolute = false) => {
 	return `${absolute ? url : ''}/@${acct(user)}${(path ? `/${path}` : '')}`;
 };


### PR DESCRIPTION
## What

引数の型を修正します。

## Why

次のTypeScriptエラーを解決したい：

```
src/filters/user.ts(9,28): error TS2503: Cannot find namespace 'misskey'.
src/filters/user.ts(17,32): error TS2503: Cannot find namespace 'misskey'.
```

ついでに要らない`any`も消したい。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
