### PR TITLE
fix: 絵文字のライセンスのActivityPub contextを追加

### DIFF
--- a/packages/backend/src/core/activitypub/misc/contexts.ts
+++ b/packages/backend/src/core/activitypub/misc/contexts.ts
@@ -558,6 +558,11 @@ const extension_context_definition = {
 	'_misskey_requireSigninToViewContents': 'misskey:_misskey_requireSigninToViewContents',
 	'_misskey_makeNotesFollowersOnlyBefore': 'misskey:_misskey_makeNotesFollowersOnlyBefore',
 	'_misskey_makeNotesHiddenBefore': 'misskey:_misskey_makeNotesHiddenBefore',
+	'_misskey_license': 'misskey:_misskey_license',
+	'freeText': {
+		'@id': 'misskey:freeText',
+		'@type': 'schema:text',
+	},
 	'isCat': 'misskey:isCat',
 	// vcard
 	vcard: 'http://www.w3.org/2006/vcard/ns#',


### PR DESCRIPTION
fix #15182 