### PR TITLE
fix(dev): devcontainerのcorepackのバージョンを指定するように

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
 		"ghcr.io/devcontainers/features/node:1": {
 			"version": "22.11.0"
 		},
-		"ghcr.io/devcontainers-contrib/features/corepack:1": {}
+		"ghcr.io/devcontainers-extra/features/corepack:1": {
+			"version": "0.31.0"
+		}
 	},
 	"forwardPorts": [3000],
 	"postCreateCommand": "/bin/bash .devcontainer/init.sh",


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- `devcontainer.json`でcorepackのバージョンを0.31.0に指定
- featuresのcorepackを`ghcr.io/devcontainers-extra/features/corepack`に変更

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
close #15412

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- `ghcr.io/devcontainers-contrib/features/corepack`はリポジトリがアーカイブされているため、後継と思しき`ghcr.io/devcontainers-extra/features/corepack`を使用したほうがいいと思われます。

- `init.sh`に`export COREPACK_DEFAULT_TO_LATEST=0`を指定してもcorepackのインストールは`devcontainer.json`のfeaturesで行うため意味がありませんでした

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
