### PR TITLE
fix(frontend): 投稿フォームで投稿先アカウントを切り替えた際、添付ファイルがあるとノートに失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix: テーマプレビューが見れない問題を修正
 - Fix: ショートカットキーが連打できる問題を修正  
   (Cherry-picked from https://github.com/taiyme/misskey/pull/234)
+- Fix: 投稿フォームで投稿先アカウントを切り替えた際、添付ファイルがあるとノートに失敗する問題を修正
 
 ### Server
 - Feat: レートリミット制限に引っかかったときに`Retry-After`ヘッダーを返すように (#13949)

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -187,7 +187,7 @@ const showAddMfmFunction = ref(defaultStore.state.enableQuickAddMfmFunction);
 watch(showAddMfmFunction, () => defaultStore.set('enableQuickAddMfmFunction', showAddMfmFunction.value));
 const cw = ref<string | null>(props.initialCw ?? null);
 const localOnly = ref(props.initialLocalOnly ?? (defaultStore.state.rememberNoteVisibility ? defaultStore.state.localOnly : defaultStore.state.defaultNoteLocalOnly));
-const visibility = ref(props.initialVisibility ?? (defaultStore.state.rememberNoteVisibility ? defaultStore.state.visibility : defaultStore.state.defaultNoteVisibility));
+const visibility = ref<Misskey.entities.Note['visibility']>(props.initialVisibility ?? (defaultStore.state.rememberNoteVisibility ? defaultStore.state.visibility : defaultStore.state.defaultNoteVisibility) as Misskey.entities.Note['visibility']);
 const visibleUsers = ref<Misskey.entities.UserDetailed[]>([]);
 if (props.initialVisibleUsers) {
 	props.initialVisibleUsers.forEach(u => pushVisibleUser(u));

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -433,7 +433,7 @@ function detachFile(id) {
 	files.value = files.value.filter(x => x.id !== id);
 }
 
-function updateFileSensitive(file, sensitive) {
+function updateFileSensitive(file: Misskey.entities.DriveFile, sensitive: boolean) {
 	if (props.mock) {
 		emit('fileChangeSensitive', file.id, sensitive);
 	}
@@ -448,12 +448,19 @@ function replaceFile(file: Misskey.entities.DriveFile, newFile: Misskey.entities
 	files.value[files.value.findIndex(x => x.id === file.id)] = newFile;
 }
 
-async function upload(file: File, name?: string, keepOriginal?: boolean, token?: string): Promise<void> {
+async function upload(file: File, name?: string, keepOriginal?: boolean, options?: { isSensitive?: boolean, comment?: string | null }, token?: string): Promise<Misskey.entities.DriveFile | void> {
 	if (props.mock) return;
 
-	await uploadFile(file, defaultStore.state.uploadFolder, name, keepOriginal, token).then(res => {
+	let uploaded : Misskey.entities.DriveFile | null = null;
+
+	await uploadFile(file, defaultStore.state.uploadFolder, name, keepOriginal, options, token).then(res => {
 		files.value.push(res);
+		uploaded = res;
 	});
+
+	if (uploaded != null) {
+		return uploaded;
+	}
 }
 
 function setVisibility() {
@@ -783,7 +790,7 @@ async function post(ev?: MouseEvent) {
 			for (let f of files.value) {
 				const fileBase = await fetch(f.url).then(res => res.blob()).then(blob => new File([blob], f.name, { type: blob.type }));
 				detachFile(f.id);
-				await upload(fileBase, f.name, undefined, token);
+				await upload(fileBase, f.name, undefined, { isSensitive: f.isSensitive, comment: f.comment }, token);
 			}
 		}
 	}

--- a/packages/frontend/src/scripts/upload.ts
+++ b/packages/frontend/src/scripts/upload.ts
@@ -34,6 +34,10 @@ export function uploadFile(
 	folder?: any,
 	name?: string,
 	keepOriginal: boolean = defaultStore.state.keepOriginalUploading,
+	options?: {
+		isSensitive?: boolean,
+		comment?: string | null,
+	},
 	token?: string,
 ): Promise<Misskey.entities.DriveFile> {
 	if ($i == null && token == null) throw new Error('Not logged in');
@@ -86,6 +90,10 @@ export function uploadFile(
 			formData.append('force', 'true');
 			formData.append('file', resizedImage ?? file);
 			formData.append('name', ctx.name);
+			if (options != null) {
+				if (options.isSensitive === true) formData.append('isSensitive', 'true');
+				if (options.comment != null) formData.append('comment', options.comment);
+			}
 			if (folder) formData.append('folderId', folder);
 
 			const xhr = new XMLHttpRequest();

--- a/packages/frontend/src/scripts/upload.ts
+++ b/packages/frontend/src/scripts/upload.ts
@@ -34,8 +34,11 @@ export function uploadFile(
 	folder?: any,
 	name?: string,
 	keepOriginal: boolean = defaultStore.state.keepOriginalUploading,
+	token?: string,
 ): Promise<Misskey.entities.DriveFile> {
-	if ($i == null) throw new Error('Not logged in');
+	if ($i == null && token == null) throw new Error('Not logged in');
+	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+	const tokenToUse = token ?? $i!.token;
 
 	if (folder && typeof folder === 'object') folder = folder.id;
 
@@ -79,7 +82,7 @@ export function uploadFile(
 			}
 
 			const formData = new FormData();
-			formData.append('i', $i.token);
+			formData.append('i', tokenToUse);
 			formData.append('force', 'true');
 			formData.append('file', resizedImage ?? file);
 			formData.append('name', ctx.name);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

アカウントAのドライブ画像をダウンロードした上でアカウントBのドライブに再度アップロードしなおすような処理が必要やね

(os.tsとかは置いておいて例えば #10425 のようなアプローチをすれば解消するかも?

_Originally posted by @tamaina in https://github.com/misskey-dev/misskey/issues/11464#issuecomment-2220363708_

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Fix: #11464

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
