### PR TITLE
refactor(frontend/aiscript): AiScriptバージョン取得・判定ロジックを統一

### DIFF
--- a/packages/frontend/src/aiscript/common.ts
+++ b/packages/frontend/src/aiscript/common.ts
@@ -6,13 +6,6 @@
 import { errors, utils } from '@syuilo/aiscript';
 import type { values } from '@syuilo/aiscript';
 
-const extractVersionIdentifier = /^\/\/\/\s*@\s*(\d+)\.(\d+)\.\d+$/m;
-
-export function getAiScriptVersion(script: string): { major: number; minor: number } | undefined {
-	const match = extractVersionIdentifier.exec(script);
-	return match ? { major: Number(match[1]), minor: Number(match[2]) } : undefined;
-}
-
 export function assertStringAndIsIn<A extends readonly string[]>(value: values.Value | undefined, expects: A): asserts value is values.VStr & { value: A[number] } {
 	utils.assertString(value);
 	const str = value.value;

--- a/packages/frontend/src/pages/flash/flash.vue
+++ b/packages/frontend/src/pages/flash/flash.vue
@@ -192,7 +192,6 @@ function start() {
 	run();
 }
 
-/** returns whether the version is legacy (less than 1.0.0) */
 function getIsLegacy(version: string | null): boolean {
 	if (version == null) return false;
 	try {

--- a/packages/frontend/src/pages/flash/flash.vue
+++ b/packages/frontend/src/pages/flash/flash.vue
@@ -63,6 +63,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script lang="ts" setup>
 import { computed, onDeactivated, onUnmounted, ref, watch, shallowRef, defineAsyncComponent } from 'vue';
 import * as Misskey from 'misskey-js';
+import { utils } from '@syuilo/aiscript';
+import { compareVersions } from 'compare-versions';
 import { url } from '@@/js/config.js';
 import type { Ref } from 'vue';
 import type { AsUiComponent, AsUiRoot } from '@/aiscript/ui.js';
@@ -74,7 +76,6 @@ import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';
 import { definePage } from '@/page.js';
 import MkAsUi from '@/components/MkAsUi.vue';
-import { getAiScriptVersion } from '@/aiscript/common.js';
 import { registerAsUiLib } from '@/aiscript/ui.js';
 import { aiScriptReadline, createAiScriptEnv } from '@/aiscript/api.js';
 import MkFolder from '@/components/MkFolder.vue';
@@ -191,12 +192,22 @@ function start() {
 	run();
 }
 
+/** returns whether the version is legacy (less than 1.0.0) */
+function getIsLegacy(version: string | null): boolean {
+	if (version == null) return false;
+	try {
+		return compareVersions(version, '1.0.0') < 0;
+	} catch {
+		return false;
+	}
+}
+
 async function run() {
 	if (aiscript.value) aiscript.value.abort();
 	if (!flash.value) return;
 
-	const version = getAiScriptVersion(flash.value.script);
-	const isLegacy = version ? version.major < 1 : false;
+	const version = utils.getLangVersion(flash.value.script);
+	const isLegacy = version != null && getIsLegacy(version);
 
 	const { Interpreter, Parser, values } = isLegacy ? (await import('@syuilo/aiscript-0-19-0') as any) : await import('@syuilo/aiscript');
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
AiScript側から提供されている `utils.getLangVersion()` を使用するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
https://github.com/misskey-dev/misskey/pull/16843#issuecomment-3570462532

- 公式提供のインターフェイスを使用することで分界点をはっきりさせる
- 既存のバージョン判定ロジックと同一の流れを取る

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
