### PR TITLE
fix(i18n): 通知タイプのcreateTokenが抜けていたのを修正

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -9778,6 +9778,10 @@ export interface Locale extends ILocale {
              */
             "login": string;
             /**
+             * アクセストークンの作成
+             */
+            "createToken": string;
+            /**
              * 通知のテスト
              */
             "test": string;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2584,6 +2584,7 @@ _notification:
     achievementEarned: "実績の獲得"
     exportCompleted: "エクスポートが完了した"
     login: "ログイン"
+    createToken: "アクセストークンの作成"
     test: "通知のテスト"
     app: "連携アプリからの通知"
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
e3392936736c16000b837f1549943d2f241e01b2 にて追加されていた機能のローカライゼーションが抜けていたのを修正

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`settings/notifications`にて無が表示されていたが、正しく表示されるようになる

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
