### PR TITLE
fix: フォロワー限定投稿の本人リプライ、リノートを解決できるように（signed getされた際にfollowers, specifiedのノートも取得可能に）

### DIFF
--- a/packages/backend/src/core/UserFollowingService.ts
+++ b/packages/backend/src/core/UserFollowingService.ts
@@ -738,6 +738,14 @@ export class UserFollowingService implements OnModuleInit {
 	}
 
 	@bindThis
+	public getFollowers(userId: MiUser['id']) {
+		return this.followingsRepository.createQueryBuilder('following')
+			.select('following.followerId')
+			.where('following.followeeId = :followeeId', { followeeId: userId })
+			.getMany();
+	}
+
+	@bindThis
 	public isFollowing(followerId: MiUser['id'], followeeId: MiUser['id']) {
 		return this.followingsRepository.exists({
 			where: {

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -458,7 +458,7 @@ export class ApInboxService {
 			const exist = await this.apNoteService.fetchNote(note);
 			if (exist) return 'skip: note exists';
 
-			await this.apNoteService.createNote(note, actor, resolver, silent)
+			await this.apNoteService.createNote(note, actor, resolver, silent, true)
 				.catch(async (err) => {
 					if (err instanceof StatusError && [401, 403].includes(err.statusCode)) {
 						// 適切な権限がない場合、createしたactorのフォロワーを探し、フォロワーであるactorで再度resolveを試みる

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -290,8 +290,6 @@ export class ApInboxService {
 		const targetUri = getApId(activity.object);
 		if (targetUri.startsWith('bear:')) return 'skip: bearcaps url not supported.';
 
-		let resolverForAnnounce = resolver;
-
 		const target = await resolver.resolve(activity.object).catch(async e => {
 			if (e instanceof StatusError && [401, 403].includes(e.statusCode)) {
 				// 適切な権限がない場合、announceしたactorのフォロワーを探し、フォロワーであるactorで再度resolveを試みる
@@ -302,7 +300,6 @@ export class ApInboxService {
 					if (followerUser) {
 						const newResolver = this.apResolverService.createResolver(followerUser as MiLocalUser);
 						const resolved = await newResolver.resolve(activity.object);
-						resolverForAnnounce = newResolver;
 						return resolved;
 					}
 				}
@@ -312,7 +309,7 @@ export class ApInboxService {
 			throw e;
 		});
 
-		if (isPost(target)) return await this.announceNote(actor, activity, target, resolverForAnnounce);
+		if (isPost(target)) return await this.announceNote(actor, activity, target);
 
 		return `skip: unknown object type ${getApType(target)}`;
 	}

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -4,7 +4,7 @@
  */
 
 import { Inject, Injectable } from '@nestjs/common';
-import { In } from 'typeorm';
+import { In, IsNull } from 'typeorm';
 import { DI } from '@/di-symbols.js';
 import type { Config } from '@/config.js';
 import { UserFollowingService } from '@/core/UserFollowingService.js';
@@ -25,7 +25,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { QueueService } from '@/core/QueueService.js';
 import type { UsersRepository, NotesRepository, FollowingsRepository, AbuseUserReportsRepository, FollowRequestsRepository, MiMeta } from '@/models/_.js';
 import { bindThis } from '@/decorators.js';
-import type { MiRemoteUser } from '@/models/User.js';
+import type { MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import { GlobalEventService } from '@/core/GlobalEventService.js';
 import { AbuseReportService } from '@/core/AbuseReportService.js';
 import { IdentifiableError } from '@/misc/identifiable-error.js';
@@ -290,12 +290,29 @@ export class ApInboxService {
 		const targetUri = getApId(activity.object);
 		if (targetUri.startsWith('bear:')) return 'skip: bearcaps url not supported.';
 
-		const target = await resolver.resolve(activity.object).catch(e => {
+		let resolverForAnnounce = resolver;
+
+		const target = await resolver.resolve(activity.object).catch(async e => {
+			if (e instanceof StatusError && [401, 403].includes(e.statusCode)) {
+				// 適切な権限がない場合、announceしたactorのフォロワーを探し、フォロワーであるactorで再度resolveを試みる
+				const followers = await this.userFollowingService.getFollowers(actor.id);
+				if (followers.length > 0) {
+					const follower = followers[0].followerId;
+					const followerUser = await this.usersRepository.findOneBy({ id: follower, host: IsNull() });
+					if (followerUser) {
+						const newResolver = this.apResolverService.createResolver(followerUser as MiLocalUser);
+						const resolved = await newResolver.resolve(activity.object);
+						resolverForAnnounce = newResolver;
+						return resolved;
+					}
+				}
+			}
+
 			this.logger.error(`Resolution failed: ${e}`);
 			throw e;
 		});
 
-		if (isPost(target)) return await this.announceNote(actor, activity, target);
+		if (isPost(target)) return await this.announceNote(actor, activity, target, resolverForAnnounce);
 
 		return `skip: unknown object type ${getApType(target)}`;
 	}

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -458,7 +458,21 @@ export class ApInboxService {
 			const exist = await this.apNoteService.fetchNote(note);
 			if (exist) return 'skip: note exists';
 
-			await this.apNoteService.createNote(note, actor, resolver, silent);
+			await this.apNoteService.createNote(note, actor, resolver, silent)
+				.catch(async (err) => {
+					if (err instanceof StatusError && [401, 403].includes(err.statusCode)) {
+						// 適切な権限がない場合、createしたactorのフォロワーを探し、フォロワーであるactorで再度resolveを試みる
+						const followers = await this.userFollowingService.getFollowers(actor.id);
+						if (followers.length > 0) {
+							const follower = followers[0].followerId;
+							const followerUser = await this.usersRepository.findOneBy({ id: follower, host: IsNull() });
+							if (followerUser) {
+								return await this.apNoteService.createNote(note, actor, this.apResolverService.createResolver(followerUser as MiLocalUser), silent);
+							}
+						}
+					}
+					throw err;
+				});
 			return 'ok';
 		} catch (err) {
 			if (err instanceof StatusError && !err.isRetryable) {

--- a/packages/backend/src/core/activitypub/ApResolverService.ts
+++ b/packages/backend/src/core/activitypub/ApResolverService.ts
@@ -44,8 +44,12 @@ export class Resolver {
 		private apDbResolverService: ApDbResolverService,
 		private loggerService: LoggerService,
 		private recursionLimit = 256,
+		private resolvedBy?: MiLocalUser,
 	) {
 		this.history = new Set();
+		if (this.resolvedBy) {
+			this.user = this.resolvedBy;
+		}
 		this.logger = this.loggerService.getLogger('ap-resolve');
 	}
 
@@ -212,7 +216,7 @@ export class ApResolverService {
 	}
 
 	@bindThis
-	public createResolver(): Resolver {
+	public createResolver(resolvedBy: (MiLocalUser | undefined) = undefined): Resolver {
 		return new Resolver(
 			this.config,
 			this.meta,
@@ -228,6 +232,8 @@ export class ApResolverService {
 			this.apRendererService,
 			this.apDbResolverService,
 			this.loggerService,
+			undefined,
+			resolvedBy,
 		);
 	}
 }

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -123,7 +123,7 @@ export class ApNoteService {
 	 * Noteを作成します。
 	 */
 	@bindThis
-	public async createNote(value: string | IObject, actor?: MiRemoteUser, resolver?: Resolver, silent = false): Promise<MiNote | null> {
+	public async createNote(value: string | IObject, actor?: MiRemoteUser, resolver?: Resolver, silent = false, throwErrorOnQuoteForbidden = false): Promise<MiNote | null> {
 		// eslint-disable-next-line no-param-reassign
 		if (resolver == null) resolver = this.apResolverService.createResolver();
 
@@ -254,16 +254,17 @@ export class ApNoteService {
 		if (note._misskey_quote ?? note.quoteUrl) {
 			const tryResolveNote = async (uri: string): Promise<
 				| { status: 'ok'; res: MiNote }
-				| { status: 'permerror' | 'temperror' }
+				| { status: 'permerror' | 'temperror', error?: Error }
 			> => {
 				if (!/^https?:/.test(uri)) return { status: 'permerror' };
 				try {
-					const res = await this.resolveNote(uri);
+					const res = await this.resolveNote(uri, { resolver });
 					if (res == null) return { status: 'permerror' };
 					return { status: 'ok', res };
 				} catch (e) {
 					return {
 						status: (e instanceof StatusError && !e.isRetryable) ? 'permerror' : 'temperror',
+						error: (e instanceof Error || e instanceof StatusError) ? e : undefined,
 					};
 				}
 			};
@@ -273,6 +274,12 @@ export class ApNoteService {
 
 			quote = results.filter((x): x is { status: 'ok', res: MiNote } => x.status === 'ok').map(x => x.res).at(0);
 			if (!quote) {
+				if (throwErrorOnQuoteForbidden) {
+					const forbiddenQuote = results.find(x => (x.status === 'permerror' || x.status === 'temperror') && x.error instanceof StatusError && [401, 403, 404].includes(x.error.statusCode));
+					if (forbiddenQuote != null && forbiddenQuote.status !== 'ok' && forbiddenQuote.error) {
+						throw forbiddenQuote.error;
+					}
+				}
 				if (results.some(x => x.status === 'temperror')) {
 					throw new Error('quote resolve failed');
 				}
@@ -409,7 +416,7 @@ export class ApNoteService {
 						publicUrl: tag.icon.url,
 						updatedAt: new Date(),
 						// _misskey_license が存在しなければ `null`
-						license: (tag._misskey_license?.freeText ?? null)
+						license: (tag._misskey_license?.freeText ?? null),
 					});
 
 					const emoji = await this.emojisRepository.findOneBy({ host, name });
@@ -432,7 +439,7 @@ export class ApNoteService {
 				updatedAt: new Date(),
 				aliases: [],
 				// _misskey_license が存在しなければ `null`
-				license: (tag._misskey_license?.freeText ?? null)
+				license: (tag._misskey_license?.freeText ?? null),
 			});
 		}));
 	}

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -669,7 +669,6 @@ export class ActivityPubServerService {
 
 			const note = await this.notesRepository.findOneBy({
 				id: request.params.note,
-				visibility: In(['public', 'home', 'followers', 'specified']),
 				localOnly: false,
 			});
 

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -17,6 +17,7 @@ import type { FollowingsRepository, NotesRepository, EmojisRepository, NoteReact
 import * as url from '@/misc/prelude/url.js';
 import type { Config } from '@/config.js';
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
+import { ApDbResolverService } from '@/core/activitypub/ApDbResolverService.js';
 import { QueueService } from '@/core/QueueService.js';
 import type { MiLocalUser, MiRemoteUser, MiUser } from '@/models/User.js';
 import { UserKeypairService } from '@/core/UserKeypairService.js';
@@ -30,9 +31,9 @@ import { bindThis } from '@/decorators.js';
 import { IActivity } from '@/core/activitypub/type.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 import * as Acct from '@/misc/acct.js';
+import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointService.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginOptions, FastifyBodyParser } from 'fastify';
 import type { FindOptionsWhere } from 'typeorm';
-import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointService.js';
 
 const ACTIVITY_JSON = 'application/activity+json; charset=utf-8';
 const LD_JSON = 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"; charset=utf-8';
@@ -73,12 +74,31 @@ export class ActivityPubServerService {
 		private utilityService: UtilityService,
 		private userEntityService: UserEntityService,
 		private apRendererService: ApRendererService,
+		private apDbResolverService: ApDbResolverService,
 		private queueService: QueueService,
 		private userKeypairService: UserKeypairService,
 		private queryService: QueryService,
 		private fanoutTimelineEndpointService: FanoutTimelineEndpointService,
 	) {
 		//this.createServer = this.createServer.bind(this);
+	}
+
+	@bindThis
+	private async authenticate(request: FastifyRequest): Promise<MiUser | null> {
+		let signature;
+
+		try {
+			signature = httpSignature.parseRequest(request.raw, { 'headers': ['(request-target)', 'host', 'date'], authorizationHeaderName: 'signature' });
+		} catch (e) {
+			return null;
+		}
+
+		const authUser = await this.apDbResolverService.getAuthUserFromKeyId(signature.keyId);
+		if (authUser == null) return null;
+
+		if (!httpSignature.verifySignature(signature, authUser.key.keyPem)) return null;
+
+		return authUser.user;
 	}
 
 	@bindThis
@@ -645,15 +665,43 @@ export class ActivityPubServerService {
 				return;
 			}
 
+			const user = await this.authenticate(request);
+
 			const note = await this.notesRepository.findOneBy({
 				id: request.params.note,
-				visibility: In(['public', 'home']),
+				visibility: In(['public', 'home', 'followers', 'specified']),
 				localOnly: false,
 			});
 
 			if (note == null) {
 				reply.code(404);
 				return;
+			}
+
+			// followersの場合、認証ユーザーがフォロワーであることを確認
+			if (note.visibility === 'followers') {
+				if (user == null) {
+					reply.code(403);
+					return;
+				}
+
+				const isFollowing = await this.followingsRepository.exist({
+					where: {
+						followerId: user.id,
+						followeeId: note.userId,
+					},
+				});
+
+				if (!isFollowing) {
+					reply.code(403);
+					return;
+				}
+			} else if (note.visibility === 'specified') {
+				// specifiedの場合、認証ユーザーがvisibleUserIdsに含まれていることを確認
+				if (user == null || !note.visibleUserIds.includes(user.id)) {
+					reply.code(403);
+					return;
+				}
 			}
 
 			// リモートだったらリダイレクト

--- a/packages/backend/src/server/api/endpoints/ap/show.ts
+++ b/packages/backend/src/server/api/endpoints/ap/show.ts
@@ -148,7 +148,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		if (this.utilityService.isSelfHost(host)) return null;
 
 		// リモートから一旦オブジェクトフェッチ
-		const resolver = this.apResolverService.createResolver();
+		const resolver = this.apResolverService.createResolver(me ?? undefined);
 		// allow ap/show exclusively to lookup URLs that are cross-origin or non-canonical (like https://alice.example.com/@bob@bob.example.com -> https://bob.example.com/@bob)
 		const object = await resolver.resolve(uri, FetchAllowSoftFailMask.CrossOrigin | FetchAllowSoftFailMask.NonCanonicalId).catch((err) => {
 			if (err instanceof IdentifiableError) {

--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -378,4 +378,33 @@ describe('Note', () => {
 			});
 		});
 	});
+
+	describe('Visibility', () => {
+		test('Followers-only note can be fetched after following', async () => {
+			const note = (await bob.client.request('notes/create', {
+				text: 'secret',
+				visibility: 'followers',
+			})).createdNote;
+
+			const noteUri = `https://b.test/notes/${note.id}`;
+
+			// Alice tries to fetch the note (should fail)
+			await rejects(
+				async () => await alice.client.request('ap/show', { uri: noteUri }),
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				(err: any) => {
+					strictEqual(err.code, 'REQUEST_FAILED');
+					return true;
+				},
+			);
+
+			// Alice follows Bob
+			await alice.client.request('following/create', { userId: bobInA.id });
+			await sleep();
+
+			// Alice tries to fetch the note again (should success)
+			const resolvedNote = await resolveRemoteNote('b.test', note.id, alice);
+			strictEqual(resolvedNote.text, 'secret');
+		});
+	});
 });

--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -406,5 +406,42 @@ describe('Note', () => {
 			const resolvedNote = await resolveRemoteNote('b.test', note.id, alice);
 			strictEqual(resolvedNote.text, 'secret');
 		});
+
+		test('Followers-only note can be fetched via Announce if the receiver follows the announcer', async () => {
+			// Ensure Alice is NOT following Bob
+			try {
+				await alice.client.request('following/delete', { userId: bobInA.id });
+			} catch {
+				// ignore if not following
+			}
+			await sleep();
+
+			// Bob creates a followers-only note
+			const note = (await bob.client.request('notes/create', {
+				text: 'followers only',
+				visibility: 'followers',
+			})).createdNote;
+
+			// Alice follows Bob
+			await alice.client.request('following/create', { userId: bobInA.id });
+			await sleep();
+
+			// Bob renote the note
+			const bobRenote = await bob.client.request('notes/create', {
+				renoteId: note.id,
+			});
+
+			await sleep();
+
+			// Alice should be able to see the renote and the original note
+			const timeline = await alice.client.request('notes/timeline', { limit: 10 });
+			const renoteUri = `https://b.test/notes/${bobRenote.createdNote.id}/activity`;
+			const renoteInA = timeline.find(n => n.uri === renoteUri);
+
+			assert(renoteInA != null);
+			assert(renoteInA.renote != null);
+			strictEqual(renoteInA.renote.text, 'followers only');
+			strictEqual(renoteInA.renote.visibility, 'followers');
+		});
 	});
 });

--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -381,16 +381,23 @@ describe('Note', () => {
 
 	describe('Visibility', () => {
 		test('Followers-only note can be fetched after following', async () => {
-			const note = (await bob.client.request('notes/create', {
+			const [author, follower] = await Promise.all([
+				createAccount('b.test'),
+				createAccount('a.test'),
+			]);
+
+			const authorInA = await resolveRemoteUser('b.test', author.id, follower);
+
+			const note = (await author.client.request('notes/create', {
 				text: 'secret',
 				visibility: 'followers',
 			})).createdNote;
 
 			const noteUri = `https://b.test/notes/${note.id}`;
 
-			// Alice tries to fetch the note (should fail)
+			// Follower tries to fetch the note (should fail)
 			await rejects(
-				async () => await alice.client.request('ap/show', { uri: noteUri }),
+				async () => await follower.client.request('ap/show', { uri: noteUri }),
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				(err: any) => {
 					strictEqual(err.code, 'REQUEST_FAILED');
@@ -398,50 +405,101 @@ describe('Note', () => {
 				},
 			);
 
-			// Alice follows Bob
-			await alice.client.request('following/create', { userId: bobInA.id });
+			// Follower follows Author
+			await follower.client.request('following/create', { userId: authorInA.id });
 			await sleep();
 
-			// Alice tries to fetch the note again (should success)
-			const resolvedNote = await resolveRemoteNote('b.test', note.id, alice);
+			// Follower tries to fetch the note again (should success)
+			const resolvedNote = await resolveRemoteNote('b.test', note.id, follower);
 			strictEqual(resolvedNote.text, 'secret');
 		});
 
 		test('Followers-only note can be fetched via Announce if the receiver follows the announcer', async () => {
-			// Ensure Alice is NOT following Bob
-			try {
-				await alice.client.request('following/delete', { userId: bobInA.id });
-			} catch {
-				// ignore if not following
-			}
-			await sleep();
+			const [author, follower] = await Promise.all([
+				createAccount('b.test'),
+				createAccount('a.test'),
+			]);
 
-			// Bob creates a followers-only note
-			const note = (await bob.client.request('notes/create', {
-				text: 'followers only',
+			const authorInA = await resolveRemoteUser('b.test', author.id, follower);
+
+			// Author creates a followers-only note
+			const noteText = `followers only ${Date.now()}`;
+
+			const note = (await author.client.request('notes/create', {
+				text: noteText,
 				visibility: 'followers',
 			})).createdNote;
 
-			// Alice follows Bob
-			await alice.client.request('following/create', { userId: bobInA.id });
+			// Follower follows Author
+			await follower.client.request('following/create', { userId: authorInA.id });
 			await sleep();
 
-			// Bob renote the note
-			const bobRenote = await bob.client.request('notes/create', {
+			// Author renote the note
+			const authorRenote = await author.client.request('notes/create', {
 				renoteId: note.id,
 			});
 
 			await sleep();
 
-			// Alice should be able to see the renote and the original note
-			const timeline = await alice.client.request('notes/timeline', { limit: 10 });
-			const renoteUri = `https://b.test/notes/${bobRenote.createdNote.id}/activity`;
+			// Follower should be able to see the renote and the original note
+			const timeline = await follower.client.request('notes/timeline', { limit: 10 });
+			const renoteUri = `https://b.test/notes/${authorRenote.createdNote.id}/activity`;
 			const renoteInA = timeline.find(n => n.uri === renoteUri);
 
 			assert(renoteInA != null);
 			assert(renoteInA.renote != null);
-			strictEqual(renoteInA.renote.text, 'followers only');
+			strictEqual(renoteInA.renote.text, noteText);
 			strictEqual(renoteInA.renote.visibility, 'followers');
+		});
+
+		test('Followers-only note can be fetched via Reply if the receiver follows the author', async () => {
+			const [author, follower] = await Promise.all([
+				createAccount('b.test'),
+				createAccount('a.test'),
+			]);
+
+			const authorInA = await resolveRemoteUser('b.test', author.id, follower);
+
+			const noteText = `followers only ${Date.now()}`;
+
+			// Author creates a followers-only note
+			const note = (await author.client.request('notes/create', {
+				text: noteText,
+				visibility: 'followers',
+			})).createdNote;
+
+			const noteUri = `https://b.test/notes/${note.id}`;
+
+			// Follower tries to fetch the note (should fail)
+			await rejects(
+				async () => await follower.client.request('ap/show', { uri: noteUri }),
+				(err: any) => {
+					strictEqual(err.code, 'REQUEST_FAILED');
+					return true;
+				},
+			);
+
+			// Follower follows Author
+			await follower.client.request('following/create', { userId: authorInA.id });
+			await sleep();
+
+			// Author replies to the note
+			const reply = (await author.client.request('notes/create', {
+				text: 'reply to followers only',
+				replyId: note.id,
+				visibility: 'followers',
+			})).createdNote;
+
+			await sleep();
+
+			// Follower should be able to see the reply and the original note
+			const timeline = await follower.client.request('notes/timeline', { limit: 10 });
+			const replyInA = timeline.find(n => n.uri === `https://b.test/notes/${reply.id}`);
+
+			assert(replyInA != null);
+			assert(replyInA.reply != null);
+			strictEqual(replyInA.reply.text, noteText);
+			strictEqual(replyInA.reply.visibility, 'followers');
 		});
 	});
 });

--- a/packages/backend/test-federation/test/note.test.ts
+++ b/packages/backend/test-federation/test/note.test.ts
@@ -501,5 +501,64 @@ describe('Note', () => {
 			strictEqual(replyInA.reply.text, noteText);
 			strictEqual(replyInA.reply.visibility, 'followers');
 		});
+
+		test('Followers-only note can be fetched via Quote if the receiver follows the author', async () => {
+			const [author, follower] = await Promise.all([
+				createAccount('b.test'),
+				createAccount('a.test'),
+			]);
+
+			const authorInA = await resolveRemoteUser('b.test', author.id, follower);
+
+			// Author creates a followers-only note
+			const noteText = `followers only source ${Date.now()}`;
+			const note = (await author.client.request('notes/create', {
+				text: noteText,
+				visibility: 'followers',
+			})).createdNote;
+
+			const noteUri = `https://b.test/notes/${note.id}`;
+
+			// Follower tries to fetch the note (should fail)
+			await rejects(
+				async () => await follower.client.request('ap/show', { uri: noteUri }),
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				(err: any) => {
+					strictEqual(err.code, 'REQUEST_FAILED');
+					return true;
+				},
+			);
+
+			// Follower follows Author
+			await follower.client.request('following/create', { userId: authorInA.id });
+			await sleep();
+
+			// Author quotes the note
+			const quoteText = `quoting secret note ${Date.now()}`;
+			const quote = (await author.client.request('notes/create', {
+				text: quoteText,
+				renoteId: note.id,
+				visibility: 'public',
+			})).createdNote;
+			await sleep();
+
+			// Follower should be able to see the Quote and the Original Note
+			const timeline = await follower.client.request('notes/timeline', { limit: 10 });
+			const quotesInA = timeline.filter(n => n.text === quoteText);
+
+			const quoteUri = `https://b.test/notes/${quote.id}`;
+
+			// Check duplication of quote
+			strictEqual(quotesInA.length, 1);
+
+			const quoteInA = quotesInA[0];
+			strictEqual(quoteInA.text, quoteText);
+			strictEqual(quoteInA.uri, quoteUri);
+
+			// Check renote content
+			assert(quoteInA.renote != null);
+			strictEqual(quoteInA.renote.text, noteText);
+			strictEqual(quoteInA.renote.visibility, 'followers');
+		});
 	});
 });


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

- Signed Getを受け取った場合にユーザーを判定してフォロワー限定や指名ノートを返せるように
- Announceの解決にActorに対するローカルのフォロワーでSigned Getすることで解決を図る
- quote系やreplyに関しても同様に解決

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Resolve #15521

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
