### PR TITLE
fix(frontend): ビルド成果物のファイル名にlocalesのhashを含めるように

### DIFF
--- a/packages/frontend-embed/vite.config.ts
+++ b/packages/frontend-embed/vite.config.ts
@@ -64,6 +64,8 @@ function toBase62(n: number): string {
 }
 
 export function getConfig(): UserConfig {
+	const localesHash = toBase62(hash(JSON.stringify(locales)));
+
 	return {
 		base: '/embed_vite/',
 
@@ -148,9 +150,9 @@ export function getConfig(): UserConfig {
 						// dependencies of i18n.ts
 						'config': ['@@/js/config.js'],
 					},
-					entryFileNames: 'scripts/[hash:8].js',
-					chunkFileNames: 'scripts/[hash:8].js',
-					assetFileNames: 'assets/[hash:8][extname]',
+					entryFileNames: `scripts/${localesHash}-[hash:8].js`,
+					chunkFileNames: `scripts/${localesHash}-[hash:8].js`,
+					assetFileNames: `assets/${localesHash}-[hash:8][extname]`,
 					paths(id) {
 						for (const p of externalPackages) {
 							if (p.match.test(id)) {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -85,6 +85,8 @@ export function toBase62(n: number): string {
 }
 
 export function getConfig(): UserConfig {
+	const localesHash = toBase62(hash(JSON.stringify(locales)));
+
 	return {
 		base: '/vite/',
 
@@ -188,9 +190,9 @@ export function getConfig(): UserConfig {
 						// dependencies of i18n.ts
 						'config': ['@@/js/config.js'],
 					},
-					entryFileNames: 'scripts/[hash:8].js',
-					chunkFileNames: 'scripts/[hash:8].js',
-					assetFileNames: 'assets/[hash:8][extname]',
+					entryFileNames: `scripts/${localesHash}-[hash:8].js`,
+					chunkFileNames: `scripts/${localesHash}-[hash:8].js`,
+					assetFileNames: `assets/${localesHash}-[hash:8][extname]`,
 					paths(id) {
 						for (const p of externalPackages) {
 							if (p.match.test(id)) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
出力されるファイル名にlocalesオブジェクトのハッシュを含めるようにした

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #16518

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
vite.config.ts にある toBase62 と hash が locales のような大きなものに使用されることを想定して設計されているかどうかがわからないが、言語ファイルに変更を加えるとハッシュが変わることは確認した

<img width="272" height="143" alt="image" src="https://github.com/user-attachments/assets/55c141bc-7223-476c-a6a6-9ee06db2c608" />

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
