### PR TITLE
fix(frontend): 非タッチ対応端末ではpull to refreshのデフォルトを無効にする

### DIFF
--- a/packages/frontend/src/preferences/def.ts
+++ b/packages/frontend/src/preferences/def.ts
@@ -5,6 +5,7 @@
 
 import * as Misskey from 'misskey-js';
 import { hemisphere } from '@@/js/intl-const.js';
+import { isTouchUsing } from '@/utility/touch.js';
 import type { Theme } from '@/theme.js';
 import type { SoundType } from '@/utility/sound.js';
 import type { Plugin } from '@/plugin.js';
@@ -301,7 +302,7 @@ export const PREF_DEF = {
 		default: true,
 	},
 	enablePullToRefresh: {
-		default: true,
+		default: isTouchUsing,
 	},
 	useNativeUiForVideoAudioPlayer: {
 		default: false,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
タッチ対応端末でのデフォルト値はtrueとし、タッチ非対応でのデフォルト値はfalseとした。
これにより、従来の挙動（pull to refreshはタッチ操作でのみ利用できる）を保ちつつ、試したいユーザーはオプトインにてタッチ非対応端末でpull to refreshを利用できるようになる。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #15931
#15931 の解決策のうちの一つ

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ← 同一バージョンのため記載不要と判断
- [ ] (If possible) Add tests
