### PR TITLE
リリースPRがないときにrelease-edit-with-push.ymlがfailして見栄えが悪いのを修正

### DIFF
--- a/.github/workflows/release-edit-with-push.yml
+++ b/.github/workflows/release-edit-with-push.yml
@@ -28,16 +28,19 @@ jobs:
         env:
           STABLE_BRANCH: ${{ vars.STABLE_BRANCH }}
       - name: Get target version
+        if: steps.get_pr.outputs.pr_number != ''
         uses: misskey-dev/release-manager-actions/.github/actions/get-target-version@v2
         id: v
       # CHANGELOG.mdの内容を取得
       - name: Get changelog
+        if: steps.get_pr.outputs.pr_number != ''
         uses: misskey-dev/release-manager-actions/.github/actions/get-changelog@v2
         with:
           version: ${{ steps.v.outputs.target_version }}
         id: changelog
       # PRのnotesを更新
       - name: Update PR
+        if: steps.get_pr.outputs.pr_number != ''
         run: |
           gh pr edit "$PR_NUMBER" --body "$CHANGELOG"
         env:


### PR DESCRIPTION
Fix of #13941 

https://github.com/misskey-dev/misskey/actions/runs/9854066988/job/27206018983 のようにリリースPRがないときにrelease-edit-with-push.ymlがfailして見栄えが悪いのを修正

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
