### PR TITLE
fix(frontend-builder): 言語バンドルの作成状況がログに残るように

### DIFF
--- a/packages/frontend-builder/locale-inliner.ts
+++ b/packages/frontend-builder/locale-inliner.ts
@@ -69,8 +69,10 @@ export class LocaleInliner {
 	async saveAllLocales(locales: Record<string, Locale>) {
 		const localeNames = Object.keys(locales);
 		for (const localeName of localeNames) {
+			this.logger.info(`Creating bundle for ${localeName}`);
 			await this.saveLocale(localeName, locales[localeName]);
 		}
+		this.logger.info('Done');
 	}
 
 	async saveLocale(localeName: string, localeJson: Locale) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
言語バンドルの作成状況がログに残るように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
現状、フロントエンドのビルドが完了してからlocale inlinerが走るが、問題がなければ何も出力されないので、コマンドが終了しない異常を疑ったため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
