### PR TITLE
enhance(frontend): デッキ表示時にサイドバーを展開・折りたたみできるように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Enhance: ノート詳細画面にロールのバッジを表示
 - Enhance: 過去に送信したフォローリクエストを確認できるように  
   (Based on https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/663)
+- Enhance: デッキ表示時にサイドバーを展開・折りたたみできるように ( #14981 )
 - Fix: 通知の範囲指定の設定項目が必要ない通知設定でも範囲指定の設定がでている問題を修正
 - Fix: Turnstileが失敗・期限切れした際にも成功扱いとなってしまう問題を修正  
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/768)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Enhance: ノート詳細画面にロールのバッジを表示
 - Enhance: 過去に送信したフォローリクエストを確認できるように  
   (Based on https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/663)
-- Enhance: デッキ表示時にサイドバーを展開・折りたたみできるように ( #14981 )
+- Enhance: サイドバーを簡単に展開・折りたたみできるように ( #14981 )
 - Fix: 通知の範囲指定の設定項目が必要ない通知設定でも範囲指定の設定がでている問題を修正
 - Fix: Turnstileが失敗・期限切れした際にも成功扱いとなってしまう問題を修正  
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/768)

--- a/packages/frontend/src/pages/settings/navbar.vue
+++ b/packages/frontend/src/pages/settings/navbar.vue
@@ -100,10 +100,6 @@ function reset() {
 	}));
 }
 
-watch(menuDisplay, async () => {
-	await reloadAsk({ reason: i18n.ts.reloadToApplySetting, unison: true });
-});
-
 const headerActions = computed(() => []);
 
 const headerTabs = computed(() => []);

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</button>
 		</div>
 	</div>
-	<button class="_button" :class="$style.toggleButton" @click="iconOnly = !iconOnly">
+	<button v-if="!forceIconOnly" class="_button" :class="$style.toggleButton" @click="toggleIconOnly">
 		<!--
 		<svg viewBox="0 0 16 48" :class="$style.toggleButtonShape">
 			<g transform="matrix(0.333333,0,0,0.222222,0.000895785,13.3333)">
@@ -95,9 +95,11 @@ const otherMenuItemIndicated = computed(() => {
 	return false;
 });
 
-const calcViewState = () => {
-	iconOnly.value = (window.innerWidth <= 1279) || (defaultStore.state.menuDisplay === 'sideIcon');
-};
+const forceIconOnly = window.innerWidth <= 1279;
+
+function calcViewState() {
+	iconOnly.value = forceIconOnly || (defaultStore.state.menuDisplay === 'sideIcon');
+}
 
 calcViewState();
 
@@ -106,6 +108,10 @@ window.addEventListener('resize', calcViewState);
 watch(defaultStore.reactiveState.menuDisplay, () => {
 	calcViewState();
 });
+
+function toggleIconOnly() {
+	defaultStore.set('menuDisplay', iconOnly.value ? 'sideFull' : 'sideIcon');
+}
 
 function openAccountMenu(ev: MouseEvent) {
 	openAccountMenu_({

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -131,19 +131,6 @@ function more(ev: MouseEvent) {
 	flex: 0 0 var(--nav-width);
 	width: var(--nav-width);
 	box-sizing: border-box;
-
-	.right {
-		position: fixed;
-		top: 0;
-		right: 0;
-		width: fit-content;
-		height: 100dvh;
-
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-	}
 }
 
 .body {
@@ -173,10 +160,6 @@ function more(ev: MouseEvent) {
 }
 
 .bottom {
-	direction: ltr;
-}
-
-.right {
 	direction: ltr;
 }
 

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -171,9 +171,7 @@ function more(ev: MouseEvent) {
 
 .toggleButton {
 	position: fixed;
-	top: 0;
-	bottom: 0;
-	margin: auto;
+	bottom: 20px;
 	left: var(--nav-width);
 	z-index: 1001;
 	width: 16px;

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -55,12 +55,15 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<MkAvatar :user="$i" :class="$style.avatar"/><MkAcct class="_nowrap" :class="$style.acct" :user="$i"/>
 			</button>
 		</div>
-		<div :class="$style.right">
-			<button :class="$style.toggleButton" @click="iconOnly = !iconOnly">
-				<i :class="'ti ' + `ti-chevron-${ iconOnly ? 'right' : 'left' }`"></i>
-			</button>
-		</div>
 	</div>
+	<button class="_button" :class="$style.toggleButton" @click="iconOnly = !iconOnly">
+		<svg viewBox="0 0 16 48" :class="$style.toggleButtonShape">
+			<g transform="matrix(0.333333,0,0,0.222222,0.000895785,13.3333)">
+				<path d="M23.935,-24C37.223,-24 47.995,-7.842 47.995,12.09C47.995,34.077 47.995,62.07 47.995,84.034C47.995,93.573 45.469,102.721 40.972,109.466C36.475,116.211 30.377,120 24.018,120L23.997,120C10.743,120 -0.003,136.118 -0.003,156C-0.003,156 -0.003,156 -0.003,156L-0.003,-60L-0.003,-59.901C-0.003,-50.379 2.519,-41.248 7.007,-34.515C11.496,-27.782 17.584,-24 23.931,-24C23.932,-24 23.934,-24 23.935,-24Z" style="fill:var(--MI_THEME-navBg);"/>
+			</g>
+		</svg>
+		<i :class="'ti ' + `ti-chevron-${ iconOnly ? 'right' : 'left' }`" style="font-size: 12px; margin-left: -8px;"></i>
+	</button>
 </div>
 </template>
 
@@ -151,6 +154,44 @@ function more(ev: MouseEvent) {
 	contain: strict;
 	display: flex;
 	flex-direction: column;
+	direction: rtl; // スクロールバーを左に表示したいため
+}
+
+.top {
+	direction: ltr;
+}
+
+.middle {
+	direction: ltr;
+}
+
+.bottom {
+	direction: ltr;
+}
+
+.right {
+	direction: ltr;
+}
+
+.toggleButton {
+	position: fixed;
+	top: 0;
+	bottom: 0;
+	margin: auto;
+	left: var(--nav-width);
+	z-index: 1001;
+	width: 16px;
+	height: 48px;
+	box-sizing: border-box;
+}
+
+.toggleButtonShape {
+	position: absolute;
+	z-index: -1;
+	top: 0;
+	left: 0;
+	width: 16px;
+	height: 48px;
 }
 
 .root:not(.iconOnly) {
@@ -381,6 +422,10 @@ function more(ev: MouseEvent) {
 		position: relative;
 		font-size: 0.9em;
 	}
+
+	.toggleButton {
+		left: var(--nav-width);
+	}
 }
 
 .root.iconOnly {
@@ -581,17 +626,9 @@ function more(ev: MouseEvent) {
 			font-size: 10px;
 		}
 	}
-}
 
-.toggleButton {
-	width: fit-content;
-	height: 80px;
-	margin: 0;
-	padding: 0;
-	background-color: transparent;
-	border: none;
-	border-radius: 9999px;
-	box-sizing: border-box;
-	font-size: 0.75em;
+	.toggleButton {
+		left: var(--nav-icon-only-width);
+	}
 }
 </style>

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -57,9 +57,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 		</div>
 	</div>
 	<button class="_button" :class="$style.toggleButton" @click="iconOnly = !iconOnly">
+		<!--
 		<svg viewBox="0 0 16 48" :class="$style.toggleButtonShape">
 			<g transform="matrix(0.333333,0,0,0.222222,0.000895785,13.3333)">
 				<path d="M23.935,-24C37.223,-24 47.995,-7.842 47.995,12.09C47.995,34.077 47.995,62.07 47.995,84.034C47.995,93.573 45.469,102.721 40.972,109.466C36.475,116.211 30.377,120 24.018,120L23.997,120C10.743,120 -0.003,136.118 -0.003,156C-0.003,156 -0.003,156 -0.003,156L-0.003,-60L-0.003,-59.901C-0.003,-50.379 2.519,-41.248 7.007,-34.515C11.496,-27.782 17.584,-24 23.931,-24C23.932,-24 23.934,-24 23.935,-24Z" style="fill:var(--MI_THEME-navBg);"/>
+			</g>
+		</svg>
+		-->
+		<svg viewBox="0 0 16 64" :class="$style.toggleButtonShape">
+			<g transform="matrix(0.333333,0,0,0.222222,0.000895785,21.3333)">
+				<path d="M47.488,7.995C47.79,10.11 47.943,12.266 47.943,14.429C47.997,26.989 47.997,84 47.997,84C47.997,84 44.018,118.246 23.997,133.5C-0.374,152.07 -0.003,192 -0.003,192L-0.003,-96C-0.003,-96 0.151,-56.216 23.997,-37.5C40.861,-24.265 46.043,-1.243 47.488,7.995Z" style="fill:var(--MI_THEME-navBg);"/>
 			</g>
 		</svg>
 		<i :class="'ti ' + `ti-chevron-${ iconOnly ? 'right' : 'left' }`" style="font-size: 12px; margin-left: -8px;"></i>
@@ -181,7 +188,7 @@ function more(ev: MouseEvent) {
 	left: var(--nav-width);
 	z-index: 1001;
 	width: 16px;
-	height: 48px;
+	height: 64px;
 	box-sizing: border-box;
 }
 
@@ -191,7 +198,7 @@ function more(ev: MouseEvent) {
 	top: 0;
 	left: 0;
 	width: 16px;
-	height: 48px;
+	height: 64px;
 }
 
 .root:not(.iconOnly) {

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -55,6 +55,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<MkAvatar :user="$i" :class="$style.avatar"/><MkAcct class="_nowrap" :class="$style.acct" :user="$i"/>
 			</button>
 		</div>
+		<div :class="$style.right">
+			<button :class="$style.toggleButton" @click="iconOnly = !iconOnly">
+				<i :class="'ti ' + `ti-chevron-${ iconOnly ? 'right' : 'left' }`"></i>
+			</button>
+		</div>
 	</div>
 </div>
 </template>
@@ -116,6 +121,19 @@ function more(ev: MouseEvent) {
 	flex: 0 0 var(--nav-width);
 	width: var(--nav-width);
 	box-sizing: border-box;
+
+	.right {
+		position: fixed;
+		top: 0;
+		right: 0;
+		width: fit-content;
+		height: 100dvh;
+
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+	}
 }
 
 .body {
@@ -563,5 +581,17 @@ function more(ev: MouseEvent) {
 			font-size: 10px;
 		}
 	}
+}
+
+.toggleButton {
+	width: fit-content;
+	height: 80px;
+	margin: 0;
+	padding: 0;
+	background-color: transparent;
+	border: none;
+	border-radius: 9999px;
+	box-sizing: border-box;
+	font-size: 0.75em;
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

デッキ表示時のサイドバーに小さな矢印ボタンを追加し、サイドバーを展開・折りたたみ出来るようにしました。この機能は常に広げておきたい人、常に折りたたんでおきたい人向けというよりも、状況に応じて頻繁に切り替えたい人向けの機能です。
![image](https://github.com/user-attachments/assets/1376e3ba-6d77-4f03-bb44-7ab6ead740f6)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
fix https://github.com/misskey-dev/misskey/issues/14981

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
実際にローカルで動作確認

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
