### PR TITLE
enhance(backend) : リモートユーザーの照会をオリジナルにリダイレクトするように (#12892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/706)
 - Fix: 連合への配信時に、acctの大小文字が区別されてしまい正しくメンションが処理されないことがある問題を修正  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/711)
+- Enhance: リモートユーザーの照会をオリジナルにリダイレクトするように
 
 ### Misskey.js
 - Fix: Stream初期化時、別途WebSocketを指定する場合の型定義を修正

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -674,7 +674,7 @@ export class ActivityPubServerService {
 		fastify.get<{ Params: { acct: string; } }>('/@:acct', { constraints: { apOrHtml: 'ap' } }, async (request, reply) => {
 			vary(reply.raw, 'Accept');
 
-			const acct = Acct.parse(request.params.acct)
+			const acct = Acct.parse(request.params.acct);
 
 			const user = await this.usersRepository.findOneBy({
 				usernameLower: acct.username,

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -29,6 +29,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { bindThis } from '@/decorators.js';
 import { IActivity } from '@/core/activitypub/type.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
+import * as Acct from '@/misc/acct.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginOptions, FastifyBodyParser } from 'fastify';
 import type { FindOptionsWhere } from 'typeorm';
 
@@ -673,18 +674,11 @@ export class ActivityPubServerService {
 		fastify.get<{ Params: { acct: string; } }>('/@:acct', { constraints: { apOrHtml: 'ap' } }, async (request, reply) => {
 			vary(reply.raw, 'Accept');
 
-			const spritedAcct = request.params.acct.toLowerCase().split('@');
-
-			//@foo@bar@baz なんてないはず
-			if (spritedAcct.length > 2) {
-				reply.code(400);
-			}
-
-			console.log(spritedAcct);
+			const acct = Acct.parse(request.params.acct)
 
 			const user = await this.usersRepository.findOneBy({
-				usernameLower: spritedAcct[0],
-				host: spritedAcct[1] ?? IsNull(),
+				usernameLower: acct.username,
+				host: acct.host ?? IsNull(),
 				isSuspended: false,
 			});
 

--- a/packages/backend/test/e2e/fetch-resource.ts
+++ b/packages/backend/test/e2e/fetch-resource.ts
@@ -230,6 +230,7 @@ describe('Webリソース', () => {
 				path: path('xxxxxxxxxx'),
 				type: HTML,
 			}));
+			test.todo('HTMLとしてGETできる。(リモートユーザーでもリダイレクトせず)');
 		});
 
 		describe.each([
@@ -249,6 +250,7 @@ describe('Webリソース', () => {
 				path: path('xxxxxxxxxx'),
 				accept,
 			}));
+			test.todo('はオリジナルにリダイレクトされる。(リモートユーザー)');
 		});
 	});
 


### PR DESCRIPTION
## What
Fix #12892
リモートにいるユーザーの照会が来た時にオリジナルにリダイレクトさせる。

## Additional info (optional)
e2eテストにはリモートユーザーを交えたテストはまだのようなのでtodoだけ追加してあります。
動くかどうかは`curl -H "accept: application/activity+json" -L "{URL}"`で確認できます。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
