### PR TITLE
fix(backend): api.jsonに`i`を公開するように

### DIFF
--- a/packages/backend/scripts/generate_api_json.js
+++ b/packages/backend/scripts/generate_api_json.js
@@ -8,6 +8,6 @@ import { genOpenapiSpec } from '../built/server/api/openapi/gen-spec.js'
 import { writeFileSync } from "node:fs";
 
 const config = loadConfig();
-const spec = genOpenapiSpec(config, true);
+const spec = genOpenapiSpec(config, true, false);
 
 writeFileSync('./built/api.json', JSON.stringify(spec), 'utf-8');


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
デフォルトの`securitySchemes`では`i`に対応できなかったため、公開される`api.json`に`i`を含むように（misskey-jsのスキーマを変えないために、misskey-js向けに生成するときは`i`を含まないようにした）

![image](https://github.com/user-attachments/assets/d1ffc85b-a56e-4ed9-bf04-b6742699e143)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #14275

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
これでいいのかは不明

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
