### PR TITLE
fix(backend): Accept arrays in ActivityPub `icon` and `image` properties

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApPersonService.ts
+++ b/packages/backend/src/core/activitypub/models/ApPersonService.ts
@@ -232,6 +232,12 @@ export class ApPersonService implements OnModuleInit {
 		if (user == null) throw new Error('failed to create user: user is null');
 
 		const [avatar, banner] = await Promise.all([icon, image].map(img => {
+			// icon and image may be arrays
+			// see https://www.w3.org/TR/activitystreams-vocabulary/#dfn-icon
+			if (Array.isArray(img)) {
+				img = img.find(item => item && item.url) ?? null;
+			}
+			
 			// if we have an explicitly missing image, return an
 			// explicitly-null set of values
 			if ((img == null) || (typeof img === 'object' && img.url == null)) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This fixes #14823 by using the first avatar `icon` or banner `image` object of a remote ActivityPub Actor if an array of objects is provided.

Note that this supports only [Image](https://www.w3.org/TR/activitystreams-vocabulary/#dfn-image)s with `url` property.
Link objects with `href` rather than `url`, which are also valid in this position, as well as plain strings, are skipped when encountered as array items.
(Misskey also accepts a plain string when provided directly as `icon` or `image`, if I'm not mistaken.)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

This fixes a partial incompatibility with Bridgy Fed that was reported to us at https://github.com/snarfed/bridgy-fed/issues/1408.

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

I tried to match the existing code style as well as possible, but let me know if anything is amiss.

Apologies for not authoring tests or updating CHANGELOG.md.

I'm aware that testing is the larger part of the work here, but I don't have the spare time to learn enough about Misskey's repository structure on my own to do so. I'm also not sure where to place the changelog entry.

I wanted to provide at least the fix itself here, since I already found the root issue.
With further instruction, I should be able to add the missing tests eventually, but that would take some time since I'm relatively busy.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
