### PR TITLE
enhance(frontend): 投稿フォームでEscキーが押されたときIME入力中ならダイアログは閉じない

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/751)
 - Enhance: ドライブでソートができるように 
 - Fix: 通知の範囲指定の設定項目が必要ない通知設定でも範囲指定の設定がでている問題を修正
+- Enhance: 投稿フォームでEscキーを押したときIME入力中ならフォームを閉じないように（ #10866 ）  
 
 ### Server
 -


### PR DESCRIPTION
## What

投稿フォームMkPostFormの入力エリア（通常入力エリアとCW入力エリア）でEscキーが押されたとき、  
IME変換セッション中ならばフォームを閉じないようにします。

#10866 を実現します。

## Why

打ち込みかけの日本語入力をEscキーで解除する操作はよくありますが、  
それでダイアログまで閉じてしまうのはユーザーの意図ではないため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
