### PR TITLE
fix(frontend): Safari 26でモバイルUIが崩れる問題に対するhotfix

### DIFF
--- a/packages/frontend/src/components/global/RouterView.vue
+++ b/packages/frontend/src/components/global/RouterView.vue
@@ -65,5 +65,12 @@ router.useListener('change', ({ resolved }) => {
 .root {
 	height: 100%;
 	background-color: var(--MI_THEME-bg);
+
+	/**
+	 * FIXME: Safari 26 で contain: layout を指定するとバグるので、hotfixとして _pageContainer の content: strict を上書き
+	 * https://github.com/misskey-dev/misskey/issues/16204#issuecomment-3265404776
+	 * https://bugs.webkit.org/show_bug.cgi?id=297186
+	 */
+	contain: size style paint !important;
 }
 </style>


### PR DESCRIPTION
Related to #16204

## What
RouterViewの.rootのスタイルに`contain: size style paint !important;`を追加し、`_pageContainer` の `content: strict` を上書き

## Why
[#16204 ](https://github.com/misskey-dev/misskey/issues/16204#issuecomment-3172553454) , https://bugs.webkit.org/show_bug.cgi?id=297186

CSS `contain: layout`とflexboxの噛み合わせの問題？

## Additional info (optional)
p1.a9z.devに適用

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
