### PR TITLE
enhance(backend): DB note (userId) インデクス -> (userId, id) 複合インデクスにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Enhance: ジョブキューの成功/失敗したジョブも一定数・一定期間保存するようにし、後から問題を調査することを容易に
 - Enhance: フォローしているユーザーならフォロワー限定投稿のノートでもアンテナで検知できるように  
 	(Cherry-picked from https://github.com/yojo-art/cherrypick/pull/568 and https://github.com/team-shahu/misskey/pull/38)
+- Enhance: ユーザーごとにノートの表示が高速化するように
 - Fix: システムアカウントの名前がサーバー名と同期されない問題を修正
 - Fix: 大文字を含むユーザの URL で紹介された場合に 404 エラーを返す問題 #15813
 - Fix: リードレプリカ設定時にレコードの追加・更新・削除を伴うクエリを発行した際はmasterノードで実行されるように調整( #10897 )

--- a/packages/backend/migration/1745378064470-composite-note-index.js
+++ b/packages/backend/migration/1745378064470-composite-note-index.js
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class CompositeNoteIndex1745378064470 {
+	name = 'CompositeNoteIndex1745378064470';
+
+	async up(queryRunner) {
+		await queryRunner.query(`CREATE INDEX "IDX_724b311e6f883751f261ebe378" ON "note" ("userId", "id" DESC)`);
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_5b87d9d19127bd5d92026017a7"`);
+		// Flush all cached Linear Scan Plans and redo statistics for composite index
+		// this is important for Postgres to learn that even in highly complex queries, using this index first can reduce the result set significantly
+		await queryRunner.query(`ANALYZE "user", "note"`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`DROP INDEX IF EXISTS "IDX_724b311e6f883751f261ebe378"`);
+		await queryRunner.query(`CREATE INDEX "IDX_5b87d9d19127bd5d92026017a7" ON "note" ("userId")`);
+	}
+}

--- a/packages/backend/src/models/Note.ts
+++ b/packages/backend/src/models/Note.ts
@@ -10,6 +10,7 @@ import { MiUser } from './User.js';
 import { MiChannel } from './Channel.js';
 import type { MiDriveFile } from './DriveFile.js';
 
+@Index(['userId', 'id'])
 @Entity('note')
 export class MiNote {
 	@PrimaryColumn(id())
@@ -65,7 +66,6 @@ export class MiNote {
 	})
 	public cw: string | null;
 
-	@Index()
 	@Column({
 		...id(),
 		comment: 'The ID of author.',


### PR DESCRIPTION
Fixes #11094 

## What

Replaced the user ID only index in note table with composite ones. QueryService.ts#makePaginationQuery always order by the primary key so a composite index should handle this case and prevent regression due to b-tree characteristics.

## Why

See https://github.com/misskey-dev/misskey/issues/11094#issuecomment-2822849494 , this should be reproducible by just picking any user who exclusively posts follow-only posts, or someone with large posting history but has not posted for some time and try to list their notes.

ANALYZE without vacuum runs very quick (even on big tables the index creation would take the majority of time anyways), so I added it to make sure query plans are flushed.

Dropped the old (userId) index because (userId, id) btree indices can be used as (userId), with a tiny constant factor overhead if the query isn't actually ordered by ID. Generally with a legitimate reason to use composite index the overhead of maintaining the original index is not worth it.

## Additional info (optional)

Not sure whether I should write perf() or enhance(), perf() certainly fit the purpose more but doesn't seem to be used actually.

## Checklist
- [X] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [X] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [X] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
