### PR TITLE
fix: jest.js exits with zero value even if underlying jest exited with non-zero value

### DIFF
--- a/packages/backend/jest.js
+++ b/packages/backend/jest.js
@@ -17,4 +17,15 @@ args.push(...[
 	...process.argv.slice(2),
 ]);
 
-child_process.spawn(process.execPath, args, { stdio: 'inherit' });
+const child = child_process.spawn(process.execPath, args, { stdio: 'inherit' });
+child.on('error', (err) => {
+	console.error('Failed to start Jest:', err);
+	process.exit(1);
+});
+child.on('exit', (code, signal) => {
+	if (code === null) {
+		process.exit(128 + signal);
+	} else {
+		process.exit(code);
+	}
+});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Fix #16106

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
