### PR TITLE
MkPostFormでファイルをアップロードした際に、添付ファイルの順序をドラッグ&ドロップで並べ替えられるようにする

### DIFF
--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -86,7 +86,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<MkTip k="postFormUploader">
 			{{ i18n.ts._postForm.uploaderTip }}
 		</MkTip>
-		<MkUploaderItems :items="uploader.items.value" @showMenu="(item, ev) => showPerUploadItemMenu(item, ev)" @showMenuViaContextmenu="(item, ev) => showPerUploadItemMenuViaContextmenu(item, ev)"/>
+		<MkUploaderItems :items="uploader.items.value" @update:modelValue="uploader.reorderItems" @showMenu="(item, ev) => showPerUploadItemMenu(item, ev)" @showMenuViaContextmenu="(item, ev) => showPerUploadItemMenuViaContextmenu(item, ev)"/>
 	</div>
 	<MkPollEditor v-if="poll" v-model="poll" @destroyed="poll = null"/>
 	<MkNotePreview v-if="showPreview" :class="$style.preview" :text="text" :files="files" :poll="poll ?? undefined" :useCw="useCw" :cw="cw" :user="postAccount ?? $i"/>

--- a/packages/frontend/src/components/MkUploaderItems.vue
+++ b/packages/frontend/src/components/MkUploaderItems.vue
@@ -5,58 +5,64 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div :class="$style.root" class="_gaps_s">
-	<div
-		v-for="item in props.items"
-		:key="item.id"
-		v-panel
-		:class="[$style.item, { [$style.itemWaiting]: item.preprocessing, [$style.itemCompleted]: item.uploaded, [$style.itemFailed]: item.uploadFailed }]"
-		:style="{
-			'--p': item.progress != null ? `${item.progress.value / item.progress.max * 100}%` : '0%',
-			'--pp': item.preprocessProgress != null ? `${item.preprocessProgress * 100}%` : '100%',
-		}"
-		@contextmenu.prevent.stop="onContextmenu(item, $event)"
-	>
-		<div :class="$style.itemInner">
-			<div :class="$style.itemActionWrapper">
-				<MkButton :iconOnly="true" rounded @click="emit('showMenu', item, $event)"><i class="ti ti-dots"></i></MkButton>
-			</div>
-			<div :class="$style.itemThumbnail" :style="{ backgroundImage: `url(${ item.thumbnail })` }" @click="onThumbnailClick(item, $event)"></div>
-			<div :class="$style.itemBody">
-				<div>
-					<i v-if="item.isSensitive" style="color: var(--MI_THEME-warn); margin-right: 0.5em;" class="ti ti-eye-exclamation"></i>
-					<MkCondensedLine :minScale="2 / 3">{{ item.name }}</MkCondensedLine>
+	<Sortable :modelValue="props.items" itemKey="id" :animation="150" :delay="100" :delayOnTouchOnly="true" @update:modelValue="v => emit('update:modelValue', v)">
+		<template #item="{ element }">
+			<div
+				v-panel
+				:class="[$style.item, { [$style.itemWaiting]: element.preprocessing, [$style.itemCompleted]: element.uploaded, [$style.itemFailed]: element.uploadFailed }]"
+				:style="{
+					'--p': element.progress != null ? `${element.progress.value / element.progress.max * 100}%` : '0%',
+					'--pp': element.preprocessProgress != null ? `${element.preprocessProgress * 100}%` : '100%',
+				}"
+				@contextmenu.prevent.stop="onContextmenu(element, $event)"
+			>
+				<div :class="$style.itemInner">
+					<div :class="$style.itemActionWrapper">
+						<MkButton :iconOnly="true" rounded @click="emit('showMenu', element, $event)"><i class="ti ti-dots"></i></MkButton>
+					</div>
+					<div :class="$style.itemThumbnail" :style="{ backgroundImage: `url(${ element.thumbnail })` }" @click="onThumbnailClick(element, $event)"></div>
+					<div :class="$style.itemBody">
+						<div>
+							<i v-if="element.isSensitive" style="color: var(--MI_THEME-warn); margin-right: 0.5em;" class="ti ti-eye-exclamation"></i>
+							<MkCondensedLine :minScale="2 / 3">{{ element.name }}</MkCondensedLine>
+						</div>
+						<div :class="$style.itemInfo">
+							<span>{{ element.file.type }}</span>
+							<span v-if="element.compressedSize">({{ i18n.tsx._uploader.compressedToX({ x: bytes(element.compressedSize) }) }} = {{ i18n.tsx._uploader.savedXPercent({ x: Math.round((1 - element.compressedSize / element.file.size) * 100) }) }})</span>
+							<span v-else>{{ bytes(element.file.size) }}</span>
+							<span v-if="element.preprocessing">{{ i18n.ts.preprocessing }}<MkLoading inline em style="margin-left: 0.5em;"/></span>
+						</div>
+						<div>
+						</div>
+					</div>
+					<div :class="$style.itemIconWrapper">
+						<MkSystemIcon v-if="element.uploading" :class="$style.itemIcon" type="waiting"/>
+						<MkSystemIcon v-else-if="element.uploaded" :class="$style.itemIcon" type="success"/>
+						<MkSystemIcon v-else-if="element.uploadFailed" :class="$style.itemIcon" type="error"/>
+					</div>
 				</div>
-				<div :class="$style.itemInfo">
-					<span>{{ item.file.type }}</span>
-					<span v-if="item.compressedSize">({{ i18n.tsx._uploader.compressedToX({ x: bytes(item.compressedSize) }) }} = {{ i18n.tsx._uploader.savedXPercent({ x: Math.round((1 - item.compressedSize / item.file.size) * 100) }) }})</span>
-					<span v-else>{{ bytes(item.file.size) }}</span>
-					<span v-if="item.preprocessing">{{ i18n.ts.preprocessing }}<MkLoading inline em style="margin-left: 0.5em;"/></span>
-				</div>
-				<div>
-				</div>
 			</div>
-			<div :class="$style.itemIconWrapper">
-				<MkSystemIcon v-if="item.uploading" :class="$style.itemIcon" type="waiting"/>
-				<MkSystemIcon v-else-if="item.uploaded" :class="$style.itemIcon" type="success"/>
-				<MkSystemIcon v-else-if="item.uploadFailed" :class="$style.itemIcon" type="error"/>
-			</div>
-		</div>
-	</div>
+		</template>
+	</Sortable>
 </div>
 </template>
 
 <script lang="ts" setup>
+import { defineAsyncComponent } from 'vue';
 import { isLink } from '@@/js/is-link.js';
 import type { UploaderItem } from '@/composables/use-uploader.js';
 import { i18n } from '@/i18n.js';
 import MkButton from '@/components/MkButton.vue';
 import bytes from '@/filters/bytes.js';
 
+const Sortable = defineAsyncComponent(() => import('vuedraggable').then(x => x.default));
+
 const props = defineProps<{
 	items: UploaderItem[];
 }>();
 
 const emit = defineEmits<{
+	(ev: 'update:modelValue', value: UploaderItem[]): void;
 	(ev: 'showMenu', item: UploaderItem, event: MouseEvent): void;
 	(ev: 'showMenuViaContextmenu', item: UploaderItem, event: MouseEvent): void;
 }>();
@@ -82,6 +88,7 @@ function onThumbnailClick(item: UploaderItem, ev: MouseEvent) {
 	position: relative;
 	border-radius: 10px;
 	overflow: clip;
+	cursor: move;
 
 	&::before {
 		content: '';

--- a/packages/frontend/src/composables/use-uploader.ts
+++ b/packages/frontend/src/composables/use-uploader.ts
@@ -766,10 +766,15 @@ export function useUploader(options: {
 		dispose();
 	});
 
+	function reorderItems(newItems: UploaderItem[]) {
+		items.value = newItems;
+	}
+
 	return {
 		items,
 		addFiles,
 		removeItem,
+		reorderItems,
 		abortAll,
 		dispose,
 		upload,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
添付済み状態では並べ替えられたが、仮添付状態（MkUploadItems）は並び替えられないので並び替えられるようにする

https://github.com/user-attachments/assets/dc84c200-463b-454f-8e91-df26cd98d857


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
できたほうが便利

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

- MkUplaodItems と MkPostFormAttachmentsは相互に並び替えることが出来ない

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
