### PR TITLE
fix(backend): ロックダウンされた期間指定のノートがStreaming経由でLTLに出現するのを修正

### DIFF
--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -462,7 +462,7 @@ export class NoteEntityService implements OnModuleInit {
 		});
 
 		if (!opts.skipTreatVisibility) {
-			await this.treatVisibility(packed, meId);
+			await this.treatVisibility(packed);
 		}
 
 		if (!opts.skipHide) {

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -102,8 +102,7 @@ export class NoteEntityService implements OnModuleInit {
 	}
 
 	@bindThis
-	private async hideNote(packedNote: Packed<'Note'>, meId: MiUser['id'] | null): Promise<void> {
-		// FIXME: このvisibility変更処理が当関数にあるのは若干不自然かもしれない(関数名を treatVisibility とかに変える手もある)
+	private async treatVisibility(packedNote: Packed<'Note'>): Promise<void> {
 		if (packedNote.visibility === 'public' || packedNote.visibility === 'home') {
 			const followersOnlyBefore = packedNote.user.makeNotesFollowersOnlyBefore;
 			if ((followersOnlyBefore != null)
@@ -115,7 +114,10 @@ export class NoteEntityService implements OnModuleInit {
 				packedNote.visibility = 'followers';
 			}
 		}
+	}
 
+	@bindThis
+	private async hideNote(packedNote: Packed<'Note'>, meId: MiUser['id'] | null): Promise<void> {
 		if (meId === packedNote.userId) return;
 
 		// TODO: isVisibleForMe を使うようにしても良さそう(型違うけど)
@@ -359,6 +361,7 @@ export class NoteEntityService implements OnModuleInit {
 		const opts = Object.assign({
 			detail: true,
 			skipHide: false,
+			skipTreatVisibility: false,
 			withReactionAndUserPairCache: false,
 		}, options);
 
@@ -457,6 +460,10 @@ export class NoteEntityService implements OnModuleInit {
 				} : {}),
 			} : {}),
 		});
+
+		if (!opts.skipTreatVisibility) {
+			await this.treatVisibility(packed, meId);
+		}
 
 		if (!opts.skipHide) {
 			await this.hideNote(packed, meId);

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -463,7 +463,7 @@ export class NoteEntityService implements OnModuleInit {
 		});
 
 		if (!opts.skipTreatVisibility) {
-			await this.treatVisibility(packed);
+			his.treatVisibility(packed);
 		}
 
 		if (!opts.skipHide) {

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -463,7 +463,7 @@ export class NoteEntityService implements OnModuleInit {
 		});
 
 		if (!opts.skipTreatVisibility) {
-			his.treatVisibility(packed);
+			this.treatVisibility(packed);
 		}
 
 		if (!opts.skipHide) {

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -362,7 +362,6 @@ export class NoteEntityService implements OnModuleInit {
 		const opts = Object.assign({
 			detail: true,
 			skipHide: false,
-			skipTreatVisibility: false,
 			withReactionAndUserPairCache: false,
 		}, options);
 
@@ -462,9 +461,7 @@ export class NoteEntityService implements OnModuleInit {
 			} : {}),
 		});
 
-		if (!opts.skipTreatVisibility) {
-			this.treatVisibility(packed);
-		}
+		this.treatVisibility(packed);
 
 		if (!opts.skipHide) {
 			await this.hideNote(packed, meId);

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -102,7 +102,7 @@ export class NoteEntityService implements OnModuleInit {
 	}
 
 	@bindThis
-	private treatVisibility(packedNote: Packed<'Note'>): Promise<void> {
+	private treatVisibility(packedNote: Packed<'Note'>): Packed<'Note'>['visibility'] {
 		if (packedNote.visibility === 'public' || packedNote.visibility === 'home') {
 			const followersOnlyBefore = packedNote.user.makeNotesFollowersOnlyBefore;
 			if ((followersOnlyBefore != null)
@@ -114,6 +114,7 @@ export class NoteEntityService implements OnModuleInit {
 				packedNote.visibility = 'followers';
 			}
 		}
+		return packedNote.visibility;
 	}
 
 	@bindThis

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -102,7 +102,7 @@ export class NoteEntityService implements OnModuleInit {
 	}
 
 	@bindThis
-	private async treatVisibility(packedNote: Packed<'Note'>): Promise<void> {
+	private treatVisibility(packedNote: Packed<'Note'>): Promise<void> {
 		if (packedNote.visibility === 'public' || packedNote.visibility === 'home') {
 			const followersOnlyBefore = packedNote.user.makeNotesFollowersOnlyBefore;
 			if ((followersOnlyBefore != null)


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

下記現象の修正

- LTLにストリーム経由でロックダウンされたノートがノートの内容が表示されたまま流れることがある（未来の日時を設定している等）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

ロックダウンしたノートが表示され続けるのは本意ではないと考えられるため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
