### PR TITLE
feat(backend): config(default.yml)からSQLログ全文を出力するか否かを設定可能に

### DIFF
--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -224,12 +224,8 @@ signToActivityPubGet: true
 # logging:
 #   sql:
 #     # Outputs query parameters during SQL execution to the log.
-#     # When NODE_ENV == 'production', setting this value to true has no effect (equivalent to false).
 #     # default: false
 #     enableQueryParamLogging: false
 #     # Disable query truncation. If set to true, the full text of the query will be output to the log.
 #     # default: false
 #     disableQueryTruncation: false
-#     # Disable query highlighting. When set to true, query highlighting is suppressed.
-#     # default: false
-#     disableHighlight: false

--- a/.config/docker_example.yml
+++ b/.config/docker_example.yml
@@ -219,3 +219,17 @@ signToActivityPubGet: true
 
 # Upload or download file size limits (bytes)
 #maxFileSize: 262144000
+
+# Log settings
+# logging:
+#   sql:
+#     # Outputs query parameters during SQL execution to the log.
+#     # When NODE_ENV == 'production', setting this value to true has no effect (equivalent to false).
+#     # default: false
+#     enableQueryParamLogging: false
+#     # Disable query truncation. If set to true, the full text of the query will be output to the log.
+#     # default: false
+#     disableQueryTruncation: false
+#     # Disable query highlighting. When set to true, query highlighting is suppressed.
+#     # default: false
+#     disableHighlight: false

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -326,12 +326,8 @@ signToActivityPubGet: true
 # logging:
 #   sql:
 #     # Outputs query parameters during SQL execution to the log.
-#     # When NODE_ENV == 'production', setting this value to true has no effect (equivalent to false).
 #     # default: false
 #     enableQueryParamLogging: false
 #     # Disable query truncation. If set to true, the full text of the query will be output to the log.
 #     # default: false
 #     disableQueryTruncation: false
-#     # Disable query highlighting. When set to true, query highlighting is suppressed.
-#     # default: false
-#     disableHighlight: false

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -321,3 +321,17 @@ signToActivityPubGet: true
 
 # PID File of master process
 #pidFile: /tmp/misskey.pid
+
+# Log settings
+# logging:
+#   sql:
+#     # Outputs query parameters during SQL execution to the log.
+#     # When NODE_ENV == 'production', setting this value to true has no effect (equivalent to false).
+#     # default: false
+#     enableQueryParamLogging: false
+#     # Disable query truncation. If set to true, the full text of the query will be output to the log.
+#     # default: false
+#     disableQueryTruncation: false
+#     # Disable query highlighting. When set to true, query highlighting is suppressed.
+#     # default: false
+#     disableHighlight: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Enhance: pg_bigmが利用できるよう、ノートの検索をILIKE演算子でなくLIKE演算子でLOWER()をかけたテキストに対して行うように
 - Enhance: チャート更新時にDBに同時接続しないように  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/830)
+- Enhance: config(default.yml)からSQLログ全文を出力するか否かを設定可能に ( #15266 )
 - Fix: ユーザーのプロフィール画面をアドレス入力などで直接表示した際に概要タブの描画に失敗する問題の修正( #15032 )
 - Fix: 起動前の疎通チェックが機能しなくなっていた問題を修正  
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/737)

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -102,7 +102,6 @@ type Source = {
 
 	logging?: {
 		sql?: {
-			disableHighlight? : boolean,
 			disableQueryTruncation? : boolean,
 			enableQueryParamLogging? : boolean,
 		}
@@ -161,7 +160,6 @@ export type Config = {
 	signToActivityPubGet: boolean | undefined;
 	logging?: {
 		sql?: {
-			disableHighlight? : boolean,
 			disableQueryTruncation? : boolean,
 			enableQueryParamLogging? : boolean,
 		}

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -99,6 +99,14 @@ type Source = {
 	perUserNotificationsMaxCount?: number;
 	deactivateAntennaThreshold?: number;
 	pidFile: string;
+
+	logging?: {
+		sql?: {
+			disableHighlight? : boolean,
+			disableQueryTruncation? : boolean,
+			enableQueryParamLogging? : boolean,
+		}
+	}
 };
 
 export type Config = {
@@ -151,6 +159,13 @@ export type Config = {
 	inboxJobMaxAttempts: number | undefined;
 	proxyRemoteFiles: boolean | undefined;
 	signToActivityPubGet: boolean | undefined;
+	logging?: {
+		sql?: {
+			disableHighlight? : boolean,
+			disableQueryTruncation? : boolean,
+			enableQueryParamLogging? : boolean,
+		}
+	}
 
 	version: string;
 	publishTarballInsteadOfProvideRepositoryUrl: boolean;
@@ -293,6 +308,7 @@ export function loadConfig(): Config {
 		perUserNotificationsMaxCount: config.perUserNotificationsMaxCount ?? 500,
 		deactivateAntennaThreshold: config.deactivateAntennaThreshold ?? (1000 * 60 * 60 * 24 * 7),
 		pidFile: config.pidFile,
+		logging: config.logging,
 	};
 }
 

--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -104,6 +104,14 @@ function truncateSql(sql: string) {
 	return sql.length > 100 ? `${sql.substring(0, 100)}...` : sql;
 }
 
+function stringifyParameter(param: any) {
+	if (param instanceof Date) {
+		return param.toISOString();
+	} else {
+		return param;
+	}
+}
+
 class MyCustomLogger implements Logger {
 	constructor(private props: LoggerProps = {}) {
 	}
@@ -120,19 +128,11 @@ class MyCustomLogger implements Logger {
 
 	@bindThis
 	private transformParameters(parameters?: any[]) {
-		function stringifyParameter(param: any) {
-			if (param instanceof Date) {
-				return param.toISOString();
-			} else {
-				return param;
-			}
+		if (this.props.enableQueryParamLogging && parameters && parameters.length > 0) {
+			return parameters.map(stringifyParameter);
 		}
 
-		if (!this.props.enableQueryParamLogging || !parameters || parameters.length === 0) {
-			return undefined;
-		}
-
-		return parameters.map(stringifyParameter);
+		return undefined;
 	}
 
 	@bindThis

--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -89,27 +89,68 @@ export const dbLogger = new MisskeyLogger('db');
 
 const sqlLogger = dbLogger.createSubLogger('sql', 'gray');
 
+export type LoggerProps = {
+	disableHighlight?: boolean;
+	disableQueryTruncation?: boolean;
+	enableQueryParamLogging?: boolean;
+}
+
+function highlightSql(sql: string) {
+	return highlight.highlight(sql, {
+		language: 'sql', ignoreIllegals: true,
+	});
+}
+
+function truncateSql(sql: string) {
+	return sql.length > 100 ? `${sql.substring(0, 100)}...` : sql;
+}
+
 class MyCustomLogger implements Logger {
+	constructor(private props: LoggerProps = {}) {
+	}
+
 	@bindThis
-	private highlight(sql: string) {
-		return highlight.highlight(sql, {
-			language: 'sql', ignoreIllegals: true,
-		});
+	private transformQueryLog(sql: string) {
+		let modded = sql;
+		if (!this.props.disableQueryTruncation) {
+			modded = truncateSql(modded);
+		}
+		if (!this.props.disableHighlight) {
+			modded = highlightSql(modded);
+		}
+		return modded;
+	}
+
+	@bindThis
+	private transformParameters(parameters?: any[]) {
+		function stringifyParameter(param: any) {
+			if (param instanceof Date) {
+				return param.toISOString();
+			} else {
+				return param;
+			}
+		}
+
+		if (!this.props.enableQueryParamLogging || !parameters || parameters.length === 0) {
+			return undefined;
+		}
+
+		return parameters.map(stringifyParameter);
 	}
 
 	@bindThis
 	public logQuery(query: string, parameters?: any[]) {
-		sqlLogger.info(this.highlight(query).substring(0, 100));
+		sqlLogger.info(this.transformQueryLog(query), this.transformParameters(parameters));
 	}
 
 	@bindThis
 	public logQueryError(error: string, query: string, parameters?: any[]) {
-		sqlLogger.error(this.highlight(query));
+		sqlLogger.error(this.transformQueryLog(query), this.transformParameters(parameters));
 	}
 
 	@bindThis
 	public logQuerySlow(time: number, query: string, parameters?: any[]) {
-		sqlLogger.warn(this.highlight(query));
+		sqlLogger.warn(this.transformQueryLog(query), this.transformParameters(parameters));
 	}
 
 	@bindThis
@@ -247,7 +288,13 @@ export function createPostgresDataSource(config: Config) {
 			},
 		} : false,
 		logging: log,
-		logger: log ? new MyCustomLogger() : undefined,
+		logger: log
+			? new MyCustomLogger({
+				disableHighlight: config.logging?.sql?.disableHighlight,
+				disableQueryTruncation: config.logging?.sql?.disableQueryTruncation,
+				enableQueryParamLogging: config.logging?.sql?.enableQueryParamLogging,
+			})
+			: undefined,
 		maxQueryExecutionTime: 300,
 		entities: entities,
 		migrations: ['../../migration/*.js'],

--- a/packages/backend/src/postgres.ts
+++ b/packages/backend/src/postgres.ts
@@ -90,7 +90,6 @@ export const dbLogger = new MisskeyLogger('db');
 const sqlLogger = dbLogger.createSubLogger('sql', 'gray');
 
 export type LoggerProps = {
-	disableHighlight?: boolean;
 	disableQueryTruncation?: boolean;
 	enableQueryParamLogging?: boolean;
 }
@@ -115,10 +114,8 @@ class MyCustomLogger implements Logger {
 		if (!this.props.disableQueryTruncation) {
 			modded = truncateSql(modded);
 		}
-		if (!this.props.disableHighlight) {
-			modded = highlightSql(modded);
-		}
-		return modded;
+
+		return highlightSql(modded);
 	}
 
 	@bindThis
@@ -290,7 +287,6 @@ export function createPostgresDataSource(config: Config) {
 		logging: log,
 		logger: log
 			? new MyCustomLogger({
-				disableHighlight: config.logging?.sql?.disableHighlight,
 				disableQueryTruncation: config.logging?.sql?.disableQueryTruncation,
 				enableQueryParamLogging: config.logging?.sql?.enableQueryParamLogging,
 			})


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

タイトルの通りです。以下のことが出来るようになります。
- クエリを100文字で切り捨てず全文出すかを設定可能に
- クエリパラメータをログに出力するかを設定可能に

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix https://github.com/misskey-dev/misskey/issues/15266

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

ローカルで実際に動作確認

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
