### PR TITLE
perf(frontend): draw-blurhash workerの結果をpostMessageする際にImageBitmapを移譲する

### DIFF
--- a/packages/frontend-embed/src/workers/draw-blurhash.ts
+++ b/packages/frontend-embed/src/workers/draw-blurhash.ts
@@ -18,5 +18,5 @@ onmessage = (event) => {
 
 	render(event.data.hash, canvas);
 	const bitmap = canvas.transferToImageBitmap();
-	postMessage({ id: event.data.id, bitmap });
+	postMessage({ id: event.data.id, bitmap }, [bitmap]);
 };

--- a/packages/frontend/src/workers/draw-blurhash.ts
+++ b/packages/frontend/src/workers/draw-blurhash.ts
@@ -18,5 +18,5 @@ onmessage = (event) => {
 
 	render(event.data.hash, canvas);
 	const bitmap = canvas.transferToImageBitmap();
-	postMessage({ id: event.data.id, bitmap });
+	postMessage({ id: event.data.id, bitmap }, [bitmap]);
 };


### PR DESCRIPTION
## What
draw-blurhash workerの結果をpostMessageする際にImageBitmapをtranferするようにします

## Why
better memory management?

ブラウザ内部でどういう風にメモリが管理されたりGCされたりするのかは知らないけどベターではありそう

## Additional info (optional)
p1.a9z.devに適用

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
