### PR TITLE
fix(frontend): TypeScriptの型チェック対象ファイルを限定して高速化するように

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - Fix: メールアドレス登録有効化時の「完了」ダイアログボックスの表示条件を修正
 - Fix: 画面幅が狭い環境でデザインが崩れる問題を修正  
 	(Cherry-picked from https://github.com/MisskeyIO/misskey/pull/815)
+- Fix: TypeScriptの型チェック対象ファイルを限定してビルドを高速化するように  
+	(Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/725)
 
 ### Server
 - Enhance: DockerのNode.jsを22.11.0に更新

--- a/packages/frontend-embed/tsconfig.json
+++ b/packages/frontend-embed/tsconfig.json
@@ -45,7 +45,8 @@
 	"compileOnSave": false,
 	"include": [
 		"./src/**/*.ts",
-		"./src/**/*.vue"
+		"./src/**/*.vue",
+		"./@types/**/*.ts"
 	],
 	"exclude": [
 		".storybook/**/*"

--- a/packages/frontend-embed/tsconfig.json
+++ b/packages/frontend-embed/tsconfig.json
@@ -33,7 +33,7 @@
 			"./node_modules"
 		],
 		"types": [
-			"vite/client",
+			"vite/client"
 		],
 		"lib": [
 			"esnext",
@@ -44,8 +44,8 @@
 	},
 	"compileOnSave": false,
 	"include": [
-		"./**/*.ts",
-		"./**/*.vue"
+		"./src/**/*.ts",
+		"./src/**/*.vue"
 	],
 	"exclude": [
 		".storybook/**/*"

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -48,7 +48,8 @@
 		"./src/**/*.ts",
 		"./src/**/*.vue",
 		"./test/**/*.ts",
-		"./test/**/*.vue"
+		"./test/**/*.vue",
+		"./@types/**/*.ts"
 	],
 	"exclude": [
 		".storybook/**/*"

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -45,8 +45,10 @@
 	},
 	"compileOnSave": false,
 	"include": [
-		"./**/*.ts",
-		"./**/*.vue"
+		"./src/**/*.ts",
+		"./src/**/*.vue",
+		"./test/**/*.ts",
+		"./test/**/*.vue"
 	],
 	"exclude": [
 		".storybook/**/*"


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
> Modifies the `frontend` and `frontend-embed` TS configs to include only the project source. This fixes type errors and slow linting caused by TS trying to check the JS-based config files and various auto-generated code.

TypeScriptが自動生成されたファイルやJavaScriptで書かれたコンフィグファイルまでチェックしてしまい、型チェックが遅くなる問題を修正（tsconfigのsourceをプロジェクトルートに限定）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
