### PR TITLE
fix(ci): quote `branches-ignore` pattern in Storybook workflow

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -12,8 +12,8 @@ on:
       # This is a waste of chromatic build quota, so we don't run storybook CI on pull requests targets master.
       - master
       # Neither Dependabot nor Renovate will change the actual behavior for components.
-      - dependabot/**
-      - renovate/**
+      - 'dependabot/**'
+      - 'renovate/**'
 
 jobs:
   build:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
> The `*` character is a special character in YAML. When you start a pattern with `*`, you must use quotes.
> https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Storybook ワークフローの `branches-ignore` が効いていないため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
