### PR TITLE
chore: continue backend E2E test even if fail with minimum Node.js version

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -108,11 +108,14 @@ jobs:
   e2e:
     name: E2E tests (backend)
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
-        node-version-file:
-          - .node-version
-          - .github/min.node-version
+        node-version-file: [.node-version]
+        continue-on-error: [false]
+        include:
+          - node-version-file: .github/min.node-version
+            continue-on-error: true
 
     services:
       postgres:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -108,14 +108,12 @@ jobs:
   e2e:
     name: E2E tests (backend)
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
+      fail-fast: false
       matrix:
-        node-version-file: [.node-version]
-        continue-on-error: [false]
-        include:
-          - node-version-file: .github/min.node-version
-            continue-on-error: true
+        node-version-file:
+          - .node-version
+          - .github/min.node-version
 
     services:
       postgres:


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
E2E テストのワークフローで最小 Node.js バージョンでテストが落ちても推奨バージョンでは続けるように

参考: https://docs.github.com/actions/reference/workflows-and-actions/workflow-syntax#example-preventing-a-specific-failing-matrix-job-from-failing-a-workflow-run

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
https://github.com/misskey-dev/misskey/issues/16312#issuecomment-3097185687

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
