### PR TITLE
enhance(frontend): タイムラインpush時のアニメーションを調整

### DIFF
--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -112,7 +112,7 @@ defineExpose({
 
 	&.item,
 	.item {
-		/* Skip Note Rendering有効時、TransitionGroupでnoteを追加するときに一瞬がくっとなる問題を抑制する */
+		/* Skip Note Rendering有効時、TransitionGroupで通知を追加するときに一瞬がくっとなる問題を抑制する */
 		content-visibility: visible !important;
 	}
 }

--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -120,10 +120,15 @@ defineExpose({
 	transform: translateY(max(-64px, -100%));
 }
 
+@supports (interpolate-size: allow-keywords) {
+	.transition_x_enterFrom {
+		interpolate-size: allow-keywords; // heightのtransitionを動作させるために必要
+		height: 0;
+	}
+}
+
 .transition_x_leaveTo {
-	interpolate-size: allow-keywords;
-	height: 0;
-	overflow: clip;
+	opacity: 0;
 }
 
 .notifications {

--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -103,18 +103,17 @@ defineExpose({
 </script>
 
 <style lang="scss" module>
-.transition_x_move,
-.transition_x_enterActive,
-.transition_x_leaveActive {
-	transition: opacity 0.3s cubic-bezier(0,.5,.5,1), transform 0.3s cubic-bezier(0,.5,.5,1) !important;
+.transition_x_move {
+	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1);
 }
-.transition_x_enterFrom,
-.transition_x_leaveTo {
+
+.transition_x_enterActive {
+	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.transition_x_enterFrom {
 	opacity: 0;
-	transform: translateY(-50%);
-}
-.transition_x_leaveActive {
-	position: absolute;
+	transform: translateY(max(-64px, -100%));
 }
 
 .notifications {

--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -111,9 +111,19 @@ defineExpose({
 	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
+.transition_x_leaveActive {
+	transition: height 0.2s cubic-bezier(0,.5,.5,1), opacity 0.2s cubic-bezier(0,.5,.5,1);
+}
+
 .transition_x_enterFrom {
 	opacity: 0;
 	transform: translateY(max(-64px, -100%));
+}
+
+.transition_x_leaveTo {
+	interpolate-size: allow-keywords;
+	height: 0;
+	overflow: clip;
 }
 
 .notifications {

--- a/packages/frontend/src/components/MkNotifications.vue
+++ b/packages/frontend/src/components/MkNotifications.vue
@@ -109,6 +109,12 @@ defineExpose({
 
 .transition_x_enterActive {
 	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
+
+	&.item,
+	.item {
+		/* Skip Note Rendering有効時、TransitionGroupでnoteを追加するときに一瞬がくっとなる問題を抑制する */
+		content-visibility: visible !important;
+	}
 }
 
 .transition_x_leaveActive {

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -305,18 +305,17 @@ defineExpose({
 </script>
 
 <style lang="scss" module>
-.transition_x_move,
-.transition_x_enterActive,
-.transition_x_leaveActive {
-	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1) !important;
+.transition_x_move {
+	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1);
 }
-.transition_x_enterFrom,
-.transition_x_leaveTo {
+
+.transition_x_enterActive {
+	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.transition_x_enterFrom {
 	opacity: 0;
-	transform: translateY(-64px);
-}
-.transition_x_leaveActive {
-	position: absolute;
+	transform: translateY(max(-64px, -100%));
 }
 
 .reverse {

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -322,10 +322,15 @@ defineExpose({
 	transform: translateY(max(-64px, -100%));
 }
 
+@supports (interpolate-size: allow-keywords) {
+	.transition_x_leaveTo {
+		interpolate-size: allow-keywords; // heightのtransitionを動作させるために必要
+		height: 0;
+	}
+}
+
 .transition_x_leaveTo {
-	interpolate-size: allow-keywords;
-	height: 0;
-	overflow: clip;
+	opacity: 0;
 }
 
 .reverse {

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				:leaveActiveClass="$style.transition_x_leaveActive"
 				:enterFromClass="$style.transition_x_enterFrom"
 				:leaveToClass="$style.transition_x_leaveTo"
-				:moveClass=" $style.transition_x_move"
+				:moveClass="$style.transition_x_move"
 				tag="div"
 			>
 				<template v-for="(note, i) in notes" :key="note.id">
@@ -311,6 +311,12 @@ defineExpose({
 
 .transition_x_enterActive {
 	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
+
+	&.note,
+	.note {
+		/* Skip Note Rendering有効時、TransitionGroupでnoteを追加するときに一瞬がくっとなる問題を抑制する */
+		content-visibility: visible !important;
+	}
 }
 
 .transition_x_leaveActive {

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -313,9 +313,19 @@ defineExpose({
 	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.7s cubic-bezier(0.23, 1, 0.32, 1);
 }
 
+.transition_x_leaveActive {
+	transition: height 0.2s cubic-bezier(0,.5,.5,1), opacity 0.2s cubic-bezier(0,.5,.5,1);
+}
+
 .transition_x_enterFrom {
 	opacity: 0;
 	transform: translateY(max(-64px, -100%));
+}
+
+.transition_x_leaveTo {
+	interpolate-size: allow-keywords;
+	height: 0;
+	overflow: clip;
 }
 
 .reverse {

--- a/packages/frontend/src/components/MkTimeline.vue
+++ b/packages/frontend/src/components/MkTimeline.vue
@@ -308,12 +308,12 @@ defineExpose({
 .transition_x_move,
 .transition_x_enterActive,
 .transition_x_leaveActive {
-	transition: opacity 0.3s cubic-bezier(0,.5,.5,1), transform 0.3s cubic-bezier(0,.5,.5,1) !important;
+	transition: transform 0.7s cubic-bezier(0.23, 1, 0.32, 1) !important;
 }
 .transition_x_enterFrom,
 .transition_x_leaveTo {
 	opacity: 0;
-	transform: translateY(-50%);
+	transform: translateY(-64px);
 }
 .transition_x_leaveActive {
 	position: absolute;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
通知タイムライン・ノートタイムラインの追加時のアニメーションを微調整

- 追加時のアニメーションをMkDateSeparatedList準拠のものに変更
- 削除時のアニメーションを変更（Slackのようにheightが0に向かってアニメーションするようにした。`@supports` ルールにより、 `interpolate-size: allow-keywords`未対応の場合はフェードアウトのみ行われる）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
MkDateSeparatedListのアニメーションのほうが個人的には良かったとおもったため

タイムラインはユーザー体験の核となる部分なので微調整が効きそう

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
正直好みの問題なので要らなければ要らないでよい

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
