### PR TITLE
Fix: SystemWebhook設定でsecretを空に出来ない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### Server
 - Enhance: ノートの削除処理の効率化
 - Enhance: 全体的なパフォーマンスの向上
+- Fix: SystemWebhook設定でsecretを空に出来ない問題を修正
 
 
 ## 2025.7.0

--- a/packages/backend/src/server/api/endpoints/admin/system-webhook/create.ts
+++ b/packages/backend/src/server/api/endpoints/admin/system-webhook/create.ts
@@ -48,8 +48,8 @@ export const paramDef = {
 		},
 		secret: {
 			type: 'string',
-			minLength: 1,
 			maxLength: 1024,
+			default: '',
 		},
 	},
 	required: [
@@ -57,7 +57,6 @@ export const paramDef = {
 		'name',
 		'on',
 		'url',
-		'secret',
 	],
 } as const;
 

--- a/packages/backend/src/server/api/endpoints/admin/system-webhook/update.ts
+++ b/packages/backend/src/server/api/endpoints/admin/system-webhook/update.ts
@@ -52,8 +52,8 @@ export const paramDef = {
 		},
 		secret: {
 			type: 'string',
-			minLength: 1,
 			maxLength: 1024,
+			default: '',
 		},
 	},
 	required: [
@@ -62,7 +62,6 @@ export const paramDef = {
 		'name',
 		'on',
 		'url',
-		'secret',
 	],
 } as const;
 

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -11887,7 +11887,8 @@ export interface operations {
                     name: string;
                     on: ('abuseReport' | 'abuseReportResolved' | 'userCreated' | 'inactiveModeratorsWarning' | 'inactiveModeratorsInvitationOnlyChanged')[];
                     url: string;
-                    secret: string;
+                    /** @default  */
+                    secret?: string;
                 };
             };
         };
@@ -12231,7 +12232,8 @@ export interface operations {
                     name: string;
                     on: ('abuseReport' | 'abuseReportResolved' | 'userCreated' | 'inactiveModeratorsWarning' | 'inactiveModeratorsInvitationOnlyChanged')[];
                     url: string;
-                    secret: string;
+                    /** @default  */
+                    secret?: string;
                 };
             };
         };


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Fix: #15822 
#11784 と同様の変更をSystemWebhookに適用

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
webhookにおいてsecretは必須ではないため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
通常webhookのupdateでは、必須パラメーターがwebhookIdのみに限定されていますが、SystemWebhookではそうではありませんでした。
現状手を付けていませんが、調整の余地はありそうです。
https://github.com/misskey-dev/misskey/blob/ee9dc9406376e2a8112c89edd3843f5359e9aef8/packages/backend/src/server/api/endpoints/i/webhooks/update.ts#L43
https://github.com/misskey-dev/misskey/blob/f11ca4d81f965259e39f13e5b9111cdf19039b13/packages/backend/src/server/api/endpoints/admin/system-webhook/update.ts#L59-L65

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
