### PR TITLE
fix(frontend): 条件により保存できない場合のメッセージを汎用的なものへ

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -12270,9 +12270,9 @@ export interface Locale extends ILocale {
          */
         "cannotCreateDraftAnymore": string;
         /**
-         * リノートの下書きは作成できません。
+         * この内容では下書きを作成できません。
          */
-        "cannotCreateDraftOfRenote": string;
+        "cannotCreateDraft": string;
         /**
          * 下書きを削除
          */

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -3288,7 +3288,7 @@ drafts: "下書き"
 _drafts:
   select: "下書きを選択"
   cannotCreateDraftAnymore: "下書きの作成可能数を超えています。"
-  cannotCreateDraftOfRenote: "リノートの下書きは作成できません。"
+  cannotCreateDraft: "この内容では下書きを作成できません。"
   delete: "下書きを削除"
   deleteAreYouSure: "下書きを削除しますか？"
   noDrafts: "下書きはありません"

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -1195,7 +1195,7 @@ function showDraftMenu(ev: MouseEvent) {
 			if (!canSaveAsServerDraft.value) {
 				return os.alert({
 					type: 'error',
-					text: i18n.ts._drafts.cannotCreateDraftOfRenote,
+					text: i18n.ts._drafts.cannotCreateDraft,
 				});
 			}
 			saveServerDraft();


### PR DESCRIPTION
Fix #16228

## What
![image](https://github.com/user-attachments/assets/d75564fe-c36c-424a-bf60-cf3fad36f3b3)


## Why
Fix #16228

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
