### PR TITLE
fix(frontend): Unicode絵文字のリアクションが表示に反映されないことがある問題の修正

### DIFF
--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -106,7 +106,9 @@ async function toggleReaction() {
 					reaction: props.reaction,
 				}).then(() => {
 					const emoji = customEmojisMap.get(emojiName.value);
-					if (emoji == null) return;
+					if (emoji == null && getUnicodeEmojiOrNull(props.reaction) == null) {
+						return;
+					}
 					noteEvents.emit(`reacted:${props.noteId}`, {
 						userId: me.id,
 						reaction: props.reaction,
@@ -138,7 +140,9 @@ async function toggleReaction() {
 			reaction: props.reaction,
 		}).then(() => {
 			const emoji = customEmojisMap.get(emojiName.value);
-			if (emoji == null) return;
+			if (emoji == null && getUnicodeEmojiOrNull(props.reaction) == null) {
+				return;
+			}
 
 			noteEvents.emit(`reacted:${props.noteId}`, {
 				userId: me.id,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
fix: #17249

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
5分以上経過したノートへのユニコード絵文字のリアクションが正しく反映されるようになります

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
