### PR TITLE
fix(frontend/dev): バックエンド経由での開発モードでHMRが効かない問題を修正

### DIFF
--- a/packages/frontend-embed/vite.config.ts
+++ b/packages/frontend-embed/vite.config.ts
@@ -63,6 +63,12 @@ export function getConfig(): UserConfig {
 
 		server: {
 			port: 5174,
+			hmr: {
+				// バックエンド経由での起動時、Viteは5174経由でアセットを参照していると思い込んでいるが実際は3000から配信される
+				// そのため、バックエンドのWSサーバーにHMRのWSリクエストが吸収されてしまい、正しくHMRが機能しない
+				// クライアント側のWSポートをViteサーバーのポートに強制させることで、正しくHMRが機能するようになる
+				clientPort: 5174,
+			},
 		},
 
 		plugins: [

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -65,6 +65,12 @@ export function getConfig(): UserConfig {
 
 		server: {
 			port: 5173,
+			hmr: {
+				// バックエンド経由での起動時、Viteは5173経由でアセットを参照していると思い込んでいるが実際は3000から配信される
+				// そのため、バックエンドのWSサーバーにHMRのWSリクエストが吸収されてしまい、正しくHMRが機能しない
+				// クライアント側のWSポートをViteサーバーのポートに強制させることで、正しくHMRが機能するようになる
+				clientPort: 5173,
+			},
 			headers: { // なんか効かない
 				'X-Frame-Options': 'DENY',
 			},


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`MK_DEV_PREFER=backend pnpm dev` （従来の開発モード）で開発サーバーを起動した際にHMRが効かないことがある問題を修正

- バックエンド経由での起動時であっても、フロントエンドのアセットは、ポート `5173` および `5174` から配信されている
- しかし、アクセスするページ自体は `3000` から配信されている
- そのため、バックエンド（`3000`）のWebSocketサーバーを参照してしまい、HMRの更新を受け取れていなかった
- [Viteの設定でHMRのためにアクセスするWSサーバーのポートを `5173` および `5174` に強制させる](https://ja.vite.dev/config/server-options#server-hmr)ことで、`MK_DEV_PREFER=backend pnpm dev` であってもHMRが効くようにすることに成功した

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
開発体験の向上

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
HMRが効かないという理由で採用された従来のバックエンド/フロントエンド別サーバーの開発モード（https://github.com/misskey-dev/misskey/pull/12452 → https://github.com/misskey-dev/misskey/pull/12593 ）は、これを機に消しても良いかもしれない？

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
