### PR TITLE
perf(frontend): MFM MkA, MkLink, MkSparkle の slot 指定方法を修正

### DIFF
--- a/packages/frontend/src/components/global/MkMfm.ts
+++ b/packages/frontend/src/components/global/MkMfm.ts
@@ -233,7 +233,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 						if (!useAnim) {
 							return genEl(token.children, scale);
 						}
-						return h(MkSparkle, {}, genEl(token.children, scale));
+						return h(MkSparkle, {}, { default: () => genEl(token.children, scale) });
 					}
 					case 'rotate': {
 						const degrees = safeParseFloat(token.props.args.deg) ?? 90;
@@ -363,7 +363,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 					url: token.props.url,
 					rel: 'nofollow noopener',
 					navigationBehavior: props.linkNavigationBehavior,
-				}, genEl(token.children, scale, true))];
+				}, { default: () => genEl(token.children, scale, true) })];
 			}
 
 			case 'mention': {
@@ -381,7 +381,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 					to: isNote ? `/tags/${encodeURIComponent(token.props.hashtag)}` : `/user-tags/${encodeURIComponent(token.props.hashtag)}`,
 					style: 'color:var(--MI_THEME-hashtag);',
 					behavior: props.linkNavigationBehavior,
-				}, `#${token.props.hashtag}`)];
+				}, { default: () => `#${token.props.hashtag}` })];
 			}
 
 			case 'blockCode': {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Vue3の推奨のコードから外れている部分を直す
パフォーマンスも良くなるらしい

https://vuejs.org/guide/extras/render-function#passing-slots

> 以下 Claudeによる解説
> 関数（現在のコード）: #${token.props.hashtag} を直接渡すと：
> 親の描画時に即座に評価される（子コンポーネントが必要とする前に）
> Vue は normalizeSlotValue で VNode 配列に変換し、後付けで () => normalized という関数にラップする（余分な処理）
> 
> 関数スロット（改善後）: { default: () => \#${token.props.hashtag}` }` にすると：
> 遅延評価 — 子コンポーネントが実際にレンダリングするときまでスロットの中身を生成しない
> Vue が SLOTS_CHILDREN として直接認識でき、normalizeVNodeSlots の余分な正規化処理とwarningをスキップ
> 親コンポーネントの更新時に、スロット内容が変わっていなければ子コンポーネントの再レンダリングをスキップできる

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

この警告が消える
<img width="552" height="492" alt="スクリーンショット 2026-02-07 15 55 04" src="https://github.com/user-attachments/assets/51c3c565-1172-4605-aef2-f81415e4d7e3" />


## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
