### PR TITLE
Docker (#16933) .configの読み込み専用を削除

### DIFF
--- a/compose_example.yml
+++ b/compose_example.yml
@@ -21,7 +21,7 @@ services:
     #   - .config/docker.env
     volumes:
       - ./files:/misskey/files
-      - ./.config:/misskey/.config:ro
+      - ./.config:/misskey/.config
 
   redis:
     restart: always


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

Docker composeで、.configの読み込み専用の設定を削除します。

#16933 

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

.configが読み込み専用だと、default.jsonの生成に失敗するためです。

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

未試験です。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
