### PR TITLE
chore(test): VS Code上で複数のjestテストを表示できるように

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,8 +6,12 @@
 	"files.associations": {
 		"*.test.ts": "typescript"
 	},
-	"jest.jestCommandLine": "pnpm run jest",
 	"jest.runMode": "on-demand",
+	"jest.virtualFolders": [
+		{ "name": "backend unit", "jestCommandLine": "pnpm -F backend run test" },
+		{ "name": "backend e2e", "jestCommandLine": "pnpm -F backend run test:e2e"},
+		{ "name": "misskey-js", "jestCommandLine": "pnpm -F misskey-js run jest" }
+	],
 	"editor.codeActionsOnSave": {
 		"source.fixAll": "explicit"
 	},


### PR DESCRIPTION
jest.virtualFoldersを用いて、VS Code上でjestのテストを複数同時に表示できるようにした

![image](https://github.com/user-attachments/assets/a1dc8abb-9aca-4169-90e1-1720241172f1)

## What
e2eとかmisskey-jsのテストを表示したり個別にテストを実行したりできる

## Why
便利そう

## Additional info (optional)
federationはdocker上で実行するので難しいかも

```
{ "name": "backend fed", "jestCommandLine": "cd packages/backend/test-federation && NODE_VERSION=22 docker compose run --no-deps --rm tester -- pnpm -F backend test:fed" },
```

みたいに書けるけど、

```
> backend@ jest:fed /misskey/packages/backend
> node ./jest.js --forceExit --config jest.config.fed.cjs --testLocationInResults --json --useStderr --outputFile /tmp/jest_runner_backend_fed_501_2.json --no-coverage --reporters default --reporters /home/aqz.linux/.vscode-server/extensions/orta.vscode-jest-6.4.4/out/reporter.js --colors --watchAll\=false

Error: Could not resolve a module for a custom reporter.
  Module name: /home/aqz.linux/.vscode-server/extensions/orta.vscode-jest-6.4.4/out/reporter.js
    at /misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/normalize.js:426:15
    at Array.map (<anonymous>)
    at normalizeReporters (/misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/normalize.js:409:20)
    at /misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/normalize.js:747:17
    at Array.reduce (<anonymous>)
    at normalize (/misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/normalize.js:608:14)
    at readConfig (/misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/index.js:160:74)
    at async readConfigs (/misskey/node_modules/.pnpm/jest-config@29.7.0_@types+node@22.15.31/node_modules/jest-config/build/index.js:424:26)
    at async runCLI (/misskey/node_modules/.pnpm/@jest+core@29.7.0/node_modules/@jest/core/build/cli/index.js:151:59)
    at async Object.run (/misskey/node_modules/.pnpm/jest-cli@29.7.0_@types+node@22.15.31/node_modules/jest-cli/build/run.js:130:37)
 ELIFECYCLE  Command failed with exit code 1.
/misskey/packages/backend:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  backend@ test:fed: `pnpm jest:fed --testLocationInResults --json --useStderr --outputFile /tmp/jest_runner_backend_fed_501_2.json --no-coverage --reporters default --reporters /home/aqz.linux/.vscode-server/extensions/orta.vscode-jest-6.4.4/out/reporter.js --colors --watchAll\=false`
Exit status 1
```

となって難しい感じがある(Could not resolve a module for a custom reporter.なのでdockerに外部のカスタムレポーターを読みこませる必要がある)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
