### PR TITLE
fix(backend): better nullable ref schema representation

### DIFF
--- a/packages/backend/src/server/api/openapi/schemas.ts
+++ b/packages/backend/src/server/api/openapi/schemas.ts
@@ -38,14 +38,14 @@ export function convertSchemaToOpenApiSchema(schema: Schema, type: 'param' | 're
 
 	if (type === 'res' && schema.ref && (!schema.selfRef || includeSelfRef)) {
 		const $ref = `#/components/schemas/${schema.ref}`;
-		if (schema.nullable || schema.optional) {
-			res.allOf = [{ $ref }];
+		if (schema.nullable) {
+			res.oneOf = [{ $ref }];
+			res.oneOf.push({ type: 'null' });
 		} else {
 			res.$ref = $ref;
 		}
-	}
-
-	if (schema.nullable) {
+		delete res.type;
+	} else if (schema.nullable) {
 		if (Array.isArray(schema.type) && !schema.type.includes('null')) {
 			res.type.push('null');
 		} else if (typeof schema.type === 'string') {

--- a/packages/backend/src/server/api/openapi/schemas.ts
+++ b/packages/backend/src/server/api/openapi/schemas.ts
@@ -39,8 +39,7 @@ export function convertSchemaToOpenApiSchema(schema: Schema, type: 'param' | 're
 	if (type === 'res' && schema.ref && (!schema.selfRef || includeSelfRef)) {
 		const $ref = `#/components/schemas/${schema.ref}`;
 		if (schema.nullable) {
-			res.oneOf = [{ $ref }];
-			res.oneOf.push({ type: 'null' });
+			res.oneOf = [{ $ref }, { type: 'null' }];
 		} else {
 			res.$ref = $ref;
 		}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- nullable な ref は `oneOf: [{ $ref: "#/foo" }, { type: "null" }]` で表現するように変更
- optional な ref も `allOf` にラップされてしまっていたのを修正
- ref に不要な `type` がつくのを削除

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
https://github.com/misskey-dev/misskey/pull/15491#issuecomment-2904021728

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
