### PR TITLE
RoleService.testがPostgreSQLのdeadlockでrandom failする問題を修正

### DIFF
--- a/packages/backend/test/unit/RoleService.ts
+++ b/packages/backend/test/unit/RoleService.ts
@@ -158,11 +158,12 @@ describe('RoleService', () => {
 	afterEach(async () => {
 		clock.uninstall();
 
+		// schemaに依存関係があるのでdeadlock回避のためmetaとroleAssignmentを先にdeleteする
+		await app.get(DI.metasRepository).createQueryBuilder().delete().execute();
+		await roleAssignmentsRepository.createQueryBuilder().delete().execute();
 		await Promise.all([
-			app.get(DI.metasRepository).createQueryBuilder().delete().execute(),
 			usersRepository.createQueryBuilder().delete().execute(),
 			rolesRepository.createQueryBuilder().delete().execute(),
-			roleAssignmentsRepository.createQueryBuilder().delete().execute(),
 		]);
 
 		await app.close();

--- a/packages/backend/test/unit/RoleService.ts
+++ b/packages/backend/test/unit/RoleService.ts
@@ -158,7 +158,10 @@ describe('RoleService', () => {
 	afterEach(async () => {
 		clock.uninstall();
 
-		// schemaに依存関係があるのでdeadlock回避のためmetaとroleAssignmentを先にdeleteする
+		/**
+		 * Delete meta and roleAssignment first to avoid deadlock due to schema dependencies
+		 * https://github.com/misskey-dev/misskey/issues/16783
+		 */ 
 		await app.get(DI.metasRepository).createQueryBuilder().delete().execute();
 		await roleAssignmentsRepository.createQueryBuilder().delete().execute();
 		await Promise.all([


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
RoleServiceのテストで `metas` と `roleAssignments` のDELETEを `Promise.all` の外側に移動し、`roles` と `users` よりも先に削除されるようにした
これによりPostgreSQLのdeadlockが発生しなくなる

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
PostgreSQLのdeadlockによってテストがrandom failしていた問題の修正
ref: https://github.com/misskey-dev/misskey/issues/16783

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
`metas` と `roleAssignments` の両者間に依存関係は無い（FK独立）が、どちらも `users` への依存関係があるため、SHARE ROW EXCLUSIVEロックの可能性を考慮し、逐次実行としている

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
