### PR TITLE
enhance(frontend): シンタックスハイライトのエンジンをJavaScriptベースのものに変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   (Based on https://github.com/taiyme/misskey/pull/198, https://github.com/taiyme/misskey/pull/211, https://github.com/taiyme/misskey/pull/283)
 - Enhance: ユーザー設定でURLプレビューを無効化できるように
 - Enhance: AiScriptからtoastを表示する関数 `Mk:toast` を追加
+- Enhance: シンタックスハイライトのエンジンをJavaScriptベースのものに変更
+  - フロントエンドの読み込みサイズを軽量化しました
+	- ほとんどの言語のハイライトは問題なく行えますが、互換性の問題により一部の言語が正常にハイライトできなくなる可能性があります。詳しくは https://shiki.style/references/engine-js-compat をご覧ください。
 - Fix: "時計"ウィジェット(Clock)において、Transparent設定が有効でも、その背景が透過されない問題を修正
 
 ### Server

--- a/packages/frontend/src/utility/code-highlighter.ts
+++ b/packages/frontend/src/utility/code-highlighter.ts
@@ -4,7 +4,7 @@
  */
 
 import { createHighlighterCore } from 'shiki/core';
-import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
 import darkPlus from 'shiki/themes/dark-plus.mjs';
 import { bundledThemesInfo } from 'shiki/themes';
 import { bundledLanguagesInfo } from 'shiki/langs';
@@ -71,7 +71,7 @@ async function initHighlighter() {
 
 	const jsLangInfo = bundledLanguagesInfo.find(t => t.id === 'javascript');
 	const highlighter = await createHighlighterCore({
-		engine: createOnigurumaEngine(() => import('shiki/onig.wasm?init')),
+		engine: createJavaScriptRegexEngine({ forgiving: true }),
 		themes,
 		langs: [
 			...(jsLangInfo ? [async () => await jsLangInfo.import()] : []),


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
シンタックスハイライトの定義が正規表現を拡張した構文「鬼車」を使用しているためWebAssemblyを使用してパースしていたところを、 https://shiki.style/guide/regex-engines にあるJavaScriptネイティブ正規表現への互換レイヤをかます方式に置き換え

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
バンドルサイズを削減・コードハイライター読み込みの読み込みを高速化

> The advantages of using the JavaScript engine are that it doesn't require loading a large WebAssembly file for Oniguruma and it is faster for some languages (since the regular expressions run as native JavaScript).

（参考：frontend_distフォルダのサイズ比較）
前：16132kB
後：11740kB

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
https://shiki.style/references/engine-js-compat#unsupported-languages

AiScript VSCode tmLanguageがJavaScriptエンジンで動作するかは AiScript Docs で検証済み（↓ Shiki JavaScriptエンジンで動作中）
https://aiscript-dev.github.io/ja/playground.html

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
