### PR TITLE
プロフィールの「ユーザーのノートを検索」でローカルのユーザーを検索できないのを修正

### DIFF
--- a/packages/frontend/src/utility/get-user-menu.ts
+++ b/packages/frontend/src/utility/get-user-menu.ts
@@ -232,10 +232,12 @@ export function getUserMenu(user: Misskey.entities.UserDetailed, router: Router 
 			action: () => {
 				const query = {
 						username: user.username,
-					} as { username: string, host?: string}
-				if(user.host !== null){
-					query.host = user.host
+					} as { username: string, host?: string };
+
+				if (user.host !== null) {
+					query.host = user.host;
 				}
+
 				router.push('/search', {
 					query
 				});

--- a/packages/frontend/src/utility/get-user-menu.ts
+++ b/packages/frontend/src/utility/get-user-menu.ts
@@ -230,11 +230,14 @@ export function getUserMenu(user: Misskey.entities.UserDetailed, router: Router 
 			icon: 'ti ti-search',
 			text: i18n.ts.searchThisUsersNotes,
 			action: () => {
-				router.push('/search', {
-					query: {
+				const query = {
 						username: user.username,
-						host: user.host ?? undefined,
-					},
+					} as { username: string, host?: string}
+				if(user.host !== null){
+					query.host = user.host
+				}
+				router.push('/search', {
+					query
 				});
 			},
 		});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ローカルのユーザーをプロフィールから「ユーザーのノートを検索」したとき、リモートサーバー「undefined」になってしまうのを修正する
fix #16495

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
「nullish演算子によって値がundefinedになるから、 router.push() したときに値が undefinedになるキーごと取り除かれる」という振る舞いを期待しているが、実際にはそうはならないので
user.host が nullでない場合にquery.hostを追加するようにする



## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
