### PR TITLE
ノートのサーバー情報(InstanceTicker)のデザイン/パフォーマンス改善(-webkit-text-stroke ver)

### DIFF
--- a/packages/frontend/src/components/MkInstanceTicker.vue
+++ b/packages/frontend/src/components/MkInstanceTicker.vue
@@ -86,7 +86,7 @@ $height: 2ex;
 
 	// text-shadowは重いから使うな
 	color: var(--MI_THEME-fg);
-	-webkit-text-stroke: var(--MI_THEME-bg) .225em;
+	-webkit-text-stroke: var(--MI_THEME-panel) .225em;
 	paint-order: stroke fill;
 }
 </style>

--- a/packages/frontend/src/components/MkInstanceTicker.vue
+++ b/packages/frontend/src/components/MkInstanceTicker.vue
@@ -86,7 +86,7 @@ $height: 2ex;
 
 	// text-shadowは重いから使うな
 	color: #fff;
-	-webkit-text-stroke: #000 .25em;
+	-webkit-text-stroke: rgba(0, 0, 0, .8) .225em;
 	paint-order: stroke fill;
 }
 </style>

--- a/packages/frontend/src/components/MkInstanceTicker.vue
+++ b/packages/frontend/src/components/MkInstanceTicker.vue
@@ -83,5 +83,10 @@ $height: 2ex;
 	font-weight: bold;
 	white-space: nowrap;
 	overflow: visible;
+
+	// text-shadowは重いから使うな
+	color: #fff;
+	-webkit-text-stroke: #000 .25em;
+	paint-order: stroke fill;
 }
 </style>

--- a/packages/frontend/src/components/MkInstanceTicker.vue
+++ b/packages/frontend/src/components/MkInstanceTicker.vue
@@ -85,8 +85,8 @@ $height: 2ex;
 	overflow: visible;
 
 	// text-shadowは重いから使うな
-	color: #fff;
-	-webkit-text-stroke: rgba(0, 0, 0, .8) .225em;
+	color: var(--MI_THEME-fg);
+	-webkit-text-stroke: var(--MI_THEME-bg) .225em;
 	paint-order: stroke fill;
 }
 </style>

--- a/packages/frontend/src/components/MkInstanceTicker.vue
+++ b/packages/frontend/src/components/MkInstanceTicker.vue
@@ -12,7 +12,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <script lang="ts" setup>
 import { computed } from 'vue';
-import tinycolor from 'tinycolor2';
 import { instanceName as localInstanceName } from '@@/js/config.js';
 import type { CSSProperties } from 'vue';
 import { instance as localInstance } from '@/instance.js';
@@ -44,33 +43,10 @@ const faviconUrl = computed(() => {
 	return getProxiedImageUrlNullable(imageSrc);
 });
 
-type ITickerColors = {
-	readonly bg: string;
-	readonly fg: string;
-};
-
-const TICKER_YUV_THRESHOLD = 191 as const;
-const TICKER_FG_COLOR_LIGHT = '#ffffff' as const;
-const TICKER_FG_COLOR_DARK = '#2f2f2fcc' as const;
-
-function getTickerColors(bgHex: string): ITickerColors {
-	const tinycolorInstance = tinycolor(bgHex);
-	const { r, g, b } = tinycolorInstance.toRgb();
-	const yuv = 0.299 * r + 0.587 * g + 0.114 * b;
-	const fgHex = yuv > TICKER_YUV_THRESHOLD ? TICKER_FG_COLOR_DARK : TICKER_FG_COLOR_LIGHT;
-
-	return {
-		fg: fgHex,
-		bg: bgHex,
-	} as const satisfies ITickerColors;
-}
-
 const themeColorStyle = computed<CSSProperties>(() => {
 	const themeColor = (props.host == null ? localInstance.themeColor : props.instance?.themeColor) ?? '#777777';
-	const colors = getTickerColors(themeColor);
 	return {
-		background: `linear-gradient(90deg, ${colors.bg}, ${colors.bg}00)`,
-		color: colors.fg,
+		background: `linear-gradient(90deg, ${themeColor}, ${themeColor}00)`,
 	};
 });
 </script>
@@ -84,6 +60,7 @@ $height: 2ex;
 	height: $height;
 	border-radius: 4px 0 0 4px;
 	overflow: clip;
+	color: #fff;
 
 	// text-shadowは重いから使うな
 


### PR DESCRIPTION
## What
ノートのサーバー情報(InstanceTicker)を前のスタイル（白文字に黒の縁取り）に戻します。

パフォーマンスが悪く廃止理由であったtext-shadowではなく、-webkit-text-strokeおよびpaint-orderで実現しています。

![image](https://github.com/user-attachments/assets/7493c3d3-7245-41a6-adcf-91298ed3aa36)

![image](https://github.com/user-attachments/assets/1eecbf84-0755-484d-bad9-672400aa975c)

![image](https://github.com/user-attachments/assets/9349982a-3192-4f7b-88aa-9bccceaad3a6)

![image](https://github.com/user-attachments/assets/5dde6ab8-7712-4fda-9cf4-5d952a3a2060)

## Why
前のスタイルの方が好き

## Additional info (optional)
下記環境で動作確認済
MacBook Pro = Firefox 141.0b2 (aarch64), Safari 26.0 (21622.1.16.11.2), Chrome 137.0.7151.122. 
Android 14スマホ = 138.0.7204.45. 
iPhone 16 @ iOS 18.5 Safari(PWA)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
