### PR TITLE
chore: fix a tiny type error for makeGetterSetter

### DIFF
--- a/packages/frontend/src/pizzax.ts
+++ b/packages/frontend/src/pizzax.ts
@@ -241,9 +241,13 @@ export class Storage<T extends StateDef> {
 	 * 特定のキーの、簡易的なgetter/setterを作ります
 	 * 主にvue上で設定コントロールのmodelとして使う用
 	 */
-	public makeGetterSetter<K extends keyof T>(key: K, getter?: (v: T[K]) => unknown, setter?: (v: unknown) => T[K]): {
-		get: () => T[K]['default'];
-		set: (value: T[K]['default']) => void;
+	public makeGetterSetter<K extends keyof T, R = T[K]['default']>(
+		key: K,
+		getter?: (v: T[K]['default']) => R,
+		setter?: (v: R) => T[K]['default'],
+	): {
+		get: () => R;
+		set: (value: R) => void;
 	} {
 		const valueRef = ref(this.state[key]);
 
@@ -265,7 +269,7 @@ export class Storage<T extends StateDef> {
 					return valueRef.value;
 				}
 			},
-			set: (value: unknown) => {
+			set: (value) => {
 				const val = setter ? setter(value) : value;
 				this.set(key, val);
 				valueRef.value = val;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Make `makeGetterSetter` take the correct type associated with getter and setter

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Fix a tiny type error [here](https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/pages/settings/general.vue#L287) in `general.vue`

```typescript
const reduceAnimation = computed(defaultStore.makeGetterSetter('animation', v => !v, v => !v));
```

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment