### PR TITLE
enhance(frontend): bootでonunhandledrejectionでrenderErrorする場合、PromiseRejectionEvent.reasonを渡すように

### DIFF
--- a/packages/backend/src/server/web/boot.js
+++ b/packages/backend/src/server/web/boot.js
@@ -13,7 +13,7 @@
 	};
 	window.onunhandledrejection = (e) => {
 		console.error(e);
-		renderError('SOMETHING_HAPPENED_IN_PROMISE', e);
+		renderError('SOMETHING_HAPPENED_IN_PROMISE', e.reason || e);
 	};
 
 	let forceError = localStorage.getItem('forceError');


### PR DESCRIPTION
## What
コンソールを開かなくてもハンドルされていないPromiseの失敗理由がわかるように

After

<img width="790" height="951" alt="image" src="https://github.com/user-attachments/assets/64af6336-7b7e-4b25-8f39-8c4017ebf414" />

## Why
[object PromiseRejectionEvent] としか表示されず不便

Before https://github.com/misskey-dev/misskey/issues/16562#issuecomment-3306570038

<img width="723" height="576" alt="image" src="https://github.com/user-attachments/assets/10e2c7ef-9aec-409b-823f-fa0abec7ba24" />

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
