### PR TITLE
[WIP] enhance(backend): hoist HTTP signature and note lockdown checks for existing users to ActivityPubServerService

### DIFF
--- a/packages/backend/src/core/IdService.ts
+++ b/packages/backend/src/core/IdService.ts
@@ -7,11 +7,11 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ulid } from 'ulid';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
-import { genAid, isSafeAidT, parseAid } from '@/misc/id/aid.js';
-import { genAidx, isSafeAidxT, parseAidx } from '@/misc/id/aidx.js';
-import { genMeid, isSafeMeidT, parseMeid } from '@/misc/id/meid.js';
-import { genMeidg, isSafeMeidgT, parseMeidg } from '@/misc/id/meidg.js';
-import { genObjectId, isSafeObjectIdT, parseObjectId } from '@/misc/id/object-id.js';
+import { floorAid, ceilAid, genAid, isSafeAidT, parseAid } from '@/misc/id/aid.js';
+import { floorAidx, ceilAidx, genAidx, isSafeAidxT, parseAidx } from '@/misc/id/aidx.js';
+import { floorMeid, ceilMeid, genMeid, isSafeMeidT, parseMeid } from '@/misc/id/meid.js';
+import { floorMeidg, ceilMeidg, genMeidg, isSafeMeidgT, parseMeidg } from '@/misc/id/meidg.js';
+import { floorObjectId, ceilObjectId, genObjectId, isSafeObjectIdT, parseObjectId } from '@/misc/id/object-id.js';
 import { bindThis } from '@/decorators.js';
 import { parseUlid } from '@/misc/id/ulid.js';
 
@@ -54,6 +54,32 @@ export class IdService {
 			case 'meidg': return genMeidg(t);
 			case 'ulid': return ulid(t);
 			case 'objectid': return genObjectId(t);
+			default: throw new Error('unrecognized id generation method');
+		}
+	}
+
+	@bindThis
+	public floor(time: number): string {
+		switch (this.method) {
+			case 'aid': return floorAid(time);
+			case 'aidx': return floorAidx(time);
+			case 'meid': return floorMeid(time);
+			case 'meidg': return floorMeidg(time);
+			case 'ulid': return ulid(time);
+			case 'objectid': return floorObjectId(time);
+			default: throw new Error('unrecognized id generation method');
+		}
+	}
+
+	@bindThis
+	public ceil(time: number): string {
+		switch (this.method) {
+			case 'aid': return ceilAid(time);
+			case 'aidx': return ceilAidx(time);
+			case 'meid': return ceilMeid(time);
+			case 'meidg': return ceilMeidg(time);
+			case 'ulid': return ulid(time);
+			case 'objectid': return ceilObjectId(time);
 			default: throw new Error('unrecognized id generation method');
 		}
 	}

--- a/packages/backend/src/core/QueueService.ts
+++ b/packages/backend/src/core/QueueService.ts
@@ -37,6 +37,7 @@ import type {
 } from './QueueModule.js';
 import type httpSignature from '@peertube/http-signature';
 import type * as Bull from 'bullmq';
+import type { HttpSignatureContext } from '@/server/ActivityPubServerService.js';
 
 @Injectable()
 export class QueueService {
@@ -170,10 +171,10 @@ export class QueueService {
 	}
 
 	@bindThis
-	public inbox(activity: IActivity, signature: httpSignature.IParsedSignature) {
+	public inbox(activity: IActivity, context: HttpSignatureContext) {
 		const data = {
 			activity: activity,
-			signature,
+			signature: context
 		};
 
 		return this.inboxQueue.add('', data, {

--- a/packages/backend/src/misc/id/aid.ts
+++ b/packages/backend/src/misc/id/aid.ts
@@ -30,6 +30,15 @@ export function genAid(t: number): string {
 	return getTime(t) + getNoise();
 }
 
+export function floorAid(t: number): string {
+	return getTime(t) + '00';
+}
+
+export function ceilAid(t: number): string {
+	return getTime(t) + 'zz';
+}
+
+
 export function parseAid(id: string): { date: Date; } {
 	const time = parseInt(id.slice(0, 8), 36) + TIME2000;
 	return { date: new Date(time) };

--- a/packages/backend/src/misc/id/aidx.ts
+++ b/packages/backend/src/misc/id/aidx.ts
@@ -37,6 +37,14 @@ export function genAidx(t: number): string {
 	return getTime(t) + nodeId + getNoise();
 }
 
+export function floorAidx(t: number): string {
+	return getTime(t) + nodeId + '0000';
+}
+
+export function ceilAidx(t: number): string {
+	return getTime(t) + nodeId + 'zzzz';
+}
+
 export function parseAidx(id: string): { date: Date; } {
 	const time = parseInt(id.slice(0, TIME_LENGTH), 36) + TIME2000;
 	return { date: new Date(time) };

--- a/packages/backend/src/misc/id/meid.ts
+++ b/packages/backend/src/misc/id/meid.ts
@@ -33,6 +33,14 @@ export function genMeid(t: number): string {
 	return getTime(t) + getRandom();
 }
 
+export function floorMeid(t: number): string {
+	return getTime(t) + '000000000000';
+}
+
+export function ceilMeid(t: number): string {
+	return getTime(t) + 'zzzzzzzzzzzz';
+}
+
 export function parseMeid(id: string): { date: Date; } {
 	return {
 		date: new Date(parseInt(id.slice(0, 12), 16) - 0x800000000000),

--- a/packages/backend/src/misc/id/meidg.ts
+++ b/packages/backend/src/misc/id/meidg.ts
@@ -33,6 +33,14 @@ export function genMeidg(t: number): string {
 	return 'g' + getTime(t) + getRandom();
 }
 
+export function floorMeidg(t: number): string {
+	return 'g' + getTime(t) + '000000000000';
+}
+
+export function ceilMeidg(t: number): string {
+	return 'g' + getTime(t) + 'zzzzzzzzzzzz';
+}
+
 export function parseMeidg(id: string): { date: Date; } {
 	return {
 		date: new Date(parseInt(id.slice(1, 12), 16)),

--- a/packages/backend/src/misc/id/object-id.ts
+++ b/packages/backend/src/misc/id/object-id.ts
@@ -33,6 +33,14 @@ export function genObjectId(t: number): string {
 	return getTime(t) + getRandom();
 }
 
+export function floorObjectId(t: number): string {
+	return getTime(t) + '0000000000000000';
+}
+
+export function ceilObjectId(t: number): string {
+	return getTime(t) + 'zzzzzzzzzzzzzzzz';
+}
+
 export function parseObjectId(id: string): { date: Date; } {
 	return {
 		date: new Date(parseInt(id.slice(0, 8), 16) * 1000),

--- a/packages/backend/src/queue/types.ts
+++ b/packages/backend/src/queue/types.ts
@@ -12,7 +12,7 @@ import type { MiWebhook, WebhookEventTypes } from '@/models/Webhook.js';
 import type { IActivity } from '@/core/activitypub/type.js';
 import type { SystemWebhookPayload } from '@/core/SystemWebhookService.js';
 import type { UserWebhookPayload } from '@/core/UserWebhookService.js';
-import type httpSignature from '@peertube/http-signature';
+import type { HttpSignatureContext } from '@/server/ActivityPubServerService.js';
 
 export type DeliverJobData = {
 	/** Actor */
@@ -29,7 +29,7 @@ export type DeliverJobData = {
 
 export type InboxJobData = {
 	activity: IActivity;
-	signature: httpSignature.IParsedSignature;
+	signature: HttpSignatureContext;
 };
 
 export type RelationshipJobData = {

--- a/packages/backend/src/server/api/endpoints/admin/queue/inbox-delayed.ts
+++ b/packages/backend/src/server/api/endpoints/admin/queue/inbox-delayed.ts
@@ -55,7 +55,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			const res = [] as [string, number][];
 
 			for (const job of jobs) {
-				const host = new URL(job.data.signature.keyId).host;
+				const host = new URL(job.data.signature.signature).host;
 				if (res.find(x => x[0] === host)) {
 					res.find(x => x[0] === host)![1]++;
 				} else {


### PR DESCRIPTION
## What

タイトル通りです。

Some minor sideline changes:

Removed 'Vary' header for /note/:id/activity, I think it always return AP?

## Why

- Fixes #15644 
- Makes #14684 much easier to implement
- Hoisted HTTP signature validation upwards to HTTP handler (see addn. info) to enable filtering notes by lockdown settings.


## Additional info (optional)

RSA signature validation is pretty fast in the grand scheme of RSA (in the order of 20-50kops/s IIRC), I think we can hoist it up to provide more opportunities for filtering with less impact on legitimate federation.

## Checklist
- [X] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] TODO: Test working in a local environment
- [ ] TODO: Update CHANGELOG.md
- [ ] TODO: Add tests
