### PR TITLE
fix(frontend): blurhashが無い場合に何も出力されないのを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix: MkSignin.vueのcredentialRequestからReactivityを削除（ProxyがPasskey認証処理に渡ることを避けるため）
 - Fix: 「アニメーション画像を再生しない」がオンのときでもサーバーのバナー画像・背景画像がアニメーションしてしまう問題を修正  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/574)
+- Fix: 一部の画像がセンシティブ指定されているときに画面に何も表示されないことがあるのを修正
 
 ### Server
 - Feat: レートリミット制限に引っかかったときに`Retry-After`ヘッダーを返すように (#13949)

--- a/packages/frontend/src/components/MkImgWithBlurhash.vue
+++ b/packages/frontend/src/components/MkImgWithBlurhash.vue
@@ -155,7 +155,7 @@ function drawAvg() {
 
 	const color = (props.hash != null && extractAvgColorFromBlurhash(props.hash)) || '#888';
 
-	const ctx = canvas.value?.getContext('2d');
+	const ctx = canvas.value.getContext('2d');
 	if (!ctx) return;
 
 	// avgColorでお茶をにごす
@@ -165,6 +165,8 @@ function drawAvg() {
 }
 
 async function draw() {
+	if (import.meta.env.MODE === 'test' && props.hash == null) return;
+
 	drawAvg();
 
 	if (props.hash == null) return;

--- a/packages/frontend/src/components/MkImgWithBlurhash.vue
+++ b/packages/frontend/src/components/MkImgWithBlurhash.vue
@@ -159,7 +159,7 @@ function drawAvg() {
 		color = extractAvgColorFromBlurhash(props.hash) ?? '#888';
 	}
 
-	const ctx = canvas.value.getContext('2d');
+	const ctx = canvas.value?.getContext('2d');
 	if (!ctx) return;
 
 	// avgColorでお茶をにごす

--- a/packages/frontend/src/components/MkImgWithBlurhash.vue
+++ b/packages/frontend/src/components/MkImgWithBlurhash.vue
@@ -153,11 +153,7 @@ function drawImage(bitmap: CanvasImageSource) {
 function drawAvg() {
 	if (!canvas.value) return;
 
-	let color = '#888'; // blurhashが無い場合のフォールバック
-
-	if (props.hash != null) {
-		color = extractAvgColorFromBlurhash(props.hash) ?? '#888';
-	}
+	const color = (props.hash != null && extractAvgColorFromBlurhash(props.hash)) ?? '#888';
 
 	const ctx = canvas.value.getContext('2d');
 	if (!ctx) return;

--- a/packages/frontend/src/components/MkImgWithBlurhash.vue
+++ b/packages/frontend/src/components/MkImgWithBlurhash.vue
@@ -151,21 +151,27 @@ function drawImage(bitmap: CanvasImageSource) {
 }
 
 function drawAvg() {
-	if (!canvas.value || !props.hash) return;
+	if (!canvas.value) return;
+
+	let color = '#888'; // blurhashが無い場合のフォールバック
+
+	if (props.hash != null) {
+		color = extractAvgColorFromBlurhash(props.hash) ?? '#888';
+	}
 
 	const ctx = canvas.value.getContext('2d');
 	if (!ctx) return;
 
 	// avgColorでお茶をにごす
 	ctx.beginPath();
-	ctx.fillStyle = extractAvgColorFromBlurhash(props.hash) ?? '#888';
+	ctx.fillStyle = color;
 	ctx.fillRect(0, 0, canvasWidth.value, canvasHeight.value);
 }
 
 async function draw() {
-	if (props.hash == null) return;
-
 	drawAvg();
+
+	if (props.hash == null) return;
 
 	if (props.onlyAvgColor) return;
 

--- a/packages/frontend/src/components/MkImgWithBlurhash.vue
+++ b/packages/frontend/src/components/MkImgWithBlurhash.vue
@@ -153,7 +153,7 @@ function drawImage(bitmap: CanvasImageSource) {
 function drawAvg() {
 	if (!canvas.value) return;
 
-	const color = (props.hash != null && extractAvgColorFromBlurhash(props.hash)) ?? '#888';
+	const color = (props.hash != null && extractAvgColorFromBlurhash(props.hash)) || '#888';
 
 	const ctx = canvas.value?.getContext('2d');
 	if (!ctx) return;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`drawAvg`をblurhashが無い場合のフォールバックとしても使用するようにした

![image](https://github.com/user-attachments/assets/83b8a332-fb2a-41dc-b870-b0324456b1cc)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #13946

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
