### PR TITLE
fix(ci): change Chromatic build to be triggered when frontend `package.json` is edited instead of lockfile

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -18,8 +18,8 @@ jobs:
     # Neither Dependabot nor Renovate will change the actual behavior for components.
     if: >-
       github.repository == 'misskey-dev/misskey' &&
-      startsWith(github.head_ref, 'refs/heads/dependabot/') != true &&
-      startsWith(github.head_ref, 'refs/heads/renovate/') != true
+      startsWith(github.head_ref, 'dependabot/') != true &&
+      startsWith(github.head_ref, 'renovate/') != true
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,11 +15,7 @@ on:
 jobs:
   build:
     # Chromatic is not likely to be available for fork repositories, so we disable for fork repositories.
-    # Neither Dependabot nor Renovate will change the actual behavior for components.
-    if: >-
-      github.repository == 'misskey-dev/misskey' &&
-      startsWith(github.head_ref, 'dependabot/') != true &&
-      startsWith(github.head_ref, 'renovate/') != true
+    if: github.repository == 'misskey-dev/misskey'
     runs-on: ubuntu-latest
 
     env:

--- a/packages/frontend/.storybook/changes.ts
+++ b/packages/frontend/.storybook/changes.ts
@@ -55,7 +55,7 @@ await fs.readFile(
 			'../../locales/ja-JP.yml',
 			'assets/**',
 			'public/**',
-			'../../pnpm-lock.yaml',
+			'package.json',
 		]).length
 	) {
 		return;

--- a/renovate.json5
+++ b/renovate.json5
@@ -38,6 +38,8 @@
 				'packages/misskey-reversi/**/package.json',
 				'packages/sw/**/package.json',
 			],
+			// prevent wastage of Chromatic snapshots
+			rebaseWhen: 'never',
 		},
 		{
 			groupName: '[misskey-js] Update dependencies',


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
#15783 の修正が再びうまく行ってなかったのを直します。公式ドキュメントを見る限り `refs/heads/` は不要だったようです[^1]。確認不足で申し訳ないです。

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#running-your-pull_request_target-workflow-based-on-the-head-or-base-branch-of-a-pull-request

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Follow-up to #15783

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
