### PR TITLE
enhance(frontend): 共有ページで、titleとtextに同じ内容が入っていた際の削除ロジックを強化 

### DIFF
--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -64,7 +64,7 @@ async function init() {
 
 		//#region add text to note text
 		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s*`, 'u');
-		if (text && text.search(duplicateTextRegex) >= 0) {
+		if (text && duplicateTextRegex.test(text)) {
 			// For the Google app https://github.com/misskey-dev/misskey/issues/16224
 			noteText += text.replace(duplicateTextRegex, '');
 		} else if (text && title.value === text) {

--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -63,12 +63,9 @@ async function init() {
 		noteText += `[ ${title.value} ]\n`;
 
 		//#region add text to note text
-		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s*`, 'u');
-		if (text && duplicateTextRegex.test(text)) {
+		if (text?.startsWith(title.value)) {
 			// For the Google app https://github.com/misskey-dev/misskey/issues/16224
-			noteText += text.replace(duplicateTextRegex, '');
-		} else if (text && title.value === text) {
-			// Nothing to do
+			noteText += text.replace(title.value, '').trimStart();
 		} else if (text) {
 			noteText += `${text}\n`;
 		}

--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -60,9 +60,19 @@ const visibleUsers = ref([] as Misskey.entities.UserDetailed[]);
 async function init() {
 	let noteText = '';
 	if (title.value) noteText += `[ ${title.value} ]\n`;
-	// Googleニュース対策
-	if (text?.startsWith(`${title.value}.\n`)) noteText += text.replace(`${title.value}.\n`, '');
-	else if (text && title.value !== text) noteText += `${text}\n`;
+
+	//#region add text to note text
+	const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}(\\s|\\s+|\\s*\\n)`);
+	if (text?.search(duplicateTextRegex)) {
+		// For the Google app https://github.com/misskey-dev/misskey/issues/16224
+		noteText += text.replace(duplicateTextRegex, '');
+	} else if (text && title.value === text) {
+		// Nothing to do
+	} else if (text) {
+		noteText += `${text}\n`;
+	}
+	//#endregion
+
 	if (url) {
 		try {
 			// Normalize the URL to URL-encoded and puny-coded from with the URL constructor.

--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -63,7 +63,7 @@ async function init() {
 		noteText += `[ ${title.value} ]\n`;
 
 		//#region add text to note text
-		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s+`, 'u');
+		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s*`, 'u');
 		if (text?.search(duplicateTextRegex)) {
 			// For the Google app https://github.com/misskey-dev/misskey/issues/16224
 			noteText += text.replace(duplicateTextRegex, '');

--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -64,7 +64,7 @@ async function init() {
 
 		//#region add text to note text
 		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s*`, 'u');
-		if (text?.search(duplicateTextRegex)) {
+		if (text && text.search(duplicateTextRegex) >= 0) {
 			// For the Google app https://github.com/misskey-dev/misskey/issues/16224
 			noteText += text.replace(duplicateTextRegex, '');
 		} else if (text && title.value === text) {

--- a/packages/frontend/src/pages/share.vue
+++ b/packages/frontend/src/pages/share.vue
@@ -59,19 +59,23 @@ const visibleUsers = ref([] as Misskey.entities.UserDetailed[]);
 
 async function init() {
 	let noteText = '';
-	if (title.value) noteText += `[ ${title.value} ]\n`;
+	if (title.value) {
+		noteText += `[ ${title.value} ]\n`;
 
-	//#region add text to note text
-	const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}(\\s|\\s+|\\s*\\n)`);
-	if (text?.search(duplicateTextRegex)) {
-		// For the Google app https://github.com/misskey-dev/misskey/issues/16224
-		noteText += text.replace(duplicateTextRegex, '');
-	} else if (text && title.value === text) {
-		// Nothing to do
+		//#region add text to note text
+		const duplicateTextRegex = new RegExp(`^${RegExp.escape(title.value)}\\s+`, 'u');
+		if (text?.search(duplicateTextRegex)) {
+			// For the Google app https://github.com/misskey-dev/misskey/issues/16224
+			noteText += text.replace(duplicateTextRegex, '');
+		} else if (text && title.value === text) {
+			// Nothing to do
+		} else if (text) {
+			noteText += `${text}\n`;
+		}
+		//#endregion
 	} else if (text) {
 		noteText += `${text}\n`;
 	}
-	//#endregion
 
 	if (url) {
 		try {


### PR DESCRIPTION
Fix #16224

## What
titleとtextに同じ内容が入っていた際の削除ロジックを強化します。

## Why
Fix #16224

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
