### PR TITLE
fix(backend): Handle array values for `Actor.publicKey`

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -181,9 +181,8 @@ export class ApPersonService implements OnModuleInit {
 			throw new Error('invalid Actor: id has different host');
 		}
 
+		x.publicKey = toSingle(x.publicKey);
 		if (x.publicKey) {
-			x.publicKey = toSingle(x.publicKey);
-
 			if (typeof x.publicKey.id !== 'string') {
 				throw new Error('invalid Actor: publicKey.id is not a string');
 			}

--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -20,7 +20,7 @@ import type Logger from '@/logger.js';
 import type { MiNote } from '@/models/Note.js';
 import type { IdService } from '@/core/IdService.js';
 import type { MfmService } from '@/core/MfmService.js';
-import { toArray } from '@/misc/prelude/array.js';
+import { toArray, toSingle } from '@/misc/prelude/array.js';
 import type { GlobalEventService } from '@/core/GlobalEventService.js';
 import type { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import type { FetchInstanceMetadataService } from '@/core/FetchInstanceMetadataService.js';
@@ -182,6 +182,8 @@ export class ApPersonService implements OnModuleInit {
 		}
 
 		if (x.publicKey) {
+			x.publicKey = toSingle(x.publicKey);
+
 			if (typeof x.publicKey.id !== 'string') {
 				throw new Error('invalid Actor: publicKey.id is not a string');
 			}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
リモートのActivityPubの`Actor`の`publicKey`の値として配列が設定されているケースに対応します。配列が設定されている場合はその先頭の値をアクターの公開鍵として採用します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

ActivityPub and HTTP Signatures community group reportに`publicKey`が複数の値を持つ場合の処理についての記述があり、ActivityPub標準としては`publicKey`は複数の値を取りうるという立場であることが読み取れます（関連：swicg/activitypub-http-signature#9）。

https://swicg.github.io/activitypub-http-signature/#how-to-obtain-a-signature-s-public-key:

> 7. The public key object will be in the actor's `publicKey` property. If there are multiple values, find the one whose `id` matches the original `keyId`.

引用元の仕様では複数の値から目的の鍵の`id`に合致するものを選ぶように定められていますが、本パッチではとりあえずエラーを抑止するのを主目的とし、簡単のためMastodonの挙動に合わせて先頭の値を取る形で対応しています。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [X] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [X] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
