### PR TITLE
fix(backend): webpなどの画像に対してセンシティブなメディアの検出が適用されていなかった問題を修正

### DIFF
--- a/packages/backend/src/core/AiService.ts
+++ b/packages/backend/src/core/AiService.ts
@@ -29,7 +29,7 @@ export class AiService {
 	}
 
 	@bindThis
-	public async detectSensitive(path: string): Promise<nsfw.PredictionType[] | null> {
+	public async detectSensitive(source: string | Buffer): Promise<nsfw.PredictionType[] | null> {
 		try {
 			if (isSupportedCpu === undefined) {
 				isSupportedCpu = await this.computeIsSupportedCpu();
@@ -51,7 +51,7 @@ export class AiService {
 				});
 			}
 
-			const buffer = await fs.promises.readFile(path);
+			const buffer = source instanceof Buffer ? source : await fs.promises.readFile(source);
 			const image = await tf.node.decodeImage(buffer, 3) as any;
 			try {
 				const predictions = await this.model.classify(image);


### PR DESCRIPTION
Fix #16513
Resolve #10665

## What
画像をnsfwjsにかける前にsharpで変換にするようにし、sharp-convertible-image-with-bmp(webpやavifなどを含む)に対応するように (apngはffmpegで処理される、従来通り)

## Why
Fix #16513

webpなどの画像に対してセンシティブなメディアの検出が適用されていなかった

## Additional info (optional)
手持ちの環境がARMばかりなのでテストができない

(テストもないし現状のコードはテストに不向きかも？CIでテストできるかも怪しそう)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
