### PR TITLE
fix(frontend): PlayのAiScriptバージョン判定が正しく動作しない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Fix: ヘッダーメニューのチャンネルの新規作成の項目でチャンネル作成ページに飛べない問題を修正 #16816
 - Fix: 一部のシチュエーションで投稿フォームのツアーが正しく表示されない問題を修正
 - Fix: 投稿フォームのリセットボタンで注釈がリセットされない問題を修正
+- Fix: PlayのAiScriptバージョン判定（v0.x系・v1.x系の判定）が正しく動作しない問題を修正  
+  (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/1129)
 
 ### Server
 - Enhance: `clips/my-favorites` APIがページネーションに対応しました

--- a/packages/frontend/src/aiscript/common.ts
+++ b/packages/frontend/src/aiscript/common.ts
@@ -6,6 +6,13 @@
 import { errors, utils } from '@syuilo/aiscript';
 import type { values } from '@syuilo/aiscript';
 
+const extractVersionIdentifier = /^\/\/\/\s*@\s*(\d+)\.(\d+)\.\d+$/m;
+
+export function getAiScriptVersion(script: string): { major: number; minor: number } | undefined {
+	const match = extractVersionIdentifier.exec(script);
+	return match ? { major: Number(match[1]), minor: Number(match[2]) } : undefined;
+}
+
 export function assertStringAndIsIn<A extends readonly string[]>(value: values.Value | undefined, expects: A): asserts value is values.VStr & { value: A[number] } {
 	utils.assertString(value);
 	const str = value.value;

--- a/packages/frontend/src/pages/flash/flash.vue
+++ b/packages/frontend/src/pages/flash/flash.vue
@@ -74,6 +74,7 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { definePage } from '@/page.js';
 import MkAsUi from '@/components/MkAsUi.vue';
+import { getAiScriptVersion } from '@/aiscript/common.js';
 import { registerAsUiLib } from '@/aiscript/ui.js';
 import { aiScriptReadline, createAiScriptEnv } from '@/aiscript/api.js';
 import MkFolder from '@/components/MkFolder.vue';
@@ -194,7 +195,8 @@ async function run() {
 	if (aiscript.value) aiscript.value.abort();
 	if (!flash.value) return;
 
-	const isLegacy = !flash.value.script.replaceAll(' ', '').startsWith('///@1.0.0');
+	const version = getAiScriptVersion(flash.value.script);
+	const isLegacy = version ? version.major < 1 : false;
 
 	const { Interpreter, Parser, values } = isLegacy ? (await import('@syuilo/aiscript-0-19-0') as any) : await import('@syuilo/aiscript');
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Cherry-picked from https://github.com/MisskeyIO/misskey/pull/1129

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
semverのライブラリが入ってるのでそっちでパースしたほうがよいかもしれない？（どちらにせよバージョンの入ってる行からバージョンを読み出すのに正規表現は必要だけど）

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
