### PR TITLE
perf(backend): optimize drive/files query for old root content

### DIFF
--- a/packages/backend/migration/1756824506000-optimize-drive-files-query.js
+++ b/packages/backend/migration/1756824506000-optimize-drive-files-query.js
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class OptimizeDriveFilesQuery1756824506000 {
+	name = 'OptimizeDriveFilesQuery1756824506000'
+
+	async up(queryRunner) {
+		// Create optimized partial index for drive files query performance
+		// This index is specifically designed for the common query pattern:
+		// SELECT * FROM drive_file WHERE userId = ? AND folderId IS NULL ORDER BY id DESC
+		await queryRunner.query(`CREATE INDEX "IDX_drive_file_userid_null_folderid_id_desc" ON "drive_file" ("userId", ("folderId" IS NULL), "id" DESC)`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`DROP INDEX "IDX_drive_file_userid_null_folderid_id_desc"`);
+	}
+}

--- a/packages/backend/migration/1756824506000-optimize-drive-files-query.js
+++ b/packages/backend/migration/1756824506000-optimize-drive-files-query.js
@@ -4,16 +4,16 @@
  */
 
 export class OptimizeDriveFilesQuery1756824506000 {
-	name = 'OptimizeDriveFilesQuery1756824506000'
+    name = 'OptimizeDriveFilesQuery1756824506000'
 
-	async up(queryRunner) {
-		// Create optimized partial index for drive files query performance
-		// This index is specifically designed for the common query pattern:
-		// SELECT * FROM drive_file WHERE userId = ? AND folderId IS NULL ORDER BY id DESC
-		await queryRunner.query(`CREATE INDEX "IDX_drive_file_userid_null_folderid_id_desc" ON "drive_file" ("userId", ("folderId" IS NULL), "id" DESC)`);
-	}
+    async up(queryRunner) {
+        // Create optimized composite index for drive files query performance
+        await queryRunner.query(`DROP INDEX "IDX_860fa6f6c7df5bb887249fba22"`);
+        await queryRunner.query(`CREATE INDEX "IDX_a76118b66adb3228e0ee69c281" ON "drive_file" ("userId", "id" DESC)`);
+    }
 
-	async down(queryRunner) {
-		await queryRunner.query(`DROP INDEX "IDX_drive_file_userid_null_folderid_id_desc"`);
-	}
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX "IDX_a76118b66adb3228e0ee69c281"`);
+        await queryRunner.query(`CREATE INDEX "IDX_860fa6f6c7df5bb887249fba22" ON "drive_file" ("userId")`);
+    }
 }

--- a/packages/backend/src/models/DriveFile.ts
+++ b/packages/backend/src/models/DriveFile.ts
@@ -10,12 +10,11 @@ import { MiDriveFolder } from './DriveFolder.js';
 
 @Entity('drive_file')
 @Index(['userId', 'folderId', 'id'])
-@Index('IDX_drive_file_userid_null_folderid_id_desc', { synchronize: false })
+@Index(['userId', 'id'])
 export class MiDriveFile {
 	@PrimaryColumn(id())
 	public id: string;
 
-	@Index()
 	@Column({
 		...id(),
 		nullable: true,

--- a/packages/backend/src/models/DriveFile.ts
+++ b/packages/backend/src/models/DriveFile.ts
@@ -10,6 +10,7 @@ import { MiDriveFolder } from './DriveFolder.js';
 
 @Entity('drive_file')
 @Index(['userId', 'folderId', 'id'])
+@Index('IDX_drive_file_userid_null_folderid_id_desc', { synchronize: false })
 export class MiDriveFile {
 	@PrimaryColumn(id())
 	public id: string;


### PR DESCRIPTION
## What
Resolve #14217 

This PR speeds up the `drive/files` endpoint for users who have old content in the root folder by adding a partial index on `drive_file (userId, folderId IS NULL, id DESC)`. There are no API or behavior changes; it only adds a migration.

## Why
Some users were hitting statement timeouts because PostgreSQL chose the primary key for `ORDER BY id DESC`, leading to very wide scans when their root files were old. The new index matches the query shape so the planner can return the latest matching rows immediately.

## Additional info (optional)
On an affected account, the query improved from about 50 seconds to about 30-40 ms.

**[ TEST Query ]**
```
EXPLAIN (ANALYZE, BUFFERS) SELECT "file"."id", "file"."userId", "file"."userHost", "file"."md5", "file"."name", "file"."type", "file"."size", "file"."comment", "file"."blurhash", "file"."properties", "file"."storedInternal", "file"."url", "file"."thumbnailUrl", "file"."webpublicUrl", "file"."webpublicType", "file"."accessKey", "file"."thumbnailAccessKey", "file"."webpublicAccessKey", "file"."uri", "file"."src", "file"."folderId", "file"."isSensitive", "file"."maybeSensitive", "file"."maybePorn", "file"."isLink", "file"."requestHeaders", "file"."requestIp" FROM "drive_file" "file" WHERE "file"."userId" = '8zzt247op3' AND "file"."folderId" IS NULL ORDER BY "file"."id" DESC LIMIT 31;"
```

**[ Before ]**
```
QUERY PLAN
Limit  (cost=0.43..6225.04 rows=31 width=1997) (actual time=211.896..51068.746 rows=22 loops=1)
  Buffers: shared hit=1702945 read=701470
  ->  Index Scan Backward using "PK_43ddaaaf18c9e68029b7cbb032e" on drive_file file  (cost=0.43..1091916.33 rows=5438 width=1997) (actual time=211.893..51068.629 rows=22 loops=1)
        Filter: (("folderId" IS NULL) AND (("userId")::text = '8zzt247op3'::text))
        Rows Removed by Filter: 4547669
        Buffers: shared hit=1702945 read=701470
Planning:
  Buffers: shared hit=358 read=68
Planning Time: 19.364 ms
Execution Time: 51068.991 ms
(10 rows)
```

<video src="https://github.com/user-attachments/assets/6fa52988-3bc5-4754-98fa-b24481465a66" controls preload></video>

**[ After ]**
```
QUERY PLAN
Limit  (cost=0.43..118.09 rows=31 width=1997) (actual time=6.629..30.655 rows=22 loops=1)
  Buffers: shared hit=3814
  ->  Index Scan Backward using "IDX_a76118b66adb3228e0ee69c281" on drive_file file  (cost=0.43..25190.51 rows=6637 width=1997) (actual time=6.627..30.648 rows=22 loops=1)
        Index Cond: (("userId")::text = '8zzt247op3'::text)
        Filter: ("folderId" IS NULL)
        Rows Removed by Filter: 4898
        Buffers: shared hit=3814
Planning:
  Buffers: shared hit=463 dirtied=13
Planning Time: 18.885 ms
Execution Time: 30.709 ms
(11 rows)
```

<video src="https://github.com/user-attachments/assets/79a7a283-5726-472b-abfa-c425e4a7e2db" controls preload></video>

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
