### PR TITLE
chore(ci/lint): ESLintのキャッシュが保存できない問題を修正

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,8 +40,6 @@ jobs:
     needs: [pnpm_install]
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      eslint-cache-version: v1
     strategy:
       matrix:
         workspace:
@@ -49,6 +47,9 @@ jobs:
         - frontend
         - sw
         - misskey-js
+    env:
+      eslint-cache-version: v1
+      eslint-cache-path: ${{ github.workspace }}/node_modules/.cache/eslint-${{ matrix.workspace }}
     steps:
     - uses: actions/checkout@v4.1.1
       with:
@@ -64,11 +65,10 @@ jobs:
     - name: Restore eslint cache
       uses: actions/cache@v4.0.2
       with:
-        path: node_modules/.cache/eslint
-        key: eslint-${{ env.eslint-cache-version }}-${{ hashFiles('/pnpm-lock.yaml') }}-${{ github.ref_name }}-${{ github.sha }}
-        restore-keys: |
-          eslint-${{ env.eslint-cache-version }}-${{ hashFiles('/pnpm-lock.yaml') }}-
-    - run: pnpm --filter ${{ matrix.workspace }} run eslint --cache --cache-location node_modules/.cache/eslint --cache-strategy content
+        path: ${{ env.eslint-cache-path }}
+        key: eslint-${{ env.eslint-cache-version }}-${{ matrix.workspace }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: eslint-${{ env.eslint-cache-version }}-${{ matrix.workspace }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
+    - run: pnpm --filter ${{ matrix.workspace }} run eslint --cache --cache-location ${{ env.eslint-cache-path }} --cache-strategy content
 
   typecheck:
     needs: [pnpm_install]


### PR DESCRIPTION
## What
LintワークフローでESLintがキャッシュされない問題を修正しました

## Why
frontendのLintにすごーく時間がかかってしまうため

## Additional info (optional)
- taiyme/misskeyで動作しています: [lint.yaml](https://github.com/taiyme/misskey/blob/taiyme/.github/workflows/lint.yaml)
- これまでESLintのキャッシュは保存されていなかったので `eslint-cache-version` はあえて上げませんでした

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
