### PR TITLE
refactor(frontend): TouchEventとMouseEventをPointerEventに統合

### DIFF
--- a/packages/frontend/src/components/MkPullToRefresh.vue
+++ b/packages/frontend/src/components/MkPullToRefresh.vue
@@ -42,6 +42,7 @@ const isRefreshing = ref(false);
 const pullDistance = ref(0);
 
 let startScreenY: number | null = null;
+let pullingPointerId: number | null = null;
 
 const rootEl = useTemplateRef('rootEl');
 let scrollEl: HTMLElement | null = null;
@@ -56,14 +57,30 @@ const emit = defineEmits<{
 	(ev: 'refresh'): void;
 }>();
 
-function getScreenY(event: TouchEvent | MouseEvent | PointerEvent): number {
-	if (('touches' in event) && event.touches[0] && event.touches[0].screenY != null) {
-		return event.touches[0].screenY;
-	} else if ('screenY' in event) {
-		return event.screenY;
-	} else {
-		return 0; // TSを黙らせるため
+function detachPullListeners() {
+	if (rootEl.value == null) return;
+	rootEl.value.removeEventListener('pointermove', onPullPointerMove);
+	rootEl.value.removeEventListener('pointerup', onPullPointerUpOrCancel);
+	rootEl.value.removeEventListener('pointercancel', onPullPointerUpOrCancel);
+}
+
+function safeReleasePointerCapture(pointerId: number | null) {
+	if (rootEl.value == null) return;
+	if (pointerId == null) return;
+	try {
+		if (rootEl.value.hasPointerCapture(pointerId)) {
+			rootEl.value.releasePointerCapture(pointerId);
+		}
+	} catch {
+		// ignore
 	}
+}
+
+function cleanupPullInteraction() {
+	detachPullListeners();
+	safeReleasePointerCapture(pullingPointerId);
+	pullingPointerId = null;
+	startScreenY = null;
 }
 
 // When at the top of the page, disable vertical overscroll so passive touch listeners can take over.
@@ -79,9 +96,13 @@ function unlockDownScroll() {
 	scrollEl.style.overscrollBehavior = 'auto contain';
 }
 
-function moveStartByMouse(event: MouseEvent) {
-	if (event.button !== 1) return;
+function moveStartByPointer(event: PointerEvent) {
 	if (isRefreshing.value) return;
+	if (isPulling.value) return;
+	if (!event.isPrimary) return;
+
+	// マウス操作は従来通り「中クリックドラッグ」でのみ開始
+	if (event.pointerType === 'mouse' && event.button !== 1) return;
 
 	const scrollPos = scrollEl!.scrollTop;
 	if (scrollPos !== 0) {
@@ -91,39 +112,26 @@ function moveStartByMouse(event: MouseEvent) {
 
 	lockDownScroll();
 
-	event.preventDefault(); // 中クリックによるスクロール、テキスト選択などを防ぐ
-
-	isPulling.value = true;
-	startScreenY = getScreenY(event);
-	pullDistance.value = 0;
-
-	window.addEventListener('mousemove', moving, { passive: true });
-	window.addEventListener('mouseup', () => {
-		window.removeEventListener('mousemove', moving);
-		onPullRelease();
-	}, { passive: true, once: true });
-}
-
-function moveStartByTouch(event: TouchEvent) {
-	if (isRefreshing.value) return;
-
-	const scrollPos = scrollEl!.scrollTop;
-	if (scrollPos !== 0) {
-		unlockDownScroll();
-		return;
+	if (event.pointerType === 'mouse') {
+		// 中クリックによるスクロール、テキスト選択などを防ぐ
+		event.preventDefault();
 	}
 
-	lockDownScroll();
-
 	isPulling.value = true;
-	startScreenY = getScreenY(event);
+	isPulledEnough.value = false;
+	startScreenY = event.screenY;
 	pullDistance.value = 0;
+	pullingPointerId = event.pointerId;
 
-	window.addEventListener('touchmove', moving, { passive: true });
-	window.addEventListener('touchend', () => {
-		window.removeEventListener('touchmove', moving);
-		onPullRelease();
-	}, { passive: true, once: true });
+	try {
+		rootEl.value?.setPointerCapture(event.pointerId);
+	} catch {
+		// ignore
+	}
+
+	rootEl.value?.addEventListener('pointermove', onPullPointerMove, { passive: true });
+	rootEl.value?.addEventListener('pointerup', onPullPointerUpOrCancel, { passive: true });
+	rootEl.value?.addEventListener('pointercancel', onPullPointerUpOrCancel, { passive: true });
 }
 
 function moveBySystem(to: number): Promise<void> {
@@ -163,7 +171,7 @@ async function closeContent() {
 }
 
 function onPullRelease() {
-	startScreenY = null;
+	cleanupPullInteraction();
 	if (isPulledEnough.value) {
 		isPulledEnough.value = false;
 		isRefreshing.value = true;
@@ -178,7 +186,7 @@ function onPullRelease() {
 	}
 }
 
-function toggleScrollLockOnTouchEnd() {
+function toggleScrollLockOnPointerEnd() {
 	const scrollPos = scrollEl!.scrollTop;
 	if (scrollPos === 0) {
 		lockDownScroll();
@@ -187,7 +195,7 @@ function toggleScrollLockOnTouchEnd() {
 	}
 }
 
-function moving(event: MouseEvent | TouchEvent) {
+function moving(event: PointerEvent) {
 	if ((scrollEl?.scrollTop ?? 0) > SCROLL_STOP + pullDistance.value || isHorizontalSwipeSwiping.value) {
 		pullDistance.value = 0;
 		isPulledEnough.value = false;
@@ -196,9 +204,9 @@ function moving(event: MouseEvent | TouchEvent) {
 	}
 
 	if (startScreenY === null) {
-		startScreenY = getScreenY(event);
+		startScreenY = event.screenY;
 	}
-	const moveScreenY = getScreenY(event);
+	const moveScreenY = event.screenY;
 
 	const moveHeight = moveScreenY - startScreenY!;
 	pullDistance.value = Math.min(Math.max(moveHeight, 0), MAX_PULL_DISTANCE);
@@ -206,6 +214,24 @@ function moving(event: MouseEvent | TouchEvent) {
 	isPulledEnough.value = pullDistance.value >= FIRE_THRESHOLD;
 
 	if (isPulledEnough.value) haptic();
+}
+
+function onPullPointerMove(event: PointerEvent) {
+	if (pullingPointerId == null) return;
+	if (event.pointerId !== pullingPointerId) return;
+	moving(event);
+}
+
+function onPullPointerUpOrCancel(event: PointerEvent) {
+	if (pullingPointerId == null) return;
+	if (event.pointerId !== pullingPointerId) return;
+	onPullRelease();
+}
+
+function onRootPointerUpOrCancel(event: PointerEvent) {
+	// 既存実装の touchend 相当: マウスは対象外
+	if (event.pointerType === 'mouse') return;
+	toggleScrollLockOnPointerEnd();
 }
 
 /**
@@ -224,16 +250,17 @@ onMounted(() => {
 	if (rootEl.value == null) return;
 	scrollEl = getScrollContainer(rootEl.value);
 	lockDownScroll();
-	rootEl.value.addEventListener('mousedown', moveStartByMouse, { passive: false }); // preventDefaultするため
-	rootEl.value.addEventListener('touchstart', moveStartByTouch, { passive: true });
-	rootEl.value.addEventListener('touchend', toggleScrollLockOnTouchEnd, { passive: true });
+	rootEl.value.addEventListener('pointerdown', moveStartByPointer, { passive: false }); // preventDefaultする可能性があるため
+	rootEl.value.addEventListener('pointerup', onRootPointerUpOrCancel, { passive: true });
+	rootEl.value.addEventListener('pointercancel', onRootPointerUpOrCancel, { passive: true });
 });
 
 onUnmounted(() => {
 	unlockDownScroll();
-	if (rootEl.value) rootEl.value.removeEventListener('mousedown', moveStartByMouse);
-	if (rootEl.value) rootEl.value.removeEventListener('touchstart', moveStartByTouch);
-	if (rootEl.value) rootEl.value.removeEventListener('touchend', toggleScrollLockOnTouchEnd);
+	cleanupPullInteraction();
+	if (rootEl.value) rootEl.value.removeEventListener('pointerdown', moveStartByPointer);
+	if (rootEl.value) rootEl.value.removeEventListener('pointerup', onRootPointerUpOrCancel);
+	if (rootEl.value) rootEl.value.removeEventListener('pointercancel', onRootPointerUpOrCancel);
 });
 </script>
 

--- a/packages/frontend/src/components/MkRange.vue
+++ b/packages/frontend/src/components/MkRange.vue
@@ -27,8 +27,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				class="thumb"
 				:style="{ left: thumbPosition + 'px' }"
 				@mouseenter.passive="onMouseenter"
-				@mousedown="onMousedown"
-				@touchstart="onMousedown"
+				@pointerdown="onPointerdown"
 			>
 				<div class="thumbInner"></div>
 			</div>
@@ -179,7 +178,7 @@ function onMouseenter() {
 
 let lastClickTime: number | null = null;
 
-function onMousedown(ev: MouseEvent | TouchEvent) {
+function onPointerdown(ev: PointerEvent) {
 	if (props.disabled) return; // Prevent interaction if disabled
 
 	ev.preventDefault();
@@ -201,12 +200,19 @@ function onMousedown(ev: MouseEvent | TouchEvent) {
 	window.document.head.appendChild(style);
 
 	const thumbWidth = getThumbWidth();
+	const draggingPointerId = ev.pointerId;
+	try {
+		thumbEl.value?.setPointerCapture(draggingPointerId);
+	} catch {
+		// ignore
+	}
 
-	const onDrag = (ev: MouseEvent | TouchEvent) => {
+	const onDrag = (ev: PointerEvent) => {
+		if (ev.pointerId !== draggingPointerId) return;
 		ev.preventDefault();
 		let beforeValue = finalValue.value;
 		const containerRect = containerEl.value!.getBoundingClientRect();
-		const pointerX = 'touches' in ev && ev.touches.length > 0 ? ev.touches[0].clientX : 'clientX' in ev ? ev.clientX : 0;
+		const pointerX = ev.clientX;
 		const pointerPositionOnContainer = pointerX - (containerRect.left + (thumbWidth / 2));
 		rawValue.value = Math.min(1, Math.max(0, pointerPositionOnContainer / (containerEl.value!.offsetWidth - thumbWidth)));
 
@@ -217,13 +223,18 @@ function onMousedown(ev: MouseEvent | TouchEvent) {
 
 	let beforeValue = finalValue.value;
 
-	const onMouseup = () => {
+	const onPointerup = (ev: PointerEvent) => {
+		if (ev.pointerId !== draggingPointerId) return;
 		window.document.head.removeChild(style);
 		tooltipForDragShowing.value = false;
-		window.removeEventListener('mousemove', onDrag);
-		window.removeEventListener('touchmove', onDrag);
-		window.removeEventListener('mouseup', onMouseup);
-		window.removeEventListener('touchend', onMouseup);
+		window.removeEventListener('pointermove', onDrag);
+		window.removeEventListener('pointerup', onPointerup);
+		window.removeEventListener('pointercancel', onPointerup);
+		try {
+			thumbEl.value?.releasePointerCapture(draggingPointerId);
+		} catch {
+			// ignore
+		}
 
 		// 値が変わってたら通知
 		if (beforeValue !== finalValue.value) {
@@ -232,10 +243,9 @@ function onMousedown(ev: MouseEvent | TouchEvent) {
 		}
 	};
 
-	window.addEventListener('mousemove', onDrag);
-	window.addEventListener('touchmove', onDrag);
-	window.addEventListener('mouseup', onMouseup, { once: true });
-	window.addEventListener('touchend', onMouseup, { once: true });
+	window.addEventListener('pointermove', onDrag, { passive: false });
+	window.addEventListener('pointerup', onPointerup, { passive: true });
+	window.addEventListener('pointercancel', onPointerup, { passive: true });
 
 	if (lastClickTime == null) {
 		lastClickTime = Date.now();
@@ -374,6 +384,7 @@ function onMousedown(ev: MouseEvent | TouchEvent) {
 				width: $thumbWidth;
 				height: $thumbHeight;
 				cursor: grab;
+				touch-action: none;
 
 				&:hover {
 					> .thumbInner {

--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -30,7 +30,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		</template>
 		<div v-if="(!thin_ && narrow && !hideTitle) || (actions && actions.length > 0)" :class="$style.buttons">
 			<template v-for="action in actions">
-				<button v-tooltip.noDelay="action.text" class="_button" :class="[$style.button, { [$style.highlighted]: action.highlighted }]" @click.stop="action.handler" @touchstart="preventDrag"><i :class="action.icon"></i></button>
+				<button v-tooltip.noDelay="action.text" class="_button" :class="[$style.button, { [$style.highlighted]: action.highlighted }]" @click.stop="action.handler" @pointerdown="preventDrag"><i :class="action.icon"></i></button>
 			</template>
 		</div>
 	</div>
@@ -89,7 +89,9 @@ const show = computed(() => {
 	return !hideTitle.value || hasTabs.value || hasActions.value;
 });
 
-const preventDrag = (ev: TouchEvent) => {
+const preventDrag = (ev: PointerEvent) => {
+	// マウス操作には影響させない
+	if (ev.pointerType === 'mouse') return;
 	ev.stopPropagation();
 };
 

--- a/packages/frontend/src/os.ts
+++ b/packages/frontend/src/os.ts
@@ -8,7 +8,7 @@
 import { markRaw, ref, defineAsyncComponent, nextTick } from 'vue';
 import { EventEmitter } from 'eventemitter3';
 import * as Misskey from 'misskey-js';
-import type { Component, MaybeRef } from 'vue';
+import type { Component, ComputedRef, MaybeRef } from 'vue';
 import type { ComponentEmit, ComponentProps as CP } from 'vue-component-type-helpers';
 import type { Form, GetFormResultType } from '@/utility/form.js';
 import type { MenuItem } from '@/types/menu.js';
@@ -162,7 +162,7 @@ export function claimZIndex(priority: keyof typeof zIndexes = 'low'): number {
 }
 
 // props に ref を許可するようにする
-type PropsWithRefs<P> = { [K in keyof P]: MaybeRef<P[K]> };
+type PropsWithRefs<P> = { [K in keyof P]: MaybeRef<P[K]> | ComputedRef<P[K]> };
 type ComponentProps<T extends Component> = PropsWithRefs<CP<T>>;
 
 // 関数の引数が any[] (もっとも広義なもの) かどうかを判定し、any[] の場合は排除 (never) するヘルパー

--- a/packages/frontend/src/pages/drop-and-fusion.game.vue
+++ b/packages/frontend/src/pages/drop-and-fusion.game.vue
@@ -55,7 +55,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</div>
 			</div>
 
-			<div ref="containerEl" :class="[$style.gameContainer, { [$style.gameOver]: isGameOver && !replaying }]" @contextmenu.stop.prevent @click.stop.prevent="onClick" @touchmove.stop.prevent="onTouchmove" @touchend="onTouchend" @mousemove="onMousemove">
+			<div
+				ref="containerEl"
+				:class="[$style.gameContainer, { [$style.gameOver]: isGameOver && !replaying }]"
+				@contextmenu.stop.prevent
+				@click.stop.prevent
+				@pointerdown="onPointerdown"
+				@pointermove.stop.prevent="onPointermove"
+				@pointerup.stop.prevent="onPointerup"
+				@pointercancel.stop.prevent="onPointercancel"
+			>
 				<img v-if="store.s.darkMode" src="/client-assets/drop-and-fusion/frame-dark.svg" :class="$style.mainFrameImg"/>
 				<img v-else src="/client-assets/drop-and-fusion/frame-light.svg" :class="$style.mainFrameImg"/>
 				<canvas ref="canvasEl" :class="$style.canvas"></canvas>
@@ -729,30 +738,120 @@ async function start() {
 	}, 1500);
 }
 
-function onClick(ev: PointerEvent) {
-	if (!containerElRect) return;
-	if (replaying.value) return;
-	const x = (ev.clientX - containerElRect.left) / viewScale;
-	game.drop(x);
+const MOUSE_CLICK_MOVE_THRESHOLD_PX = 6;
+
+let activePointerId: number | null = null;
+let activePointerType: PointerEvent['pointerType'] | null = null;
+let pointerDownClientX: number | null = null;
+let pointerDownClientY: number | null = null;
+let pointerMovedBeyondThreshold = false;
+
+function cleanupPointerInteraction(ev?: PointerEvent) {
+	if (ev) {
+		const el = ev.currentTarget as HTMLElement | null;
+		try {
+			if (el?.hasPointerCapture(ev.pointerId)) {
+				el.releasePointerCapture(ev.pointerId);
+			}
+		} catch {
+			// ignore
+		}
+	}
+	activePointerId = null;
+	activePointerType = null;
+	pointerDownClientX = null;
+	pointerDownClientY = null;
+	pointerMovedBeyondThreshold = false;
 }
 
-function onTouchend(ev: TouchEvent) {
+function onPointerdown(ev: PointerEvent) {
 	if (!containerElRect) return;
 	if (replaying.value) return;
-	const x = (ev.changedTouches[0].clientX - containerElRect.left) / viewScale;
-	game.drop(x);
+	if (!ev.isPrimary) return;
+	if (ev.pointerType === 'mouse' && ev.button !== 0) return;
+
+	activePointerId = ev.pointerId;
+	activePointerType = ev.pointerType;
+	pointerDownClientX = ev.clientX;
+	pointerDownClientY = ev.clientY;
+	pointerMovedBeyondThreshold = false;
+	if (ev.pointerType !== 'mouse') {
+		// touch/pen: スクロールや疑似clickを抑止
+		ev.preventDefault();
+	}
+
+	const el = ev.currentTarget as HTMLElement | null;
+	try {
+		el?.setPointerCapture(ev.pointerId);
+	} catch {
+		// ignore
+	}
+
+	// touch/pen は触れた時点でも位置追従させる
+	if (ev.pointerType !== 'mouse') {
+		const x = (ev.clientX - containerElRect.left);
+		moveDropper(containerElRect, x);
+	}
 }
 
-function onMousemove(ev: MouseEvent) {
+function onPointermove(ev: PointerEvent) {
 	if (!containerElRect) return;
+
+	// mouse はホバーだけでも追従
+	if (ev.pointerType === 'mouse' && (activePointerId == null || ev.pointerId !== activePointerId)) {
+		const x = (ev.clientX - containerElRect.left);
+		moveDropper(containerElRect, x);
+		return;
+	}
+
+	if (activePointerId == null) return;
+	if (ev.pointerId !== activePointerId) return;
+	if (!pointerMovedBeyondThreshold && pointerDownClientX != null && pointerDownClientY != null) {
+		const dx = ev.clientX - pointerDownClientX;
+		const dy = ev.clientY - pointerDownClientY;
+		if ((dx * dx) + (dy * dy) > (MOUSE_CLICK_MOVE_THRESHOLD_PX * MOUSE_CLICK_MOVE_THRESHOLD_PX)) {
+			pointerMovedBeyondThreshold = true;
+		}
+	}
 	const x = (ev.clientX - containerElRect.left);
 	moveDropper(containerElRect, x);
 }
 
-function onTouchmove(ev: TouchEvent) {
+function onPointerup(ev: PointerEvent) {
 	if (!containerElRect) return;
-	const x = (ev.touches[0].clientX - containerElRect.left);
-	moveDropper(containerElRect, x);
+	if (replaying.value) {
+		cleanupPointerInteraction(ev);
+		return;
+	}
+	if (activePointerId == null) {
+		cleanupPointerInteraction(ev);
+		return;
+	}
+	if (ev.pointerId !== activePointerId) return;
+
+	const x = (ev.clientX - containerElRect.left) / viewScale;
+	const pointerType = activePointerType;
+	const moved = pointerMovedBeyondThreshold;
+	cleanupPointerInteraction(ev);
+
+	if (pointerType === 'mouse') {
+		// マウスは「クリック相当」のときだけdrop（ドラッグ終了ではdropしない）
+		if (moved) return;
+		game.drop(x);
+		return;
+	}
+
+	// touch/pen は離した位置でdrop
+	game.drop(x);
+}
+
+function onPointercancel(ev: PointerEvent) {
+	if (activePointerId == null) {
+		cleanupPointerInteraction(ev);
+		return;
+	}
+	if (ev.pointerId !== activePointerId) return;
+	cleanupPointerInteraction(ev);
 }
 
 function moveDropper(rect: DOMRect, x: number) {
@@ -1383,6 +1482,7 @@ definePage(() => ({
 .gameContainer {
 	position: relative;
 	margin-top: -20px;
+	touch-action: none;
 }
 
 .stock {

--- a/packages/frontend/src/types/menu.ts
+++ b/packages/frontend/src/types/menu.ts
@@ -8,7 +8,7 @@ import type { Component, ComputedRef, Ref, MaybeRef } from 'vue';
 import type { ComponentProps as CP } from 'vue-component-type-helpers';
 import type { OptionValue } from '@/types/option-value.js';
 
-type ComponentProps<T extends Component> = { [K in keyof CP<T>]: MaybeRef<CP<T>[K]> };
+type ComponentProps<T extends Component> = { [K in keyof CP<T>]: MaybeRef<CP<T>[K]> | ComputedRef<CP<T>[K]> };
 
 type MenuRadioOptionsDef = Record<string, OptionValue>;
 

--- a/packages/frontend/src/widgets/WidgetActivity.chart.vue
+++ b/packages/frontend/src/widgets/WidgetActivity.chart.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<svg :viewBox="`0 0 ${ viewBoxX } ${ viewBoxY }`" :class="$style.root" @mousedown.prevent="onMousedown">
+<svg :viewBox="`0 0 ${ viewBoxX } ${ viewBoxY }`" :class="$style.root" @pointerdown.prevent="onPointerdown">
 	<polyline
 		:points="pointsNote"
 		fill="none"
@@ -53,46 +53,50 @@ const pointsReply = ref<string>();
 const pointsRenote = ref<string>();
 const pointsTotal = ref<string>();
 
-function dragListen(fn: (ev: MouseEvent | TouchEvent) => void) {
-	window.addEventListener('mousemove', fn);
-	window.addEventListener('mouseleave', dragClear.bind(null, fn));
-	window.addEventListener('mouseup', dragClear.bind(null, fn));
-}
-
-function dragClear(fn: (ev: MouseEvent | TouchEvent) => void) {
-	window.removeEventListener('mousemove', fn);
-	window.removeEventListener('mouseleave', dragClear as any);
-	window.removeEventListener('mouseup', dragClear as any);
-}
-
-function getPositionX(event: MouseEvent | TouchEvent) {
-	return 'touches' in event && event.touches.length > 0 ? event.touches[0].clientX : 'clientX' in event ? event.clientX : 0;
-}
-
-function getPositionY(event: MouseEvent | TouchEvent) {
-	return 'touches' in event && event.touches.length > 0 ? event.touches[0].clientY : 'clientY' in event ? event.clientY : 0;
-}
-
-function onMousedown(ev: MouseEvent) {
+function onPointerdown(ev: PointerEvent) {
 	const clickX = ev.clientX;
 	const clickY = ev.clientY;
 	const baseZoom = zoom.value;
 	const basePos = pos.value;
+	const draggingPointerId = ev.pointerId;
+	const target = ev.currentTarget as SVGSVGElement | null;
+	try {
+		target?.setPointerCapture(draggingPointerId);
+	} catch {
+		// ignore
+	}
 
-	// 動かした時
-	dragListen(me => {
-		const x = getPositionX(me);
-		const y = getPositionY(me);
+	const onDrag = (me: PointerEvent) => {
+		if (me.pointerId !== draggingPointerId) return;
 
-		let moveLeft = x - clickX;
-		let moveTop = y - clickY;
+		const x = me.clientX;
+		const y = me.clientY;
+
+		const moveLeft = x - clickX;
+		const moveTop = y - clickY;
 
 		zoom.value = Math.max(1, baseZoom + (-moveTop / 20));
 		pos.value = Math.min(0, basePos + moveLeft);
 		if (pos.value < -(((props.activity.length - 1) * zoom.value) - viewBoxX.value)) pos.value = -(((props.activity.length - 1) * zoom.value) - viewBoxX.value);
 
 		render();
-	});
+	};
+
+	const onDragEnd = (me: PointerEvent) => {
+		if (me.pointerId !== draggingPointerId) return;
+		window.removeEventListener('pointermove', onDrag);
+		window.removeEventListener('pointerup', onDragEnd);
+		window.removeEventListener('pointercancel', onDragEnd);
+		try {
+			target?.releasePointerCapture(draggingPointerId);
+		} catch {
+			// ignore
+		}
+	};
+
+	window.addEventListener('pointermove', onDrag, { passive: true });
+	window.addEventListener('pointerup', onDragEnd, { passive: true });
+	window.addEventListener('pointercancel', onDragEnd, { passive: true });
 }
 
 function render() {
@@ -118,5 +122,6 @@ onMounted(() => {
 	width: 100%;
 	box-sizing: border-box;
 	cursor: all-scroll;
+	touch-action: none;
 }
 </style>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- MouseEventとTouchEventを両方受け付けている箇所を統一できる

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
MkSwiperは別途作業中 → https://github.com/misskey-dev/misskey/pull/17101

**For next release (v2026.2.0に入れない）**

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
