### PR TITLE
fix memory leak and inconsistent behavior in memory caches

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -175,6 +175,130 @@ id: 'aidx'
 # deliverJobMaxAttempts: 12
 # inboxJobMaxAttempts: 8
 
+caches:
+  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+  userByIdMemoryLifetime: 43200000
+  # Maximum number of ID->user lookups cached in memory. Default: 15000
+  userByIdMemoryCapacity: 15000
+
+  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+  localUserByIdMemoryLifetime: 43200000
+  # Maximum number of ID->local user lookups cached in memory. Default: 10000
+  localUserByIdMemoryCapacity: 10000
+
+  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+  userByTokenMemoryLifetime: 43200000
+  # Maximum number of token->user lookups cached in memory. Default: 10000
+  userByTokenMemoryCapacity: 10000
+
+  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+  userByUriMemoryLifetime: 43200000
+  # Maximum number of URI->user lookups cached in memory. Default: 10000
+  userByUriMemoryCapacity: 10000
+
+  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+  userProfileRedisLifetime: 1800000
+  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+  userProfileMemoryLifetime: 60000
+  # Maximum number of user profiles cached in memory. Default: 10000
+  userProfileMemoryCapacity: 10000
+
+  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+  userKeyPairRedisLifetime: 86400000
+  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+  userKeyPairMemoryLifetime: 43200000
+  # Maximum number of user keypairs cached in memory. Default: 10000
+  userKeyPairMemoryCapacity: 10000
+
+  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+  rolesMemoryLifetime: 3600000
+
+  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+  userRolesMemoryLifetime: 3600000
+  # Maximum number of user roles cached in memory. Default: 10000
+  userRolesMemoryCapacity: 10000
+
+  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+  userMutesRedisLifetime: 1800000
+  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+  userMutesMemoryLifetime: 60000
+  # Maximum number of user mutes cached in memory. Default: 1000
+  userMutesMemoryCapacity: 1000
+
+  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+  userBlocksRedisLifetime: 1800000
+  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+  userBlocksMemoryLifetime: 60000
+  # Maximum number of user blocks cached in memory. Default: 1000
+  userBlocksMemoryCapacity: 1000
+
+  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+  userFollowingsRedisLifetime: 1800000
+  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+  userFollowingsMemoryLifetime: 60000
+  # Maximum number of user followings cached in memory. Default: 1000
+  userFollowingsMemoryCapacity: 1000
+
+  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+  userChannelsRedisLifetime: 1800000
+  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+  userChannelsMemoryLifetime: 60000
+  # Maximum number of user channel followings cached in memory. Default: 1000
+  userChannelsMemoryCapacity: 1000
+
+  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+  publicKeysMemoryLifetime: 43200000
+  # Maximum number of public keys cached in memory. Default: 15000
+  publicKeysMemoryCapacity: 15000
+
+  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+  emojisMemoryLifetime: 43200000
+  # Maximum number of emojis cached in memory. Default: 5000
+  emojisMemoryCapacity: 5000
+
+  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+  localEmojisRedisLifetime: 1800000
+  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+  localEmojisMemoryLifetime: 180000
+
+  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+  instanceRedisLifetime: 1800000
+  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+  instanceMemoryLifetime: 180000
+  # Maximum number of federated instances cached in memory. Default: 5000
+  instanceMemoryCapacity: 5000
+
+  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+  swSubscriptionRedisLifetime: 3600000
+  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+  swSubscriptionMemoryLifetime: 180000
+  # Maximum number of service worker subscriptions cached in memory. Default: 1000
+  swSubscriptionMemoryCapacity: 1000
+
+  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+  listMembershipRedisLifetime: 1800000
+  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+  listMembershipMemoryLifetime: 60000
+  # Maximum number of list memberships cached in memory. Default: 1000
+  listMembershipMemoryCapacity: 1000
+
+  # Lifetime of client apps in memory. Default: 604800000 (1 week)
+  clientAppMemoryLifetime: 604800000
+  # Maximum number of client apps cached in memory. Default: 1000
+  clientAppMemoryCapacity: 1000
+
+  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+  avatarDecorationsMemoryLifetime: 1800000
+
+  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+  relaysMemoryLifetime: 600000
+
+  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+  suspendedHostsMemoryLifetime: 3600000
+
+  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+  nodeInfoMemoryLifetime: 600000
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -176,128 +176,184 @@ id: 'aidx'
 # inboxJobMaxAttempts: 8
 
 caches:
-  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
-  userByIdMemoryLifetime: 43200000
-  # Maximum number of ID->user lookups cached in memory. Default: 15000
-  userByIdMemoryCapacity: 15000
+  localUserById:
+    memory:
+      # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->local user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
-  localUserByIdMemoryLifetime: 43200000
-  # Maximum number of ID->local user lookups cached in memory. Default: 10000
-  localUserByIdMemoryCapacity: 10000
+  userById:
+    memory:
+      # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->user lookups cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
-  userByTokenMemoryLifetime: 43200000
-  # Maximum number of token->user lookups cached in memory. Default: 10000
-  userByTokenMemoryCapacity: 10000
+  userByToken:
+    memory:
+      # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of token->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
-  userByUriMemoryLifetime: 43200000
-  # Maximum number of URI->user lookups cached in memory. Default: 10000
-  userByUriMemoryCapacity: 10000
+  userByUri:
+    memory:
+      # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of URI->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
-  userProfileRedisLifetime: 1800000
-  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
-  userProfileMemoryLifetime: 60000
-  # Maximum number of user profiles cached in memory. Default: 10000
-  userProfileMemoryCapacity: 10000
+  userProfile:
+    redis:
+      # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user profiles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
-  userKeyPairRedisLifetime: 86400000
-  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
-  userKeyPairMemoryLifetime: 43200000
-  # Maximum number of user keypairs cached in memory. Default: 10000
-  userKeyPairMemoryCapacity: 10000
+  userKeyPair:
+    redis:
+      # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+      lifetime: 86400000
+    memory:
+      # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of user keypairs cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
-  rolesMemoryLifetime: 3600000
+  roles:
+    memory:
+      # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
-  userRolesMemoryLifetime: 3600000
-  # Maximum number of user roles cached in memory. Default: 10000
-  userRolesMemoryCapacity: 10000
+  userRoles:
+    memory:
+      # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
+      # Maximum number of user roles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
-  userMutesRedisLifetime: 1800000
-  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
-  userMutesMemoryLifetime: 60000
-  # Maximum number of user mutes cached in memory. Default: 1000
-  userMutesMemoryCapacity: 1000
+  userMutes:
+    redis:
+      # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user mutes cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
-  userBlocksRedisLifetime: 1800000
-  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
-  userBlocksMemoryLifetime: 60000
-  # Maximum number of user blocks cached in memory. Default: 1000
-  userBlocksMemoryCapacity: 1000
+  userBlocks:
+    redis:
+      # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user blocks cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
-  userFollowingsRedisLifetime: 1800000
-  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
-  userFollowingsMemoryLifetime: 60000
-  # Maximum number of user followings cached in memory. Default: 1000
-  userFollowingsMemoryCapacity: 1000
+  userFollowings:
+    redis:
+      # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
-  userChannelsRedisLifetime: 1800000
-  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
-  userChannelsMemoryLifetime: 60000
-  # Maximum number of user channel followings cached in memory. Default: 1000
-  userChannelsMemoryCapacity: 1000
+  userChannels:
+    redis:
+      # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user channel followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
-  publicKeysMemoryLifetime: 43200000
-  # Maximum number of public keys cached in memory. Default: 15000
-  publicKeysMemoryCapacity: 15000
+  publicKeys:
+    memory:
+      # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of public keys cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
-  emojisMemoryLifetime: 43200000
-  # Maximum number of emojis cached in memory. Default: 5000
-  emojisMemoryCapacity: 5000
+  emojis:
+    memory:
+      # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of emojis cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
-  localEmojisRedisLifetime: 1800000
-  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
-  localEmojisMemoryLifetime: 180000
+  localEmojis:
+    redis:
+      # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+      lifetime: 180000
 
-  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
-  instanceRedisLifetime: 1800000
-  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
-  instanceMemoryLifetime: 180000
-  # Maximum number of federated instances cached in memory. Default: 5000
-  instanceMemoryCapacity: 5000
+  instance:
+    redis:
+      # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of federated instances cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
-  swSubscriptionRedisLifetime: 3600000
-  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
-  swSubscriptionMemoryLifetime: 180000
-  # Maximum number of service worker subscriptions cached in memory. Default: 1000
-  swSubscriptionMemoryCapacity: 1000
+  swSubscription:
+    redis:
+      # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+      lifetime: 3600000
+    memory:
+      # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of service worker subscriptions cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
-  listMembershipRedisLifetime: 1800000
-  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
-  listMembershipMemoryLifetime: 60000
-  # Maximum number of list memberships cached in memory. Default: 1000
-  listMembershipMemoryCapacity: 1000
+  listMembership:
+    redis:
+      # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of list memberships cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of client apps in memory. Default: 604800000 (1 week)
-  clientAppMemoryLifetime: 604800000
-  # Maximum number of client apps cached in memory. Default: 1000
-  clientAppMemoryCapacity: 1000
+  clientApp:
+    memory:
+      # Lifetime of client apps in memory. Default: 604800000 (1 week)
+      lifetime: 604800000
+      # Maximum number of client apps cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
-  avatarDecorationsMemoryLifetime: 1800000
+  avatarDecorations:
+    memory:
+      # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+      lifetime: 1800000
 
-  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
-  relaysMemoryLifetime: 600000
+  relays:
+    memory:
+      # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
-  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
-  suspendedHostsMemoryLifetime: 3600000
+  suspendedHosts:
+    memory:
+      # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
-  nodeInfoMemoryLifetime: 600000
+  nodeInfo:
+    memory:
+      # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -245,6 +245,131 @@ id: 'aidx'
 #deliverJobMaxAttempts: 12
 #inboxJobMaxAttempts: 8
 
+caches:
+  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+  userByIdMemoryLifetime: 43200000
+  # Maximum number of ID->user lookups cached in memory. Default: 15000
+  userByIdMemoryCapacity: 15000
+
+  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+  localUserByIdMemoryLifetime: 43200000
+  # Maximum number of ID->local user lookups cached in memory. Default: 10000
+  localUserByIdMemoryCapacity: 10000
+
+  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+  userByTokenMemoryLifetime: 43200000
+  # Maximum number of token->user lookups cached in memory. Default: 10000
+  userByTokenMemoryCapacity: 10000
+
+  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+  userByUriMemoryLifetime: 43200000
+  # Maximum number of URI->user lookups cached in memory. Default: 10000
+  userByUriMemoryCapacity: 10000
+
+  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+  userProfileRedisLifetime: 1800000
+  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+  userProfileMemoryLifetime: 60000
+  # Maximum number of user profiles cached in memory. Default: 10000
+  userProfileMemoryCapacity: 10000
+
+  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+  userKeyPairRedisLifetime: 86400000
+  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+  userKeyPairMemoryLifetime: 43200000
+  # Maximum number of user keypairs cached in memory. Default: 10000
+  userKeyPairMemoryCapacity: 10000
+
+  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+  rolesMemoryLifetime: 3600000
+
+  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+  userRolesMemoryLifetime: 3600000
+  # Maximum number of user roles cached in memory. Default: 10000
+  userRolesMemoryCapacity: 10000
+
+  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+  userMutesRedisLifetime: 1800000
+  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+  userMutesMemoryLifetime: 60000
+  # Maximum number of user mutes cached in memory. Default: 1000
+  userMutesMemoryCapacity: 1000
+
+  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+  userBlocksRedisLifetime: 1800000
+  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+  userBlocksMemoryLifetime: 60000
+  # Maximum number of user blocks cached in memory. Default: 1000
+  userBlocksMemoryCapacity: 1000
+
+  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+  userFollowingsRedisLifetime: 1800000
+  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+  userFollowingsMemoryLifetime: 60000
+  # Maximum number of user followings cached in memory. Default: 1000
+  userFollowingsMemoryCapacity: 1000
+
+  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+  userChannelsRedisLifetime: 1800000
+  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+  userChannelsMemoryLifetime: 60000
+  # Maximum number of user channel followings cached in memory. Default: 1000
+  userChannelsMemoryCapacity: 1000
+
+  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+  publicKeysMemoryLifetime: 43200000
+  # Maximum number of public keys cached in memory. Default: 15000
+  publicKeysMemoryCapacity: 15000
+
+  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+  emojisMemoryLifetime: 43200000
+  # Maximum number of emojis cached in memory. Default: 5000
+  emojisMemoryCapacity: 5000
+
+  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+  localEmojisRedisLifetime: 1800000
+  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+  localEmojisMemoryLifetime: 180000
+
+  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+  instanceRedisLifetime: 1800000
+  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+  instanceMemoryLifetime: 180000
+  # Maximum number of federated instances cached in memory. Default: 5000
+  instanceMemoryCapacity: 5000
+
+  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+  swSubscriptionRedisLifetime: 3600000
+  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+  swSubscriptionMemoryLifetime: 180000
+  # Maximum number of service worker subscriptions cached in memory. Default: 1000
+  swSubscriptionMemoryCapacity: 1000
+
+  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+  listMembershipRedisLifetime: 1800000
+  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+  listMembershipMemoryLifetime: 60000
+  # Maximum number of list memberships cached in memory. Default: 1000
+  listMembershipMemoryCapacity: 1000
+
+  # Lifetime of client apps in memory. Default: 604800000 (1 week)
+  clientAppMemoryLifetime: 604800000
+  # Maximum number of client apps cached in memory. Default: 1000
+  clientAppMemoryCapacity: 1000
+
+  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+  avatarDecorationsMemoryLifetime: 1800000
+
+  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+  relaysMemoryLifetime: 600000
+
+  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+  suspendedHostsMemoryLifetime: 3600000
+
+  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+  nodeInfoMemoryLifetime: 600000
+
+
 # Local address used for outgoing requests
 #outgoingAddress: 127.0.0.1
 

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -246,128 +246,184 @@ id: 'aidx'
 #inboxJobMaxAttempts: 8
 
 caches:
-  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
-  userByIdMemoryLifetime: 43200000
-  # Maximum number of ID->user lookups cached in memory. Default: 15000
-  userByIdMemoryCapacity: 15000
+  localUserById:
+    memory:
+      # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->local user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
-  localUserByIdMemoryLifetime: 43200000
-  # Maximum number of ID->local user lookups cached in memory. Default: 10000
-  localUserByIdMemoryCapacity: 10000
+  userById:
+    memory:
+      # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->user lookups cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
-  userByTokenMemoryLifetime: 43200000
-  # Maximum number of token->user lookups cached in memory. Default: 10000
-  userByTokenMemoryCapacity: 10000
+  userByToken:
+    memory:
+      # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of token->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
-  userByUriMemoryLifetime: 43200000
-  # Maximum number of URI->user lookups cached in memory. Default: 10000
-  userByUriMemoryCapacity: 10000
+  userByUri:
+    memory:
+      # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of URI->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
-  userProfileRedisLifetime: 1800000
-  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
-  userProfileMemoryLifetime: 60000
-  # Maximum number of user profiles cached in memory. Default: 10000
-  userProfileMemoryCapacity: 10000
+  userProfile:
+    redis:
+      # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user profiles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
-  userKeyPairRedisLifetime: 86400000
-  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
-  userKeyPairMemoryLifetime: 43200000
-  # Maximum number of user keypairs cached in memory. Default: 10000
-  userKeyPairMemoryCapacity: 10000
+  userKeyPair:
+    redis:
+      # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+      lifetime: 86400000
+    memory:
+      # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of user keypairs cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
-  rolesMemoryLifetime: 3600000
+  roles:
+    memory:
+      # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
-  userRolesMemoryLifetime: 3600000
-  # Maximum number of user roles cached in memory. Default: 10000
-  userRolesMemoryCapacity: 10000
+  userRoles:
+    memory:
+      # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
+      # Maximum number of user roles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
-  userMutesRedisLifetime: 1800000
-  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
-  userMutesMemoryLifetime: 60000
-  # Maximum number of user mutes cached in memory. Default: 1000
-  userMutesMemoryCapacity: 1000
+  userMutes:
+    redis:
+      # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user mutes cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
-  userBlocksRedisLifetime: 1800000
-  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
-  userBlocksMemoryLifetime: 60000
-  # Maximum number of user blocks cached in memory. Default: 1000
-  userBlocksMemoryCapacity: 1000
+  userBlocks:
+    redis:
+      # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user blocks cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
-  userFollowingsRedisLifetime: 1800000
-  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
-  userFollowingsMemoryLifetime: 60000
-  # Maximum number of user followings cached in memory. Default: 1000
-  userFollowingsMemoryCapacity: 1000
+  userFollowings:
+    redis:
+      # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
-  userChannelsRedisLifetime: 1800000
-  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
-  userChannelsMemoryLifetime: 60000
-  # Maximum number of user channel followings cached in memory. Default: 1000
-  userChannelsMemoryCapacity: 1000
+  userChannels:
+    redis:
+      # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user channel followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
-  publicKeysMemoryLifetime: 43200000
-  # Maximum number of public keys cached in memory. Default: 15000
-  publicKeysMemoryCapacity: 15000
+  publicKeys:
+    memory:
+      # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of public keys cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
-  emojisMemoryLifetime: 43200000
-  # Maximum number of emojis cached in memory. Default: 5000
-  emojisMemoryCapacity: 5000
+  emojis:
+    memory:
+      # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of emojis cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
-  localEmojisRedisLifetime: 1800000
-  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
-  localEmojisMemoryLifetime: 180000
+  localEmojis:
+    redis:
+      # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+      lifetime: 180000
 
-  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
-  instanceRedisLifetime: 1800000
-  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
-  instanceMemoryLifetime: 180000
-  # Maximum number of federated instances cached in memory. Default: 5000
-  instanceMemoryCapacity: 5000
+  instance:
+    redis:
+      # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of federated instances cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
-  swSubscriptionRedisLifetime: 3600000
-  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
-  swSubscriptionMemoryLifetime: 180000
-  # Maximum number of service worker subscriptions cached in memory. Default: 1000
-  swSubscriptionMemoryCapacity: 1000
+  swSubscription:
+    redis:
+      # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+      lifetime: 3600000
+    memory:
+      # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of service worker subscriptions cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
-  listMembershipRedisLifetime: 1800000
-  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
-  listMembershipMemoryLifetime: 60000
-  # Maximum number of list memberships cached in memory. Default: 1000
-  listMembershipMemoryCapacity: 1000
+  listMembership:
+    redis:
+      # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of list memberships cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of client apps in memory. Default: 604800000 (1 week)
-  clientAppMemoryLifetime: 604800000
-  # Maximum number of client apps cached in memory. Default: 1000
-  clientAppMemoryCapacity: 1000
+  clientApp:
+    memory:
+      # Lifetime of client apps in memory. Default: 604800000 (1 week)
+      lifetime: 604800000
+      # Maximum number of client apps cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
-  avatarDecorationsMemoryLifetime: 1800000
+  avatarDecorations:
+    memory:
+      # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+      lifetime: 1800000
 
-  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
-  relaysMemoryLifetime: 600000
+  relays:
+    memory:
+      # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
-  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
-  suspendedHostsMemoryLifetime: 3600000
+  suspendedHosts:
+    memory:
+      # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
-  nodeInfoMemoryLifetime: 600000
+  nodeInfo:
+    memory:
+      # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
 
 # Local address used for outgoing requests

--- a/.devcontainer/devcontainer.yml
+++ b/.devcontainer/devcontainer.yml
@@ -169,128 +169,184 @@ id: 'aidx'
 # inboxJobMaxAttempts: 8
 
 caches:
-  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
-  userByIdMemoryLifetime: 43200000
-  # Maximum number of ID->user lookups cached in memory. Default: 15000
-  userByIdMemoryCapacity: 15000
+  localUserById:
+    memory:
+      # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->local user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
-  localUserByIdMemoryLifetime: 43200000
-  # Maximum number of ID->local user lookups cached in memory. Default: 10000
-  localUserByIdMemoryCapacity: 10000
+  userById:
+    memory:
+      # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->user lookups cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
-  userByTokenMemoryLifetime: 43200000
-  # Maximum number of token->user lookups cached in memory. Default: 10000
-  userByTokenMemoryCapacity: 10000
+  userByToken:
+    memory:
+      # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of token->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
-  userByUriMemoryLifetime: 43200000
-  # Maximum number of URI->user lookups cached in memory. Default: 10000
-  userByUriMemoryCapacity: 10000
+  userByUri:
+    memory:
+      # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of URI->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
-  userProfileRedisLifetime: 1800000
-  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
-  userProfileMemoryLifetime: 60000
-  # Maximum number of user profiles cached in memory. Default: 10000
-  userProfileMemoryCapacity: 10000
+  userProfile:
+    redis:
+      # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user profiles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
-  userKeyPairRedisLifetime: 86400000
-  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
-  userKeyPairMemoryLifetime: 43200000
-  # Maximum number of user keypairs cached in memory. Default: 10000
-  userKeyPairMemoryCapacity: 10000
+  userKeyPair:
+    redis:
+      # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+      lifetime: 86400000
+    memory:
+      # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of user keypairs cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
-  rolesMemoryLifetime: 3600000
+  roles:
+    memory:
+      # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
-  userRolesMemoryLifetime: 3600000
-  # Maximum number of user roles cached in memory. Default: 10000
-  userRolesMemoryCapacity: 10000
+  userRoles:
+    memory:
+      # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
+      # Maximum number of user roles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
-  userMutesRedisLifetime: 1800000
-  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
-  userMutesMemoryLifetime: 60000
-  # Maximum number of user mutes cached in memory. Default: 1000
-  userMutesMemoryCapacity: 1000
+  userMutes:
+    redis:
+      # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user mutes cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
-  userBlocksRedisLifetime: 1800000
-  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
-  userBlocksMemoryLifetime: 60000
-  # Maximum number of user blocks cached in memory. Default: 1000
-  userBlocksMemoryCapacity: 1000
+  userBlocks:
+    redis:
+      # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user blocks cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
-  userFollowingsRedisLifetime: 1800000
-  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
-  userFollowingsMemoryLifetime: 60000
-  # Maximum number of user followings cached in memory. Default: 1000
-  userFollowingsMemoryCapacity: 1000
+  userFollowings:
+    redis:
+      # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
-  userChannelsRedisLifetime: 1800000
-  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
-  userChannelsMemoryLifetime: 60000
-  # Maximum number of user channel followings cached in memory. Default: 1000
-  userChannelsMemoryCapacity: 1000
+  userChannels:
+    redis:
+      # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user channel followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
-  publicKeysMemoryLifetime: 43200000
-  # Maximum number of public keys cached in memory. Default: 15000
-  publicKeysMemoryCapacity: 15000
+  publicKeys:
+    memory:
+      # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of public keys cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
-  emojisMemoryLifetime: 43200000
-  # Maximum number of emojis cached in memory. Default: 5000
-  emojisMemoryCapacity: 5000
+  emojis:
+    memory:
+      # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of emojis cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
-  localEmojisRedisLifetime: 1800000
-  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
-  localEmojisMemoryLifetime: 180000
+  localEmojis:
+    redis:
+      # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+      lifetime: 180000
 
-  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
-  instanceRedisLifetime: 1800000
-  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
-  instanceMemoryLifetime: 180000
-  # Maximum number of federated instances cached in memory. Default: 5000
-  instanceMemoryCapacity: 5000
+  instance:
+    redis:
+      # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of federated instances cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
-  swSubscriptionRedisLifetime: 3600000
-  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
-  swSubscriptionMemoryLifetime: 180000
-  # Maximum number of service worker subscriptions cached in memory. Default: 1000
-  swSubscriptionMemoryCapacity: 1000
+  swSubscription:
+    redis:
+      # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+      lifetime: 3600000
+    memory:
+      # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of service worker subscriptions cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
-  listMembershipRedisLifetime: 1800000
-  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
-  listMembershipMemoryLifetime: 60000
-  # Maximum number of list memberships cached in memory. Default: 1000
-  listMembershipMemoryCapacity: 1000
+  listMembership:
+    redis:
+      # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of list memberships cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of client apps in memory. Default: 604800000 (1 week)
-  clientAppMemoryLifetime: 604800000
-  # Maximum number of client apps cached in memory. Default: 1000
-  clientAppMemoryCapacity: 1000
+  clientApp:
+    memory:
+      # Lifetime of client apps in memory. Default: 604800000 (1 week)
+      lifetime: 604800000
+      # Maximum number of client apps cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
-  avatarDecorationsMemoryLifetime: 1800000
+  avatarDecorations:
+    memory:
+      # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+      lifetime: 1800000
 
-  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
-  relaysMemoryLifetime: 600000
+  relays:
+    memory:
+      # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
-  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
-  suspendedHostsMemoryLifetime: 3600000
+  suspendedHosts:
+    memory:
+      # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
-  nodeInfoMemoryLifetime: 600000
+  nodeInfo:
+    memory:
+      # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4

--- a/.devcontainer/devcontainer.yml
+++ b/.devcontainer/devcontainer.yml
@@ -168,6 +168,130 @@ id: 'aidx'
 # deliverJobMaxAttempts: 12
 # inboxJobMaxAttempts: 8
 
+caches:
+  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+  userByIdMemoryLifetime: 43200000
+  # Maximum number of ID->user lookups cached in memory. Default: 15000
+  userByIdMemoryCapacity: 15000
+
+  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+  localUserByIdMemoryLifetime: 43200000
+  # Maximum number of ID->local user lookups cached in memory. Default: 10000
+  localUserByIdMemoryCapacity: 10000
+
+  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+  userByTokenMemoryLifetime: 43200000
+  # Maximum number of token->user lookups cached in memory. Default: 10000
+  userByTokenMemoryCapacity: 10000
+
+  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+  userByUriMemoryLifetime: 43200000
+  # Maximum number of URI->user lookups cached in memory. Default: 10000
+  userByUriMemoryCapacity: 10000
+
+  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+  userProfileRedisLifetime: 1800000
+  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+  userProfileMemoryLifetime: 60000
+  # Maximum number of user profiles cached in memory. Default: 10000
+  userProfileMemoryCapacity: 10000
+
+  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+  userKeyPairRedisLifetime: 86400000
+  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+  userKeyPairMemoryLifetime: 43200000
+  # Maximum number of user keypairs cached in memory. Default: 10000
+  userKeyPairMemoryCapacity: 10000
+
+  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+  rolesMemoryLifetime: 3600000
+
+  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+  userRolesMemoryLifetime: 3600000
+  # Maximum number of user roles cached in memory. Default: 10000
+  userRolesMemoryCapacity: 10000
+
+  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+  userMutesRedisLifetime: 1800000
+  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+  userMutesMemoryLifetime: 60000
+  # Maximum number of user mutes cached in memory. Default: 1000
+  userMutesMemoryCapacity: 1000
+
+  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+  userBlocksRedisLifetime: 1800000
+  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+  userBlocksMemoryLifetime: 60000
+  # Maximum number of user blocks cached in memory. Default: 1000
+  userBlocksMemoryCapacity: 1000
+
+  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+  userFollowingsRedisLifetime: 1800000
+  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+  userFollowingsMemoryLifetime: 60000
+  # Maximum number of user followings cached in memory. Default: 1000
+  userFollowingsMemoryCapacity: 1000
+
+  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+  userChannelsRedisLifetime: 1800000
+  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+  userChannelsMemoryLifetime: 60000
+  # Maximum number of user channel followings cached in memory. Default: 1000
+  userChannelsMemoryCapacity: 1000
+
+  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+  publicKeysMemoryLifetime: 43200000
+  # Maximum number of public keys cached in memory. Default: 15000
+  publicKeysMemoryCapacity: 15000
+
+  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+  emojisMemoryLifetime: 43200000
+  # Maximum number of emojis cached in memory. Default: 5000
+  emojisMemoryCapacity: 5000
+
+  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+  localEmojisRedisLifetime: 1800000
+  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+  localEmojisMemoryLifetime: 180000
+
+  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+  instanceRedisLifetime: 1800000
+  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+  instanceMemoryLifetime: 180000
+  # Maximum number of federated instances cached in memory. Default: 5000
+  instanceMemoryCapacity: 5000
+
+  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+  swSubscriptionRedisLifetime: 3600000
+  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+  swSubscriptionMemoryLifetime: 180000
+  # Maximum number of service worker subscriptions cached in memory. Default: 1000
+  swSubscriptionMemoryCapacity: 1000
+
+  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+  listMembershipRedisLifetime: 1800000
+  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+  listMembershipMemoryLifetime: 60000
+  # Maximum number of list memberships cached in memory. Default: 1000
+  listMembershipMemoryCapacity: 1000
+
+  # Lifetime of client apps in memory. Default: 604800000 (1 week)
+  clientAppMemoryLifetime: 604800000
+  # Maximum number of client apps cached in memory. Default: 1000
+  clientAppMemoryCapacity: 1000
+
+  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+  avatarDecorationsMemoryLifetime: 1800000
+
+  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+  relaysMemoryLifetime: 600000
+
+  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+  suspendedHostsMemoryLifetime: 3600000
+
+  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+  nodeInfoMemoryLifetime: 600000
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Server
 - Feat: レートリミット制限に引っかかったときに`Retry-After`ヘッダーを返すように (#13949)
+- Feat: expose configuration for Redis and Memory Cache parameters
 - Enhance: エンドポイント`clips/update`の必須項目を`clipId`のみに
 - Enhance: エンドポイント`admin/roles/update`の必須項目を`roleId`のみに
 - Enhance: エンドポイント`pages/update`の必須項目を`pageId`のみに
@@ -78,6 +79,8 @@
 - Fix: リノートのミュートが適用されるまでに時間がかかることがある問題を修正  
   (Cherry-picked from https://github.com/Type4ny-Project/Type4ny/commit/e9601029b52e0ad43d9131b555b614e56c84ebc1)
 - Fix: Steaming APIが不正なデータを受けた場合の動作が不安定である問題 #14251
+- Fix: Prevent memory leak from memory caches (#14310)
+- Fix: More reliable memory cache eviction (#14311)
 
 ### Misskey.js
 - Feat: `/drive/files/create` のリクエストに対応（`multipart/form-data`に対応）

--- a/chart/files/default.yml
+++ b/chart/files/default.yml
@@ -189,6 +189,130 @@ id: "aidx"
 # deliverJobMaxAttempts: 12
 # inboxJobMaxAttempts: 8
 
+caches:
+  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+  userByIdMemoryLifetime: 43200000
+  # Maximum number of ID->user lookups cached in memory. Default: 15000
+  userByIdMemoryCapacity: 15000
+
+  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+  localUserByIdMemoryLifetime: 43200000
+  # Maximum number of ID->local user lookups cached in memory. Default: 10000
+  localUserByIdMemoryCapacity: 10000
+
+  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+  userByTokenMemoryLifetime: 43200000
+  # Maximum number of token->user lookups cached in memory. Default: 10000
+  userByTokenMemoryCapacity: 10000
+
+  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+  userByUriMemoryLifetime: 43200000
+  # Maximum number of URI->user lookups cached in memory. Default: 10000
+  userByUriMemoryCapacity: 10000
+
+  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+  userProfileRedisLifetime: 1800000
+  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+  userProfileMemoryLifetime: 60000
+  # Maximum number of user profiles cached in memory. Default: 10000
+  userProfileMemoryCapacity: 10000
+
+  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+  userKeyPairRedisLifetime: 86400000
+  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+  userKeyPairMemoryLifetime: 43200000
+  # Maximum number of user keypairs cached in memory. Default: 10000
+  userKeyPairMemoryCapacity: 10000
+
+  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+  rolesMemoryLifetime: 3600000
+
+  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+  userRolesMemoryLifetime: 3600000
+  # Maximum number of user roles cached in memory. Default: 10000
+  userRolesMemoryCapacity: 10000
+
+  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+  userMutesRedisLifetime: 1800000
+  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+  userMutesMemoryLifetime: 60000
+  # Maximum number of user mutes cached in memory. Default: 1000
+  userMutesMemoryCapacity: 1000
+
+  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+  userBlocksRedisLifetime: 1800000
+  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+  userBlocksMemoryLifetime: 60000
+  # Maximum number of user blocks cached in memory. Default: 1000
+  userBlocksMemoryCapacity: 1000
+
+  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+  userFollowingsRedisLifetime: 1800000
+  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+  userFollowingsMemoryLifetime: 60000
+  # Maximum number of user followings cached in memory. Default: 1000
+  userFollowingsMemoryCapacity: 1000
+
+  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+  userChannelsRedisLifetime: 1800000
+  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+  userChannelsMemoryLifetime: 60000
+  # Maximum number of user channel followings cached in memory. Default: 1000
+  userChannelsMemoryCapacity: 1000
+
+  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+  publicKeysMemoryLifetime: 43200000
+  # Maximum number of public keys cached in memory. Default: 15000
+  publicKeysMemoryCapacity: 15000
+
+  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+  emojisMemoryLifetime: 43200000
+  # Maximum number of emojis cached in memory. Default: 5000
+  emojisMemoryCapacity: 5000
+
+  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+  localEmojisRedisLifetime: 1800000
+  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+  localEmojisMemoryLifetime: 180000
+
+  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+  instanceRedisLifetime: 1800000
+  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+  instanceMemoryLifetime: 180000
+  # Maximum number of federated instances cached in memory. Default: 5000
+  instanceMemoryCapacity: 5000
+
+  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+  swSubscriptionRedisLifetime: 3600000
+  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+  swSubscriptionMemoryLifetime: 180000
+  # Maximum number of service worker subscriptions cached in memory. Default: 1000
+  swSubscriptionMemoryCapacity: 1000
+
+  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+  listMembershipRedisLifetime: 1800000
+  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+  listMembershipMemoryLifetime: 60000
+  # Maximum number of list memberships cached in memory. Default: 1000
+  listMembershipMemoryCapacity: 1000
+
+  # Lifetime of client apps in memory. Default: 604800000 (1 week)
+  clientAppMemoryLifetime: 604800000
+  # Maximum number of client apps cached in memory. Default: 1000
+  clientAppMemoryCapacity: 1000
+
+  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+  avatarDecorationsMemoryLifetime: 1800000
+
+  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+  relaysMemoryLifetime: 600000
+
+  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+  suspendedHostsMemoryLifetime: 3600000
+
+  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+  nodeInfoMemoryLifetime: 600000
+
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4
 

--- a/chart/files/default.yml
+++ b/chart/files/default.yml
@@ -190,128 +190,184 @@ id: "aidx"
 # inboxJobMaxAttempts: 8
 
 caches:
-  # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
-  userByIdMemoryLifetime: 43200000
-  # Maximum number of ID->user lookups cached in memory. Default: 15000
-  userByIdMemoryCapacity: 15000
+  localUserById:
+    memory:
+      # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->local user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached ID->local user lookups in memory. Default: 43200000 (12 hours)
-  localUserByIdMemoryLifetime: 43200000
-  # Maximum number of ID->local user lookups cached in memory. Default: 10000
-  localUserByIdMemoryCapacity: 10000
+  userById:
+    memory:
+      # Lifetime of cached ID->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of ID->user lookups cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
-  userByTokenMemoryLifetime: 43200000
-  # Maximum number of token->user lookups cached in memory. Default: 10000
-  userByTokenMemoryCapacity: 10000
+  userByToken:
+    memory:
+      # Lifetime of cached token->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of token->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
-  userByUriMemoryLifetime: 43200000
-  # Maximum number of URI->user lookups cached in memory. Default: 10000
-  userByUriMemoryCapacity: 10000
+  userByUri:
+    memory:
+      # Lifetime of cached URI->user lookups in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of URI->user lookups cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
-  userProfileRedisLifetime: 1800000
-  # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
-  userProfileMemoryLifetime: 60000
-  # Maximum number of user profiles cached in memory. Default: 10000
-  userProfileMemoryCapacity: 10000
+  userProfile:
+    redis:
+      # Lifetime of cached user profiles in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user profiles in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user profiles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
-  userKeyPairRedisLifetime: 86400000
-  # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
-  userKeyPairMemoryLifetime: 43200000
-  # Maximum number of user keypairs cached in memory. Default: 10000
-  userKeyPairMemoryCapacity: 10000
+  userKeyPair:
+    redis:
+      # Lifetime of cached user keypairs in redis. Default: 86400000 (1 day)
+      lifetime: 86400000
+    memory:
+      # Lifetime of cached user keypairs in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of user keypairs cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
-  rolesMemoryLifetime: 3600000
+  roles:
+    memory:
+      # Lifetime of cached roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
-  userRolesMemoryLifetime: 3600000
-  # Maximum number of user roles cached in memory. Default: 10000
-  userRolesMemoryCapacity: 10000
+  userRoles:
+    memory:
+      # Lifetime of cached user roles in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
+      # Maximum number of user roles cached in memory. Default: 10000
+      capacity: 10000
 
-  # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
-  userMutesRedisLifetime: 1800000
-  # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
-  userMutesMemoryLifetime: 60000
-  # Maximum number of user mutes cached in memory. Default: 1000
-  userMutesMemoryCapacity: 1000
+  userMutes:
+    redis:
+      # Lifetime of cached user mutes in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user mutes in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user mutes cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
-  userBlocksRedisLifetime: 1800000
-  # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
-  userBlocksMemoryLifetime: 60000
-  # Maximum number of user blocks cached in memory. Default: 1000
-  userBlocksMemoryCapacity: 1000
+  userBlocks:
+    redis:
+      # Lifetime of cached user blocks in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user blocks in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user blocks cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
-  userFollowingsRedisLifetime: 1800000
-  # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
-  userFollowingsMemoryLifetime: 60000
-  # Maximum number of user followings cached in memory. Default: 1000
-  userFollowingsMemoryCapacity: 1000
+  userFollowings:
+    redis:
+      # Lifetime of cached user followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
-  userChannelsRedisLifetime: 1800000
-  # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
-  userChannelsMemoryLifetime: 60000
-  # Maximum number of user channel followings cached in memory. Default: 1000
-  userChannelsMemoryCapacity: 1000
+  userChannels:
+    redis:
+      # Lifetime of cached user channel followings in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached user channel followings in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of user channel followings cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
-  publicKeysMemoryLifetime: 43200000
-  # Maximum number of public keys cached in memory. Default: 15000
-  publicKeysMemoryCapacity: 15000
+  publicKeys:
+    memory:
+      # Lifetime of cached public keys in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of public keys cached in memory. Default: 15000
+      capacity: 15000
 
-  # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
-  emojisMemoryLifetime: 43200000
-  # Maximum number of emojis cached in memory. Default: 5000
-  emojisMemoryCapacity: 5000
+  emojis:
+    memory:
+      # Lifetime of cached emojis in memory. Default: 43200000 (12 hours)
+      lifetime: 43200000
+      # Maximum number of emojis cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
-  localEmojisRedisLifetime: 1800000
-  # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
-  localEmojisMemoryLifetime: 180000
+  localEmojis:
+    redis:
+      # Lifetime of cached local emojis in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached local emojis in memory. Default: 180000 (3 minutes)
+      lifetime: 180000
 
-  # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
-  instanceRedisLifetime: 1800000
-  # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
-  instanceMemoryLifetime: 180000
-  # Maximum number of federated instances cached in memory. Default: 5000
-  instanceMemoryCapacity: 5000
+  instance:
+    redis:
+      # Lifetime of cached federated instances in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached federated instances in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of federated instances cached in memory. Default: 5000
+      capacity: 5000
 
-  # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
-  swSubscriptionRedisLifetime: 3600000
-  # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
-  swSubscriptionMemoryLifetime: 180000
-  # Maximum number of service worker subscriptions cached in memory. Default: 1000
-  swSubscriptionMemoryCapacity: 1000
+  swSubscription:
+    redis:
+      # Lifetime of cached service worker subscriptions in redis. Default: 3600000 (1 hour)
+      lifetime: 3600000
+    memory:
+      # Lifetime of cached service worker subscriptions in memory. Default: 180000 (3 minute)
+      lifetime: 180000
+      # Maximum number of service worker subscriptions cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
-  listMembershipRedisLifetime: 1800000
-  # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
-  listMembershipMemoryLifetime: 60000
-  # Maximum number of list memberships cached in memory. Default: 1000
-  listMembershipMemoryCapacity: 1000
+  listMembership:
+    redis:
+      # Lifetime of cached list memberships in redis. Default: 1800000 (30 minutes)
+      lifetime: 1800000
+    memory:
+      # Lifetime of cached list memberships in memory. Default: 60000 (1 minute)
+      lifetime: 60000
+      # Maximum number of list memberships cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of client apps in memory. Default: 604800000 (1 week)
-  clientAppMemoryLifetime: 604800000
-  # Maximum number of client apps cached in memory. Default: 1000
-  clientAppMemoryCapacity: 1000
+  clientApp:
+    memory:
+      # Lifetime of client apps in memory. Default: 604800000 (1 week)
+      lifetime: 604800000
+      # Maximum number of client apps cached in memory. Default: 1000
+      capacity: 1000
 
-  # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
-  avatarDecorationsMemoryLifetime: 1800000
+  avatarDecorations:
+    memory:
+      # Lifetime of cached avatar decorations in memory. Default: 1800000 (30 minutes)
+      lifetime: 1800000
 
-  # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
-  relaysMemoryLifetime: 600000
+  relays:
+    memory:
+      # Lifetime of cached relays in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
-  # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
-  suspendedHostsMemoryLifetime: 3600000
+  suspendedHosts:
+    memory:
+      # Lifetime of cached suspended hosts in memory. Default: 3600000 (1 hour)
+      lifetime: 3600000
 
-  # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
-  nodeInfoMemoryLifetime: 600000
+  nodeInfo:
+    memory:
+      # Lifetime of cached node info in memory. Default: 600000 (10 minutes)
+      lifetime: 600000
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -86,78 +86,29 @@ type Source = {
 	deliverJobMaxAttempts?: number;
 	inboxJobMaxAttempts?: number;
 	caches?: {
-		userByIdMemoryLifetime?: number;
-		userByIdMemoryCapacity?: number;
-
-		localUserByIdMemoryLifetime?: number;
-		localUserByIdMemoryCapacity?: number;
-
-		userByTokenMemoryLifetime?: number;
-		userByTokenMemoryCapacity?: number;
-
-		userByUriMemoryLifetime?: number;
-		userByUriMemoryCapacity?: number;
-
-		userProfileRedisLifetime?: number;
-		userProfileMemoryLifetime?: number;
-		userProfileMemoryCapacity?: number;
-
-		userKeyPairRedisLifetime?: number;
-		userKeyPairMemoryLifetime?: number;
-		userKeyPairMemoryCapacity?: number;
-
-		rolesMemoryLifetime?: number;
-
-		userRolesMemoryLifetime?: number;
-		userRolesMemoryCapacity?: number;
-
-		userMutesRedisLifetime?: number;
-		userMutesMemoryLifetime?: number;
-		userMutesMemoryCapacity?: number;
-
-		userBlocksRedisLifetime?: number;
-		userBlocksMemoryLifetime?: number;
-		userBlocksMemoryCapacity?: number;
-
-		userFollowingsRedisLifetime?: number;
-		userFollowingsMemoryLifetime?: number;
-		userFollowingsMemoryCapacity?: number;
-
-		userChannelsRedisLifetime?: number;
-		userChannelsMemoryLifetime?: number;
-		userChannelsMemoryCapacity?: number;
-
-		publicKeysMemoryLifetime?: number;
-		publicKeysMemoryCapacity?: number;
-
-		emojisMemoryLifetime?: number;
-		emojisMemoryCapacity?: number;
-
-		localEmojisRedisLifetime?: number;
-		localEmojisMemoryLifetime?: number;
-
-		instanceRedisLifetime?: number;
-		instanceMemoryLifetime?: number;
-		instanceMemoryCapacity?: number;
-
-		swSubscriptionRedisLifetime?: number;
-		swSubscriptionMemoryLifetime?: number;
-		swSubscriptionMemoryCapacity?: number;
-
-		listMembershipRedisLifetime?: number;
-		listMembershipMemoryLifetime?: number;
-		listMembershipMemoryCapacity?: number;
-
-		clientAppMemoryLifetime?: number;
-		clientAppMemoryCapacity?: number;
-
-		avatarDecorationsMemoryLifetime?: number;
-
-		relaysMemoryLifetime?: number;
-
-		suspendedHostsMemoryLifetime?: number;
-
-		nodeInfoMemoryLifetime?: number;
+		localUserById?: MemoryKVConfigPartial;
+		userById?: MemoryKVConfigPartial;
+		userByToken?: MemoryKVConfigPartial;
+		userByUri?: MemoryKVConfigPartial;
+		userProfile?: RedisKVConfigPartial;
+		userKeyPair?: RedisKVConfigPartial;
+		userRoles?: MemoryKVConfigPartial;
+		userMutes?: RedisKVConfigPartial;
+		userBlocks?: RedisKVConfigPartial;
+		userFollowings?: RedisKVConfigPartial;
+		userChannels?: RedisKVConfigPartial;
+		roles?: MemorySingleConfigPartial;
+		publicKeys?: MemoryKVConfigPartial;
+		emojis?: MemoryKVConfigPartial;
+		localEmojis?: RedisSingleConfigPartial;
+		instance?: RedisKVConfigPartial;
+		swSubscription?: RedisKVConfigPartial;
+		listMembership?: RedisKVConfigPartial;
+		clientApp?: MemoryKVConfigPartial;
+		avatarDecorations?: MemorySingleConfigPartial;
+		relays?: MemorySingleConfigPartial;
+		suspendedHosts?: MemorySingleConfigPartial;
+		nodeInfo?: MemorySingleConfigPartial;
 	};
 
 	mediaProxy?: string;
@@ -171,6 +122,27 @@ type Source = {
 	deactivateAntennaThreshold?: number;
 	pidFile: string;
 };
+interface MemorySingleConfigPartial {
+	memory?: {
+		lifetime?: number;
+	}
+}
+interface RedisSingleConfigPartial extends MemorySingleConfigPartial {
+	redis?: {
+		lifetime?: number;
+	}
+}
+interface MemoryKVConfigPartial extends MemorySingleConfigPartial {
+	memory?: {
+		lifetime?: number;
+		capacity?: number;
+	}
+}
+interface RedisKVConfigPartial extends MemoryKVConfigPartial {
+	redis?: {
+		lifetime?: number;
+	}
+}
 
 export type Config = {
 	url: string;
@@ -221,78 +193,29 @@ export type Config = {
 	deliverJobMaxAttempts: number | undefined;
 	inboxJobMaxAttempts: number | undefined;
 	caches: {
-		userByIdMemoryLifetime: number;
-		userByIdMemoryCapacity: number;
-
-		localUserByIdMemoryLifetime: number;
-		localUserByIdMemoryCapacity: number;
-
-		userByTokenMemoryLifetime: number;
-		userByTokenMemoryCapacity: number;
-
-		userByUriMemoryLifetime: number;
-		userByUriMemoryCapacity: number;
-
-		userProfileRedisLifetime: number;
-		userProfileMemoryLifetime: number;
-		userProfileMemoryCapacity: number;
-
-		userKeyPairRedisLifetime: number;
-		userKeyPairMemoryLifetime: number;
-		userKeyPairMemoryCapacity: number;
-
-		rolesMemoryLifetime: number;
-
-		userRolesMemoryLifetime: number;
-		userRolesMemoryCapacity: number;
-
-		userMutesRedisLifetime: number;
-		userMutesMemoryLifetime: number;
-		userMutesMemoryCapacity: number;
-
-		userBlocksRedisLifetime: number;
-		userBlocksMemoryLifetime: number;
-		userBlocksMemoryCapacity: number;
-
-		userFollowingsRedisLifetime: number;
-		userFollowingsMemoryLifetime: number;
-		userFollowingsMemoryCapacity: number;
-
-		userChannelsRedisLifetime: number;
-		userChannelsMemoryLifetime: number;
-		userChannelsMemoryCapacity: number;
-
-		publicKeysMemoryLifetime: number;
-		publicKeysMemoryCapacity: number;
-
-		emojisMemoryLifetime: number;
-		emojisMemoryCapacity: number;
-
-		localEmojisRedisLifetime: number;
-		localEmojisMemoryLifetime: number;
-
-		instanceRedisLifetime: number;
-		instanceMemoryLifetime: number;
-		instanceMemoryCapacity: number;
-
-		swSubscriptionRedisLifetime: number;
-		swSubscriptionMemoryLifetime: number;
-		swSubscriptionMemoryCapacity: number;
-
-		listMembershipRedisLifetime: number;
-		listMembershipMemoryLifetime: number;
-		listMembershipMemoryCapacity: number;
-
-		clientAppMemoryLifetime: number;
-		clientAppMemoryCapacity: number;
-
-		avatarDecorationsMemoryLifetime: number;
-
-		relaysMemoryLifetime: number;
-
-		suspendedHostsMemoryLifetime: number;
-
-		nodeInfoMemoryLifetime: number;
+		localUserById: MemoryKVConfig;
+		userById: MemoryKVConfig;
+		userByToken: MemoryKVConfig;
+		userByUri: MemoryKVConfig;
+		userProfile: RedisKVConfig;
+		userKeyPair: RedisKVConfig;
+		userRoles: MemoryKVConfig;
+		userMutes: RedisKVConfig;
+		userBlocks: RedisKVConfig;
+		userFollowings: RedisKVConfig;
+		userChannels: RedisKVConfig;
+		roles: MemorySingleConfig;
+		publicKeys: MemoryKVConfig;
+		emojis: MemoryKVConfig;
+		localEmojis: RedisSingleConfig;
+		instance: RedisKVConfig;
+		swSubscription: RedisKVConfig;
+		listMembership: RedisKVConfig;
+		clientApp: MemoryKVConfig;
+		avatarDecorations: MemorySingleConfig;
+		relays: MemorySingleConfig;
+		suspendedHosts: MemorySingleConfig;
+		nodeInfo: MemorySingleConfig;
 	};
 	proxyRemoteFiles: boolean | undefined;
 	signToActivityPubGet: boolean | undefined;
@@ -324,6 +247,28 @@ export type Config = {
 	deactivateAntennaThreshold: number;
 	pidFile: string;
 };
+
+export interface MemorySingleConfig {
+	memory: {
+		lifetime: number;
+	}
+}
+export interface RedisSingleConfig extends MemorySingleConfig {
+	redis: {
+		lifetime: number;
+	}
+}
+export interface MemoryKVConfig extends MemorySingleConfig {
+	memory: {
+		lifetime: number;
+		capacity: number;
+	}
+}
+export interface RedisKVConfig extends MemoryKVConfig {
+	redis: {
+		lifetime: number;
+	}
+}
 
 const _filename = fileURLToPath(import.meta.url);
 const _dirname = dirname(_filename);
@@ -411,78 +356,168 @@ export function loadConfig(): Config {
 		deliverJobMaxAttempts: config.deliverJobMaxAttempts,
 		inboxJobMaxAttempts: config.inboxJobMaxAttempts,
 		caches: {
-			userByIdMemoryLifetime: config.caches?.userByIdMemoryLifetime ?? 43200000,
-			userByIdMemoryCapacity: config.caches?.userByIdMemoryCapacity ?? 15000,
-
-			localUserByIdMemoryLifetime: config.caches?.localUserByIdMemoryLifetime ?? 43200000,
-			localUserByIdMemoryCapacity: config.caches?.localUserByIdMemoryCapacity ?? 10000,
-
-			userByTokenMemoryLifetime: config.caches?.userByTokenMemoryLifetime ?? 43200000,
-			userByTokenMemoryCapacity: config.caches?.userByTokenMemoryCapacity ?? 10000,
-
-			userByUriMemoryLifetime: config.caches?.userByUriMemoryLifetime ?? 43200000,
-			userByUriMemoryCapacity: config.caches?.userByUriMemoryCapacity ?? 10000,
-
-			userProfileRedisLifetime: config.caches?.userProfileRedisLifetime ?? 1800000,
-			userProfileMemoryLifetime: config.caches?.userProfileMemoryLifetime ?? 60000,
-			userProfileMemoryCapacity: config.caches?.userProfileMemoryCapacity ?? 10000,
-
-			userKeyPairRedisLifetime: config.caches?.userKeyPairRedisLifetime ?? 86400000,
-			userKeyPairMemoryLifetime: config.caches?.userKeyPairMemoryLifetime ?? 43200000,
-			userKeyPairMemoryCapacity: config.caches?.userKeyPairMemoryCapacity ?? 10000,
-
-			rolesMemoryLifetime: config.caches?.rolesMemoryLifetime ?? 3600000,
-
-			userRolesMemoryLifetime: config.caches?.userRolesMemoryLifetime ?? 3600000,
-			userRolesMemoryCapacity: config.caches?.userRolesMemoryCapacity ?? 10000,
-
-			userMutesRedisLifetime: config.caches?.userMutesRedisLifetime ?? 1800000,
-			userMutesMemoryLifetime: config.caches?.userMutesMemoryLifetime ?? 60000,
-			userMutesMemoryCapacity: config.caches?.userMutesMemoryCapacity ?? 10000,
-
-			userBlocksRedisLifetime: config.caches?.userBlocksRedisLifetime ?? 1800000,
-			userBlocksMemoryLifetime: config.caches?.userBlocksMemoryLifetime ?? 60000,
-			userBlocksMemoryCapacity: config.caches?.userBlocksMemoryCapacity ?? 10000,
-
-			userFollowingsRedisLifetime: config.caches?.userFollowingsRedisLifetime ?? 1800000,
-			userFollowingsMemoryLifetime: config.caches?.userFollowingsMemoryLifetime ?? 60000,
-			userFollowingsMemoryCapacity: config.caches?.userFollowingsMemoryCapacity ?? 10000,
-
-			userChannelsRedisLifetime: config.caches?.userChannelsRedisLifetime ?? 1800000,
-			userChannelsMemoryLifetime: config.caches?.userChannelsMemoryLifetime ?? 60000,
-			userChannelsMemoryCapacity: config.caches?.userChannelsMemoryCapacity ?? 1000,
-
-			publicKeysMemoryLifetime: config.caches?.publicKeysMemoryLifetime ?? 43200000,
-			publicKeysMemoryCapacity: config.caches?.publicKeysMemoryCapacity ?? 15000,
-
-			emojisMemoryLifetime: config.caches?.emojisMemoryLifetime ?? 43200000,
-			emojisMemoryCapacity: config.caches?.emojisMemoryCapacity ?? 5000,
-
-			localEmojisRedisLifetime: config.caches?.localEmojisRedisLifetime ?? 1800000,
-			localEmojisMemoryLifetime: config.caches?.localEmojisMemoryLifetime ?? 180000,
-
-			instanceRedisLifetime: config.caches?.instanceRedisLifetime ?? 1800000,
-			instanceMemoryLifetime: config.caches?.instanceMemoryLifetime ?? 180000,
-			instanceMemoryCapacity: config.caches?.instanceMemoryCapacity ?? 5000,
-
-			swSubscriptionRedisLifetime: config.caches?.swSubscriptionRedisLifetime ?? 3600000,
-			swSubscriptionMemoryLifetime: config.caches?.swSubscriptionMemoryLifetime ?? 180000,
-			swSubscriptionMemoryCapacity: config.caches?.swSubscriptionMemoryCapacity ?? 1000,
-
-			listMembershipRedisLifetime: config.caches?.listMembershipRedisLifetime ?? 1800000,
-			listMembershipMemoryLifetime: config.caches?.listMembershipMemoryLifetime ?? 60000,
-			listMembershipMemoryCapacity: config.caches?.listMembershipMemoryCapacity ?? 1000,
-
-			clientAppMemoryLifetime: config.caches?.clientAppMemoryLifetime ?? 604800000,
-			clientAppMemoryCapacity: config.caches?.clientAppMemoryCapacity ?? 1000,
-
-			avatarDecorationsMemoryLifetime: config.caches?.avatarDecorationsMemoryLifetime ?? 1800000,
-
-			relaysMemoryLifetime: config.caches?.relaysMemoryLifetime ?? 600000,
-
-			suspendedHostsMemoryLifetime: config.caches?.suspendedHostsMemoryLifetime ?? 3600000,
-
-			nodeInfoMemoryLifetime: config.caches?.nodeInfoMemoryLifetime ?? 600000,
+			localUserById: {
+				memory: {
+					lifetime: config.caches?.localUserById?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.localUserById?.memory?.capacity ?? 10000,
+				},
+			},
+			userById: {
+				memory: {
+					lifetime: config.caches?.userById?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.userById?.memory?.capacity ?? 15000,
+				},
+			},
+			userByToken: {
+				memory: {
+					lifetime: config.caches?.userByToken?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.userByToken?.memory?.capacity ?? 10000,
+				},
+			},
+			userByUri: {
+				memory: {
+					lifetime: config.caches?.userByUri?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.userByUri?.memory?.capacity ?? 10000,
+				},
+			},
+			userProfile: {
+				redis: {
+					lifetime: config.caches?.userProfile?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.userProfile?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.userProfile?.memory?.capacity ?? 10000,
+				},
+			},
+			userKeyPair: {
+				redis: {
+					lifetime: config.caches?.userKeyPair?.redis?.lifetime ?? 86400000,
+				},
+				memory: {
+					lifetime: config.caches?.userKeyPair?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.userKeyPair?.memory?.capacity ?? 10000,
+				},
+			},
+			userRoles: {
+				memory: {
+					lifetime: config.caches?.userRoles?.memory?.lifetime ?? 3600000,
+					capacity: config.caches?.userRoles?.memory?.capacity ?? 10000,
+				},
+			},
+			userMutes: {
+				redis: {
+					lifetime: config.caches?.userMutes?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.userMutes?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.userMutes?.memory?.capacity ?? 10000,
+				},
+			},
+			userBlocks: {
+				redis: {
+					lifetime: config.caches?.userBlocks?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.userBlocks?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.userBlocks?.memory?.capacity ?? 10000,
+				},
+			},
+			userFollowings: {
+				redis: {
+					lifetime: config.caches?.userFollowings?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.userFollowings?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.userFollowings?.memory?.capacity ?? 10000,
+				},
+			},
+			userChannels: {
+				redis: {
+					lifetime: config.caches?.userChannels?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.userChannels?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.userChannels?.memory?.capacity ?? 10000,
+				},
+			},
+			roles: {
+				memory: {
+					lifetime: config.caches?.roles?.memory?.lifetime ?? 3600000,
+				},
+			},
+			publicKeys: {
+				memory: {
+					lifetime: config.caches?.publicKeys?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.publicKeys?.memory?.capacity ?? 15000,
+				},
+			},
+			emojis: {
+				memory: {
+					lifetime: config.caches?.emojis?.memory?.lifetime ?? 43200000,
+					capacity: config.caches?.emojis?.memory?.capacity ?? 5000,
+				},
+			},
+			localEmojis: {
+				redis: {
+					lifetime: config.caches?.localEmojis?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.localEmojis?.memory?.lifetime ?? 180000,
+				},
+			},
+			instance: {
+				redis: {
+					lifetime: config.caches?.instance?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.instance?.memory?.lifetime ?? 180000,
+					capacity: config.caches?.instance?.memory?.capacity ?? 5000,
+				},
+			},
+			swSubscription: {
+				redis: {
+					lifetime: config.caches?.swSubscription?.redis?.lifetime ?? 3600000,
+				},
+				memory: {
+					lifetime: config.caches?.swSubscription?.memory?.lifetime ?? 180000,
+					capacity: config.caches?.swSubscription?.memory?.capacity ?? 1000,
+				},
+			},
+			listMembership: {
+				redis: {
+					lifetime: config.caches?.listMembership?.redis?.lifetime ?? 1800000,
+				},
+				memory: {
+					lifetime: config.caches?.listMembership?.memory?.lifetime ?? 60000,
+					capacity: config.caches?.listMembership?.memory?.capacity ?? 1000,
+				},
+			},
+			clientApp: {
+				memory: {
+					lifetime: config.caches?.clientApp?.memory?.lifetime ?? 604800000,
+					capacity: config.caches?.clientApp?.memory?.capacity ?? 1000,
+				},
+			},
+			avatarDecorations: {
+				memory: {
+					lifetime: config.caches?.avatarDecorations?.memory?.lifetime ?? 1800000,
+				},
+			},
+			relays: {
+				memory: {
+					lifetime: config.caches?.relays?.memory?.lifetime ?? 600000,
+				},
+			},
+			suspendedHosts: {
+				memory: {
+					lifetime: config.caches?.suspendedHosts?.memory?.lifetime ?? 3600000,
+				},
+			},
+			nodeInfo: {
+				memory: {
+					lifetime: config.caches?.nodeInfo?.memory?.lifetime ?? 600000,
+				},
+			},
 		},
 		proxyRemoteFiles: config.proxyRemoteFiles,
 		signToActivityPubGet: config.signToActivityPubGet ?? true,

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -85,6 +85,80 @@ type Source = {
 	relationshipJobPerSec?: number;
 	deliverJobMaxAttempts?: number;
 	inboxJobMaxAttempts?: number;
+	caches?: {
+		userByIdMemoryLifetime?: number;
+		userByIdMemoryCapacity?: number;
+
+		localUserByIdMemoryLifetime?: number;
+		localUserByIdMemoryCapacity?: number;
+
+		userByTokenMemoryLifetime?: number;
+		userByTokenMemoryCapacity?: number;
+
+		userByUriMemoryLifetime?: number;
+		userByUriMemoryCapacity?: number;
+
+		userProfileRedisLifetime?: number;
+		userProfileMemoryLifetime?: number;
+		userProfileMemoryCapacity?: number;
+
+		userKeyPairRedisLifetime?: number;
+		userKeyPairMemoryLifetime?: number;
+		userKeyPairMemoryCapacity?: number;
+
+		rolesMemoryLifetime?: number;
+
+		userRolesMemoryLifetime?: number;
+		userRolesMemoryCapacity?: number;
+
+		userMutesRedisLifetime?: number;
+		userMutesMemoryLifetime?: number;
+		userMutesMemoryCapacity?: number;
+
+		userBlocksRedisLifetime?: number;
+		userBlocksMemoryLifetime?: number;
+		userBlocksMemoryCapacity?: number;
+
+		userFollowingsRedisLifetime?: number;
+		userFollowingsMemoryLifetime?: number;
+		userFollowingsMemoryCapacity?: number;
+
+		userChannelsRedisLifetime?: number;
+		userChannelsMemoryLifetime?: number;
+		userChannelsMemoryCapacity?: number;
+
+		publicKeysMemoryLifetime?: number;
+		publicKeysMemoryCapacity?: number;
+
+		emojisMemoryLifetime?: number;
+		emojisMemoryCapacity?: number;
+
+		localEmojisRedisLifetime?: number;
+		localEmojisMemoryLifetime?: number;
+
+		instanceRedisLifetime?: number;
+		instanceMemoryLifetime?: number;
+		instanceMemoryCapacity?: number;
+
+		swSubscriptionRedisLifetime?: number;
+		swSubscriptionMemoryLifetime?: number;
+		swSubscriptionMemoryCapacity?: number;
+
+		listMembershipRedisLifetime?: number;
+		listMembershipMemoryLifetime?: number;
+		listMembershipMemoryCapacity?: number;
+
+		clientAppMemoryLifetime?: number;
+		clientAppMemoryCapacity?: number;
+
+		avatarDecorationsMemoryLifetime?: number;
+
+		relaysMemoryLifetime?: number;
+
+		suspendedHostsMemoryLifetime?: number;
+
+		nodeInfoMemoryLifetime?: number;
+	};
 
 	mediaProxy?: string;
 	proxyRemoteFiles?: boolean;
@@ -146,6 +220,80 @@ export type Config = {
 	relationshipJobPerSec: number | undefined;
 	deliverJobMaxAttempts: number | undefined;
 	inboxJobMaxAttempts: number | undefined;
+	caches: {
+		userByIdMemoryLifetime: number;
+		userByIdMemoryCapacity: number;
+
+		localUserByIdMemoryLifetime: number;
+		localUserByIdMemoryCapacity: number;
+
+		userByTokenMemoryLifetime: number;
+		userByTokenMemoryCapacity: number;
+
+		userByUriMemoryLifetime: number;
+		userByUriMemoryCapacity: number;
+
+		userProfileRedisLifetime: number;
+		userProfileMemoryLifetime: number;
+		userProfileMemoryCapacity: number;
+
+		userKeyPairRedisLifetime: number;
+		userKeyPairMemoryLifetime: number;
+		userKeyPairMemoryCapacity: number;
+
+		rolesMemoryLifetime: number;
+
+		userRolesMemoryLifetime: number;
+		userRolesMemoryCapacity: number;
+
+		userMutesRedisLifetime: number;
+		userMutesMemoryLifetime: number;
+		userMutesMemoryCapacity: number;
+
+		userBlocksRedisLifetime: number;
+		userBlocksMemoryLifetime: number;
+		userBlocksMemoryCapacity: number;
+
+		userFollowingsRedisLifetime: number;
+		userFollowingsMemoryLifetime: number;
+		userFollowingsMemoryCapacity: number;
+
+		userChannelsRedisLifetime: number;
+		userChannelsMemoryLifetime: number;
+		userChannelsMemoryCapacity: number;
+
+		publicKeysMemoryLifetime: number;
+		publicKeysMemoryCapacity: number;
+
+		emojisMemoryLifetime: number;
+		emojisMemoryCapacity: number;
+
+		localEmojisRedisLifetime: number;
+		localEmojisMemoryLifetime: number;
+
+		instanceRedisLifetime: number;
+		instanceMemoryLifetime: number;
+		instanceMemoryCapacity: number;
+
+		swSubscriptionRedisLifetime: number;
+		swSubscriptionMemoryLifetime: number;
+		swSubscriptionMemoryCapacity: number;
+
+		listMembershipRedisLifetime: number;
+		listMembershipMemoryLifetime: number;
+		listMembershipMemoryCapacity: number;
+
+		clientAppMemoryLifetime: number;
+		clientAppMemoryCapacity: number;
+
+		avatarDecorationsMemoryLifetime: number;
+
+		relaysMemoryLifetime: number;
+
+		suspendedHostsMemoryLifetime: number;
+
+		nodeInfoMemoryLifetime: number;
+	};
 	proxyRemoteFiles: boolean | undefined;
 	signToActivityPubGet: boolean | undefined;
 
@@ -262,6 +410,80 @@ export function loadConfig(): Config {
 		relationshipJobPerSec: config.relationshipJobPerSec,
 		deliverJobMaxAttempts: config.deliverJobMaxAttempts,
 		inboxJobMaxAttempts: config.inboxJobMaxAttempts,
+		caches: {
+			userByIdMemoryLifetime: config.caches?.userByIdMemoryLifetime ?? 43200000,
+			userByIdMemoryCapacity: config.caches?.userByIdMemoryCapacity ?? 15000,
+
+			localUserByIdMemoryLifetime: config.caches?.localUserByIdMemoryLifetime ?? 43200000,
+			localUserByIdMemoryCapacity: config.caches?.localUserByIdMemoryCapacity ?? 10000,
+
+			userByTokenMemoryLifetime: config.caches?.userByTokenMemoryLifetime ?? 43200000,
+			userByTokenMemoryCapacity: config.caches?.userByTokenMemoryCapacity ?? 10000,
+
+			userByUriMemoryLifetime: config.caches?.userByUriMemoryLifetime ?? 43200000,
+			userByUriMemoryCapacity: config.caches?.userByUriMemoryCapacity ?? 10000,
+
+			userProfileRedisLifetime: config.caches?.userProfileRedisLifetime ?? 1800000,
+			userProfileMemoryLifetime: config.caches?.userProfileMemoryLifetime ?? 60000,
+			userProfileMemoryCapacity: config.caches?.userProfileMemoryCapacity ?? 10000,
+
+			userKeyPairRedisLifetime: config.caches?.userKeyPairRedisLifetime ?? 86400000,
+			userKeyPairMemoryLifetime: config.caches?.userKeyPairMemoryLifetime ?? 43200000,
+			userKeyPairMemoryCapacity: config.caches?.userKeyPairMemoryCapacity ?? 10000,
+
+			rolesMemoryLifetime: config.caches?.rolesMemoryLifetime ?? 3600000,
+
+			userRolesMemoryLifetime: config.caches?.userRolesMemoryLifetime ?? 3600000,
+			userRolesMemoryCapacity: config.caches?.userRolesMemoryCapacity ?? 10000,
+
+			userMutesRedisLifetime: config.caches?.userMutesRedisLifetime ?? 1800000,
+			userMutesMemoryLifetime: config.caches?.userMutesMemoryLifetime ?? 60000,
+			userMutesMemoryCapacity: config.caches?.userMutesMemoryCapacity ?? 10000,
+
+			userBlocksRedisLifetime: config.caches?.userBlocksRedisLifetime ?? 1800000,
+			userBlocksMemoryLifetime: config.caches?.userBlocksMemoryLifetime ?? 60000,
+			userBlocksMemoryCapacity: config.caches?.userBlocksMemoryCapacity ?? 10000,
+
+			userFollowingsRedisLifetime: config.caches?.userFollowingsRedisLifetime ?? 1800000,
+			userFollowingsMemoryLifetime: config.caches?.userFollowingsMemoryLifetime ?? 60000,
+			userFollowingsMemoryCapacity: config.caches?.userFollowingsMemoryCapacity ?? 10000,
+
+			userChannelsRedisLifetime: config.caches?.userChannelsRedisLifetime ?? 1800000,
+			userChannelsMemoryLifetime: config.caches?.userChannelsMemoryLifetime ?? 60000,
+			userChannelsMemoryCapacity: config.caches?.userChannelsMemoryCapacity ?? 1000,
+
+			publicKeysMemoryLifetime: config.caches?.publicKeysMemoryLifetime ?? 43200000,
+			publicKeysMemoryCapacity: config.caches?.publicKeysMemoryCapacity ?? 15000,
+
+			emojisMemoryLifetime: config.caches?.emojisMemoryLifetime ?? 43200000,
+			emojisMemoryCapacity: config.caches?.emojisMemoryCapacity ?? 5000,
+
+			localEmojisRedisLifetime: config.caches?.localEmojisRedisLifetime ?? 1800000,
+			localEmojisMemoryLifetime: config.caches?.localEmojisMemoryLifetime ?? 180000,
+
+			instanceRedisLifetime: config.caches?.instanceRedisLifetime ?? 1800000,
+			instanceMemoryLifetime: config.caches?.instanceMemoryLifetime ?? 180000,
+			instanceMemoryCapacity: config.caches?.instanceMemoryCapacity ?? 5000,
+
+			swSubscriptionRedisLifetime: config.caches?.swSubscriptionRedisLifetime ?? 3600000,
+			swSubscriptionMemoryLifetime: config.caches?.swSubscriptionMemoryLifetime ?? 180000,
+			swSubscriptionMemoryCapacity: config.caches?.swSubscriptionMemoryCapacity ?? 1000,
+
+			listMembershipRedisLifetime: config.caches?.listMembershipRedisLifetime ?? 1800000,
+			listMembershipMemoryLifetime: config.caches?.listMembershipMemoryLifetime ?? 60000,
+			listMembershipMemoryCapacity: config.caches?.listMembershipMemoryCapacity ?? 1000,
+
+			clientAppMemoryLifetime: config.caches?.clientAppMemoryLifetime ?? 604800000,
+			clientAppMemoryCapacity: config.caches?.clientAppMemoryCapacity ?? 1000,
+
+			avatarDecorationsMemoryLifetime: config.caches?.avatarDecorationsMemoryLifetime ?? 1800000,
+
+			relaysMemoryLifetime: config.caches?.relaysMemoryLifetime ?? 600000,
+
+			suspendedHostsMemoryLifetime: config.caches?.suspendedHostsMemoryLifetime ?? 3600000,
+
+			nodeInfoMemoryLifetime: config.caches?.nodeInfoMemoryLifetime ?? 600000,
+		},
 		proxyRemoteFiles: config.proxyRemoteFiles,
 		signToActivityPubGet: config.signToActivityPubGet ?? true,
 		mediaProxy: externalMediaProxy ?? internalMediaProxy,

--- a/packages/backend/src/core/AvatarDecorationService.ts
+++ b/packages/backend/src/core/AvatarDecorationService.ts
@@ -13,12 +13,16 @@ import { bindThis } from '@/decorators.js';
 import { MemorySingleCache } from '@/misc/cache.js';
 import type { GlobalEvents } from '@/core/GlobalEventService.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
+import type { Config } from '@/config.js';
 
 @Injectable()
 export class AvatarDecorationService implements OnApplicationShutdown {
 	public cache: MemorySingleCache<MiAvatarDecoration[]>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.redisForSub)
 		private redisForSub: Redis.Redis,
 
@@ -29,7 +33,7 @@ export class AvatarDecorationService implements OnApplicationShutdown {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemorySingleCache<MiAvatarDecoration[]>(1000 * 60 * 30);
+		this.cache = new MemorySingleCache<MiAvatarDecoration[]>(config.caches.avatarDecorationsMemoryLifetime);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/AvatarDecorationService.ts
+++ b/packages/backend/src/core/AvatarDecorationService.ts
@@ -33,7 +33,7 @@ export class AvatarDecorationService implements OnApplicationShutdown {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemorySingleCache<MiAvatarDecoration[]>(config.caches.avatarDecorationsMemoryLifetime);
+		this.cache = new MemorySingleCache<MiAvatarDecoration[]>(config.caches.avatarDecorations);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/CacheService.ts
+++ b/packages/backend/src/core/CacheService.ts
@@ -56,10 +56,10 @@ export class CacheService implements OnApplicationShutdown {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.userByIdCache = new MemoryKVCache<MiUser>(Infinity, Infinity);
-		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(Infinity, Infinity);
-		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(Infinity, Infinity);
-		this.uriPersonCache = new MemoryKVCache<MiUser | null>(Infinity, Infinity);
+		this.userByIdCache = new MemoryKVCache<MiUser>(1000 * 60 * 60 * 12, 15_000); // 12h (used by AP *and* Auth)
+		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(1000 * 60 * 60 * 12, 10_000); // 12h (used by auth)
+		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(1000 * 60 * 60 * 12, 10_000); // 12h (used by auth)
+		this.uriPersonCache = new MemoryKVCache<MiUser | null>(1000 * 60 * 60 * 12, 10_000); // 12h (used by AP)
 
 		this.userProfileCache = new RedisKVCache<MiUserProfile>(this.redisClient, 'userProfile', {
 			lifetime: 1000 * 60 * 30, // 30m

--- a/packages/backend/src/core/CacheService.ts
+++ b/packages/backend/src/core/CacheService.ts
@@ -56,10 +56,10 @@ export class CacheService implements OnApplicationShutdown {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.userByIdCache = new MemoryKVCache<MiUser>(Infinity);
-		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(Infinity);
-		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(Infinity);
-		this.uriPersonCache = new MemoryKVCache<MiUser | null>(Infinity);
+		this.userByIdCache = new MemoryKVCache<MiUser>(Infinity, Infinity);
+		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(Infinity, Infinity);
+		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(Infinity, Infinity);
+		this.uriPersonCache = new MemoryKVCache<MiUser | null>(Infinity, Infinity);
 
 		this.userProfileCache = new RedisKVCache<MiUserProfile>(this.redisClient, 'userProfile', {
 			lifetime: 1000 * 60 * 30, // 30m
@@ -135,14 +135,14 @@ export class CacheService implements OnApplicationShutdown {
 					if (user == null) {
 						this.userByIdCache.delete(body.id);
 						this.localUserByIdCache.delete(body.id);
-						for (const [k, v] of this.uriPersonCache.cache.entries()) {
+						for (const [k, v] of this.uriPersonCache.entries()) {
 							if (v.value?.id === body.id) {
 								this.uriPersonCache.delete(k);
 							}
 						}
 					} else {
 						this.userByIdCache.set(user.id, user);
-						for (const [k, v] of this.uriPersonCache.cache.entries()) {
+						for (const [k, v] of this.uriPersonCache.entries()) {
 							if (v.value?.id === user.id) {
 								this.uriPersonCache.set(k, user);
 							}

--- a/packages/backend/src/core/CacheService.ts
+++ b/packages/backend/src/core/CacheService.ts
@@ -60,60 +60,48 @@ export class CacheService implements OnApplicationShutdown {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.userByIdCache = new MemoryKVCache<MiUser>(config.caches.userByIdMemoryLifetime, config.caches.userByIdMemoryCapacity);
-		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(config.caches.userByTokenMemoryLifetime, config.caches.userByTokenMemoryCapacity);
-		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(config.caches.localUserByIdMemoryLifetime, config.caches.localUserByIdMemoryCapacity); // 12h (used by auth)
-		this.uriPersonCache = new MemoryKVCache<MiUser | null>(config.caches.userByUriMemoryLifetime, config.caches.userByUriMemoryCapacity);
+		this.userByIdCache = new MemoryKVCache<MiUser>(config.caches.userById);
+		this.localUserByNativeTokenCache = new MemoryKVCache<MiLocalUser | null>(config.caches.userByToken);
+		this.localUserByIdCache = new MemoryKVCache<MiLocalUser>(config.caches.localUserById); // 12h (used by auth)
+		this.uriPersonCache = new MemoryKVCache<MiUser | null>(config.caches.userByUri);
 
 		this.userProfileCache = new RedisKVCache<MiUserProfile>(this.redisClient, 'userProfile', {
-			lifetime: config.caches.userProfileRedisLifetime,
-			memoryCacheLifetime: config.caches.userProfileMemoryLifetime,
-			memoryCacheCapacity: config.caches.userProfileMemoryCapacity,
+			config: config.caches.userProfile,
 			fetcher: (key) => this.userProfilesRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value), // TODO: date型の考慮
 		});
 
 		this.userMutingsCache = new RedisKVCache<Set<string>>(this.redisClient, 'userMutings', {
-			lifetime: config.caches.userMutesRedisLifetime,
-			memoryCacheLifetime: config.caches.userMutesMemoryLifetime,
-			memoryCacheCapacity: config.caches.userMutesMemoryCapacity,
+			config: config.caches.userMutes,
 			fetcher: (key) => this.mutingsRepository.find({ where: { muterId: key }, select: ['muteeId'] }).then(xs => new Set(xs.map(x => x.muteeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
 		});
 
 		this.userBlockingCache = new RedisKVCache<Set<string>>(this.redisClient, 'userBlocking', {
-			lifetime: config.caches.userBlocksRedisLifetime,
-			memoryCacheLifetime: config.caches.userBlocksMemoryLifetime,
-			memoryCacheCapacity: config.caches.userBlocksMemoryCapacity,
+			config: config.caches.userBlocks,
 			fetcher: (key) => this.blockingsRepository.find({ where: { blockerId: key }, select: ['blockeeId'] }).then(xs => new Set(xs.map(x => x.blockeeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
 		});
 
 		this.userBlockedCache = new RedisKVCache<Set<string>>(this.redisClient, 'userBlocked', {
-			lifetime: config.caches.userBlocksRedisLifetime,
-			memoryCacheLifetime: config.caches.userBlocksMemoryLifetime,
-			memoryCacheCapacity: config.caches.userBlocksMemoryCapacity,
+			config: config.caches.userBlocks,
 			fetcher: (key) => this.blockingsRepository.find({ where: { blockeeId: key }, select: ['blockerId'] }).then(xs => new Set(xs.map(x => x.blockerId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
 		});
 
 		this.renoteMutingsCache = new RedisKVCache<Set<string>>(this.redisClient, 'renoteMutings', {
-			lifetime: config.caches.userMutesRedisLifetime,
-			memoryCacheLifetime: config.caches.userMutesMemoryLifetime,
-			memoryCacheCapacity: config.caches.userMutesMemoryCapacity,
+			config: config.caches.userMutes,
 			fetcher: (key) => this.renoteMutingsRepository.find({ where: { muterId: key }, select: ['muteeId'] }).then(xs => new Set(xs.map(x => x.muteeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
 		});
 
 		this.userFollowingsCache = new RedisKVCache<Record<string, Pick<MiFollowing, 'withReplies'> | undefined>>(this.redisClient, 'userFollowings', {
-			lifetime: config.caches.userFollowingsRedisLifetime,
-			memoryCacheLifetime: config.caches.userFollowingsMemoryLifetime,
-			memoryCacheCapacity: config.caches.userFollowingsMemoryCapacity,
+			config: config.caches.userFollowings,
 			fetcher: (key) => this.followingsRepository.find({ where: { followerId: key }, select: ['followeeId', 'withReplies'] }).then(xs => {
 				const obj: Record<string, Pick<MiFollowing, 'withReplies'> | undefined> = {};
 				for (const x of xs) {

--- a/packages/backend/src/core/CacheService.ts
+++ b/packages/backend/src/core/CacheService.ts
@@ -64,6 +64,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.userProfileCache = new RedisKVCache<MiUserProfile>(this.redisClient, 'userProfile', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 10_000,
 			fetcher: (key) => this.userProfilesRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value), // TODO: date型の考慮
@@ -72,6 +73,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.userMutingsCache = new RedisKVCache<Set<string>>(this.redisClient, 'userMutings', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.mutingsRepository.find({ where: { muterId: key }, select: ['muteeId'] }).then(xs => new Set(xs.map(x => x.muteeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
@@ -80,6 +82,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.userBlockingCache = new RedisKVCache<Set<string>>(this.redisClient, 'userBlocking', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.blockingsRepository.find({ where: { blockerId: key }, select: ['blockeeId'] }).then(xs => new Set(xs.map(x => x.blockeeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
@@ -88,6 +91,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.userBlockedCache = new RedisKVCache<Set<string>>(this.redisClient, 'userBlocked', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.blockingsRepository.find({ where: { blockeeId: key }, select: ['blockerId'] }).then(xs => new Set(xs.map(x => x.blockerId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
@@ -96,6 +100,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.renoteMutingsCache = new RedisKVCache<Set<string>>(this.redisClient, 'renoteMutings', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.renoteMutingsRepository.find({ where: { muterId: key }, select: ['muteeId'] }).then(xs => new Set(xs.map(x => x.muteeId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),
@@ -104,6 +109,7 @@ export class CacheService implements OnApplicationShutdown {
 		this.userFollowingsCache = new RedisKVCache<Record<string, Pick<MiFollowing, 'withReplies'> | undefined>>(this.redisClient, 'userFollowings', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.followingsRepository.find({ where: { followerId: key }, select: ['followeeId', 'withReplies'] }).then(xs => {
 				const obj: Record<string, Pick<MiFollowing, 'withReplies'> | undefined> = {};
 				for (const x of xs) {

--- a/packages/backend/src/core/CacheService.ts
+++ b/packages/backend/src/core/CacheService.ts
@@ -188,16 +188,6 @@ export class CacheService implements OnApplicationShutdown {
 	@bindThis
 	public dispose(): void {
 		this.redisForSub.off('message', this.onMessage);
-		this.userByIdCache.dispose();
-		this.localUserByNativeTokenCache.dispose();
-		this.localUserByIdCache.dispose();
-		this.uriPersonCache.dispose();
-		this.userProfileCache.dispose();
-		this.userMutingsCache.dispose();
-		this.userBlockingCache.dispose();
-		this.userBlockedCache.dispose();
-		this.renoteMutingsCache.dispose();
-		this.userFollowingsCache.dispose();
 	}
 
 	@bindThis

--- a/packages/backend/src/core/ChannelFollowingService.ts
+++ b/packages/backend/src/core/ChannelFollowingService.ts
@@ -31,6 +31,7 @@ export class ChannelFollowingService implements OnModuleInit {
 		this.userFollowingChannelsCache = new RedisKVCache<Set<string>>(this.redisClient, 'userFollowingChannels', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.channelFollowingsRepository.find({
 				where: { followerId: key },
 				select: ['followeeId'],

--- a/packages/backend/src/core/ChannelFollowingService.ts
+++ b/packages/backend/src/core/ChannelFollowingService.ts
@@ -32,9 +32,7 @@ export class ChannelFollowingService implements OnModuleInit {
 		private globalEventService: GlobalEventService,
 	) {
 		this.userFollowingChannelsCache = new RedisKVCache<Set<string>>(this.redisClient, 'userFollowingChannels', {
-			lifetime: config.caches.userChannelsRedisLifetime,
-			memoryCacheLifetime: config.caches.userChannelsMemoryLifetime,
-			memoryCacheCapacity: config.caches.userChannelsMemoryCapacity,
+			config: config.caches.userChannels,
 			fetcher: (key) => this.channelFollowingsRepository.find({
 				where: { followerId: key },
 				select: ['followeeId'],

--- a/packages/backend/src/core/ChannelFollowingService.ts
+++ b/packages/backend/src/core/ChannelFollowingService.ts
@@ -13,12 +13,15 @@ import { GlobalEvents, GlobalEventService } from '@/core/GlobalEventService.js';
 import { bindThis } from '@/decorators.js';
 import type { MiLocalUser } from '@/models/User.js';
 import { RedisKVCache } from '@/misc/cache.js';
+import type { Config } from "@/config.js";
 
 @Injectable()
 export class ChannelFollowingService implements OnModuleInit {
 	public userFollowingChannelsCache: RedisKVCache<Set<string>>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 		@Inject(DI.redisForSub)
@@ -29,9 +32,9 @@ export class ChannelFollowingService implements OnModuleInit {
 		private globalEventService: GlobalEventService,
 	) {
 		this.userFollowingChannelsCache = new RedisKVCache<Set<string>>(this.redisClient, 'userFollowingChannels', {
-			lifetime: 1000 * 60 * 30, // 30m
-			memoryCacheLifetime: 1000 * 60, // 1m
-			memoryCacheCapacity: 1_000,
+			lifetime: config.caches.userChannelsRedisLifetime,
+			memoryCacheLifetime: config.caches.userChannelsMemoryLifetime,
+			memoryCacheCapacity: config.caches.userChannelsMemoryCapacity,
 			fetcher: (key) => this.channelFollowingsRepository.find({
 				where: { followerId: key },
 				select: ['followeeId'],

--- a/packages/backend/src/core/ChannelFollowingService.ts
+++ b/packages/backend/src/core/ChannelFollowingService.ts
@@ -97,14 +97,4 @@ export class ChannelFollowingService implements OnModuleInit {
 			}
 		}
 	}
-
-	@bindThis
-	public dispose(): void {
-		this.userFollowingChannelsCache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
-	}
 }

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -40,11 +40,10 @@ export class CustomEmojiService {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemoryKVCache<MiEmoji | null>(config.caches.emojisMemoryLifetime, config.caches.emojisMemoryCapacity);
+		this.cache = new MemoryKVCache<MiEmoji | null>(config.caches.emojis);
 
 		this.localEmojisCache = new RedisSingleCache<Map<string, MiEmoji>>(this.redisClient, 'localEmojis', {
-			lifetime: config.caches.localEmojisRedisLifetime,
-			memoryCacheLifetime: config.caches.localEmojisMemoryLifetime,
+			config: config.caches.localEmojis,
 			fetcher: () => this.emojisRepository.find({ where: { host: IsNull() } }).then(emojis => new Map(emojis.map(emoji => [emoji.name, emoji]))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value.values())),
 			fromRedisConverter: (value) => {

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -40,7 +40,7 @@ export class CustomEmojiService implements OnApplicationShutdown {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12);
+		this.cache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12, Infinity);
 
 		this.localEmojisCache = new RedisSingleCache<Map<string, MiEmoji>>(this.redisClient, 'localEmojis', {
 			lifetime: 1000 * 60 * 30, // 30m

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -40,11 +40,11 @@ export class CustomEmojiService {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12, 5_000);
+		this.cache = new MemoryKVCache<MiEmoji | null>(config.caches.emojisMemoryLifetime, config.caches.emojisMemoryCapacity);
 
 		this.localEmojisCache = new RedisSingleCache<Map<string, MiEmoji>>(this.redisClient, 'localEmojis', {
-			lifetime: 1000 * 60 * 30, // 30m
-			memoryCacheLifetime: 1000 * 60 * 3, // 3m
+			lifetime: config.caches.localEmojisRedisLifetime,
+			memoryCacheLifetime: config.caches.localEmojisMemoryLifetime,
 			fetcher: () => this.emojisRepository.find({ where: { host: IsNull() } }).then(emojis => new Map(emojis.map(emoji => [emoji.name, emoji]))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value.values())),
 			fromRedisConverter: (value) => {

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -40,7 +40,7 @@ export class CustomEmojiService implements OnApplicationShutdown {
 		private moderationLogService: ModerationLogService,
 		private globalEventService: GlobalEventService,
 	) {
-		this.cache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12, Infinity);
+		this.cache = new MemoryKVCache<MiEmoji | null>(1000 * 60 * 60 * 12, 5_000);
 
 		this.localEmojisCache = new RedisSingleCache<Map<string, MiEmoji>>(this.redisClient, 'localEmojis', {
 			lifetime: 1000 * 60 * 30, // 30m

--- a/packages/backend/src/core/CustomEmojiService.ts
+++ b/packages/backend/src/core/CustomEmojiService.ts
@@ -23,7 +23,7 @@ import { ModerationLogService } from '@/core/ModerationLogService.js';
 const parseEmojiStrRegexp = /^([-\w]+)(?:@([\w.-]+))?$/;
 
 @Injectable()
-export class CustomEmojiService implements OnApplicationShutdown {
+export class CustomEmojiService {
 	private cache: MemoryKVCache<MiEmoji | null>;
 	public localEmojisCache: RedisSingleCache<Map<string, MiEmoji>>;
 
@@ -397,15 +397,5 @@ export class CustomEmojiService implements OnApplicationShutdown {
 	@bindThis
 	public getEmojiByName(name: string): Promise<MiEmoji | null> {
 		return this.emojisRepository.findOneBy({ name, host: IsNull() });
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.cache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/core/FederatedInstanceService.ts
+++ b/packages/backend/src/core/FederatedInstanceService.ts
@@ -30,6 +30,7 @@ export class FederatedInstanceService implements OnApplicationShutdown {
 		this.federatedInstanceCache = new RedisKVCache<MiInstance | null>(this.redisClient, 'federatedInstance', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60 * 3, // 3m
+			memoryCacheCapacity: 5_000,
 			fetcher: (key) => this.instancesRepository.findOneBy({ host: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => {

--- a/packages/backend/src/core/FederatedInstanceService.ts
+++ b/packages/backend/src/core/FederatedInstanceService.ts
@@ -12,12 +12,16 @@ import { IdService } from '@/core/IdService.js';
 import { DI } from '@/di-symbols.js';
 import { UtilityService } from '@/core/UtilityService.js';
 import { bindThis } from '@/decorators.js';
+import type { Config } from "@/config.js";
 
 @Injectable()
 export class FederatedInstanceService {
 	public federatedInstanceCache: RedisKVCache<MiInstance | null>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 
@@ -28,9 +32,9 @@ export class FederatedInstanceService {
 		private idService: IdService,
 	) {
 		this.federatedInstanceCache = new RedisKVCache<MiInstance | null>(this.redisClient, 'federatedInstance', {
-			lifetime: 1000 * 60 * 30, // 30m
-			memoryCacheLifetime: 1000 * 60 * 3, // 3m
-			memoryCacheCapacity: 5_000,
+			lifetime: config.caches.instanceRedisLifetime,
+			memoryCacheLifetime: config.caches.instanceMemoryLifetime,
+			memoryCacheCapacity: config.caches.instanceMemoryCapacity,
 			fetcher: (key) => this.instancesRepository.findOneBy({ host: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => {

--- a/packages/backend/src/core/FederatedInstanceService.ts
+++ b/packages/backend/src/core/FederatedInstanceService.ts
@@ -14,7 +14,7 @@ import { UtilityService } from '@/core/UtilityService.js';
 import { bindThis } from '@/decorators.js';
 
 @Injectable()
-export class FederatedInstanceService implements OnApplicationShutdown {
+export class FederatedInstanceService {
 	public federatedInstanceCache: RedisKVCache<MiInstance | null>;
 
 	constructor(
@@ -83,15 +83,5 @@ export class FederatedInstanceService implements OnApplicationShutdown {
 			});
 
 		this.federatedInstanceCache.set(result.host, result);
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.federatedInstanceCache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/core/FederatedInstanceService.ts
+++ b/packages/backend/src/core/FederatedInstanceService.ts
@@ -32,9 +32,7 @@ export class FederatedInstanceService {
 		private idService: IdService,
 	) {
 		this.federatedInstanceCache = new RedisKVCache<MiInstance | null>(this.redisClient, 'federatedInstance', {
-			lifetime: config.caches.instanceRedisLifetime,
-			memoryCacheLifetime: config.caches.instanceMemoryLifetime,
-			memoryCacheCapacity: config.caches.instanceMemoryCapacity,
+			config: config.caches.instance,
 			fetcher: (key) => this.instancesRepository.findOneBy({ host: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => {

--- a/packages/backend/src/core/InstanceActorService.ts
+++ b/packages/backend/src/core/InstanceActorService.ts
@@ -24,7 +24,11 @@ export class InstanceActorService {
 
 		private createSystemUserService: CreateSystemUserService,
 	) {
-		this.cache = new MemorySingleCache<MiLocalUser>(Infinity);
+		this.cache = new MemorySingleCache<MiLocalUser>({
+			memory: {
+				lifetime: Infinity,
+			},
+		});
 	}
 
 	@bindThis

--- a/packages/backend/src/core/PushNotificationService.ts
+++ b/packages/backend/src/core/PushNotificationService.ts
@@ -63,9 +63,9 @@ export class PushNotificationService {
 		private metaService: MetaService,
 	) {
 		this.subscriptionsCache = new RedisKVCache<MiSwSubscription[]>(this.redisClient, 'userSwSubscriptions', {
-			lifetime: 1000 * 60 * 60 * 1, // 1h
-			memoryCacheLifetime: 1000 * 60 * 3, // 3m
-			memoryCacheCapacity: 1_000,
+			lifetime: config.caches.swSubscriptionRedisLifetime,
+			memoryCacheLifetime: config.caches.swSubscriptionMemoryLifetime,
+			memoryCacheCapacity: config.caches.swSubscriptionMemoryCapacity,
 			fetcher: (key) => this.swSubscriptionsRepository.findBy({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/PushNotificationService.ts
+++ b/packages/backend/src/core/PushNotificationService.ts
@@ -63,9 +63,7 @@ export class PushNotificationService {
 		private metaService: MetaService,
 	) {
 		this.subscriptionsCache = new RedisKVCache<MiSwSubscription[]>(this.redisClient, 'userSwSubscriptions', {
-			lifetime: config.caches.swSubscriptionRedisLifetime,
-			memoryCacheLifetime: config.caches.swSubscriptionMemoryLifetime,
-			memoryCacheCapacity: config.caches.swSubscriptionMemoryCapacity,
+			config: config.caches.swSubscription,
 			fetcher: (key) => this.swSubscriptionsRepository.findBy({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/PushNotificationService.ts
+++ b/packages/backend/src/core/PushNotificationService.ts
@@ -65,6 +65,7 @@ export class PushNotificationService implements OnApplicationShutdown {
 		this.subscriptionsCache = new RedisKVCache<MiSwSubscription[]>(this.redisClient, 'userSwSubscriptions', {
 			lifetime: 1000 * 60 * 60 * 1, // 1h
 			memoryCacheLifetime: 1000 * 60 * 3, // 3m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.swSubscriptionsRepository.findBy({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/PushNotificationService.ts
+++ b/packages/backend/src/core/PushNotificationService.ts
@@ -47,7 +47,7 @@ function truncateBody<T extends keyof PushNotificationsTypes>(type: T, body: Pus
 }
 
 @Injectable()
-export class PushNotificationService implements OnApplicationShutdown {
+export class PushNotificationService {
 	private subscriptionsCache: RedisKVCache<MiSwSubscription[]>;
 
 	constructor(
@@ -127,15 +127,5 @@ export class PushNotificationService implements OnApplicationShutdown {
 	@bindThis
 	public refreshCache(userId: string): void {
 		this.subscriptionsCache.refresh(userId);
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.subscriptionsCache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/core/RelayService.ts
+++ b/packages/backend/src/core/RelayService.ts
@@ -16,6 +16,7 @@ import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { DI } from '@/di-symbols.js';
 import { deepClone } from '@/misc/clone.js';
 import { bindThis } from '@/decorators.js';
+import type { Config } from "@/config.js";
 
 const ACTOR_USERNAME = 'relay.actor' as const;
 
@@ -24,6 +25,9 @@ export class RelayService {
 	private relaysCache: MemorySingleCache<MiRelay[]>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
 
@@ -35,7 +39,7 @@ export class RelayService {
 		private createSystemUserService: CreateSystemUserService,
 		private apRendererService: ApRendererService,
 	) {
-		this.relaysCache = new MemorySingleCache<MiRelay[]>(1000 * 60 * 10);
+		this.relaysCache = new MemorySingleCache<MiRelay[]>(config.caches.relaysMemoryLifetime);
 	}
 
 	@bindThis

--- a/packages/backend/src/core/RelayService.ts
+++ b/packages/backend/src/core/RelayService.ts
@@ -39,7 +39,7 @@ export class RelayService {
 		private createSystemUserService: CreateSystemUserService,
 		private apRendererService: ApRendererService,
 	) {
-		this.relaysCache = new MemorySingleCache<MiRelay[]>(config.caches.relaysMemoryLifetime);
+		this.relaysCache = new MemorySingleCache<MiRelay[]>(config.caches.relays);
 	}
 
 	@bindThis

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -129,8 +129,8 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.rolesCache = new MemorySingleCache<MiRole[]>(1000 * 60 * 60 * 1);
-		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(1000 * 60 * 60 * 1);
+		this.rolesCache = new MemorySingleCache<MiRole[]>(1000 * 60 * 60);
+		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(1000 * 60 * 60, Infinity);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -30,6 +30,7 @@ import type { Packed } from '@/misc/json-schema.js';
 import { FanoutTimelineService } from '@/core/FanoutTimelineService.js';
 import { NotificationService } from '@/core/NotificationService.js';
 import type { OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
+import type { Config } from "@/config.js";
 
 export type RolePolicies = {
 	gtlAvailable: boolean;
@@ -101,6 +102,9 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 	constructor(
 		private moduleRef: ModuleRef,
 
+		@Inject(DI.config)
+		config: Config,
+
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 
@@ -129,8 +133,8 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.rolesCache = new MemorySingleCache<MiRole[]>(1000 * 60 * 60);
-		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(1000 * 60 * 60, 10_000);
+		this.rolesCache = new MemorySingleCache<MiRole[]>(config.caches.rolesMemoryLifetime);
+		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(config.caches.userRolesMemoryLifetime, config.caches.userRolesMemoryCapacity);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -130,7 +130,7 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 		//this.onMessage = this.onMessage.bind(this);
 
 		this.rolesCache = new MemorySingleCache<MiRole[]>(1000 * 60 * 60);
-		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(1000 * 60 * 60, Infinity);
+		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(1000 * 60 * 60, 10_000);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -648,7 +648,6 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 	@bindThis
 	public dispose(): void {
 		this.redisForSub.off('message', this.onMessage);
-		this.roleAssignmentByUserIdCache.dispose();
 	}
 
 	@bindThis

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -133,8 +133,8 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 	) {
 		//this.onMessage = this.onMessage.bind(this);
 
-		this.rolesCache = new MemorySingleCache<MiRole[]>(config.caches.rolesMemoryLifetime);
-		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(config.caches.userRolesMemoryLifetime, config.caches.userRolesMemoryCapacity);
+		this.rolesCache = new MemorySingleCache<MiRole[]>(config.caches.roles);
+		this.roleAssignmentByUserIdCache = new MemoryKVCache<MiRoleAssignment[]>(config.caches.userRoles);
 
 		this.redisForSub.on('message', this.onMessage);
 	}

--- a/packages/backend/src/core/UserKeypairService.ts
+++ b/packages/backend/src/core/UserKeypairService.ts
@@ -26,6 +26,7 @@ export class UserKeypairService implements OnApplicationShutdown {
 		this.cache = new RedisKVCache<MiUserKeypair>(this.redisClient, 'userKeypair', {
 			lifetime: 1000 * 60 * 60 * 24, // 24h
 			memoryCacheLifetime: Infinity,
+			memoryCacheCapacity: Infinity,
 			fetcher: (key) => this.userKeypairsRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/UserKeypairService.ts
+++ b/packages/backend/src/core/UserKeypairService.ts
@@ -11,12 +11,16 @@ import { RedisKVCache } from '@/misc/cache.js';
 import type { MiUserKeypair } from '@/models/UserKeypair.js';
 import { DI } from '@/di-symbols.js';
 import { bindThis } from '@/decorators.js';
+import type { Config } from "@/config.js";
 
 @Injectable()
 export class UserKeypairService {
 	private cache: RedisKVCache<MiUserKeypair>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 
@@ -24,9 +28,9 @@ export class UserKeypairService {
 		private userKeypairsRepository: UserKeypairsRepository,
 	) {
 		this.cache = new RedisKVCache<MiUserKeypair>(this.redisClient, 'userKeypair', {
-			lifetime: 1000 * 60 * 60 * 24, // 24h
-			memoryCacheLifetime: 1000 * 60 * 60 * 12, // 12h
-			memoryCacheCapacity: 10_000, // Only local users have a keypair
+			lifetime: config.caches.userKeyPairRedisLifetime,
+			memoryCacheLifetime: config.caches.userKeyPairMemoryLifetime,
+			memoryCacheCapacity: config.caches.userKeyPairMemoryCapacity,
 			fetcher: (key) => this.userKeypairsRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/UserKeypairService.ts
+++ b/packages/backend/src/core/UserKeypairService.ts
@@ -25,8 +25,8 @@ export class UserKeypairService implements OnApplicationShutdown {
 	) {
 		this.cache = new RedisKVCache<MiUserKeypair>(this.redisClient, 'userKeypair', {
 			lifetime: 1000 * 60 * 60 * 24, // 24h
-			memoryCacheLifetime: Infinity,
-			memoryCacheCapacity: Infinity,
+			memoryCacheLifetime: 1000 * 60 * 60 * 12, // 12h
+			memoryCacheCapacity: 10_000, // Only local users have a keypair
 			fetcher: (key) => this.userKeypairsRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/UserKeypairService.ts
+++ b/packages/backend/src/core/UserKeypairService.ts
@@ -28,9 +28,7 @@ export class UserKeypairService {
 		private userKeypairsRepository: UserKeypairsRepository,
 	) {
 		this.cache = new RedisKVCache<MiUserKeypair>(this.redisClient, 'userKeypair', {
-			lifetime: config.caches.userKeyPairRedisLifetime,
-			memoryCacheLifetime: config.caches.userKeyPairMemoryLifetime,
-			memoryCacheCapacity: config.caches.userKeyPairMemoryCapacity,
+			config: config.caches.userKeyPair,
 			fetcher: (key) => this.userKeypairsRepository.findOneByOrFail({ userId: key }),
 			toRedisConverter: (value) => JSON.stringify(value),
 			fromRedisConverter: (value) => JSON.parse(value),

--- a/packages/backend/src/core/UserKeypairService.ts
+++ b/packages/backend/src/core/UserKeypairService.ts
@@ -13,7 +13,7 @@ import { DI } from '@/di-symbols.js';
 import { bindThis } from '@/decorators.js';
 
 @Injectable()
-export class UserKeypairService implements OnApplicationShutdown {
+export class UserKeypairService {
 	private cache: RedisKVCache<MiUserKeypair>;
 
 	constructor(
@@ -36,15 +36,5 @@ export class UserKeypairService implements OnApplicationShutdown {
 	@bindThis
 	public async getUserKeypair(userId: MiUser['id']): Promise<MiUserKeypair> {
 		return await this.cache.fetch(userId);
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.cache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/core/UserListService.ts
+++ b/packages/backend/src/core/UserListService.ts
@@ -51,9 +51,7 @@ export class UserListService implements OnApplicationShutdown, OnModuleInit {
 		private queueService: QueueService,
 	) {
 		this.membersCache = new RedisKVCache<Set<string>>(this.redisClient, 'userListMembers', {
-			lifetime: config.caches.listMembershipRedisLifetime,
-			memoryCacheLifetime: config.caches.listMembershipMemoryLifetime,
-			memoryCacheCapacity: config.caches.listMembershipMemoryCapacity,
+			config: config.caches.listMembership,
 			fetcher: (key) => this.userListMembershipsRepository.find({ where: { userListId: key }, select: ['userId'] }).then(xs => new Set(xs.map(x => x.userId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),

--- a/packages/backend/src/core/UserListService.ts
+++ b/packages/backend/src/core/UserListService.ts
@@ -49,6 +49,7 @@ export class UserListService implements OnApplicationShutdown, OnModuleInit {
 		this.membersCache = new RedisKVCache<Set<string>>(this.redisClient, 'userListMembers', {
 			lifetime: 1000 * 60 * 30, // 30m
 			memoryCacheLifetime: 1000 * 60, // 1m
+			memoryCacheCapacity: 1_000,
 			fetcher: (key) => this.userListMembershipsRepository.find({ where: { userListId: key }, select: ['userId'] }).then(xs => new Set(xs.map(x => x.userId))),
 			toRedisConverter: (value) => JSON.stringify(Array.from(value)),
 			fromRedisConverter: (value) => new Set(JSON.parse(value)),

--- a/packages/backend/src/core/UserListService.ts
+++ b/packages/backend/src/core/UserListService.ts
@@ -151,7 +151,6 @@ export class UserListService implements OnApplicationShutdown, OnModuleInit {
 	@bindThis
 	public dispose(): void {
 		this.redisForSub.off('message', this.onMessage);
-		this.membersCache.dispose();
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -54,8 +54,8 @@ export class ApDbResolverService implements OnApplicationShutdown {
 		private cacheService: CacheService,
 		private apPersonService: ApPersonService,
 	) {
-		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(Infinity, Infinity);
-		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(Infinity, Infinity);
+		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(1000 * 60 * 60 * 12, 15_000); // 12h (used by AP)
+		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(1000 * 60 * 60 * 12, 15_000); // 12h (used by AP)
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -34,7 +34,7 @@ export type UriParseResult = {
 };
 
 @Injectable()
-export class ApDbResolverService implements OnApplicationShutdown {
+export class ApDbResolverService {
 	private publicKeyCache: MemoryKVCache<MiUserPublickey | null>;
 	private publicKeyByUserIdCache: MemoryKVCache<MiUserPublickey | null>;
 
@@ -167,16 +167,5 @@ export class ApDbResolverService implements OnApplicationShutdown {
 			user,
 			key,
 		};
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.publicKeyCache.dispose();
-		this.publicKeyByUserIdCache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -54,8 +54,8 @@ export class ApDbResolverService {
 		private cacheService: CacheService,
 		private apPersonService: ApPersonService,
 	) {
-		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(1000 * 60 * 60 * 12, 15_000); // 12h (used by AP)
-		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(1000 * 60 * 60 * 12, 15_000); // 12h (used by AP)
+		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeysMemoryLifetime, config.caches.publicKeysMemoryCapacity);
+		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeysMemoryLifetime, config.caches.publicKeysMemoryCapacity);
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -54,8 +54,8 @@ export class ApDbResolverService implements OnApplicationShutdown {
 		private cacheService: CacheService,
 		private apPersonService: ApPersonService,
 	) {
-		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(Infinity);
-		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(Infinity);
+		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(Infinity, Infinity);
+		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(Infinity, Infinity);
 	}
 
 	@bindThis

--- a/packages/backend/src/core/activitypub/ApDbResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApDbResolverService.ts
@@ -54,8 +54,8 @@ export class ApDbResolverService {
 		private cacheService: CacheService,
 		private apPersonService: ApPersonService,
 	) {
-		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeysMemoryLifetime, config.caches.publicKeysMemoryCapacity);
-		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeysMemoryLifetime, config.caches.publicKeysMemoryCapacity);
+		this.publicKeyCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeys);
+		this.publicKeyByUserIdCache = new MemoryKVCache<MiUserPublickey | null>(config.caches.publicKeys);
 	}
 
 	@bindThis

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -89,18 +89,6 @@ export class RedisKVCache<T> {
 
 		// TODO: イベント発行して他プロセスのメモリキャッシュも更新できるようにする
 	}
-
-	/**
-	 * @deprecated No longer needed or used.
-	 */
-	@bindThis
-	public gc() {}
-
-	/**
-	 * @deprecated No longer needed or used.
-	 */
-	@bindThis
-	public dispose() {}
 }
 
 export class RedisSingleCache<T> {
@@ -291,18 +279,6 @@ export class MemoryKVCache<T> {
 		}
 		return value;
 	}
-
-	/**
-	 * @deprecated No longer needed or used.
-	 */
-	@bindThis
-	public gc(): void {}
-
-	/**
-	 * @deprecated No longer needed or used.
-	 */
-	@bindThis
-	public dispose(): void {}
 
 	private evictOldestKey(): void {
 		let oldestKey;

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -23,6 +23,15 @@ export class RedisKVCache<T> {
 		toRedisConverter: RedisKVCache<T>['toRedisConverter'];
 		fromRedisConverter: RedisKVCache<T>['fromRedisConverter'];
 	}) {
+		if (opts.lifetime <= 0) {
+			throw new Error(`Redis cache lifetime of ${opts.lifetime} is invalid - it must be greater than zero`);
+		}
+		if (opts.memoryCacheLifetime <= 0) {
+			throw new Error(`Memory cache lifetime of ${opts.memoryCacheLifetime} is invalid - it must be greater than zero`);
+		}
+		if (opts.memoryCacheCapacity <= 0) {
+			throw new Error(`Memory cache capacity of ${opts.memoryCacheCapacity} is invalid - it must be greater than zero`);
+		}
 		this.redisClient = redisClient;
 		this.name = name;
 		this.lifetime = opts.lifetime;
@@ -107,6 +116,12 @@ export class RedisSingleCache<T> {
 		toRedisConverter: RedisSingleCache<T>['toRedisConverter'];
 		fromRedisConverter: RedisSingleCache<T>['fromRedisConverter'];
 	}) {
+		if (opts.lifetime <= 0) {
+			throw new Error(`Redis cache lifetime of ${opts.lifetime} is invalid - it must be greater than zero`);
+		}
+		if (opts.memoryCacheLifetime <= 0) {
+			throw new Error(`Memory cache lifetime of ${opts.memoryCacheLifetime} is invalid - it must be greater than zero`);
+		}
 		this.redisClient = redisClient;
 		this.name = name;
 		this.lifetime = opts.lifetime;
@@ -181,7 +196,14 @@ export class MemoryKVCache<T> {
 	constructor (
 		private readonly lifetime: number,
 		private readonly capacity: number,
-	) {}
+	) {
+		if (lifetime <= 0) {
+			throw new Error(`Memory cache lifetime of ${lifetime} is invalid - it must be greater than zero`);
+		}
+		if (capacity <= 0) {
+			throw new Error(`Memory cache capacity of ${capacity} is invalid - it must be greater than zero`);
+		}
+	}
 
 	@bindThis
 	/**
@@ -313,6 +335,9 @@ export class MemorySingleCache<T> {
 	private lifetime: number;
 
 	constructor(lifetime: MemorySingleCache<never>['lifetime']) {
+		if (lifetime <= 0) {
+			throw new Error(`Cache lifetime of ${lifetime} is invalid - it must be greater than zero`);
+		}
 		this.lifetime = lifetime;
 	}
 

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -90,15 +90,17 @@ export class RedisKVCache<T> {
 		// TODO: イベント発行して他プロセスのメモリキャッシュも更新できるようにする
 	}
 
+	/**
+	 * @deprecated No longer needed or used.
+	 */
 	@bindThis
-	public gc() {
-		this.memoryCache.gc();
-	}
+	public gc() {}
 
+	/**
+	 * @deprecated No longer needed or used.
+	 */
 	@bindThis
-	public dispose() {
-		this.memoryCache.dispose();
-	}
+	public dispose() {}
 }
 
 export class RedisSingleCache<T> {
@@ -290,15 +292,17 @@ export class MemoryKVCache<T> {
 		return value;
 	}
 
+	/**
+	 * @deprecated No longer needed or used.
+	 */
 	@bindThis
-	public gc(): void {
-		// no-op, remove later
-	}
+	public gc(): void {}
 
+	/**
+	 * @deprecated No longer needed or used.
+	 */
 	@bindThis
-	public dispose(): void {
-		// no-op, remove later
-	}
+	public dispose(): void {}
 
 	private evictOldestKey(): void {
 		let oldestKey;

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -191,7 +191,7 @@ export class MemoryKVCache<T> {
 
 	constructor (
 		private readonly lifetime: number,
-		private readonly capacity: number
+		private readonly capacity: number,
 	) {}
 
 	@bindThis

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -18,6 +18,7 @@ export class RedisKVCache<T> {
 	constructor(redisClient: RedisKVCache<T>['redisClient'], name: RedisKVCache<T>['name'], opts: {
 		lifetime: RedisKVCache<T>['lifetime'];
 		memoryCacheLifetime: number;
+		memoryCacheCapacity: number;
 		fetcher: RedisKVCache<T>['fetcher'];
 		toRedisConverter: RedisKVCache<T>['toRedisConverter'];
 		fromRedisConverter: RedisKVCache<T>['fromRedisConverter'];
@@ -25,7 +26,7 @@ export class RedisKVCache<T> {
 		this.redisClient = redisClient;
 		this.name = name;
 		this.lifetime = opts.lifetime;
-		this.memoryCache = new MemoryKVCache(opts.memoryCacheLifetime, Infinity);
+		this.memoryCache = new MemoryKVCache(opts.memoryCacheLifetime, opts.memoryCacheCapacity);
 		this.fetcher = opts.fetcher;
 		this.toRedisConverter = opts.toRedisConverter;
 		this.fromRedisConverter = opts.fromRedisConverter;

--- a/packages/backend/src/misc/cache.ts
+++ b/packages/backend/src/misc/cache.ts
@@ -185,7 +185,6 @@ export class RedisSingleCache<T> {
 	}
 }
 
-// TODO: メモリ節約のためあまり参照されないキーを定期的に削除できるようにする？
 export class MemoryKVCache<T> {
 	private readonly cache = new Map<string, CacheEntry<T>>;
 

--- a/packages/backend/src/queue/processors/DeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeliverProcessorService.ts
@@ -49,7 +49,7 @@ export class DeliverProcessorService {
 		private queueLoggerService: QueueLoggerService,
 	) {
 		this.logger = this.queueLoggerService.logger.createSubLogger('deliver');
-		this.suspendedHostsCache = new MemorySingleCache<MiInstance[]>(config.caches.suspendedHostsMemoryLifetime);
+		this.suspendedHostsCache = new MemorySingleCache<MiInstance[]>(config.caches.suspendedHosts);
 	}
 
 	@bindThis

--- a/packages/backend/src/queue/processors/DeliverProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeliverProcessorService.ts
@@ -23,6 +23,7 @@ import { UtilityService } from '@/core/UtilityService.js';
 import { bindThis } from '@/decorators.js';
 import { QueueLoggerService } from '../QueueLoggerService.js';
 import type { DeliverJobData } from '../types.js';
+import type { Config } from "@/config.js";
 
 @Injectable()
 export class DeliverProcessorService {
@@ -31,6 +32,9 @@ export class DeliverProcessorService {
 	private latest: string | null;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.instancesRepository)
 		private instancesRepository: InstancesRepository,
 
@@ -45,7 +49,7 @@ export class DeliverProcessorService {
 		private queueLoggerService: QueueLoggerService,
 	) {
 		this.logger = this.queueLoggerService.logger.createSubLogger('deliver');
-		this.suspendedHostsCache = new MemorySingleCache<MiInstance[]>(1000 * 60 * 60);
+		this.suspendedHostsCache = new MemorySingleCache<MiInstance[]>(config.caches.suspendedHostsMemoryLifetime);
 	}
 
 	@bindThis

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -134,7 +134,7 @@ export class NodeinfoServerService {
 			return document;
 		};
 
-		const cache = new MemorySingleCache<Awaited<ReturnType<typeof nodeinfo2>>>(this.config.caches.nodeInfoMemoryLifetime);
+		const cache = new MemorySingleCache<Awaited<ReturnType<typeof nodeinfo2>>>(this.config.caches.nodeInfo);
 
 		fastify.get(nodeinfo2_1path, async (request, reply) => {
 			const base = await cache.fetch(() => nodeinfo2(21));

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -134,7 +134,7 @@ export class NodeinfoServerService {
 			return document;
 		};
 
-		const cache = new MemorySingleCache<Awaited<ReturnType<typeof nodeinfo2>>>(1000 * 60 * 10);
+		const cache = new MemorySingleCache<Awaited<ReturnType<typeof nodeinfo2>>>(this.config.caches.nodeInfoMemoryLifetime);
 
 		fastify.get(nodeinfo2_1path, async (request, reply) => {
 			const base = await cache.fetch(() => nodeinfo2(21));

--- a/packages/backend/src/server/api/AuthenticateService.ts
+++ b/packages/backend/src/server/api/AuthenticateService.ts
@@ -13,6 +13,7 @@ import type { MiApp } from '@/models/App.js';
 import { CacheService } from '@/core/CacheService.js';
 import isNativeToken from '@/misc/is-native-token.js';
 import { bindThis } from '@/decorators.js';
+import type { Config } from '@/config.js';
 
 export class AuthenticationError extends Error {
 	constructor(message: string) {
@@ -26,6 +27,9 @@ export class AuthenticateService {
 	private appCache: MemoryKVCache<MiApp>;
 
 	constructor(
+		@Inject(DI.config)
+			config: Config,
+
 		@Inject(DI.usersRepository)
 		private usersRepository: UsersRepository,
 
@@ -37,7 +41,7 @@ export class AuthenticateService {
 
 		private cacheService: CacheService,
 	) {
-		this.appCache = new MemoryKVCache<MiApp>(1000 * 60 * 60 * 24 * 7, 1_000); // 1w
+		this.appCache = new MemoryKVCache<MiApp>(config.caches.clientAppMemoryLifetime, config.caches.clientAppMemoryCapacity);
 	}
 
 	@bindThis

--- a/packages/backend/src/server/api/AuthenticateService.ts
+++ b/packages/backend/src/server/api/AuthenticateService.ts
@@ -37,7 +37,7 @@ export class AuthenticateService implements OnApplicationShutdown {
 
 		private cacheService: CacheService,
 	) {
-		this.appCache = new MemoryKVCache<MiApp>(Infinity, Infinity);
+		this.appCache = new MemoryKVCache<MiApp>(1000 * 60 * 60 * 24 * 7, 1_000); // 1w
 	}
 
 	@bindThis

--- a/packages/backend/src/server/api/AuthenticateService.ts
+++ b/packages/backend/src/server/api/AuthenticateService.ts
@@ -37,7 +37,7 @@ export class AuthenticateService implements OnApplicationShutdown {
 
 		private cacheService: CacheService,
 	) {
-		this.appCache = new MemoryKVCache<MiApp>(Infinity);
+		this.appCache = new MemoryKVCache<MiApp>(Infinity, Infinity);
 	}
 
 	@bindThis

--- a/packages/backend/src/server/api/AuthenticateService.ts
+++ b/packages/backend/src/server/api/AuthenticateService.ts
@@ -22,7 +22,7 @@ export class AuthenticationError extends Error {
 }
 
 @Injectable()
-export class AuthenticateService implements OnApplicationShutdown {
+export class AuthenticateService {
 	private appCache: MemoryKVCache<MiApp>;
 
 	constructor(
@@ -89,15 +89,5 @@ export class AuthenticateService implements OnApplicationShutdown {
 				return [user, accessToken];
 			}
 		}
-	}
-
-	@bindThis
-	public dispose(): void {
-		this.appCache.dispose();
-	}
-
-	@bindThis
-	public onApplicationShutdown(signal?: string | undefined): void {
-		this.dispose();
 	}
 }

--- a/packages/backend/src/server/api/AuthenticateService.ts
+++ b/packages/backend/src/server/api/AuthenticateService.ts
@@ -41,7 +41,7 @@ export class AuthenticateService {
 
 		private cacheService: CacheService,
 	) {
-		this.appCache = new MemoryKVCache<MiApp>(config.caches.clientAppMemoryLifetime, config.caches.clientAppMemoryCapacity);
+		this.appCache = new MemoryKVCache<MiApp>(config.caches.clientApp);
 	}
 
 	@bindThis

--- a/packages/backend/src/server/oauth/OAuth2ProviderService.ts
+++ b/packages/backend/src/server/oauth/OAuth2ProviderService.ts
@@ -197,7 +197,7 @@ function getQueryMode(issuerUrl: string): oauth2orize.grant.Options['modes'] {
  * 2. oauth/decision will call load() to retrieve the parameters and then remove()
  */
 class OAuth2Store {
-	#cache = new MemoryKVCache<OAuth2>(1000 * 60 * 5); // expires after 5min
+	#cache = new MemoryKVCache<OAuth2>(1000 * 60 * 5, 10_000); // expires after 5min
 
 	load(req: OAuth2DecisionRequest, cb: (err: Error | null, txn?: OAuth2) => void): void {
 		const { transaction_id } = req.body;
@@ -257,7 +257,7 @@ export class OAuth2ProviderService {
 			grantedToken?: string,
 			revoked?: boolean,
 			used?: boolean,
-		}>(1000 * 60 * 5); // expires after 5m
+		}>(1000 * 60 * 5, 10_000); // expires after 5m
 
 		// https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics
 		// "Authorization servers MUST support PKCE [RFC7636]."


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This PR resolves #14310 and #14311 by refactoring `MemoryKVCache<T>`. The new implementation supports capacity limits with Least Recently Used (LRU) eviction, and no longer requires garbage collection or manual disposal. All references to this class have been updated to specify a reasonable capacity limit.

Additionally, all cache lifetimes and capacity limits have been exposed as configuration values. This allows the limits to be adjusted by instance admins to account for available system resources, which reduces the chance of cache-related resource exhaustion. Larger instances can even *increase* the limits, thus improving cache hit rate and reducing churn.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

The linked issues pose a serious reliability issue that is affecting many instances, including my own. Resolving the memory leaks will improve stability, uptime, and performance.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

This change is upstreamed from the Sharkey fork. Please see [Sharkey MR #580](https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/580) for additional details and context.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
