### PR TITLE
fix(frontend): タブ間同期が行われるとテーマが同じでもテーマが切り替わり続ける問題を修正

### DIFF
--- a/packages/frontend/src/style.scss
+++ b/packages/frontend/src/style.scss
@@ -101,25 +101,13 @@ html._themeChanging_ {
 }
 
 html::view-transition-new(theme-changing) {
-	z-index: 4000001;
-	animation: themeChangingNew 0.5s ease;
-	animation-fill-mode: forwards;
+	z-index: 4000000;
 }
 
 html::view-transition-old(theme-changing) {
-	z-index: 4000000;
+	z-index: 4000001;
 	animation: themeChangingOld 0.5s ease;
 	animation-fill-mode: forwards;
-}
-
-@keyframes themeChangingNew {
-	0% {
-		opacity: 0;
-	}
-
-	100% {
-		opacity: 1;
-	}
 }
 
 @keyframes themeChangingOld {

--- a/packages/frontend/src/theme.ts
+++ b/packages/frontend/src/theme.ts
@@ -15,6 +15,7 @@ import { globalEvents } from '@/events.js';
 import { miLocalStorage } from '@/local-storage.js';
 import { $i } from '@/i.js';
 import { prefer } from '@/preferences.js';
+import { deepEqual } from '@/utility/deep-equal.js';
 
 export type Theme = {
 	id: string;
@@ -127,12 +128,16 @@ function applyThemeInternal(theme: Theme, persist: boolean) {
 }
 
 let timeout: number | null = null;
+let currentTheme: Theme | null = null;
 
 export function applyTheme(theme: Theme, persist = true) {
 	if (timeout) {
 		window.clearTimeout(timeout);
 		timeout = null;
 	}
+
+	if (deepEqual(currentTheme, theme)) return;
+	currentTheme = theme;
 
 	if (window.document.startViewTransition != null && prefer.s.animation) {
 		window.document.documentElement.classList.add('_themeChanging_');


### PR DESCRIPTION
テーマの中身が同じならapplyThemeを実行しないように