### PR TITLE
fix(frontend): まれに設定変更のタブ間同期に失敗する問題を修正

### DIFF
--- a/packages/frontend/src/preferences/manager.ts
+++ b/packages/frontend/src/preferences/manager.ts
@@ -257,20 +257,23 @@ export class PreferencesManager extends EventEmitter<PreferencesManagerEvents> {
 
 		this.rewriteRawState(key, v);
 
-		this.emit('committed', {
-			key,
-			value: v,
-			oldValue: this.s[key],
-		});
-
 		const record = this.getMatchedRecordOf(key);
+
+		const _save = () => {
+			this.save();
+			this.emit('committed', {
+				key,
+				value: v,
+				oldValue: this.s[key],
+			});
+		};
 
 		if (parseScope(record[0]).account == null && isAccountDependentKey(key) && currentAccount != null) {
 			this.profile.preferences[key].push([makeScope({
 				server: host,
 				account: currentAccount.id,
 			}), v, {}]);
-			this.save();
+			_save();
 			return;
 		}
 
@@ -278,12 +281,12 @@ export class PreferencesManager extends EventEmitter<PreferencesManagerEvents> {
 			this.profile.preferences[key].push([makeScope({
 				server: host,
 			}), v, {}]);
-			this.save();
+			_save();
 			return;
 		}
 
 		record[1] = v;
-		this.save();
+		_save();
 
 		if (record[2].sync) {
 			// awaitの必要なし


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
localstorageへの保存を待たずに別タブに通知しているので、localstorageへの保存前にpreferenceの再読み込みが行われる可能性がある

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
