### PR TITLE
fix(backend): disableClustering設定時の初期化ロジックを調整

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fix: ユーザーのプロフィール画面をアドレス入力などで直接表示した際に概要タブの描画に失敗する問題の修正( #15032 )
 - Fix: 起動前の疎通チェックが機能しなくなっていた問題を修正  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/737)
-
+- Fix: disableClustering設定時の初期化ロジックを調整( #15223 )
 
 ## 2024.11.0
 

--- a/packages/backend/src/boot/entry.ts
+++ b/packages/backend/src/boot/entry.ts
@@ -68,16 +68,22 @@ process.on('exit', code => {
 
 //#endregion
 
-if (cluster.isPrimary || envOption.disableClustering) {
-	await masterMain();
-
+if (!envOption.disableClustering) {
 	if (cluster.isPrimary) {
+		logger.info(`Start main process... pid: ${process.pid}`);
+		await masterMain();
 		ev.mount();
+	} else if (cluster.isWorker) {
+		logger.info(`Start worker process... pid: ${process.pid}`);
+		await workerMain();
+	} else {
+		throw new Error('Unknown process type');
 	}
-}
-
-if (cluster.isWorker || envOption.disableClustering) {
-	await workerMain();
+} else {
+	// 非clusterの場合はMasterのみが起動するため、Workerの処理は行わない(cluster.isWorker === trueの状態でこのブロックに来ることはない)
+	logger.info(`Start main process... pid: ${process.pid}`);
+	await masterMain();
+	ev.mount();
 }
 
 readyRef.value = true;

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -91,6 +91,10 @@ export async function masterMain() {
 		});
 	}
 
+	bootLogger.info(
+		`mode: [disableClustering: ${envOption.disableClustering}, onlyServer: ${envOption.onlyServer}, onlyQueue: ${envOption.onlyQueue}]`
+	);
+
 	if (!envOption.disableClustering) {
 		// clusterモジュール有効時
 

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -99,8 +99,10 @@ export async function masterMain() {
 		// clusterモジュール有効時
 
 		if (envOption.onlyServer) {
-			// onlyServer かつ enableCluster な場合、
-			// メインプロセスでlistenするとワーカープロセス側のlistenと衝突するため、メインプロセスはforkのみに制限する(listenしない)
+			// onlyServer かつ enableCluster な場合、メインプロセスはforkのみに制限する(listenしない)。
+			// ワーカープロセス側でlistenすると、メインプロセスでポートへの着信を受け入れてワーカープロセスへの分配を行う動作をする。
+			// そのため、メインプロセスでも直接listenするとポートの競合が発生して起動に失敗してしまう。
+			// see: https://nodejs.org/api/cluster.html#cluster
 		} else if (envOption.onlyQueue) {
 			await jobQueue();
 		} else {

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -91,17 +91,31 @@ export async function masterMain() {
 		});
 	}
 
-	if (envOption.onlyServer) {
-		await server();
-	} else if (envOption.onlyQueue) {
-		await jobQueue();
-	} else {
-		await server();
-		await jobQueue();
-	}
-
 	if (!envOption.disableClustering) {
+		// clusterモジュール有効時
+
+		if (envOption.onlyServer) {
+			// onlyServer かつ enableCluster な場合、
+			// メインプロセスでlistenするとワーカープロセス側のlistenと衝突するため、メインプロセスはforkのみに制限する(listenしない)
+		} else if (envOption.onlyQueue) {
+			await jobQueue();
+		} else {
+			await server();
+			await jobQueue();
+		}
+
 		await spawnWorkers(config.clusterLimit);
+	} else {
+		// clusterモジュール無効時
+
+		if (envOption.onlyServer) {
+			await server();
+		} else if (envOption.onlyQueue) {
+			await jobQueue();
+		} else {
+			await server();
+			await jobQueue();
+		}
 	}
 
 	if (envOption.onlyQueue) {

--- a/packages/backend/src/boot/master.ts
+++ b/packages/backend/src/boot/master.ts
@@ -91,24 +91,16 @@ export async function masterMain() {
 		});
 	}
 
-	if (envOption.disableClustering) {
-		if (envOption.onlyServer) {
-			await server();
-		} else if (envOption.onlyQueue) {
-			await jobQueue();
-		} else {
-			await server();
-			await jobQueue();
-		}
+	if (envOption.onlyServer) {
+		await server();
+	} else if (envOption.onlyQueue) {
+		await jobQueue();
 	} else {
-		if (envOption.onlyServer) {
-			// nop
-		} else if (envOption.onlyQueue) {
-			// nop
-		} else {
-			await server();
-		}
+		await server();
+		await jobQueue();
+	}
 
+	if (!envOption.disableClustering) {
 		await spawnWorkers(config.clusterLimit);
 	}
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix #15223

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

ローカルで環境変数を切り替えて動作確認（configのclusterLimitは2以上にしておく）
- MK_DISABLE_CLUSTERING=trueで起動できること
  - MK_ONLY_SERVER=true 併用時にAPIサーバのみが起動し、ワーカープロセスが起動しないこと
  - MK_ONLY_QUEUE=true 併用時にJobQueueのみが起動し、ワーカープロセスが起動しないこと
  - 上記どちらも併用しないとき、APIサーバとJobQueueが起動し、ワーカープロセスが起動しないこと
- MK_DISABLE_CLUSTERING設定なしで起動できること
  - MK_ONLY_SERVER=true 併用時にAPIサーバのみがclusterLimitの分だけ起動し、クラッシュしないこと
  - MK_ONLY_QUEUE=true 併用時にJobQueueのみがclusterLimitの分だけ起動し、クラッシュしないこと
  - 上記どちらも併用しないとき、APIサーバとJobQueueが起動する（デフォルトの構成はこれ）

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
