### PR TITLE
fix(frontend): 画像エフェクターに入力する画像サイズの上限を追加

### DIFF
--- a/packages/frontend/src/components/MkImageEffectorDialog.vue
+++ b/packages/frontend/src/components/MkImageEffectorDialog.vue
@@ -197,8 +197,18 @@ async function save() {
 
 	await nextTick(); // waitingがレンダリングされるまで待つ
 
-	renderer.changeResolution(imageBitmap.width, imageBitmap.height); // 本番レンダリングのためオリジナル画質に戻す
-	await renderer.render(layers); // toBlobの直前にレンダリングしないと何故か壊れる
+	try {
+		renderer.changeResolution(imageBitmap.width, imageBitmap.height); // 本番レンダリングのためオリジナル画質に戻す
+		await renderer.render(layers); // toBlobの直前にレンダリングしないと何故か壊れる
+	} catch (err) {
+		console.error(err);
+		os.alert({
+			type: 'error',
+			text: i18n.ts._imageEffector.failedToLoadImage,
+		});
+		closeWaiting();
+		return;
+	}
 	canvasEl.value.toBlob((blob) => {
 		emit('ok', new File([blob!], `image-${Date.now()}.png`, { type: 'image/png' }));
 		dialog.value?.close();

--- a/packages/frontend/src/lib/ImageCompositor.ts
+++ b/packages/frontend/src/lib/ImageCompositor.ts
@@ -39,6 +39,7 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 	private canvas: HTMLCanvasElement | null = null;
 	private renderWidth: number;
 	private renderHeight: number;
+	private maxTextureSize: number;
 	private baseTexture: WebGLTexture;
 	private shaderCache: Map<string, WebGLProgram> = new Map();
 	private perLayerResultTextures: Map<string, WebGLTexture> = new Map();
@@ -58,9 +59,6 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 		this.renderWidth = options.renderWidth;
 		this.renderHeight = options.renderHeight;
 
-		this.canvas.width = this.renderWidth;
-		this.canvas.height = this.renderHeight;
-
 		const gl = this.canvas.getContext('webgl2', {
 			preserveDrawingBuffer: false,
 			alpha: true,
@@ -71,6 +69,14 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 
 		this.gl = gl;
 
+		const maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+		this.maxTextureSize = typeof maxTextureSize === 'number' && Number.isFinite(maxTextureSize) ? maxTextureSize : 4096;
+
+		this.assertTextureSize(this.renderWidth, this.renderHeight, 'render');
+
+		this.canvas.width = this.renderWidth;
+		this.canvas.height = this.renderHeight;
+
 		gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
 		const VERTICES = new Float32Array([-1, -1, -1, 1, 1, 1, -1, -1, 1, 1, 1, -1]);
@@ -79,6 +85,7 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 		gl.bufferData(gl.ARRAY_BUFFER, VERTICES, gl.STATIC_DRAW);
 
 		if (options.image != null) {
+			this.assertTextureSize(options.image.width, options.image.height, 'image');
 			this.baseTexture = createTexture(gl);
 			gl.activeTexture(gl.TEXTURE0);
 			gl.bindTexture(gl.TEXTURE_2D, this.baseTexture);
@@ -118,6 +125,15 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 		for (const [id, fn] of Object.entries(options.functions)) {
 			const uniforms = this.extractUniformNamesFromShader(fn.shader);
 			this.registeredFunctions.set(id, { ...fn, id, uniforms });
+		}
+	}
+
+	private assertTextureSize(width: number, height: number, context: string) {
+		if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+			throw new Error(`Invalid ${context} size: ${width}x${height}`);
+		}
+		if (width > this.maxTextureSize || height > this.maxTextureSize) {
+			throw new Error(`Image ${context} size ${width}x${height} exceeds WebGL MAX_TEXTURE_SIZE ${this.maxTextureSize}`);
 		}
 	}
 
@@ -228,6 +244,8 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 	public registerTexture(key: string, image: ImageData | ImageBitmap | HTMLImageElement | HTMLCanvasElement) {
 		const gl = this.gl;
 
+		this.assertTextureSize(image.width, image.height, 'texture');
+
 		const existing = this.registeredTextures.get(key);
 		if (existing != null) {
 			gl.deleteTexture(existing.texture);
@@ -267,6 +285,8 @@ export class ImageCompositor<FNS extends Record<string, ImageCompositorFunction<
 
 	public changeResolution(width: number, height: number) {
 		if (this.renderWidth === width && this.renderHeight === height) return;
+
+		this.assertTextureSize(width, height, 'render');
 
 		this.renderWidth = width;
 		this.renderHeight = height;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ImageCompositorで処理できる寸法を超えた画像を読み込めないように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
このチェックが無いと端末のリソースを異常に食ったり、クラッシュしたりする可能性がある

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
