### PR TITLE
enhance(frontend): 共有と埋込みコード生成を親子メニューにまとめる

### DIFF
--- a/packages/frontend/src/scripts/get-appear-note.ts
+++ b/packages/frontend/src/scripts/get-appear-note.ts
@@ -6,5 +6,5 @@
 import * as Misskey from 'misskey-js';
 
 export function getAppearNote(note: Misskey.entities.Note) {
-	return Misskey.note.isPureRenote(note) ? note.renote : note;
+	return Misskey.note.isPureRenote(note) ? note.renote! : note;
 }

--- a/packages/frontend/src/scripts/get-note-menu.ts
+++ b/packages/frontend/src/scripts/get-note-menu.ts
@@ -200,7 +200,6 @@ function getNoteShareMenu(note: Misskey.entities.Note, inChild: boolean): MenuIt
 	} else {
 		return children;
 	}
-
 }
 
 export function getNoteMenu(props: {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ログイン中のノートメニューでは、ブラウザの共有ボタンと埋め込みコード生成ボタンを親メニュー内にまとめるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
ノートメニューが縦に長くなってきているので整理したい（コピー系もまとめることを考えたけど使用頻度が高そうなので除外した）

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
