### PR TITLE
refactor(frontend): Remove unused directives

### DIFF
--- a/packages/frontend/src/components/MkCaptcha.vue
+++ b/packages/frontend/src/components/MkCaptcha.vue
@@ -104,7 +104,6 @@ async function requestRender() {
 		});
 	} else if (props.provider === 'mcaptcha' && props.instanceUrl && props.sitekey) {
 		const { default: Widget } = await import('@mcaptcha/vanilla-glue');
-		// @ts-expect-error avoid typecheck error
 		new Widget({
 			siteKey: {
 				instanceUrl: new URL(props.instanceUrl),

--- a/packages/frontend/src/i18n.ts
+++ b/packages/frontend/src/i18n.ts
@@ -11,6 +11,5 @@ import { I18n } from '@/scripts/i18n.js';
 export const i18n = markRaw(new I18n<Locale>(locale));
 
 export function updateI18n(newLocale: Locale) {
-	// @ts-expect-error -- private field
 	i18n.locale = newLocale;
 }


### PR DESCRIPTION
## What

要らなくなった`@ts-expect-error`を消します。

## Why

次のTypeScriptエラーを解決：

```
src/components/MkCaptcha.vue(107,3): error TS2578: Unused '@ts-expect-error' directive.
src/i18n.ts(14,2): error TS2578: Unused '@ts-expect-error' directive.
```

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
