### PR TITLE
fix(backend): clone schema before converting to OAS schema to avoid mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Fix: `/api/pages/update`にて`name`を指定せずにリクエストするとエラーが発生する問題を修正
 - Fix: AIセンシティブ判定が arm64 環境で動作しない問題を修正
 - Fix: 非Misskey系のソフトウェアからHTML`<ruby>`タグを含むノートを受信した場合、MFMの読み仮名（ルビ）文法に変換して表示
+- Fix: `/api.json`のレスポンスが2回目のリクエスト以降おかしくなる問題を修正
 
 ### Misskey.js
 - Feat: allow setting `binaryType` of WebSocket connection

--- a/packages/backend/src/server/api/openapi/schemas.ts
+++ b/packages/backend/src/server/api/openapi/schemas.ts
@@ -9,7 +9,8 @@ import { refs } from '@/misc/json-schema.js';
 export function convertSchemaToOpenApiSchema(schema: Schema, type: 'param' | 'res', includeSelfRef: boolean): any {
 	// optional, nullable, refはスキーマ定義に含まれないので分離しておく
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { optional, nullable, ref, selfRef, ...res }: any = schema;
+	const { optional, nullable, ref, selfRef, ..._res }: any = schema;
+	const res = structuredClone(_res);
 
 	if (schema.type === 'object' && schema.properties) {
 		if (type === 'res') {

--- a/packages/backend/src/server/api/openapi/schemas.ts
+++ b/packages/backend/src/server/api/openapi/schemas.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import { deepClone } from '@/misc/clone.js';
 import type { Schema } from '@/misc/json-schema.js';
 import { refs } from '@/misc/json-schema.js';
 
@@ -10,7 +11,7 @@ export function convertSchemaToOpenApiSchema(schema: Schema, type: 'param' | 're
 	// optional, nullable, refはスキーマ定義に含まれないので分離しておく
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { optional, nullable, ref, selfRef, ..._res }: any = schema;
-	const res = structuredClone(_res);
+	const res = deepClone(_res);
 
 	if (schema.type === 'object' && schema.properties) {
 		if (type === 'res') {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
バックエンドのスキーマを OpenAPI Spec 準拠のスキーマに変更する際にスキーマを事前にクローンするようにします。

（そもそも `/api.json` を動的に生成するのをやめたほうがいい気はしますが、比較的変更量が大きくなりそうなので後回しにします）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
スキーマのメモリが汚れて2回目以降のレスポンスに影響するため

Closes #15293

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
