### PR TITLE
enhance(frontend): PWA WindowControlsOverlayに対応

### DIFF
--- a/packages/backend/src/server/web/ClientServerService.ts
+++ b/packages/backend/src/server/web/ClientServerService.ts
@@ -196,6 +196,9 @@ export class ClientServerService {
 					'url': 'url',
 				},
 			},
+			'display_override': [
+				'window-controls-overlay',
+			],
 			'shortcuts': [{
 				'name': 'Safemode',
 				'url': '/?safemode=true',

--- a/packages/frontend/public/loader/boot.js
+++ b/packages/frontend/public/loader/boot.js
@@ -79,12 +79,13 @@
 	//#region Theme
 	if (!isSafeMode) {
 		const theme = localStorage.getItem('theme');
+		const isWindowControlsOverlayVisible = navigator.windowControlsOverlay?.visible ?? false;
 		if (theme) {
 			for (const [k, v] of Object.entries(JSON.parse(theme))) {
 				document.documentElement.style.setProperty(`--MI_THEME-${k}`, v.toString());
 
 				// HTMLの theme-color 適用
-				if (k === 'htmlThemeColor') {
+				if ((k === 'htmlThemeColor' && !isWindowControlsOverlayVisible) || (k === 'navBg' && isWindowControlsOverlayVisible)) {
 					for (const tag of document.head.children) {
 						if (tag.tagName === 'META' && tag.getAttribute('name') === 'theme-color') {
 							tag.setAttribute('content', v);

--- a/packages/frontend/src/theme.ts
+++ b/packages/frontend/src/theme.ts
@@ -110,7 +110,9 @@ function applyThemeInternal(theme: Theme, persist: boolean) {
 
 	for (const tag of window.document.head.children) {
 		if (tag.tagName === 'META' && tag.getAttribute('name') === 'theme-color') {
-			tag.setAttribute('content', props['htmlThemeColor']);
+			// @ts-expect-error Experimental API
+			const windowControlsOverlayVisible = navigator.windowControlsOverlay?.visible ?? false;
+			tag.setAttribute('content', windowControlsOverlayVisible ? props['navBg'] : props['htmlThemeColor']);
 			break;
 		}
 	}

--- a/packages/frontend/src/ui/_common_/titlebar.vue
+++ b/packages/frontend/src/ui/_common_/titlebar.vue
@@ -5,16 +5,19 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div :class="$style.root">
-	<div :class="$style.title">
-		<img :src="instance.iconUrl || '/favicon.ico'" alt="" :class="$style.instanceIcon"/>
-		<span :class="$style.instanceTitle">{{ instance.name ?? host }}</span>
-	</div>
-	<div :class="$style.controls">
-		<span :class="$style.left">
-			<button v-if="canBack" class="_button" :class="$style.button" @click="goBack"><i class="ti ti-arrow-left"></i></button>
-		</span>
-		<span :class="$style.right">
-		</span>
+	<div :class="$style.titlebarDrag"></div>
+	<div :class="$style.contentRoot">
+		<div :class="$style.title">
+			<img :src="instance.iconUrl || '/favicon.ico'" alt="" :class="$style.instanceIcon"/>
+			<span :class="$style.instanceTitle">{{ instance.name ?? host }}</span>
+		</div>
+		<div :class="$style.controls">
+			<span :class="$style.left">
+				<button v-if="canBack" class="_button" :class="$style.button" @click="goBack"><i class="ti ti-arrow-left"></i></button>
+			</span>
+			<span :class="$style.right">
+			</span>
+		</div>
 	</div>
 </div>
 </template>
@@ -34,11 +37,29 @@ function goBack() {
 
 <style lang="scss" module>
 .root {
-	--height: 36px;
-
-	background: var(--MI_THEME-navBg);
+	--height: env(titlebar-area-height, 32px);
+	position: relative;
 	height: var(--height);
-	font-size: 90%;
+}
+
+.titlebarDrag {
+	app-region: drag;
+	-webkit-app-region: drag;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.contentRoot {
+	position: absolute;
+	top: 0;
+	left: env(titlebar-area-x, 0);
+	width: env(titlebar-area-width, 100%);
+	height: 100%;
+	background: var(--MI_THEME-navBg);
+	font-size: min(90%, calc(var(--height) * 0.45));
 }
 
 .title {
@@ -50,6 +71,8 @@ function goBack() {
 }
 
 .controls {
+	app-region: no-drag;
+	-webkit-app-region: no-drag;
 	position: absolute;
 	top: 0;
 	left: 0;
@@ -61,7 +84,7 @@ function goBack() {
 
 .instanceIcon {
 	display: inline-block;
-	width: 20px;
+	width: min(20px, calc(var(--height) * 0.625));
 	aspect-ratio: 1;
 	border-radius: 5px;
 	margin-right: 8px;

--- a/packages/frontend/src/ui/deck.vue
+++ b/packages/frontend/src/ui/deck.vue
@@ -5,12 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div :class="[$style.root]">
-	<XTitlebar v-if="prefer.r.showTitlebar.value" style="flex-shrink: 0;"/>
+	<XTitlebar v-if="shouldShowTitlebar" style="flex-shrink: 0;"/>
 
 	<div :class="$style.nonTitlebarArea">
 		<XSidebar v-if="!isMobile && prefer.r['deck.navbarPosition'].value === 'left'"/>
 
-		<div :class="[$style.main, { [$style.withWallpaper]: withWallpaper, [$style.withSidebarAndTitlebar]: !isMobile && prefer.r['deck.navbarPosition'].value === 'left' && prefer.r.showTitlebar.value }]" :style="{ backgroundImage: prefer.s['deck.wallpaper'] != null ? `url(${ prefer.s['deck.wallpaper'] })` : '' }">
+		<div :class="[$style.main, { [$style.withWallpaper]: withWallpaper, [$style.withSidebarAndTitlebar]: !isMobile && prefer.r['deck.navbarPosition'].value === 'left' && shouldShowTitlebar }]" :style="{ backgroundImage: prefer.s['deck.wallpaper'] != null ? `url(${ prefer.s['deck.wallpaper'] })` : '' }">
 			<XNavbarH v-if="!isMobile && prefer.r['deck.navbarPosition'].value === 'top'" :acrylic="withWallpaper"/>
 
 			<XReloadSuggestion v-if="shouldSuggestReload"/>
@@ -85,7 +85,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { defineAsyncComponent, ref, useTemplateRef } from 'vue';
+import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue';
 import XCommon from './_common_/common.vue';
 import { genId } from '@/utility/id.js';
 import XSidebar from '@/ui/_common_/navbar.vue';
@@ -118,6 +118,7 @@ import { shouldSuggestRestoreBackup } from '@/preferences/utility.js';
 import { shouldSuggestReload } from '@/utility/reload-suggest.js';
 import { startTour } from '@/utility/tour.js';
 import { closeTip } from '@/tips.js';
+import { getWindowControlsOverlayVisible } from '@/utility/pwa.js';
 
 const XStatusBars = defineAsyncComponent(() => import('@/ui/_common_/statusbars.vue'));
 const XAnnouncements = defineAsyncComponent(() => import('@/ui/_common_/announcements.vue'));
@@ -150,6 +151,9 @@ const isMobile = ref(window.innerWidth <= 500);
 window.addEventListener('resize', () => {
 	isMobile.value = window.innerWidth <= 500;
 });
+
+const windowControlsVisible = getWindowControlsOverlayVisible();
+const shouldShowTitlebar = computed(() => prefer.r.showTitlebar.value || windowControlsVisible.value);
 
 // ポインターイベント非対応用に初期値はUAから出す
 const snapScroll = ref(deviceKind === 'smartphone' || deviceKind === 'tablet');

--- a/packages/frontend/src/ui/universal.vue
+++ b/packages/frontend/src/ui/universal.vue
@@ -5,12 +5,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 <template>
 <div :class="[$style.root, { '_forceShrinkSpacer': deviceKind === 'smartphone' }]">
-	<XTitlebar v-if="prefer.r.showTitlebar.value" style="flex-shrink: 0;"/>
+	<XTitlebar v-if="shouldShowTitlebar" style="flex-shrink: 0;"/>
 
 	<div :class="$style.nonTitlebarArea">
 		<XSidebar v-if="!isMobile" :class="$style.sidebar" :showWidgetButton="!showWidgetsSide" @widgetButtonClick="widgetsShowing = true"/>
 
-		<div :class="[$style.contents, !isMobile && prefer.r.showTitlebar.value ? $style.withSidebarAndTitlebar : null]" @contextmenu.stop="onContextmenu">
+		<div :class="[$style.contents, !isMobile && shouldShowTitlebar ? $style.withSidebarAndTitlebar : null]" @contextmenu.stop="onContextmenu">
 			<div>
 				<XReloadSuggestion v-if="shouldSuggestReload"/>
 				<XPreferenceRestore v-if="shouldSuggestRestoreBackup"/>
@@ -53,6 +53,7 @@ import { prefer } from '@/preferences.js';
 import { shouldSuggestRestoreBackup } from '@/preferences/utility.js';
 import { DI } from '@/di.js';
 import { shouldSuggestReload } from '@/utility/reload-suggest.js';
+import { getWindowControlsOverlayVisible } from '@/utility/pwa.js';
 
 const XWidgets = defineAsyncComponent(() => import('./_common_/widgets.vue'));
 const XStatusBars = defineAsyncComponent(() => import('@/ui/_common_/statusbars.vue'));
@@ -70,6 +71,9 @@ const isMobile = ref(deviceKind === 'smartphone' || window.innerWidth <= MOBILE_
 window.addEventListener('resize', () => {
 	isMobile.value = deviceKind === 'smartphone' || window.innerWidth <= MOBILE_THRESHOLD;
 });
+
+const windowControlsVisible = getWindowControlsOverlayVisible();
+const shouldShowTitlebar = computed(() => prefer.r.showTitlebar.value || windowControlsVisible.value);
 
 const pageMetadata = ref<null | PageMetadata>(null);
 const widgetsShowing = ref(false);

--- a/packages/frontend/src/utility/popup-position.ts
+++ b/packages/frontend/src/utility/popup-position.ts
@@ -21,6 +21,14 @@ export function calcPopupPosition(el: HTMLElement, props: {
 		rect = props.anchorElement.getBoundingClientRect();
 	}
 
+	// タイトルバーの高さ
+	let topOffset: number = 0;
+
+	if ('windowControlsOverlay' in navigator) {
+		// @ts-expect-error Experimental API
+		topOffset = navigator.windowControlsOverlay.visible ? navigator.windowControlsOverlay.getTitlebarAreaRect().height : 0;
+	}
+
 	const calcPosWhenTop = () => {
 		let left: number;
 		let top: number;
@@ -139,7 +147,7 @@ export function calcPopupPosition(el: HTMLElement, props: {
 				const [left, top] = calcPosWhenTop();
 
 				// ツールチップを上に向かって表示するスペースがなければ下に向かって出す
-				if (top - window.scrollY < 0) {
+				if (top - window.scrollY < Math.max(topOffset, 0)) {
 					const [left, top] = calcPosWhenBottom();
 					return { left, top, transformOrigin: 'center top' };
 				}

--- a/packages/frontend/src/utility/pwa.ts
+++ b/packages/frontend/src/utility/pwa.ts
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { ref, readonly } from 'vue';
+import { store } from '@/store.js';
+import { prefer } from '@/preferences.js';
+
+interface WindowControlsOverlayGeometryChangeEvent extends Event {
+	visible: boolean;
+}
+
+const windowControlsOverlayVisible = ref(false);
+let windowControlsOverlayListenerAttached = false;
+
+function onGeometryChange(ev: WindowControlsOverlayGeometryChangeEvent) {
+	const { visible } = ev;
+	windowControlsOverlayVisible.value = visible;
+
+	let htmlThemeColor: string | null = null;
+	const computedStyle = getComputedStyle(window.document.documentElement);
+	if (visible) {
+		htmlThemeColor = computedStyle.getPropertyValue('--MI_THEME-navBg').trim() || null;
+	} else {
+		htmlThemeColor = computedStyle.getPropertyValue('--MI_THEME-htmlThemeColor').trim() || null;
+	}
+	if (htmlThemeColor) {
+		for (const tag of window.document.head.children) {
+			if (tag.tagName === 'META' && tag.getAttribute('name') === 'theme-color') {
+				tag.setAttribute('content', htmlThemeColor);
+				break;
+			}
+		}
+	}
+}
+
+export function getWindowControlsOverlayVisible() {
+	if (!windowControlsOverlayListenerAttached && 'windowControlsOverlay' in navigator) {
+		// @ts-expect-error Experimental API
+		navigator.windowControlsOverlay.addEventListener('geometrychange', onGeometryChange);
+		windowControlsOverlayListenerAttached = true;
+	}
+	// @ts-expect-error Experimental API
+	windowControlsOverlayVisible.value = 'windowControlsOverlay' in navigator && navigator.windowControlsOverlay.visible;
+
+	return readonly(windowControlsOverlayVisible);
+}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
<img width="1247" height="358" alt="image" src="https://github.com/user-attachments/assets/d638bb07-648c-4dae-bc67-e44fda606a64" />

- WindowControlsOverlayに対応している環境では強制的にタイトルバーが表示され、ウィンドウのタイトルバーとして用いられるように
- タイトルバーの幅がenvの値を反映するように
- HTML theme-colorが、WindowControlsOverlayの実行中はタイトルバーの色になるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
experimental

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
