### PR TITLE
fix(backend): Let `MfmService.fromHtml()` accept `<ruby>` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/869)
 - Fix: `/api/pages/update`にて`name`を指定せずにリクエストするとエラーが発生する問題を修正
 - Fix: AIセンシティブ判定が arm64 環境で動作しない問題を修正
+- Fix: 非Misskey系のソフトウェアからHTML`<ruby>`タグを含むノートを受信した場合、MFMの読み仮名（ルビ）文法に変換して表示
 
 ### Misskey.js
 - Feat: allow setting `binaryType` of WebSocket connection

--- a/packages/backend/src/core/MfmService.ts
+++ b/packages/backend/src/core/MfmService.ts
@@ -171,6 +171,39 @@ export class MfmService {
 					break;
 				}
 
+				case 'ruby': {
+					let ruby: [string, string][] = [];
+					for (const child of node.childNodes) {
+						if (child.nodeName === 'rp') {
+							continue;
+						}
+						if (treeAdapter.isTextNode(child) && !/\s|\[|\]/.test(child.value)) {
+							ruby.push([child.value, '']);
+							continue;
+						}
+						if (child.nodeName === 'rt' && ruby.length > 0) {
+							const rt = getText(child);
+							if (/\s|\[|\]/.test(rt)) {
+								// If any space is included in rt, it is treated as a normal text
+								ruby = [];
+								appendChildren(node.childNodes);
+								break;
+							} else {
+								ruby.at(-1)![1] = rt;
+								continue;
+							}
+						}
+						// If any other element is included in ruby, it is treated as a normal text
+						ruby = [];
+						appendChildren(node.childNodes);
+						break;
+					}
+					for (const [base, rt] of ruby) {
+						text += `$[ruby ${base} ${rt}]`;
+					}
+					break;
+				}
+
 				// block code (<pre><code>)
 				case 'pre': {
 					if (node.childNodes.length === 1 && node.childNodes[0].nodeName === 'code') {

--- a/packages/backend/test/unit/MfmService.ts
+++ b/packages/backend/test/unit/MfmService.ts
@@ -108,6 +108,24 @@ describe('MfmService', () => {
 			assert.deepStrictEqual(mfmService.fromHtml('<p>a <a></a> d</p>'), 'a  d');
 		});
 
+		test('ruby', () => {
+			assert.deepStrictEqual(mfmService.fromHtml('<p>a <ruby>Misskey<rp>(</rp><rt>ミスキー</rt><rp>)</rp></ruby> b</p>'), 'a $[ruby Misskey ミスキー] b');
+			assert.deepStrictEqual(mfmService.fromHtml('<p>a <ruby>Misskey<rp>(</rp><rt>ミスキー</rt><rp>)</rp>Misskey<rp>(</rp><rt>ミスキー</rt><rp>)</rp></ruby> b</p>'), 'a $[ruby Misskey ミスキー]$[ruby Misskey ミスキー] b');
+		});
+
+		test('ruby with spaces', () => {
+			assert.deepStrictEqual(mfmService.fromHtml('<p>a <ruby>Miss key<rp>(</rp><rt>ミスキー</rt><rp>)</rp> b</ruby> c</p>'), 'a Miss key(ミスキー) b c');
+			assert.deepStrictEqual(mfmService.fromHtml('<p>a <ruby>Misskey<rp>(</rp><rt>ミス キー</rt><rp>)</rp> b</ruby> c</p>'), 'a Misskey(ミス キー) b c');
+			assert.deepStrictEqual(
+				mfmService.fromHtml('<p>a <ruby>Misskey<rp>(</rp><rt>ミスキー</rt><rp>)</rp>Misskey<rp>(</rp><rt>ミス キー</rt><rp>)</rp>Misskey<rp>(</rp><rt>ミスキー</rt><rp>)</rp></ruby> b</p>'),
+				'a Misskey(ミスキー)Misskey(ミス キー)Misskey(ミスキー) b'
+			);
+		});
+
+		test('ruby with other inline tags', () => {
+			assert.deepStrictEqual(mfmService.fromHtml('<p>a <ruby><strong>Misskey</strong><rp>(</rp><rt>ミスキー</rt><rp>)</rp> b</ruby> c</p>'), 'a **Misskey**(ミスキー) b c');
+		});
+
 		test('mention', () => {
 			assert.deepStrictEqual(mfmService.fromHtml('<p>a <a href="https://example.com/@user" class="u-url mention">@user</a> d</p>'), 'a @user@example.com d');
 		});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

This fix makes `MfmService.fromHtml()` method accept `<ruby>` tags and translate it to MFM's [ruby characters syntax](https://misskey-hub.net/en/docs/for-users/features/mfm/#yomigana-ruby-characters) (`$[ruby ...]`).

このパッチは`MfmService.fromHtml()`メソッドが`<ruby>`タグをMFMの[読み仮名（ルビ）文法](https://misskey-hub.net/ja/docs/for-users/features/mfm/#%E3%82%88%E3%81%BF%E3%81%8C%E3%81%AA%E3%83%AB%E3%83%93)に翻訳する様に修正します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Currently, Misskey can display ruby characters via MFM for posts received from other Misskey (and Forkeys) servers, but is unable to display them properly from other software, even if the `<ruby>` tag is present in the `content` property. This fix should allow for better interoperability.

現在、MisskeyはMisskey系のサーバーから受け取った投稿の場合、MFMを通じてルビ文字（読み仮名）の表示が出来ますが、それ以外のソフトウェアからは`content`プロパティ内に`<ruby>`タグが入っていても正しく表示されません。この修正により、より相互運用性が改善されます。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

Because HTML's `<ruby>` tag is much more expressive than MFM's yomigana (ruby character) syntax, it falls back to plain text rendering as before if it goes beyond what MFM can represent (for example, if it contains spaces).

MFMの読み仮名（ルビ）の文法が表現できる範囲よりも、HTMLの`<ruby>`タグが表現できる範囲がはるかに広いため、MFMで表現できる範囲を超えた場合（例えば、空白を含む場合）、従来通りプレーンテキストレンダリングにフォールバックします。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
