### PR TITLE
fix(frontend): 外部アプリ設定のアプリアイコンに変な余白が入っているのを修正

### DIFF
--- a/packages/frontend/src/pages/settings/apps.vue
+++ b/packages/frontend/src/pages/settings/apps.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<MkFolder v-for="token in items" :key="token.id" :defaultOpen="true">
 					<template #icon>
 						<img v-if="token.iconUrl" :class="$style.appIcon" :src="token.iconUrl" alt=""/>
-						<i v-else class="ti ti-plug"/>
+						<i v-else class="ti ti-plug"></i>
 					</template>
 					<template #label>{{ token.name }}</template>
 					<template #caption>{{ token.description }}</template>
@@ -86,6 +86,7 @@ definePage(() => ({
 
 <style lang="scss" module>
 .appIcon {
+	display: block;
 	width: 20px;
 	height: 20px;
 	border-radius: 4px;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Before（画像下に不自然な余白あり）

<img width="645" height="76" alt="image" src="https://github.com/user-attachments/assets/201fe553-3662-493f-b045-ab26de0ebd0d" />

After

<img width="661" height="87" alt="image" src="https://github.com/user-attachments/assets/3d8c55b7-57e6-4ab8-bbd5-e81599babd25" />

参考

<img width="649" height="73" alt="image" src="https://github.com/user-attachments/assets/ec6e2770-cf0a-4369-9a8b-8edec8075eb5" />

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
デザイン

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
