### PR TITLE
fix(backend): correct `app`-type notification schema

### DIFF
--- a/packages/backend/src/models/Notification.ts
+++ b/packages/backend/src/models/Notification.ts
@@ -85,7 +85,7 @@ export type MiNotification = {
 	/**
 	 * アプリ通知のbody
 	 */
-	customBody: string | null;
+	customBody: string;
 
 	/**
 	 * アプリ通知のheader

--- a/packages/backend/src/models/json-schema/notification.ts
+++ b/packages/backend/src/models/json-schema/notification.ts
@@ -311,11 +311,11 @@ export const packedNotificationSchema = {
 			},
 			header: {
 				type: 'string',
-				optional: false, nullable: false,
+				optional: false, nullable: true,
 			},
 			icon: {
 				type: 'string',
-				optional: false, nullable: false,
+				optional: false, nullable: true,
 			},
 		},
 	}, {

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -4253,7 +4253,7 @@ export type components = {
       /** @enum {string} */
       type: 'achievementEarned';
       achievement: string;
-    } | {
+    } | ({
       /** Format: id */
       id: string;
       /** Format: date-time */
@@ -4261,9 +4261,9 @@ export type components = {
       /** @enum {string} */
       type: 'app';
       body: string;
-      header: string;
-      icon: string;
-    } | {
+      header: string | null;
+      icon: string | null;
+    }) | {
       /** Format: id */
       id: string;
       /** Format: date-time */


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`app` タイプの通知のスキーマ・型が不正確なのを修正します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`app` タイプの通知を発行しているのはこの部分です：
https://github.com/misskey-dev/misskey/blob/b6fdd7195725d09ab30245ac174d0ea04ef550ae/packages/backend/src/server/api/endpoints/notifications/create.ts#L42-L47
https://github.com/misskey-dev/misskey/blob/b6fdd7195725d09ab30245ac174d0ea04ef550ae/packages/backend/src/core/entities/NotificationEntityService.ts#L165-L169
次の問題があります：
- `customBody` は `null` になりえないことが Ajv のバリデーションで保証されているが、型では `null` がついてしまっていて不正確
- `header` と `icon` は `null` になりうるが、スキーマでは `nullable: false` になってしまっていて不正確

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
CHANGELOG の更新は微妙なのでとりあえず見送っています

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
