### PR TITLE
fix(frontend, build): storybookのビルドエラー修正のためas構文にリファクタ

### DIFF
--- a/packages/frontend/src/components/MkTokenGenerateWindow.vue
+++ b/packages/frontend/src/components/MkTokenGenerateWindow.vue
@@ -79,8 +79,8 @@ const adminPermissions = Misskey.permissions.filter(p => p.startsWith('read:admi
 
 const dialog = shallowRef<InstanceType<typeof MkModalWindow>>();
 const name = ref(props.initialName);
-const permissionSwitches = ref(<Record<(typeof Misskey.permissions)[number], boolean>>{});
-const permissionSwitchesForAdmin = ref(<Record<(typeof Misskey.permissions)[number], boolean>>{});
+const permissionSwitches = ref({} as Record<(typeof Misskey.permissions)[number], boolean>);
+const permissionSwitchesForAdmin = ref({} as Record<(typeof Misskey.permissions)[number], boolean>);
 
 if (props.initialPermissions) {
 	for (const kind of props.initialPermissions) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

angler-bracket`<>`を使った型宣言から`as`を使った型宣言にリファクタ

> The two samples are equivalent. Using one over the other is mostly a choice of preference; however, when using TypeScript with JSX, only as-style assertions are allowed.

ref: https://www.typescriptlang.org/docs/handbook/basic-types.html#type-assertions

TSXは利用していないが、babelでのビルドなため疑わしいと思い変更したところビルド成功

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

https://github.com/misskey-dev/misskey/commit/27e8805dcbddb73571c8d7fea79c852d9697a26b からstorybookのビルドに失敗している

https://github.com/misskey-dev/misskey/actions/runs/13746349749/job/38441697145
```
[storybook:vue-docgen-plugin] Unexpected token (87:4)
file: ./src/components/MkTokenGenerateWindow.vue:87:4
    at toParseError (/home/runner/work/misskey/misskey/node_modules/.pnpm/@babel+parser@7.25.6/node_modules/@babel/parser/src/parse-error.ts:95:45)
```

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

ローカル環境ではこれでstorybookのビルド通ったのでCIで通ったらマージしてください

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
