### PR TITLE
fix(ci): correct condition for skipping Chromatic build

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,8 +18,8 @@ jobs:
     # Neither Dependabot nor Renovate will change the actual behavior for components.
     if: >-
       github.repository == 'misskey-dev/misskey' &&
-      startsWith(github.ref, 'refs/heads/dependabot/') != true &&
-      startsWith(github.ref, 'refs/heads/renovate/') != true
+      startsWith(github.head_ref, 'refs/heads/dependabot/') != true &&
+      startsWith(github.head_ref, 'refs/heads/renovate/') != true
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
https://github.com/misskey-dev/misskey/labels/dependencies 系 PR で Chromatic CI が動いてしまっているのが直っていないのを修正します。

うまくスキップできていない原因はおそらく `pull_request_target` で動いているために `github.ref` が base ブランチに等しくなっているためで、`github.head_ref` にすれば直るものと思われます（未検証）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Follow-up to #15766

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
