### PR TITLE
fix(frontend): iOS 26でモバイルのユニバーサルUIなどでコンテンツが埋まる問題に対する暫定的な対処

### DIFF
--- a/packages/frontend/src/components/global/StackingRouterView.vue
+++ b/packages/frontend/src/components/global/StackingRouterView.vue
@@ -209,7 +209,8 @@ router.useListener('replace', ({ fullPath }) => {
 		.tabContent {
 			flex: 1;
 			width: 100%;
-			height: 100%;
+			// See https://github.com/misskey-dev/misskey/issues/16204#issuecomment-3154966557
+			height: unset !important;
 			background: var(--MI_THEME-bg);
 		}
 	}

--- a/packages/frontend/src/ui/universal.vue
+++ b/packages/frontend/src/ui/universal.vue
@@ -166,6 +166,8 @@ $widgets-hide-threshold: 1090px;
 
 .content {
 	flex: 1;
+	// See https://github.com/misskey-dev/misskey/issues/16204#issuecomment-3154966557
+	height: unset !important;
 	min-height: 0;
 }
 


### PR DESCRIPTION
Fix #16204

`height: unset !important;`を指定してみた

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
