### PR TITLE
ci: skip chromatic / storybook CI for pull requests targets master

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,6 +7,11 @@ on:
       - develop
       - dev/storybook8 # for testing
   pull_request_target:
+    branches-ignore:
+      # Since pull requests targets master mostly is the "develop" branch.
+      # Storybook CI is checked on the "push" event of "develop" branch so it would cause a duplicate build.
+      # This is a waste of chromatic build quota, so we don't run storybook CI on pull requests targets master.
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

ChromaticのCIをmasterを対象とするPRで実行しないことで develop branch で二回実行されてしまうのを避けます。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Chromaticのmonthly limitの無駄使いになると思われる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
