### PR TITLE
fix(ci): dockleのciをより安定して動かせるようにする

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   dockle:
     runs-on: ubuntu-latest
+
     env:
       DOCKER_CONTENT_TRUST: 1
       DOCKLE_VERSION: 0.4.15
@@ -20,29 +21,33 @@ jobs:
 
       - name: Download and install dockle v${{ env.DOCKLE_VERSION }}
         run: |
+          set -eux
           curl -L -o dockle.deb "https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-64bit.deb"
           sudo dpkg -i dockle.deb
 
-      - run: |
-          cp .config/docker_example.env .config/docker.env
-          cp ./compose_example.yml ./compose.yml
-
-      - run: |
-          docker compose up -d web
-          IMAGE_ID=$(docker compose images --format json web | jq -r '.[0].ID')
-          docker tag "${IMAGE_ID}" misskey-web:latest
-
-      - name: Prune docker junk (optional but recommended)
+      - name: Build web image (docker build)
         run: |
-          docker system prune -af
-          docker volume prune -f
+          set -eux
+          docker build -t "misskey-web:ci" .
+          docker image ls
 
-      - name: Save image for Dockle
+      - name: Mount tmpfs for Dockle tar
+        env:
+          TMPFS_SIZE: 8G
         run: |
-          docker save misskey-web:latest -o ./misskey-web.tar
-          ls -lh ./misskey-web.tar
+          set -eux
+          sudo mkdir -p /mnt/dockle-tmp
+          sudo mount -t tmpfs -o size=${{ env.TMPFS_SIZE }} tmpfs /mnt/dockle-tmp
+          free -h
+          df -h
 
-      - name: Run Dockle with tar input
+      - name: Save image tar into tmpfs
         run: |
-          dockle --exit-code 1 --input ./misskey-web.tar
+          set -eux
+          docker save misskey-web:ci -o /mnt/dockle-tmp/misskey-web.tar
+          ls -lh /mnt/dockle-tmp/misskey-web.tar
 
+      - name: Run Dockle Scan (tar input)
+        run: |
+          set -eux
+          dockle --exit-code 1 --input /mnt/dockle-tmp/misskey-web.tar


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

#16794 で対応した内容をより確実な方法にします。
docker buildしたイメージをtarにしてdockleに食わせるという方針は変わっていませんが、その過程に変化があります。

1. tmpfsに8GB割り当ててマウント
2. tarを1に吐き出すようにした
3. dockleからは2のtarを読むようにした

…という手順が追加されています。

また、docker composeによるビルドを廃止し、dockerでのビルドに置き換えました。
（docker compose up -dで起動しなくてもイメージを取れるようなので）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

df -hでGitHubActionsの容量を見ると、ディスクスペースがかなりカツカツです（空き5.5GB）。
現状は何とかなっていますが、tarのサイズが膨らんだらディスクフルで落ちるようになると思います。

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   67G  5.5G  93% /
tmpfs           7.9G   84K  7.9G   1% /dev/shm
tmpfs           3.2G  1.2M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb16      881M   62M  758M   8% /boot
/dev/sdb15      105M  6.2M   99M   6% /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

一方で、free -hで見たメモリ容量
```
               total        used        free      shared  buff/cache   available
Mem:            15Gi       2.8Gi       3.6Gi        44Mi       9.9Gi        12Gi
Swap:          4.0Gi        12Ki       4.0Gi
```

ディスクよりあいてるのでtmpfsを新たに用意する形にしました

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ※ユーザ・サーバ運用ともに影響ないので
- [ ] (If possible) Add tests
