### PR TITLE
ジョブキューの`Progress`の値を正しく計算する

### DIFF
--- a/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
@@ -63,7 +63,7 @@ export class CleanRemoteFilesProcessorService {
 				isLink: false,
 			});
 
-			job.updateProgress(100 / total * deletedCount);
+			job.updateProgress(deletedCount * total / 100);
 		}
 
 		this.logger.succ('All cached remote files has been deleted.');

--- a/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteFilesProcessorService.ts
@@ -34,6 +34,11 @@ export class CleanRemoteFilesProcessorService {
 		let deletedCount = 0;
 		let cursor: MiDriveFile['id'] | null = null;
 
+		const total = await this.driveFilesRepository.countBy({
+			userHost: Not(IsNull()),
+			isLink: false,
+		});
+
 		while (true) {
 			const files = await this.driveFilesRepository.find({
 				where: {
@@ -57,11 +62,6 @@ export class CleanRemoteFilesProcessorService {
 			await Promise.all(files.map(file => this.driveService.deleteFileSync(file, true)));
 
 			deletedCount += 8;
-
-			const total = await this.driveFilesRepository.countBy({
-				userHost: Not(IsNull()),
-				isLink: false,
-			});
 
 			job.updateProgress(deletedCount * total / 100);
 		}

--- a/packages/backend/src/queue/processors/DeleteDriveFilesProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeleteDriveFilesProcessorService.ts
@@ -43,6 +43,10 @@ export class DeleteDriveFilesProcessorService {
 		let deletedCount = 0;
 		let cursor: MiDriveFile['id'] | null = null;
 
+		const total = await this.driveFilesRepository.countBy({
+			userId: user.id,
+		});
+
 		while (true) {
 			const files = await this.driveFilesRepository.find({
 				where: {
@@ -66,10 +70,6 @@ export class DeleteDriveFilesProcessorService {
 				await this.driveService.deleteFileSync(file);
 				deletedCount++;
 			}
-
-			const total = await this.driveFilesRepository.countBy({
-				userId: user.id,
-			});
 
 			job.updateProgress(deletedCount / total * 100);
 		}

--- a/packages/backend/src/queue/processors/DeleteDriveFilesProcessorService.ts
+++ b/packages/backend/src/queue/processors/DeleteDriveFilesProcessorService.ts
@@ -71,7 +71,7 @@ export class DeleteDriveFilesProcessorService {
 				userId: user.id,
 			});
 
-			job.updateProgress(deletedCount / total);
+			job.updateProgress(deletedCount / total * 100);
 		}
 
 		this.logger.succ(`All drive files (${deletedCount}) of ${user.id} has been deleted.`);

--- a/packages/backend/src/queue/processors/ExportBlockingProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportBlockingProcessorService.ts
@@ -101,7 +101,7 @@ export class ExportBlockingProcessorService {
 					blockerId: user.id,
 				});
 
-				job.updateProgress(exportedCount / total);
+				job.updateProgress(exportedCount / total * 100);
 			}
 
 			stream.end();

--- a/packages/backend/src/queue/processors/ExportBlockingProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportBlockingProcessorService.ts
@@ -58,6 +58,10 @@ export class ExportBlockingProcessorService {
 			let exportedCount = 0;
 			let cursor: MiBlocking['id'] | null = null;
 
+			const total = await this.blockingsRepository.countBy({
+				blockerId: user.id,
+			});
+
 			while (true) {
 				const blockings = await this.blockingsRepository.find({
 					where: {
@@ -96,10 +100,6 @@ export class ExportBlockingProcessorService {
 					});
 					exportedCount++;
 				}
-
-				const total = await this.blockingsRepository.countBy({
-					blockerId: user.id,
-				});
 
 				job.updateProgress(exportedCount / total * 100);
 			}

--- a/packages/backend/src/queue/processors/ExportClipsProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportClipsProcessorService.ts
@@ -130,7 +130,7 @@ export class ExportClipsProcessorService {
 				userId: user.id,
 			});
 
-			job.updateProgress(exportedClipsCount / total);
+			job.updateProgress(exportedClipsCount / total * 100);
 		}
 	}
 

--- a/packages/backend/src/queue/processors/ExportClipsProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportClipsProcessorService.ts
@@ -95,6 +95,10 @@ export class ExportClipsProcessorService {
 		let exportedClipsCount = 0;
 		let cursor: MiClip['id'] | null = null;
 
+		const total = await this.clipsRepository.countBy({
+			userId: user.id,
+		});
+
 		while (true) {
 			const clips = await this.clipsRepository.find({
 				where: {
@@ -125,10 +129,6 @@ export class ExportClipsProcessorService {
 				await writer.write(']}');
 				exportedClipsCount++;
 			}
-
-			const total = await this.clipsRepository.countBy({
-				userId: user.id,
-			});
 
 			job.updateProgress(exportedClipsCount / total * 100);
 		}

--- a/packages/backend/src/queue/processors/ExportFavoritesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportFavoritesProcessorService.ts
@@ -78,6 +78,10 @@ export class ExportFavoritesProcessorService {
 			let exportedFavoritesCount = 0;
 			let cursor: MiNoteFavorite['id'] | null = null;
 
+			const total = await this.noteFavoritesRepository.countBy({
+				userId: user.id,
+			});
+
 			while (true) {
 				const favorites = await this.noteFavoritesRepository.find({
 					where: {
@@ -108,10 +112,6 @@ export class ExportFavoritesProcessorService {
 					await write(isFirst ? content : ',\n' + content);
 					exportedFavoritesCount++;
 				}
-
-				const total = await this.noteFavoritesRepository.countBy({
-					userId: user.id,
-				});
 
 				job.updateProgress(exportedFavoritesCount / total * 100);
 			}

--- a/packages/backend/src/queue/processors/ExportFavoritesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportFavoritesProcessorService.ts
@@ -113,7 +113,7 @@ export class ExportFavoritesProcessorService {
 					userId: user.id,
 				});
 
-				job.updateProgress(exportedFavoritesCount / total);
+				job.updateProgress(exportedFavoritesCount / total * 100);
 			}
 
 			await write(']');

--- a/packages/backend/src/queue/processors/ExportMutingProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportMutingProcessorService.ts
@@ -102,7 +102,7 @@ export class ExportMutingProcessorService {
 					muterId: user.id,
 				});
 
-				job.updateProgress(exportedCount / total);
+				job.updateProgress(exportedCount / total * 100);
 			}
 
 			stream.end();

--- a/packages/backend/src/queue/processors/ExportMutingProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportMutingProcessorService.ts
@@ -58,6 +58,10 @@ export class ExportMutingProcessorService {
 			let exportedCount = 0;
 			let cursor: MiMuting['id'] | null = null;
 
+			const total = await this.mutingsRepository.countBy({
+				muterId: user.id,
+			});
+
 			while (true) {
 				const mutes = await this.mutingsRepository.find({
 					where: {
@@ -97,10 +101,6 @@ export class ExportMutingProcessorService {
 					});
 					exportedCount++;
 				}
-
-				const total = await this.mutingsRepository.countBy({
-					muterId: user.id,
-				});
 
 				job.updateProgress(exportedCount / total * 100);
 			}

--- a/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
@@ -37,6 +37,8 @@ class NoteStream extends ReadableStream<Record<string, unknown>> {
 		let exportedNotesCount = 0;
 		let cursor: MiNote['id'] | null = null;
 
+		const totalPromise = notesRepository.countBy({ userId });
+
 		const serialize = (
 			note: MiNote,
 			poll: MiPoll | null,
@@ -88,7 +90,7 @@ class NoteStream extends ReadableStream<Record<string, unknown>> {
 					exportedNotesCount++;
 				}
 
-				const total = await notesRepository.countBy({ userId });
+				const total = await totalPromise;
 				job.updateProgress(exportedNotesCount / total * 100);
 			},
 		});

--- a/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/ExportNotesProcessorService.ts
@@ -89,7 +89,7 @@ class NoteStream extends ReadableStream<Record<string, unknown>> {
 				}
 
 				const total = await notesRepository.countBy({ userId });
-				job.updateProgress(exportedNotesCount / total);
+				job.updateProgress(exportedNotesCount / total * 100);
 			},
 		});
 	}

--- a/packages/frontend/src/pages/admin/job-queue.job.vue
+++ b/packages/frontend/src/pages/admin/job-queue.job.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 	</template>
 	<template #suffix>
 		<MkTime :time="job.finishedOn ?? job.processedOn ?? job.timestamp" mode="relative"/>
-		<span v-if="job.progress != null && typeof job.progress === 'number' && job.progress > 0" style="margin-left: 1em;">{{ Math.floor(job.progress * 100) }}%</span>
+		<span v-if="job.progress != null && typeof job.progress === 'number' && job.progress > 0" style="margin-left: 1em;">{{ Math.floor(job.progress) }}%</span>
 		<span v-if="job.opts.attempts != null && job.opts.attempts > 0 && job.attempts > 1" style="margin-left: 1em; color: var(--MI_THEME-warn); font-variant-numeric: diagonal-fractions;">{{ job.attempts }}/{{ job.opts.attempts }}</span>
 		<span v-if="job.isFailed && job.finishedOn != null" style="margin-left: 1em; color: var(--MI_THEME-error)"><i class="ti ti-circle-x"></i></span>
 		<span v-else-if="job.isFailed" style="margin-left: 1em; color: var(--MI_THEME-warn)"><i class="ti ti-alert-triangle"></i></span>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

resolve #16217

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

- ジョブキューのProgressの値の範囲を `0~100` に統一
  - バックエンドで `0~1` で扱っていた部分を修正
  - フロントエンドで `* 100` していた部分を削除
- Progressの計算に正しい総数を用いる
  - 以前は操作後に総数を取得していたため、「削除後に残った数」で計算していて結果が誤っていた
  - 最初に一度だけ総数を取得することで修正

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

- ジョブキューのProgressの値が実際の進捗率と異なる
- バックエンドの実装でProgressの値の扱い方が統一されていない

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
