### PR TITLE
fix(frontend): inline な SearchMarker のパスが正しくない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 -
 
 ### Client
--
+- Fix: 一部の設定検索結果が存在しないパスになる問題を修正  
+  (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/1171)
 
 ### Server
 -

--- a/packages/frontend/src/utility/settings-search-index.ts
+++ b/packages/frontend/src/utility/settings-search-index.ts
@@ -24,6 +24,7 @@ for (const item of generated) {
 			const inline = rootMods.get(id);
 			if (inline) {
 				inline.parentId = item.id;
+				inline.path = item.path;
 			} else {
 				console.log('[Settings Search Index] Failed to inline', id);
 			}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
The search index looks like:

```ts
[
 {
   id: 'foo', label: 'security',
   path: '/settings/security', inlining: ['2fa'],
 },
 {
   id: '2fa',
   label: 'two-factor auth',
   path: '/settings/2fa', // guessed wrong by the index generation
 },
 {
   id: 'aaaa',
   parentId: '2fa',
   label: 'totp',
 },
 …
]
```

This file post-processes that index and re-parents the inlined sections. Problem was, it left the (wrong) `path` untouched.

Replacing the `path` makes the search work fine.

https://activitypub.software/TransFem-org/Sharkey/-/issues/1154
https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/1171

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
