### PR TITLE
chore(frontend): 開発モード時に言語ファイルの変更を自動で反映するように

### DIFF
--- a/packages/frontend/lib/vite-plugin-watch-locales.ts
+++ b/packages/frontend/lib/vite-plugin-watch-locales.ts
@@ -4,7 +4,7 @@ import locales from '../../../locales/index.js';
 const localesDir = path.resolve(__dirname, '../../../locales')
 
 /**
- * 外部ファイルを監視し、必要に応じてサーバを再起動するViteプラグイン
+ * 外部ファイルを監視し、必要に応じてwebSocketでメッセージを送るViteプラグイン
  * @returns {import('vite').Plugin}
  */
 export default function pluginWatchLocales() {

--- a/packages/frontend/lib/vite-plugin-watch-locales.ts
+++ b/packages/frontend/lib/vite-plugin-watch-locales.ts
@@ -1,0 +1,31 @@
+import path from 'node:path'
+import locales from '../../../locales/index.js';
+
+const localesDir = path.resolve(__dirname, '../../../locales')
+
+/**
+ * 外部ファイルを監視し、必要に応じてサーバを再起動するViteプラグイン
+ * @returns {import('vite').Plugin}
+ */
+export default function pluginWatchLocales() {
+  return {
+    name: 'watch-locales',
+
+    configureServer(server) {
+      const localeYmlPaths = Object.keys(locales).map(locale => path.join(localesDir, `${locale}.yml`));
+
+      // watcherにパスを追加
+      server.watcher.add(localeYmlPaths);
+
+			server.watcher.on('change', (filePath) => {
+				if (localeYmlPaths.includes(filePath)) {
+					server.ws.send({
+						type: 'custom',
+						event: 'language-update',
+						data: filePath.match(/([^\/]+)\.yml$/)?.[1] || null,
+					})
+				}
+			});
+    },
+  };
+}

--- a/packages/frontend/lib/vite-plugin-watch-locales.ts
+++ b/packages/frontend/lib/vite-plugin-watch-locales.ts
@@ -21,7 +21,7 @@ export default function pluginWatchLocales() {
 				if (localeYmlPaths.includes(filePath)) {
 					server.ws.send({
 						type: 'custom',
-						event: 'language-update',
+						event: 'locale-update',
 						data: filePath.match(/([^\/]+)\.yml$/)?.[1] || null,
 					})
 				}

--- a/packages/frontend/lib/vite-plugin-watch-locales.ts
+++ b/packages/frontend/lib/vite-plugin-watch-locales.ts
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
 import path from 'node:path'
 import locales from '../../../locales/index.js';
 

--- a/packages/frontend/src/boot/common.ts
+++ b/packages/frontend/src/boot/common.ts
@@ -100,8 +100,8 @@ export async function common(createVue: () => Promise<App<Element>>) {
 	}
 
 	if (import.meta.hot) {
-		import.meta.hot.on('language-update', async (updatedLang: string) => {
-			console.info(`Language updated: ${updatedLang}`);
+		import.meta.hot.on('locale-update', async (updatedLang: string) => {
+			console.info(`Locale updated: ${updatedLang}`);
 			if (updatedLang === lang) {
 				await new Promise(resolve => {
 					window.setTimeout(resolve, 500);

--- a/packages/frontend/src/boot/common.ts
+++ b/packages/frontend/src/boot/common.ts
@@ -81,8 +81,10 @@ export async function common(createVue: () => Promise<App<Element>>) {
 	//#region Detect language & fetch translations
 	const localeVersion = miLocalStorage.getItem('localeVersion');
 	const localeOutdated = (localeVersion == null || localeVersion !== version || locale == null);
-	if (localeOutdated) {
-		const res = await window.fetch(`/assets/locales/${lang}.${version}.json`);
+
+	async function fetchAndUpdateLocale({ useCache } = { useCache: true }) {
+		const fetchOptions: RequestInit | undefined = useCache ? undefined : { cache: 'no-store' };
+		const res = await window.fetch(`/assets/locales/${lang}.${version}.json`, fetchOptions);
 		if (res.status === 200) {
 			const newLocale = await res.text();
 			const parsedNewLocale = JSON.parse(newLocale);
@@ -91,6 +93,23 @@ export async function common(createVue: () => Promise<App<Element>>) {
 			updateLocale(parsedNewLocale);
 			updateI18n(parsedNewLocale);
 		}
+	}
+
+	if (localeOutdated) {
+		fetchAndUpdateLocale();
+	}
+
+	if (import.meta.hot) {
+		import.meta.hot.on('language-update', async (updatedLang: string) => {
+			console.info(`Language updated: ${updatedLang}`);
+			if (updatedLang === lang) {
+				await new Promise(resolve => {
+					window.setTimeout(resolve, 500);
+				});
+				await fetchAndUpdateLocale({ useCache: false });
+				window.location.reload();
+			}
+		});
 	}
 	//#endregion
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -13,6 +13,7 @@ import pluginUnwindCssModuleClassName from './lib/rollup-plugin-unwind-css-modul
 import pluginJson5 from './vite.json5.js';
 import pluginCreateSearchIndex from './lib/vite-plugin-create-search-index.js';
 import type { Options as SearchIndexOptions } from './lib/vite-plugin-create-search-index.js';
+import pluginWatchLocales from './lib/vite-plugin-watch-locales.js';
 
 const url = process.env.NODE_ENV === 'development' ? yaml.load(await fsp.readFile('../../.config/default.yml', 'utf-8')).url : null;
 const host = url ? (new URL(url)).hostname : undefined;
@@ -102,6 +103,7 @@ export function getConfig(): UserConfig {
 		},
 
 		plugins: [
+			pluginWatchLocales(),
 			...searchIndexes.map(options => pluginCreateSearchIndex(options)),
 			pluginVue(),
 			pluginUnwindCssModuleClassName(),


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

言語ファイルを開発モード時にホットリロードする

https://github.com/user-attachments/assets/eb0a0b7b-13a5-4d8e-80a1-51a0b4a73743

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

開発モード時に新しいキーを足すと画面にすぐに反映されないので開発体験が悪い

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

[productionではTree-Shakingされるらしい (vite doc)](https://ja.vite.dev/guide/api-hmr#%E6%9D%A1%E4%BB%B6%E3%81%AB%E3%82%88%E3%82%8B%E3%82%AB%E3%82%99%E3%83%BC%E3%83%88%E3%82%99%E3%81%8B%E3%82%99%E5%BF%85%E8%A6%81)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
