### PR TITLE
fix(frontend): バナー画像の画面上でのクロップが以前の挙動と同一になるように

### DIFF
--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -380,7 +380,7 @@ onDeactivated(disposeBannerParallaxResizeObserver);
 						background-repeat: repeat-y;
 						background-position-x: center;
 						background-position-y: 50%;
-						will-change: background-position;
+						will-change: background-position-y;
 					}
 
 					> .fade {

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -368,23 +368,19 @@ onDeactivated(disposeBannerParallaxResizeObserver);
 
 				> .banner-container {
 					position: relative;
-					height: 250px;
+					--bannerHeight: 250px;
+					height: var(--bannerHeight);
 					overflow: clip;
-					background-size: cover;
-					background-position: center;
 
 					> .banner {
-						position: absolute;
-						top: 50%;
-						left: 0;
 						width: 100%;
-						height: 300%;
-						background-size: 100% auto;
+						height: 100%;
+						background-size: cover;
 						background-color: #4c5e6d;
 						background-repeat: repeat-y;
-						background-position: center;
-						will-change: transform;
-						transform: translateY(-50%);
+						background-position-x: center;
+						background-position-y: 50%;
+						will-change: background-position;
 					}
 
 					> .fade {
@@ -677,7 +673,8 @@ onDeactivated(disposeBannerParallaxResizeObserver);
 		> .main {
 			> .profile > .main {
 				> .banner-container {
-					height: 140px;
+					--bannerHeight: 140px;
+					height: var(--bannerHeight);
 
 					> .fade {
 						display: none;
@@ -763,10 +760,10 @@ onDeactivated(disposeBannerParallaxResizeObserver);
 
 @keyframes bannerParallaxKeyframes {
 	from {
-		transform: translateY(-50%);
+		background-position-y: 50%;
 	}
 	to {
-		transform: translateY(-30%);
+		background-position-y: calc(50% + var(--bannerHeight, 250px) / 3);
 	}
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- `background-position` をアニメーションさせるように
- `background-size` の指定は従来の `cover` に戻り、見た目での変更は最小限となるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #16648

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
はじめは、単に `background-position` の相対位置指定を scroll-driven にすることを考えていた。しかし、その相対位置は背景画像基準だったため、画像の縦横比によってアニメーションの進行度合いが変わる問題があった。そこでbanner要素の高さを伸ばしてそちらの上下をアニメーションさせる方式としていたが、bannerの高さが固定値であることを利用して、その値を background-position の `50%` に加減算することで、一定のアニメーションを実現できたので、その方式で実装を変更した。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md 同一バージョンのため無し
- [ ] (If possible) Add tests
