### PR TITLE
fix(frontend); カスタム絵文字のリアクションが二重で表示されることがある問題を修正

### DIFF
--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -228,6 +228,7 @@ import { $i } from '@/i.js';
 import { i18n } from '@/i18n.js';
 import { getAbuseNoteMenu, getCopyNoteLinkMenu, getNoteClipMenu, getNoteMenu, getRenoteMenu } from '@/utility/get-note-menu.js';
 import { noteEvents, useNoteCapture } from '@/composables/use-note-capture.js';
+import type { ReactiveNoteData } from '@/composables/use-note-capture.js';
 import { deepClone } from '@/utility/clone.js';
 import { useTooltip } from '@/composables/use-tooltip.js';
 import { claimAchievement } from '@/utility/achievements.js';
@@ -283,12 +284,12 @@ if (noteViewInterruptors.length > 0) {
 
 const isRenote = Misskey.note.isPureRenote(note);
 const appearNote = getAppearNote(note);
-const $appearNote = reactive({
+const $appearNote = reactive<ReactiveNoteData>({
 	reactions: appearNote.reactions,
 	reactionCount: appearNote.reactionCount,
 	reactionEmojis: appearNote.reactionEmojis,
 	myReaction: appearNote.myReaction,
-	pollChoices: appearNote.poll?.choices,
+	pollChoices: appearNote.poll?.choices ?? [],
 });
 
 const rootEl = useTemplateRef('rootEl');

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -582,7 +582,6 @@ function undoReact(): void {
 }
 
 function toggleReact() {
-	console.log('toggleReact', $appearNote.myReaction);
 	if ($appearNote.myReaction == null) {
 		react();
 	} else {

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -582,6 +582,7 @@ function undoReact(): void {
 }
 
 function toggleReact() {
+	console.log('toggleReact', $appearNote.myReaction);
 	if ($appearNote.myReaction == null) {
 		react();
 	} else {

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -259,6 +259,7 @@ import { $i } from '@/i.js';
 import { i18n } from '@/i18n.js';
 import { getNoteClipMenu, getNoteMenu, getRenoteMenu } from '@/utility/get-note-menu.js';
 import { noteEvents, useNoteCapture } from '@/composables/use-note-capture.js';
+import type { ReactiveNoteData } from '@/composables/use-note-capture.js';
 import { deepClone } from '@/utility/clone.js';
 import { useTooltip } from '@/composables/use-tooltip.js';
 import { claimAchievement } from '@/utility/achievements.js';
@@ -304,12 +305,12 @@ if (noteViewInterruptors.length > 0) {
 
 const isRenote = Misskey.note.isPureRenote(note);
 const appearNote = getAppearNote(note);
-const $appearNote = reactive({
+const $appearNote = reactive<ReactiveNoteData>({
 	reactions: appearNote.reactions,
 	reactionCount: appearNote.reactionCount,
 	reactionEmojis: appearNote.reactionEmojis,
 	myReaction: appearNote.myReaction,
-	pollChoices: appearNote.poll?.choices,
+	pollChoices: appearNote.poll?.choices ?? [],
 });
 
 const rootEl = useTemplateRef('rootEl');

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -228,7 +228,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { computed, inject, onMounted, provide, reactive, ref, useTemplateRef } from 'vue';
+import { computed, inject, onMounted, provide, ref, useTemplateRef } from 'vue';
 import * as mfm from 'mfm-js';
 import * as Misskey from 'misskey-js';
 import { isLink } from '@@/js/is-link.js';
@@ -259,7 +259,6 @@ import { $i } from '@/i.js';
 import { i18n } from '@/i18n.js';
 import { getNoteClipMenu, getNoteMenu, getRenoteMenu } from '@/utility/get-note-menu.js';
 import { noteEvents, useNoteCapture } from '@/composables/use-note-capture.js';
-import type { ReactiveNoteData } from '@/composables/use-note-capture.js';
 import { deepClone } from '@/utility/clone.js';
 import { useTooltip } from '@/composables/use-tooltip.js';
 import { claimAchievement } from '@/utility/achievements.js';
@@ -305,12 +304,9 @@ if (noteViewInterruptors.length > 0) {
 
 const isRenote = Misskey.note.isPureRenote(note);
 const appearNote = getAppearNote(note);
-const $appearNote = reactive<ReactiveNoteData>({
-	reactions: appearNote.reactions,
-	reactionCount: appearNote.reactionCount,
-	reactionEmojis: appearNote.reactionEmojis,
-	myReaction: appearNote.myReaction,
-	pollChoices: appearNote.poll?.choices ?? [],
+const { $note: $appearNote, subscribe: subscribeManuallyToNoteCapture } = useNoteCapture({
+	note: appearNote,
+	parentNote: note,
 });
 
 const rootEl = useTemplateRef('rootEl');
@@ -397,12 +393,6 @@ const reactionsPagination = computed(() => ({
 		type: reactionTabType.value,
 	},
 }));
-
-const { subscribe: subscribeManuallyToNoteCapture } = useNoteCapture({
-	note: appearNote,
-	parentNote: note,
-	$note: $appearNote,
-});
 
 useTooltip(renoteButton, async (showing) => {
 	const renotes = await misskeyApi('notes/renotes', {

--- a/packages/frontend/src/composables/use-note-capture.ts
+++ b/packages/frontend/src/composables/use-note-capture.ts
@@ -196,17 +196,18 @@ export function useNoteCapture(props: {
 } {
 	const { note, parentNote, $note } = props;
 
-	// Normalize reactions
-	if (Object.keys($note.reactions).length > 0) {
-		$note.reactions = Object.entries($note.reactions).reduce((acc, [name, count]) => {
-			const normalizedName = name.replace(/^:(\w+):$/, ':$1@.:');
-			if (acc[normalizedName] == null) {
-				acc[normalizedName] = count;
+	// Normalize reactions in-place
+	for (const name of Object.keys($note.reactions)) {
+		const normalizedName = name.replace(/^:(\w+):$/, ':$1@.:');
+		if (normalizedName !== name) {
+			const count = $note.reactions[name];
+			if ($note.reactions[normalizedName] == null) {
+				$note.reactions[normalizedName] = count;
 			} else {
-				acc[normalizedName] += count;
+				$note.reactions[normalizedName] += count;
 			}
-			return acc;
-		}, {} as Misskey.entities.Note['reactions']);
+			delete $note.reactions[name];
+		}
 	}
 
 	noteEvents.on(`reacted:${note.id}`, onReacted);

--- a/packages/frontend/src/composables/use-note-capture.ts
+++ b/packages/frontend/src/composables/use-note-capture.ts
@@ -13,7 +13,6 @@ import { store } from '@/store.js';
 import { misskeyApi } from '@/utility/misskey-api.js';
 import { prefer } from '@/preferences.js';
 import { globalEvents } from '@/events.js';
-import { name } from 'happy-dom/lib/PropertySymbol.js';
 
 export const noteEvents = new EventEmitter<{
 	[ev: `reacted:${string}`]: (ctx: { userId: Misskey.entities.User['id']; reaction: string; emoji?: { name: string; url: string; }; }) => void;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- カスタム絵文字のリアクションが二重で表示されることがある問題を修正
  - `:name:` と `:name@.:` でくる場合があったがすべて後者に統一するように
- 絵文字を追加して削除して再び追加しようとしたら反映されない問題を修正
  - アップデートイベントのロックメカニズムを改良、ユーザーごとにリアクションのアップデートロックを制御するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #16041

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
