### PR TITLE
fix(frontend): 照会ダイアログでap/showでローカルユーザーを解決した際@username@nullに飛ばされる問題を修正

### DIFF
--- a/packages/frontend/src/utility/lookup.ts
+++ b/packages/frontend/src/utility/lookup.ts
@@ -8,6 +8,7 @@ import * as os from '@/os.js';
 import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { mainRouter } from '@/router.js';
+import { acct } from '@/filters/user';
 
 export async function lookup(router?: Router) {
 	const _router = router ?? mainRouter;
@@ -38,7 +39,7 @@ export async function lookup(router?: Router) {
 		if (res.type === 'User') {
 			_router.push('/@:acct/:page?', {
 				params: {
-					acct: `${res.object.username}@${res.object.host}`,
+					acct: acct(res.object),
 				},
 			});
 		} else if (res.type === 'Note') {


### PR DESCRIPTION
Fix #14608

## What
acct関数で処理する

## Why
#14608

## Additional info (optional)
p1.a9z.devに適用

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
