### PR TITLE
fix(frontend/widget): AiscriptAppのスクリプト適用を手動に変更

### DIFF
--- a/packages/frontend/src/widgets/WidgetAiscriptApp.vue
+++ b/packages/frontend/src/widgets/WidgetAiscriptApp.vue
@@ -36,6 +36,7 @@ const widgetPropsDef = {
 		type: 'string',
 		label: i18n.ts.script,
 		multiline: true,
+		manualSave: true,
 		default: '',
 	},
 	showHeader: {

--- a/packages/frontend/src/widgets/WidgetButton.vue
+++ b/packages/frontend/src/widgets/WidgetButton.vue
@@ -39,7 +39,7 @@ const widgetPropsDef = {
 		type: 'string',
 		label: i18n.ts.script,
 		multiline: true,
-		default: 'Mk:dialog("hello" "world")',
+		default: 'Mk:dialog("hello", "world")',
 	},
 } satisfies FormWithDefault;
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- AiScriptAppウィジェットのスクリプト保存をmanualSaveにした
- ボタンウィジェットは、押下後にパースが走るので影響なし
- ボタンウィジェットのサンプルAiScriptの構文を1.x系に変更

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #17094

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md 同一バージョンのため記載なし
- [ ] (If possible) Add tests
