### PR TITLE
fix(test): Fix name of a test in e2e/timelines.ts

### DIFF
--- a/packages/backend/test/e2e/timelines.ts
+++ b/packages/backend/test/e2e/timelines.ts
@@ -722,7 +722,7 @@ describe('Timelines', () => {
 					assert.strictEqual(res.body.some(note => note.id === carolRenote.id), false);
 				});
 
-				test('凍結解除後に凍結されていたユーザーに対するRenoteや凍結されたユーザーのRenoteが見えなくなる', async () => {
+				test('凍結解除後に凍結されていたユーザーに対するRenoteや凍結されたユーザーのRenoteが見えるようになる', async () => {
 					await api('admin/unsuspend-user', { userId: carol.id }, root);
 					await setTimeout(100);
 


### PR DESCRIPTION
Fix of #16284 

× 凍結解除後に凍結されていたユーザーに対するRenoteや凍結されたユーザーのRenoteが見えなくなる
⚪︎ 凍結解除後に凍結されていたユーザーに対するRenoteや凍結されたユーザーのRenoteが見え**るようになる**

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
