### PR TITLE
fix(workflow): correct references to built image's ID

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -25,7 +25,7 @@ jobs:
           cp ./compose_example.yml ./compose.yml
       - run: |
           docker compose up -d web
-          docker tag "$(docker compose images web | awk 'OFS=":" {print $4}' | tail -n +2)" misskey-web:latest
+          docker tag "$(docker compose images --format json web | jq -r '.[] | .ID')" misskey-web:latest
       - run: |
           cmd="dockle --exit-code 1 misskey-web:latest ${image_name}"
           echo "> ${cmd}"


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Dockle が落ちる問題を修正します。

Docker Compose のバージョンが上がって `docker compose images` の出力形式が変わった (https://github.com/docker/compose/commit/eb3074bbda41c9068d6647cec334e08f05c1035d#diff-5da4afa6d47ded4ea99d52cb6628241f3dd59e56f5bb6a06dba8ffdefeb3d6c8L109-R110) のが影響したものと思われます。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Closes #16333

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
