### PR TITLE
chore(CI): cache ffmpeg 

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -23,7 +23,8 @@ on:
       force_ffmpeg_cache_update:
         description: 'Force update ffmpeg cache'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
 
 jobs:
   unit:
@@ -70,7 +71,7 @@ jobs:
           ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
           ${{ runner.os }}-ffmpeg-
     - name: Install FFmpeg
-      if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == 'true'
+      if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update
       run: |
         for i in {1..3}; do
           echo "Attempt $i: Installing FFmpeg..."

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -57,7 +57,7 @@ jobs:
       uses: pnpm/action-setup@v4.1.0
     - name: Get current date
       id: current-date
-      run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
     - name: Setup and Restore ffmpeg/ffprobe Cache
       id: cache-ffmpeg
       uses: actions/cache@v4

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -69,7 +69,6 @@ jobs:
         key: ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
         restore-keys: |
           ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
-          ${{ runner.os }}-ffmpeg-
     - name: Install FFmpeg
       if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update
       run: |

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -70,7 +70,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
     - name: Install FFmpeg
-      if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update
+      if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == true
       run: |
         for i in {1..3}; do
           echo "Attempt $i: Installing FFmpeg..."

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -18,6 +18,13 @@ on:
       - packages/misskey-js/**
       - .github/workflows/test-backend.yml
       - .github/misskey/test.yml
+  workflow_dispatch:
+    inputs:
+      force_ffmpeg_cache_update:
+        description: 'Force update ffmpeg cache'
+        required: false
+        default: 'false'
+
 jobs:
   unit:
     name: Unit tests (backend)
@@ -47,7 +54,23 @@ jobs:
         submodules: true
     - name: Setup pnpm
       uses: pnpm/action-setup@v4.1.0
+    - name: Get current date
+      id: current-date
+      run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - name: Setup and Restore ffmpeg/ffprobe Cache
+      id: cache-ffmpeg
+      uses: actions/cache@v4
+      with:
+        path: |
+          /usr/local/bin/ffmpeg
+          /usr/local/bin/ffprobe
+        # daily cache
+        key: ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
+        restore-keys: |
+          ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
+          ${{ runner.os }}-ffmpeg-
     - name: Install FFmpeg
+      if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == 'true'
       run: |
         for i in {1..3}; do
           echo "Attempt $i: Installing FFmpeg..."

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -51,7 +51,6 @@ jobs:
           key: ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
           restore-keys: |
             ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
-            ${{ runner.os }}-ffmpeg-
       - name: Install FFmpeg
         if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update }}
         run: |

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -52,7 +52,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
       - name: Install FFmpeg
-        if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update }}
+        if: steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == true
         run: |
           for i in {1..3}; do
             echo "Attempt $i: Installing FFmpeg..."

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -39,7 +39,7 @@ jobs:
         uses: pnpm/action-setup@v4.1.0
       - name: Get current date
         id: current-date
-        run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Setup and Restore ffmpeg/ffprobe Cache
         id: cache-ffmpeg
         uses: actions/cache@v4

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -14,6 +14,12 @@ on:
       - packages/backend/**
       - packages/misskey-js/**
       - .github/workflows/test-federation.yml
+  workflow_dispatch:
+    inputs:
+      force_ffmpeg_cache_update:
+        description: 'Force update ffmpeg cache'
+        required: false
+        default: 'false'
 
 jobs:
   test:
@@ -30,7 +36,23 @@ jobs:
           submodules: true
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.1.0
+      - name: Get current date
+        id: current-date
+        run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Setup and Restore ffmpeg/ffprobe Cache
+        id: cache-ffmpeg
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/ffmpeg
+            /usr/local/bin/ffprobe
+          # daily cache
+          key: ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
+          restore-keys: |
+            ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
+            ${{ runner.os }}-ffmpeg-
       - name: Install FFmpeg
+        if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == 'true' }}
         run: |
           for i in {1..3}; do
             echo "Attempt $i: Installing FFmpeg..."

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -19,7 +19,8 @@ on:
       force_ffmpeg_cache_update:
         description: 'Force update ffmpeg cache'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
 
 jobs:
   test:
@@ -52,7 +53,7 @@ jobs:
             ${{ runner.os }}-ffmpeg-${{ steps.current-date.outputs.today }}
             ${{ runner.os }}-ffmpeg-
       - name: Install FFmpeg
-        if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update == 'true' }}
+        if: ${{ steps.cache-ffmpeg.outputs.cache-hit != 'true' || github.event.inputs.force_ffmpeg_cache_update }}
         run: |
           for i in {1..3}; do
             echo "Attempt $i: Installing FFmpeg..."


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

actions/cacheを用いてデイリーでffmpegをキャッシュするように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

- ffmpegのインストールでコケることがまあまあある (以下、例)
  - https://github.com/misskey-dev/misskey/actions/runs/15893045113/job/44819084887
  - https://github.com/misskey-dev/misskey/actions/runs/15891082172/job/44813623815
- ffmpegのインストールに失敗するたびに我々の人生のおよそ7分を浪費する
  失敗するときは3回連続で失敗することが多い上に、失敗率が高い(ように思える)ので(7分×試行回数)奪われる
  ![image](https://github.com/user-attachments/assets/1faa8085-ffb5-4e1d-935e-d9241f9e19fa)

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

- キャッシュの保持期間を1週間にしてもいいかなとは思ったもののとりあえず1日に
- workflow_dispatchでオプション選択することでffmpegをキャッシュしなおせるようにしてあります

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
