### PR TITLE
チャンネル既読の同期

### DIFF
--- a/packages/frontend/src/boot/main-boot.ts
+++ b/packages/frontend/src/boot/main-boot.ts
@@ -29,6 +29,7 @@ import { prefer } from '@/preferences.js';
 import { updateCurrentAccountPartial } from '@/accounts.js';
 import { migrateOldSettings } from '@/pref-migrate.js';
 import { unisonReload } from '@/utility/unison-reload.js';
+import { miRegistoryItem } from '@/registry-item.js';
 
 export async function mainBoot() {
 	const { isClientUpdated, lastVersion } = await common(async () => {
@@ -285,6 +286,8 @@ export async function mainBoot() {
 		//	}
 		//}
 		//miLocalStorage.setItem('lastUsed', Date.now().toString());
+		const channelLastReadedAt = await miRegistoryItem.get('channelsLastReadedAt');
+		miLocalStorage.setItemAsJson('channelsLastReadedAt', channelLastReadedAt);
 
 		const latestDonationInfoShownAt = miLocalStorage.getItem('latestDonationInfoShownAt');
 		const neverShowDonationInfo = miLocalStorage.getItem('neverShowDonationInfo');

--- a/packages/frontend/src/components/MkChannelPreview.vue
+++ b/packages/frontend/src/components/MkChannelPreview.vue
@@ -56,7 +56,7 @@ const props = defineProps<{
 }>();
 
 const getLastReadedAt = (): number | null => {
-	return miLocalStorage.getItemAsJson(`channelLastReadedAt:${props.channel.id}`) ?? null;
+	return miLocalStorage.getItemAsJson('channelsLastReadedAt')[props.channel.id] ?? null;
 };
 
 const lastReadedAt = ref(getLastReadedAt());

--- a/packages/frontend/src/local-storage.ts
+++ b/packages/frontend/src/local-storage.ts
@@ -39,7 +39,8 @@ export type Keys = (
 	`aiscript:${string}` |
 	'lastEmojisFetchedAt' | // DEPRECATED, stored in indexeddb (13.9.0~)
 	'emojis' | // DEPRECATED, stored in indexeddb (13.9.0~);
-	`channelLastReadedAt:${string}` |
+	`channelLastReadedAt:${string}` | // DEPRECATED, stored channelsLastReadedAt and registry
+	'channelsLastReadedAt' |
 	`idbfallback::${string}`
 );
 

--- a/packages/frontend/src/pages/timeline.vue
+++ b/packages/frontend/src/pages/timeline.vue
@@ -148,7 +148,7 @@ async function chooseChannel(ev: MouseEvent): Promise<void> {
 	const channels = await favoritedChannelsCache.fetch();
 	const items: (MenuItem | undefined)[] = [
 		...channels.map(channel => {
-			const lastReadedAt = miLocalStorage.getItemAsJson(`channelLastReadedAt:${channel.id}`) ?? null;
+			const lastReadedAt = miLocalStorage.getItemAsJson('channelsLastReadedAt')[channel.id] ?? null;
 			const hasUnreadNote = (lastReadedAt && channel.lastNotedAt) ? Date.parse(channel.lastNotedAt) > lastReadedAt : !!(!lastReadedAt && channel.lastNotedAt);
 
 			return {

--- a/packages/frontend/src/registry-item.ts
+++ b/packages/frontend/src/registry-item.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { misskeyApi } from '@/utility/misskey-api.js';
+
+export type Keys =
+	'channelsLastReadedAt' | // DEPRECATED, stored registory(2025.1.xxx)
+	'somethingElse';
+
+export const miRegistoryItem = {
+	async get(key: Keys) {
+		try {
+			return JSON.parse(await misskeyApi('i/registry/get', { scope: ['client'], key }));
+		} catch (err) {
+			if (err.code === 'NO_SUCH_KEY') return {};
+			throw err;
+		}
+	},
+	async set(key: Keys, payload) {
+		await misskeyApi('i/registry/set', { scope: ['client'], key, value: JSON.stringify(payload) });
+	},
+};
+


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
チャンネルの既読状態をlocalstorageとともにレジストリを使って同期するようにしました

#related #15976

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
端末をまたぐと既読情報が維持されないのはユーザーのメンタルモデルに反します

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
- データの書き込み先にレジストリを使っています　よりベターな方法があるかもしれませんがとりあえず動きます。頻度的に他の操作より大した問題ではないと判断
- チャンネル既読のデータ構造が １チャンネルにつきlocalstorage 1レコードを使用していたのに対して、チャンネル既読そのものを1レコードとしてjsonに格納しています
- このPRを導入するとチャンネルの既読情報が一度リセットされてすべて未読状態ではじまります。初期状態は既読状態で始まるほうがUX的にはよいのでは（チカチカしてると消しにいきたくなる）という話もちらほら

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
