### PR TITLE
Pnpm engine

### DIFF
--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6.0.1
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
 

--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -18,14 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6.1.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+          cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -22,7 +22,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6.0.1
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
 

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -18,7 +18,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
 
       - name: Checkout base
         run: |

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
 
       - name: Checkout base

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -13,10 +13,11 @@ jobs:
     steps:
       - name: Checkout head
         uses: actions/checkout@v6.0.1
-      - name: Setup Node.js
-        uses: actions/setup-node@v6.1.0
+
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version-file: '.node-version'
+          cache: true
 
       - name: Checkout base
         run: |

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -18,7 +18,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
 
       - name: Checkout base
         run: |

--- a/.github/workflows/check-misskey-js-autogen.yml
+++ b/.github/workflows/check-misskey-js-autogen.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
 
       - name: install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/check-misskey-js-autogen.yml
+++ b/.github/workflows/check-misskey-js-autogen.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
 
       - name: install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/check-misskey-js-autogen.yml
+++ b/.github/workflows/check-misskey-js-autogen.yml
@@ -24,15 +24,10 @@ jobs:
           persist-credentials: false
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
-      - name: setup pnpm
+      - name: Use pnpm
         uses: pnpm/action-setup@v4
-
-      - name: setup node
-        id: setup-node
-        uses: actions/setup-node@v6.1.0
         with:
-          node-version-file: '.node-version'
-          cache: pnpm
+          cache: true
 
       - name: install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/check-misskey-js-autogen.yml
+++ b/.github/workflows/check-misskey-js-autogen.yml
@@ -25,7 +25,7 @@ jobs:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
 

--- a/.github/workflows/check-misskey-js-autogen.yml
+++ b/.github/workflows/check-misskey-js-autogen.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
 
       - name: install dependencies

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -33,7 +33,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -30,7 +30,7 @@ jobs:
         ref: ${{ matrix.ref }}
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -33,7 +33,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -29,13 +29,10 @@ jobs:
       with:
         ref: ${{ matrix.ref }}
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-api-diff.yml
+++ b/.github/workflows/get-api-diff.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -48,7 +48,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -44,6 +44,12 @@ jobs:
       with:
         ref: ${{ matrix.ref }}
         submodules: true
+    #TODO: あとで消す
+    - name: Use Node.js
+      uses: actions/setup-node@v6.1.0
+      with:
+        node-version-file: '.node-version'
+        cache: 'pnpm'
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Measure memory usage
       run: |
         # Start the server and measure memory usage
-        node packages/backend/scripts/measure-memory.mjs > ${{ matrix.memory-json-name }}
+        pnpm node packages/backend/scripts/measure-memory.mjs > ${{ matrix.memory-json-name }}
     - name: Upload Artifact
       uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -44,13 +44,10 @@ jobs:
       with:
         ref: ${{ matrix.ref }}
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -45,7 +45,7 @@ jobs:
         ref: ${{ matrix.ref }}
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -44,17 +44,17 @@ jobs:
       with:
         ref: ${{ matrix.ref }}
         submodules: true
+    - name: Use pnpm
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
+      with:
+        standalone: true
+        cache: true
     #TODO: あとで消す
     - name: Use Node.js
       uses: actions/setup-node@v6.1.0
       with:
         node-version-file: '.node-version'
         cache: 'pnpm'
-    - name: Use pnpm
-      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
-      with:
-        standalone: true
-        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/get-backend-memory.yml
+++ b/.github/workflows/get-backend-memory.yml
@@ -48,7 +48,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile
@@ -72,7 +72,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile
@@ -101,7 +101,7 @@ jobs:
         fetch-depth: 0
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
 
@@ -74,6 +75,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Restore eslint cache
@@ -103,6 +105,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - run: pnpm --filter "${{ matrix.workspace }}^..." run build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
 
   lint:
@@ -76,7 +76,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Restore eslint cache
       uses: actions/cache@v4.3.0
@@ -106,7 +106,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - run: pnpm --filter "${{ matrix.workspace }}^..." run build
     - run: pnpm --filter ${{ matrix.workspace }} run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
 
   lint:
@@ -76,7 +76,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Restore eslint cache
       uses: actions/cache@v4.3.0
@@ -106,7 +106,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - run: pnpm --filter "${{ matrix.workspace }}^..." run build
     - run: pnpm --filter ${{ matrix.workspace }} run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,12 +40,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
 
   lint:
@@ -73,12 +71,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Restore eslint cache
       uses: actions/cache@v4.3.0
@@ -104,12 +100,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - run: pnpm --filter "${{ matrix.workspace }}^..." run build
     - run: pnpm --filter ${{ matrix.workspace }} run typecheck

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
       - run: pnpm i --frozen-lockfile

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -20,12 +20,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
-      - uses: actions/setup-node@v6.1.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version-file: ".node-version"
-          cache: "pnpm"
+          cache: true
       - run: pnpm i --frozen-lockfile
       - run: pnpm --filter i18n build
       - name: Verify Locales

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
       - run: pnpm i --frozen-lockfile
       - run: pnpm --filter i18n build
       - name: Verify Locales

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -24,7 +24,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
       - run: pnpm i --frozen-lockfile
       - run: pnpm --filter i18n build
       - name: Verify Locales

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
       - run: pnpm i --frozen-lockfile
       - run: pnpm --filter i18n build

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -19,13 +19,13 @@ jobs:
       - uses: actions/checkout@v6.0.1
         with:
           submodules: true
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          cache: true
       - name: Use Node.js
         uses: actions/setup-node@v6.1.0
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
           # see https://docs.github.com/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
           registry-url: 'https://registry.npmjs.org'
       - name: Publish package

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -23,7 +23,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
       - name: Use Node.js
         uses: actions/setup-node@v6.1.0
         with:

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
       - name: Use Node.js
         uses: actions/setup-node@v6.1.0

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -23,7 +23,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
       - name: Use Node.js
         uses: actions/setup-node@v6.1.0
         with:

--- a/.github/workflows/on-release-created.yml
+++ b/.github/workflows/on-release-created.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: true
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
       - name: Use Node.js

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -60,7 +60,7 @@ jobs:
         if [ "$DIFF" = "0000000000000000000000000000000000000000 HEAD" ]; then
           DIFF="HEAD"
         fi
-        CHROMATIC_PARAMETER="$(node packages/frontend/.storybook/changes.js $(git diff-tree --no-commit-id --name-only -r $(echo "$DIFF") | xargs))"
+        CHROMATIC_PARAMETER="$(pnpm node packages/frontend/.storybook/changes.js $(git diff-tree --no-commit-id --name-only -r $(echo "$DIFF") | xargs))"
         if [ "$CHROMATIC_PARAMETER" = " --skip" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         fi
@@ -75,7 +75,7 @@ jobs:
       if: github.event_name == 'pull_request_target'
       id: chromatic_pull_request
       run: |
-        CHROMATIC_PARAMETER="$(node packages/frontend/.storybook/changes.js $(git diff --name-only origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} | xargs))"
+        CHROMATIC_PARAMETER="$(pnpm node packages/frontend/.storybook/changes.js $(git diff --name-only origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} | xargs))"
         if [ "$CHROMATIC_PARAMETER" = " --skip" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -37,7 +37,7 @@ jobs:
       if: github.event_name == 'pull_request_target'
       run: git checkout "$(git rev-list --parents -n1 HEAD | cut -d" " -f3)"
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -36,13 +36,10 @@ jobs:
     - name: Checkout actual HEAD
       if: github.event_name == 'pull_request_target'
       run: git checkout "$(git rev-list --parents -n1 HEAD | cut -d" " -f3)"
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -40,7 +40,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -40,7 +40,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -63,6 +63,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - name: Get current date
       id: current-date
@@ -139,6 +140,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
       - run: pnpm i --frozen-lockfile
       - name: Check pnpm-lock.yaml
@@ -180,6 +182,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
       - name: Get current date
         id: current-date

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -60,8 +60,10 @@ jobs:
     - uses: actions/checkout@v6.0.1
       with:
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        cache: true
     - name: Get current date
       id: current-date
       run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -92,11 +94,6 @@ jobs:
             exit 1
           fi
         done
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
-      with:
-        node-version-file: ${{ matrix.node-version-file }}
-        cache: 'pnpm'
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
@@ -139,13 +136,10 @@ jobs:
       - uses: actions/checkout@v6.0.1
         with:
           submodules: true
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
-      - name: Use Node.js
-        uses: actions/setup-node@v6.1.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version-file: ${{ matrix.node-version-file }}
-          cache: 'pnpm'
+          cache: true
       - run: pnpm i --frozen-lockfile
       - name: Check pnpm-lock.yaml
         run: git diff --exit-code pnpm-lock.yaml
@@ -183,16 +177,13 @@ jobs:
       - uses: actions/checkout@v6.0.1
         with:
           submodules: true
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-      - name: Use Node.js
-        uses: actions/setup-node@v6.1.0
-        with:
-          node-version-file: ${{ matrix.node-version-file }}
-          cache: 'pnpm'
       - run: pnpm i --frozen-lockfile
       - name: Check pnpm-lock.yaml
         run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -64,7 +64,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - name: Get current date
       id: current-date
       run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -141,7 +141,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
       - run: pnpm i --frozen-lockfile
       - name: Check pnpm-lock.yaml
         run: git diff --exit-code pnpm-lock.yaml
@@ -183,7 +183,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -61,7 +61,7 @@ jobs:
       with:
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - name: Get current date
@@ -137,7 +137,7 @@ jobs:
         with:
           submodules: true
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
       - run: pnpm i --frozen-lockfile
@@ -178,7 +178,7 @@ jobs:
         with:
           submodules: true
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
       - name: Get current date

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -64,7 +64,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - name: Get current date
       id: current-date
       run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -141,7 +141,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
       - run: pnpm i --frozen-lockfile
       - name: Check pnpm-lock.yaml
         run: git diff --exit-code pnpm-lock.yaml
@@ -183,7 +183,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -39,7 +39,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
       - name: Get current date
         id: current-date

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           submodules: true
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
       - name: Get current date

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -39,7 +39,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -35,8 +35,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          cache: true
       - name: Get current date
         id: current-date
         run: echo "today=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
@@ -67,11 +69,6 @@ jobs:
               exit 1
             fi
           done
-      - name: Use Node.js
-        uses: actions/setup-node@v6.1.0
-        with:
-          node-version-file: ${{ matrix.node-version-file }}
-          cache: 'pnpm'
       - name: Build Misskey
         run: |
           pnpm i --frozen-lockfile

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile
@@ -83,7 +83,7 @@ jobs:
     #- uses: browser-actions/setup-firefox@latest
     #  if: ${{ matrix.browser == 'firefox' }}
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
@@ -85,6 +86,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Copy Configure

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -31,13 +31,10 @@ jobs:
     - uses: actions/checkout@v6.0.1
       with:
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
@@ -85,13 +82,10 @@ jobs:
     #  if: ${{ matrix.browser == 'firefox' }}
     #- uses: browser-actions/setup-firefox@latest
     #  if: ${{ matrix.browser == 'firefox' }}
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Copy Configure
       run: cp .github/misskey/test.yml .config

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -35,7 +35,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
@@ -87,7 +87,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Copy Configure
       run: cp .github/misskey/test.yml .config

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -35,7 +35,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml
@@ -87,7 +87,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Copy Configure
       run: cp .github/misskey/test.yml .config

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          #cache: true
+          cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Use pnpm
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
+          standalone: true
           cache: true
 
       - name: Install dependencies

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           standalone: true
-          cache: true
+          #cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -24,14 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6.1.0
+      - name: Use pnpm
+        uses: pnpm/action-setup@v4
         with:
-          node-version-file: '.node-version'
-          cache: 'pnpm'
+          cache: true
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile

--- a/.github/workflows/test-misskey-js.yml
+++ b/.github/workflows/test-misskey-js.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6.0.1
 
       - name: Use pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
         with:
           cache: true
 

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -19,13 +19,10 @@ jobs:
     - uses: actions/checkout@v6.0.1
       with:
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -23,7 +23,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -23,7 +23,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - run: pnpm i --frozen-lockfile
     - name: Check pnpm-lock.yaml
       run: git diff --exit-code pnpm-lock.yaml

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         submodules: true
     - name: Use pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         cache: true
     - name: Install Redocly CLI

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Use pnpm
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
+        standalone: true
         cache: true
     - name: Install Redocly CLI
       run: npm i -g @redocly/cli

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -20,13 +20,10 @@ jobs:
     - uses: actions/checkout@v6.0.1
       with:
         submodules: true
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4.2.0
-    - name: Use Node.js
-      uses: actions/setup-node@v6.1.0
+    - name: Use pnpm
+      uses: pnpm/action-setup@v4
       with:
-        node-version-file: '.node-version'
-        cache: 'pnpm'
+        cache: true
     - name: Install Redocly CLI
       run: npm i -g @redocly/cli
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -24,7 +24,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        #cache: true
+        cache: true
     - name: Install Redocly CLI
       run: npm i -g @redocly/cli
     - run: pnpm i --frozen-lockfile

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -24,7 +24,7 @@ jobs:
       uses: pnpm/action-setup@1e1c8eafbd745f64b1ef30a7d7ed7965034c486c
       with:
         standalone: true
-        cache: true
+        #cache: true
     - name: Install Redocly CLI
       run: npm i -g @redocly/cli
     - run: pnpm i --frozen-lockfile

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-engine-strict = true
+#engine-strict = true
 save-exact = true
 shell-emulator = true

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
-#engine-strict = true
 save-exact = true
 shell-emulator = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ COPY --link ["packages/misskey-bubble-game/package.json", "./packages/misskey-bu
 
 ARG NODE_ENV=production
 
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 	pnpm i --frozen-lockfile --aggregate-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ COPY --link ["packages/misskey-bubble-game/package.json", "./packages/misskey-bu
 
 ARG NODE_ENV=production
 
-RUN node -e "console.log(JSON.parse(require('node:fs').readFileSync('./package.json')).packageManager)" | xargs npm install -g
-
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 	pnpm i --frozen-lockfile --aggregate-output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache \
 	&& apt-get update \
 	&& apt-get install -yqq --no-install-recommends \
-	build-essential
+	build-essential wget
 
 WORKDIR /misskey
 
@@ -48,7 +48,7 @@ FROM --platform=$TARGETPLATFORM debian:bookworm AS target-builder
 
 RUN apt-get update \
 	&& apt-get install -yqq --no-install-recommends \
-	build-essential
+	build-essential wget
 
 WORKDIR /misskey
 
@@ -85,7 +85,7 @@ RUN apt-get update \
 
 # add package.json to add pnpm
 COPY ./package.json ./package.json
-RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
+RUN curl -fsSL https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
 
 USER misskey
 WORKDIR /misskey

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 # syntax = docker/dockerfile:1.4
 
-ARG NODE_VERSION=22.15.0-bookworm
-
 # build assets & compile TypeScript
 
-FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS native-builder
+FROM --platform=$BUILDPLATFORM debian:bookworm AS native-builder
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	--mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -44,7 +42,7 @@ RUN rm -rf .git/
 
 # build native dependencies for target platform
 
-FROM --platform=$TARGETPLATFORM node:${NODE_VERSION} AS target-builder
+FROM --platform=$TARGETPLATFORM debian:bookworm AS target-builder
 
 RUN apt-get update \
 	&& apt-get install -yqq --no-install-recommends \
@@ -62,12 +60,12 @@ COPY --link ["packages/misskey-bubble-game/package.json", "./packages/misskey-bu
 
 ARG NODE_ENV=production
 
-RUN node -e "console.log(JSON.parse(require('node:fs').readFileSync('./package.json')).packageManager)" | xargs npm install -g
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
 
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 	pnpm i --frozen-lockfile --aggregate-output
 
-FROM --platform=$TARGETPLATFORM node:${NODE_VERSION}-slim AS runner
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim AS runner
 
 ARG UID="991"
 ARG GID="991"
@@ -85,7 +83,7 @@ RUN apt-get update \
 
 # add package.json to add pnpm
 COPY ./package.json ./package.json
-RUN node -e "console.log(JSON.parse(require('node:fs').readFileSync('./package.json')).packageManager)" | xargs npm install -g
+RUN wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash -
 
 USER misskey
 WORKDIR /misskey

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
 		"url": "https://github.com/misskey-dev/misskey.git"
 	},
 	"packageManager": "pnpm@10.26.2",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"workspaces": [
 		"packages/misskey-js",
 		"packages/i18n",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,6 @@
 		"url": "https://github.com/misskey-dev/misskey.git"
 	},
 	"packageManager": "pnpm@10.26.2",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"workspaces": [
 		"packages/misskey-js",
 		"packages/i18n",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
 	},
 	"packageManager": "pnpm@10.26.2",
 	"engines": {
-    "runtime": {
-      "name": "node",
-      "version": "^22.15.0",
-      "onFail": "download"
-    }
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
 	},
 	"workspaces": [
 		"packages/misskey-js",
@@ -87,8 +87,8 @@
 		"globals": "16.5.0",
 		"ncp": "2.0.0",
 		"pnpm": "10.26.2",
-		"typescript": "5.9.3",
-		"start-server-and-test": "2.1.3"
+		"start-server-and-test": "2.1.3",
+		"typescript": "5.9.3"
 	},
 	"optionalDependencies": {
 		"@tensorflow/tfjs-core": "4.22.0"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
 		"url": "https://github.com/misskey-dev/misskey.git"
 	},
 	"packageManager": "pnpm@10.26.2",
+	"engines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.15.0 || ^24.10.0",
+      "onFail": "download"
+    },
+	},
 	"workspaces": [
 		"packages/misskey-js",
 		"packages/i18n",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
 	"engines": {
     "runtime": {
       "name": "node",
-      "version": "^22.15.0 || ^24.10.0",
+      "version": "^22.15.0",
       "onFail": "download"
-    },
+    }
 	},
 	"workspaces": [
 		"packages/misskey-js",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,11 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-		"node": "^22.15.0 || ^24.10.0"
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
 	},
 	"scripts": {
 		"start": "pnpm compile-config && node ./built/boot/entry.js",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,11 +4,11 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-    "runtime": {
-      "name": "node",
-      "version": "^22.15.0",
-      "onFail": "download"
-    }
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
 	},
 	"scripts": {
 		"start": "pnpm compile-config && node ./built/boot/entry.js",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,9 +6,9 @@
 	"engines": {
     "runtime": {
       "name": "node",
-      "version": "^22.15.0 || ^24.10.0",
+      "version": "^22.15.0",
       "onFail": "download"
-    },
+    }
 	},
 	"scripts": {
 		"start": "pnpm compile-config && node ./built/boot/entry.js",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,7 +4,11 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-		"node": "^22.15.0 || ^24.10.0"
+    "runtime": {
+      "name": "node",
+      "version": "^22.15.0 || ^24.10.0",
+      "onFail": "download"
+    },
 	},
 	"scripts": {
 		"start": "pnpm compile-config && node ./built/boot/entry.js",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -4,11 +4,7 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
+		"node": "^22.15.0 || ^24.10.0"
 	},
 	"scripts": {
 		"start": "pnpm compile-config && node ./built/boot/entry.js",

--- a/packages/backend/test-federation/README.md
+++ b/packages/backend/test-federation/README.md
@@ -10,15 +10,15 @@ cd packages/backend/test-federation
 First, you need to start servers by executing following commands:
 ```sh
 bash ./setup.sh
-NODE_VERSION=22 docker compose up --scale tester=0
+docker compose up --scale tester=0
 ```
 
 Then you can run all tests by a following command:
 ```sh
-NODE_VERSION=22 docker compose run --no-deps --rm tester
+docker compose run --no-deps --rm tester
 ```
 
 For testing a specific file, run a following command:
 ```sh
-NODE_VERSION=22 docker compose run --no-deps --rm tester -- pnpm -F backend test:fed packages/backend/test-federation/test/user.test.ts
+docker compose run --no-deps --rm tester -- pnpm -F backend test:fed packages/backend/test-federation/test/user.test.ts
 ```

--- a/packages/backend/test-federation/compose.yml
+++ b/packages/backend/test-federation/compose.yml
@@ -144,7 +144,7 @@ services:
         npm install -g pnpm
         pnpm -F backend i --frozen-lockfile
         pnpm exec tsgo -p ./packages/backend/test-federation
-        node ./packages/backend/test-federation/built/daemon.js
+        pnpm node ./packages/backend/test-federation/built/daemon.js
       "
 
   redis.test:

--- a/packages/frontend-builder/package.json
+++ b/packages/frontend-builder/package.json
@@ -1,6 +1,13 @@
 {
 	"name": "frontend-builder",
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"eslint": "eslint './**/*.{js,jsx,ts,tsx}'",
 		"typecheck": "tsgo --noEmit",

--- a/packages/frontend-builder/package.json
+++ b/packages/frontend-builder/package.json
@@ -1,13 +1,6 @@
 {
 	"name": "frontend-builder",
 	"type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"eslint": "eslint './**/*.{js,jsx,ts,tsx}'",
 		"typecheck": "tsgo --noEmit",

--- a/packages/frontend-builder/package.json
+++ b/packages/frontend-builder/package.json
@@ -1,6 +1,13 @@
 {
 	"name": "frontend-builder",
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"eslint": "eslint './**/*.{js,jsx,ts,tsx}'",
 		"typecheck": "tsgo --noEmit",
@@ -17,8 +24,8 @@
 		"rollup": "4.54.0"
 	},
 	"dependencies": {
-		"i18n": "workspace:*",
 		"estree-walker": "3.0.3",
+		"i18n": "workspace:*",
 		"magic-string": "0.30.21",
 		"vite": "7.3.0"
 	}

--- a/packages/frontend-embed/package.json
+++ b/packages/frontend-embed/package.json
@@ -2,13 +2,6 @@
 	"name": "frontend-embed",
 	"private": true,
 	"type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",

--- a/packages/frontend-embed/package.json
+++ b/packages/frontend-embed/package.json
@@ -2,6 +2,13 @@
 	"name": "frontend-embed",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",
@@ -11,7 +18,6 @@
 	},
 	"dependencies": {
 		"@discordapp/twemoji": "16.0.1",
-		"i18n": "workspace:*",
 		"@rollup/plugin-json": "6.1.0",
 		"@rollup/plugin-replace": "6.0.3",
 		"@rollup/pluginutils": "5.3.0",
@@ -20,6 +26,7 @@
 		"buraha": "0.0.1",
 		"estree-walker": "3.0.3",
 		"frontend-shared": "workspace:*",
+		"i18n": "workspace:*",
 		"icons-subsetter": "workspace:*",
 		"json5": "2.2.3",
 		"mfm-js": "0.25.0",

--- a/packages/frontend-embed/package.json
+++ b/packages/frontend-embed/package.json
@@ -2,6 +2,13 @@
 	"name": "frontend-embed",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -13,13 +13,6 @@
 			"types": "./js-built/*"
 		}
 	},
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/frontend-shared/package.json
+++ b/packages/frontend-shared/package.json
@@ -13,6 +13,13 @@
 			"types": "./js-built/*"
 		}
 	},
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,6 +2,13 @@
 	"name": "frontend",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",
@@ -20,7 +27,6 @@
 		"@discordapp/twemoji": "16.0.1",
 		"@github/webauthn-json": "2.1.1",
 		"@mcaptcha/vanilla-glue": "0.1.0-rc2",
-		"i18n": "workspace:*",
 		"@misskey-dev/browser-image-resizer": "2024.1.0",
 		"@rollup/plugin-json": "6.1.0",
 		"@rollup/plugin-replace": "6.0.3",
@@ -48,6 +54,7 @@
 		"execa": "9.6.1",
 		"exifreader": "4.33.1",
 		"frontend-shared": "workspace:*",
+		"i18n": "workspace:*",
 		"icons-subsetter": "workspace:*",
 		"idb-keyval": "6.2.2",
 		"insert-text-at-cursor": "0.3.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,13 +2,6 @@
 	"name": "frontend",
 	"private": true,
 	"type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -2,6 +2,13 @@
 	"name": "frontend",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "vite",
 		"build": "tsx build.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -14,6 +14,13 @@
 			"import": "./built/const.js"
 		}
 	},
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"generate": "tsx scripts/generateLocaleInterface.ts",
 		"verify": "tsx scripts/verify.ts",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -14,13 +14,6 @@
 			"import": "./built/const.js"
 		}
 	},
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"generate": "tsx scripts/generateLocaleInterface.ts",
 		"verify": "tsx scripts/verify.ts",

--- a/packages/icons-subsetter/package.json
+++ b/packages/icons-subsetter/package.json
@@ -4,13 +4,6 @@
 	"private": true,
 	"description": "Subset tabler-icons webfont",
 	"type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"build": "tsx src/generator.ts",
 		"eslint": "eslint src/**/*.ts",

--- a/packages/icons-subsetter/package.json
+++ b/packages/icons-subsetter/package.json
@@ -4,6 +4,13 @@
 	"private": true,
 	"description": "Subset tabler-icons webfont",
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"build": "tsx src/generator.ts",
 		"eslint": "eslint src/**/*.ts",

--- a/packages/misskey-bubble-game/package.json
+++ b/packages/misskey-bubble-game/package.json
@@ -16,6 +16,13 @@
 			"default": "./built/*"
 		}
 	},
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/misskey-bubble-game/package.json
+++ b/packages/misskey-bubble-game/package.json
@@ -16,13 +16,6 @@
 			"default": "./built/*"
 		}
 	},
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/misskey-js/generator/package.json
+++ b/packages/misskey-js/generator/package.json
@@ -3,13 +3,6 @@
 	"version": "0.0.0",
 	"description": "Misskey TypeGenerator",
 	"type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"generate": "tsx src/generator.ts && eslint ./built/**/*.ts --fix"
 	},

--- a/packages/misskey-js/generator/package.json
+++ b/packages/misskey-js/generator/package.json
@@ -3,6 +3,13 @@
 	"version": "0.0.0",
 	"description": "Misskey TypeGenerator",
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"generate": "tsx src/generator.ts && eslint ./built/**/*.ts --fix"
 	},

--- a/packages/misskey-js/generator/package.json
+++ b/packages/misskey-js/generator/package.json
@@ -3,6 +3,13 @@
 	"version": "0.0.0",
 	"description": "Misskey TypeGenerator",
 	"type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"generate": "tsx src/generator.ts && eslint ./built/**/*.ts --fix"
 	},
@@ -11,13 +18,14 @@
 		"@types/node": "24.10.4",
 		"@typescript-eslint/eslint-plugin": "8.50.1",
 		"@typescript-eslint/parser": "8.50.1",
+		"eslint": "9.39.2",
 		"openapi-types": "12.1.3",
 		"openapi-typescript": "7.10.1",
 		"ts-case-convert": "2.1.0",
-		"tsx": "4.21.0",
-		"eslint": "9.39.2"
+		"tsx": "4.21.0"
 	},
 	"files": [
 		"built"
-	]
+	],
+	"dependencies": {}
 }

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -18,6 +18,13 @@
 			"default": "./built/*"
 		}
 	},
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -18,13 +18,6 @@
 			"default": "./built/*"
 		}
 	},
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/misskey-reversi/package.json
+++ b/packages/misskey-reversi/package.json
@@ -16,6 +16,13 @@
 			"default": "./built/*"
 		}
 	},
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/misskey-reversi/package.json
+++ b/packages/misskey-reversi/package.json
@@ -16,13 +16,6 @@
 			"default": "./built/*"
 		}
 	},
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"build": "node ./build.js",
 		"watch": "nodemon -w package.json -e json --exec \"node ./build.js --watch\"",

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -1,6 +1,13 @@
 {
 	"name": "sw",
 	"private": true,
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "nodemon -w ../../package.json -e json --exec \"node build.js watch\"",
 		"build": "node build.js",

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -1,6 +1,13 @@
 {
 	"name": "sw",
 	"private": true,
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
 	"scripts": {
 		"watch": "nodemon -w ../../package.json -e json --exec \"node build.js watch\"",
 		"build": "node build.js",
@@ -9,8 +16,8 @@
 		"lint": "pnpm typecheck && pnpm eslint"
 	},
 	"dependencies": {
-		"i18n": "workspace:*",
 		"esbuild": "0.27.2",
+		"i18n": "workspace:*",
 		"idb-keyval": "6.2.2",
 		"misskey-js": "workspace:*"
 	},

--- a/packages/sw/package.json
+++ b/packages/sw/package.json
@@ -1,13 +1,6 @@
 {
 	"name": "sw",
 	"private": true,
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
 	"scripts": {
 		"watch": "nodemon -w ../../package.json -e json --exec \"node build.js watch\"",
 		"build": "node build.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -291,6 +294,9 @@ importers:
       nested-property:
         specifier: 4.0.0
         version: 4.0.0
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -788,6 +794,9 @@ importers:
       misskey-reversi:
         specifier: workspace:*
         version: link:../misskey-reversi
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       photoswipe:
         specifier: 5.4.4
         version: 5.4.4
@@ -1041,6 +1050,9 @@ importers:
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       vite:
         specifier: 7.3.0
         version: 7.3.0(@types/node@24.10.4)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)
@@ -1105,6 +1117,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       punycode.js:
         specifier: 2.3.1
         version: 2.3.1
@@ -1226,6 +1241,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       vue:
         specifier: 3.5.26
         version: 3.5.26(typescript@5.9.3)
@@ -1257,6 +1275,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -1294,6 +1315,9 @@ importers:
       harfbuzzjs:
         specifier: 0.4.14
         version: 0.4.14
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1322,6 +1346,9 @@ importers:
       matter-js:
         specifier: 0.20.0
         version: 0.20.0
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       seedrandom:
         specifier: 3.0.5
         version: 3.0.5
@@ -1359,6 +1386,9 @@ importers:
       eventemitter3:
         specifier: 5.0.1
         version: 5.0.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       reconnecting-websocket:
         specifier: 4.4.0
         version: 4.4.0
@@ -1401,6 +1431,10 @@ importers:
         version: 0.5.0(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(happy-dom@20.0.11)(jsdom@27.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.6(@types/node@24.10.4)(typescript@5.9.3))(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))
 
   packages/misskey-js/generator:
+    dependencies:
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@readme/openapi-parser':
         specifier: 5.4.0
@@ -1435,6 +1469,9 @@ importers:
       crc-32:
         specifier: 1.2.2
         version: 1.2.2
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@types/node':
         specifier: 24.10.4
@@ -1469,6 +1506,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@typescript-eslint/parser':
         specifier: 8.50.1
@@ -8716,6 +8756,115 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  node@runtime:22.21.1:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-nk72dIu8Vefev3klKaEIvCY1hZ9M5G0HdWaLJ8xcx1A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-wXDWVU+6g9QdJads262FSHwHflH6c1GeQayIWqQp2K8=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-jj3IlhTevmbCpq0jE6GtsG6zfbbNbEDX3m99mH99Gv0=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-yGgw3t93+JQfqmxanIY7390ZJ6M2pGlD3swGo4+Av7I=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-QNPQmu5VarwpfdeChk/Ma55grNQ4/wZgup3c1WnACSA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-sk9MGdVUbNQYZ06DveVtUKfCtl+ux6ZcNQLyhe6zqnA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-fEa9SlErNfA6y5crKwT+zC1MR+NQaauajdXNjwCRGVo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-IZoVLqhZhh11repXi97D3OgUOFPBPFGH9AxA53sBQ7I=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-udf6rNC1QLi0ZkDbyPVvQgX/Y7ed7HANTwPTZZGwMY8=
+            prefix: node-v22.21.1-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-PGJOn74H4yF1UuxSoPhOK9wub/pzSPP9+5+/j0LiP88=
+            prefix: node-v22.21.1-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-/K279FdbtlSulN5TKOd+Mj/zzqY2ByXQc7pW4sl1PlI=
+            prefix: node-v22.21.1-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.21.1
+    hasBin: true
+
   nodemailer@7.0.12:
     resolution: {integrity: sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==}
     engines: {node: '>=6.0.0'}
@@ -11158,10 +11307,12 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -20751,6 +20902,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
+
+  node@runtime:22.21.1: {}
 
   nodemailer@7.0.12: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -291,6 +294,9 @@ importers:
       nested-property:
         specifier: 4.0.0
         version: 4.0.0
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -788,6 +794,9 @@ importers:
       misskey-reversi:
         specifier: workspace:*
         version: link:../misskey-reversi
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       photoswipe:
         specifier: 5.4.4
         version: 5.4.4
@@ -1041,6 +1050,9 @@ importers:
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       vite:
         specifier: 7.3.0
         version: 7.3.0(@types/node@24.10.4)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)
@@ -1105,6 +1117,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       punycode.js:
         specifier: 2.3.1
         version: 2.3.1
@@ -1226,6 +1241,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       vue:
         specifier: 3.5.26
         version: 3.5.26(typescript@5.9.3)
@@ -1257,6 +1275,9 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -1294,6 +1315,9 @@ importers:
       harfbuzzjs:
         specifier: 0.4.14
         version: 0.4.14
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1322,6 +1346,9 @@ importers:
       matter-js:
         specifier: 0.20.0
         version: 0.20.0
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       seedrandom:
         specifier: 3.0.5
         version: 3.0.5
@@ -1359,6 +1386,9 @@ importers:
       eventemitter3:
         specifier: 5.0.1
         version: 5.0.1
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
       reconnecting-websocket:
         specifier: 4.4.0
         version: 4.4.0
@@ -1401,6 +1431,10 @@ importers:
         version: 0.5.0(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(happy-dom@20.0.11)(jsdom@27.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.6(@types/node@24.10.4)(typescript@5.9.3))(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))
 
   packages/misskey-js/generator:
+    dependencies:
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@readme/openapi-parser':
         specifier: 5.4.0
@@ -1435,6 +1469,9 @@ importers:
       crc-32:
         specifier: 1.2.2
         version: 1.2.2
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@types/node':
         specifier: 24.10.4
@@ -1469,6 +1506,9 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
+      node:
+        specifier: runtime:^22.15.0
+        version: runtime:22.21.1
     devDependencies:
       '@typescript-eslint/parser':
         specifier: 8.50.1
@@ -8715,6 +8755,115 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node@runtime:22.21.1:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-nk72dIu8Vefev3klKaEIvCY1hZ9M5G0HdWaLJ8xcx1A=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-wXDWVU+6g9QdJads262FSHwHflH6c1GeQayIWqQp2K8=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-jj3IlhTevmbCpq0jE6GtsG6zfbbNbEDX3m99mH99Gv0=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-yGgw3t93+JQfqmxanIY7390ZJ6M2pGlD3swGo4+Av7I=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-QNPQmu5VarwpfdeChk/Ma55grNQ4/wZgup3c1WnACSA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-armv7l.tar.gz
+          targets:
+            - cpu: armv7l
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-sk9MGdVUbNQYZ06DveVtUKfCtl+ux6ZcNQLyhe6zqnA=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-fEa9SlErNfA6y5crKwT+zC1MR+NQaauajdXNjwCRGVo=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-IZoVLqhZhh11repXi97D3OgUOFPBPFGH9AxA53sBQ7I=
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-udf6rNC1QLi0ZkDbyPVvQgX/Y7ed7HANTwPTZZGwMY8=
+            prefix: node-v22.21.1-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-PGJOn74H4yF1UuxSoPhOK9wub/pzSPP9+5+/j0LiP88=
+            prefix: node-v22.21.1-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-/K279FdbtlSulN5TKOd+Mj/zzqY2ByXQc7pW4sl1PlI=
+            prefix: node-v22.21.1-win-x86
+            type: binary
+            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x86.zip
+          targets:
+            - cpu: x86
+              os: win32
+    version: 22.21.1
+    hasBin: true
 
   nodemailer@7.0.12:
     resolution: {integrity: sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==}
@@ -20753,6 +20902,8 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
+
+  node@runtime:22.21.1: {}
 
   nodemailer@7.0.12: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,6 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       postcss:
         specifier: 8.5.6
         version: 8.5.6
@@ -294,9 +291,6 @@ importers:
       nested-property:
         specifier: 4.0.0
         version: 4.0.0
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       node-fetch:
         specifier: 3.3.2
         version: 3.3.2
@@ -794,9 +788,6 @@ importers:
       misskey-reversi:
         specifier: workspace:*
         version: link:../misskey-reversi
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       photoswipe:
         specifier: 5.4.4
         version: 5.4.4
@@ -1050,9 +1041,6 @@ importers:
       magic-string:
         specifier: 0.30.21
         version: 0.30.21
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       vite:
         specifier: 7.3.0
         version: 7.3.0(@types/node@24.10.4)(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0)
@@ -1117,9 +1105,6 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       punycode.js:
         specifier: 2.3.1
         version: 2.3.1
@@ -1241,9 +1226,6 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       vue:
         specifier: 3.5.26
         version: 3.5.26(typescript@5.9.3)
@@ -1275,9 +1257,6 @@ importers:
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
     devDependencies:
       '@types/js-yaml':
         specifier: 4.0.9
@@ -1315,9 +1294,6 @@ importers:
       harfbuzzjs:
         specifier: 0.4.14
         version: 0.4.14
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -1346,9 +1322,6 @@ importers:
       matter-js:
         specifier: 0.20.0
         version: 0.20.0
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       seedrandom:
         specifier: 3.0.5
         version: 3.0.5
@@ -1386,9 +1359,6 @@ importers:
       eventemitter3:
         specifier: 5.0.1
         version: 5.0.1
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
       reconnecting-websocket:
         specifier: 4.4.0
         version: 4.4.0
@@ -1431,10 +1401,6 @@ importers:
         version: 0.5.0(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@24.10.4)(happy-dom@20.0.11)(jsdom@27.2.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.6(@types/node@24.10.4)(typescript@5.9.3))(sass@1.97.1)(terser@5.44.1)(tsx@4.21.0))
 
   packages/misskey-js/generator:
-    dependencies:
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
     devDependencies:
       '@readme/openapi-parser':
         specifier: 5.4.0
@@ -1469,9 +1435,6 @@ importers:
       crc-32:
         specifier: 1.2.2
         version: 1.2.2
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
     devDependencies:
       '@types/node':
         specifier: 24.10.4
@@ -1506,9 +1469,6 @@ importers:
       misskey-js:
         specifier: workspace:*
         version: link:../misskey-js
-      node:
-        specifier: runtime:^22.15.0
-        version: runtime:22.21.1
     devDependencies:
       '@typescript-eslint/parser':
         specifier: 8.50.1
@@ -8755,115 +8715,6 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  node@runtime:22.21.1:
-    resolution:
-      type: variations
-      variants:
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-nk72dIu8Vefev3klKaEIvCY1hZ9M5G0HdWaLJ8xcx1A=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-aix-ppc64.tar.gz
-          targets:
-            - cpu: ppc64
-              os: aix
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-wXDWVU+6g9QdJads262FSHwHflH6c1GeQayIWqQp2K8=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-jj3IlhTevmbCpq0jE6GtsG6zfbbNbEDX3m99mH99Gv0=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-darwin-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: darwin
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-yGgw3t93+JQfqmxanIY7390ZJ6M2pGlD3swGo4+Av7I=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-arm64.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-QNPQmu5VarwpfdeChk/Ma55grNQ4/wZgup3c1WnACSA=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-armv7l.tar.gz
-          targets:
-            - cpu: armv7l
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-sk9MGdVUbNQYZ06DveVtUKfCtl+ux6ZcNQLyhe6zqnA=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-ppc64le.tar.gz
-          targets:
-            - cpu: ppc64le
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-fEa9SlErNfA6y5crKwT+zC1MR+NQaauajdXNjwCRGVo=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-s390x.tar.gz
-          targets:
-            - cpu: s390x
-              os: linux
-        - resolution:
-            archive: tarball
-            bin: bin/node
-            integrity: sha256-IZoVLqhZhh11repXi97D3OgUOFPBPFGH9AxA53sBQ7I=
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-linux-x64.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-udf6rNC1QLi0ZkDbyPVvQgX/Y7ed7HANTwPTZZGwMY8=
-            prefix: node-v22.21.1-win-arm64
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-arm64.zip
-          targets:
-            - cpu: arm64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-PGJOn74H4yF1UuxSoPhOK9wub/pzSPP9+5+/j0LiP88=
-            prefix: node-v22.21.1-win-x64
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x64.zip
-          targets:
-            - cpu: x64
-              os: win32
-        - resolution:
-            archive: zip
-            bin: node.exe
-            integrity: sha256-/K279FdbtlSulN5TKOd+Mj/zzqY2ByXQc7pW4sl1PlI=
-            prefix: node-v22.21.1-win-x86
-            type: binary
-            url: https://nodejs.org/download/release/v22.21.1/node-v22.21.1-win-x86.zip
-          targets:
-            - cpu: x86
-              os: win32
-    version: 22.21.1
-    hasBin: true
 
   nodemailer@7.0.12:
     resolution: {integrity: sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==}
@@ -20902,8 +20753,6 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.27: {}
-
-  node@runtime:22.21.1: {}
 
   nodemailer@7.0.12: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
-useNodeVersion: 24.12.0
 packages:
   - packages/backend
   - packages/frontend-shared

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
+useNodeVersion: 24.12.0
 packages:
   - packages/backend
   - packages/frontend-shared

--- a/scripts/changelog-checker/package.json
+++ b/scripts/changelog-checker/package.json
@@ -3,6 +3,13 @@
   "version": "1.0.0",
   "description": "",
   "type": "module",
+	"engines": {
+		"runtime": {
+			"name": "node",
+			"version": "^22.15.0",
+			"onFail": "download"
+		}
+	},
   "scripts": {
     "run": "vite-node src/index.ts",
     "test": "vitest run",

--- a/scripts/changelog-checker/package.json
+++ b/scripts/changelog-checker/package.json
@@ -3,13 +3,6 @@
   "version": "1.0.0",
   "description": "",
   "type": "module",
-	"engines": {
-		"runtime": {
-			"name": "node",
-			"version": "^22.15.0",
-			"onFail": "download"
-		}
-	},
   "scripts": {
     "run": "vite-node src/index.ts",
     "test": "vitest run",


### PR DESCRIPTION
Resolve #16950

## What
pnpmにnodeを管理させます

* nodeのバージョンやバイナリを、npmパッケージのようにpnpmに管理させます
* ターミナルでは`node`の代わりに`pnpm node`を使います

ローカルでなんも動かしてない

## Why
サーバー管理者側のメリット

- re2など、メジャーバージョンアップした際にネイティブパッケージのビルド周りでエラーが出なくなる
- nodeのバージョン管理にこれといったものがない問題が解消する

misskey-dev側のメリット

- 使用者ごとのバージョンの差異を気にしなくて良くなる

misskey-dev側のデメリット

- nodeに脆弱性修正のバージョンアップがあった場合、Misskeyも併せてリリースする必要がありそう
- package.json全てにengines.runtimeを記載する必要がある

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
