### PR TITLE
fix(frontend): MkSignin.vueのcredentialRequestからReactivityを削除

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix: テーマプレビューが見れない問題を修正
 - Fix: ショートカットキーが連打できる問題を修正  
   (Cherry-picked from https://github.com/taiyme/misskey/pull/234)
+- Fix: MkSignin.vueのcredentialRequestからReactivityを削除（ProxyがPasskey認証処理に渡ることを避けるため）
 
 ### Server
 - Feat: レートリミット制限に引っかかったときに`Retry-After`ヘッダーを返すように (#13949)

--- a/packages/frontend/src/components/MkSignin.vue
+++ b/packages/frontend/src/components/MkSignin.vue
@@ -87,7 +87,7 @@ const host = ref(toUnicode(configHost));
 const totpLogin = ref(false);
 const isBackupCode = ref(false);
 const queryingKey = ref(false);
-const credentialRequest = ref<CredentialRequestOptions | null>(null);
+let credentialRequest: CredentialRequestOptions | null = null;
 
 const emit = defineEmits<{
 	(ev: 'login', v: any): void;
@@ -122,14 +122,14 @@ function onLogin(res: any): Promise<void> | void {
 }
 
 async function queryKey(): Promise<void> {
-	if (credentialRequest.value == null) return;
+	if (credentialRequest == null) return;
 	queryingKey.value = true;
-	await webAuthnRequest(credentialRequest.value)
+	await webAuthnRequest(credentialRequest)
 		.catch(() => {
 			queryingKey.value = false;
 			return Promise.reject(null);
 		}).then(credential => {
-			credentialRequest.value = null;
+			credentialRequest = null;
 			queryingKey.value = false;
 			signing.value = true;
 			return misskeyApi('signin', {
@@ -160,7 +160,7 @@ function onSubmit(): void {
 			}).then(res => {
 				totpLogin.value = true;
 				signing.value = false;
-				credentialRequest.value = parseRequestOptionsFromJSON({
+				credentialRequest = parseRequestOptionsFromJSON({
 					publicKey: res,
 				});
 			})


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

MkSignin.vueのcredentialRequestにおいて、refによる宣言をやめて、Vue.jsのReactivityを削除しました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

+ credentialRequestは&lt;template&gt;部で参照されていないので、refで宣言する必要はないと考えられます。
+ credentialRequestがrefで宣言されていると、Vue.jsの実装により、valueプロパティで取得するオブジェクトがプレーンオブジェクトでなく[Proxy](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Proxy)となり、Passkeyの認証処理にそのまま渡されます。認証処理がブラウザー拡張機能によって実現されている場合、Proxyがページスクリプトから拡張機能スクリプトに渡せず、Passkey認証が成立しない場合がありました。
+ 本事象は、KeePassXCのブラウザー拡張機能において観測しました。KeePassXC側での対応も検討しましたが、KeePassXC以外との互換性も考慮し、Misskey側の修正を提案させていただきました。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

テストはUbuntu上のDockerで動作させたMisskeyにローカルホストでアクセスし、Ubuntu上のChromeとFirefox、およびそれぞれに対応するKeePassXCのブラウザー拡張機能と、Linux版KeePassXCで行いました。修正後にPasskeyによるログインが行えることを確認しました。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
