### PR TITLE
fix(backend): ULIDを正しく処理できない問題を修正

### DIFF
--- a/packages/backend/src/misc/id/ulid.ts
+++ b/packages/backend/src/misc/id/ulid.ts
@@ -5,11 +5,18 @@
 
 // Crockford's Base32
 // https://github.com/ulid/spec#encoding
-import { parseBigInt32 } from '@/misc/bigint.js';
 
 const CHARS = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
 export const ulidRegExp = /^[0123456789ABCDEFGHJKMNPQRSTVWXYZ]{26}$/;
+
+function parseBigIntCrockford(str: string): bigint {
+	let result = 0n;
+	for (let i = 0; i < str.length; i++) {
+		result = result * 32n + BigInt(CHARS.indexOf(str[i]));
+	}
+	return result;
+}
 
 function parseBase32(timestamp: string) {
 	let time = 0;
@@ -26,6 +33,6 @@ export function parseUlid(id: string): { date: Date; } {
 export function parseUlidFull(id: string): { date: number; additional: bigint; } {
 	return {
 		date: parseBase32(id.slice(0, 10)),
-		additional: parseBigInt32(id.slice(10, 26)),
+		additional: parseBigIntCrockford(id.slice(10, 26)),
 	};
 }

--- a/packages/backend/test/unit/misc/ulid.ts
+++ b/packages/backend/test/unit/misc/ulid.ts
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test } from '@jest/globals';
+import { parseUlidFull } from '@/misc/id/ulid.js';
+
+// Timestamp part "01KPS7S300" encodes 1776816000000ms (2026-04-22T00:00:00.000Z)
+// Verified: 1*32^8 + 19*32^7 + 22*32^6 + 25*32^5 + 7*32^4 + 25*32^3 + 3*32^2 = 1776816000000
+
+describe('misc:ulid', () => {
+	test('parseUlidFull - timestamp is parsed correctly', () => {
+		// id[10..25] = all zeros (valid Crockford Base32)
+		// 2026-04-22T00:00:00.000Z
+		const { date } = parseUlidFull('01KPS7S3000000000000000000');
+		expect(date).toBe(1776816000000);
+	});
+
+	test('parseUlidFull - W/X/Y/Z at id[10] (chunk 1 head) do not throw', () => {
+		// id[10] = W
+		expect(() => parseUlidFull('01KPS7S300W000000000000000')).not.toThrow();
+		// id[10] = X
+		expect(() => parseUlidFull('01KPS7S300X000000000000000')).not.toThrow();
+		// id[10] = Y
+		expect(() => parseUlidFull('01KPS7S300Y000000000000000')).not.toThrow();
+		// id[10] = Z
+		expect(() => parseUlidFull('01KPS7S300Z000000000000000')).not.toThrow();
+	});
+
+	test('parseUlidFull - W/X/Y/Z at id[16] (chunk 2 head) do not throw', () => {
+		// id[16] = W
+		expect(() => parseUlidFull('01KPS7S300ABCDEFW000000000')).not.toThrow();
+		// id[16] = X
+		expect(() => parseUlidFull('01KPS7S300ABCDEFX000000000')).not.toThrow();
+		// id[16] = Y
+		expect(() => parseUlidFull('01KPS7S300ABCDEFY000000000')).not.toThrow();
+		// id[16] = Z
+		expect(() => parseUlidFull('01KPS7S300ABCDEFZ000000000')).not.toThrow();
+	});
+});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`parseUlidFull`がULIDのランダム部のパースに`parseBigInt32`(内部で`parseInt(chunk, 32)`を使用)を呼んでいた実装を、Crockford Base32に対応した`parseBigIntCrockford`に置き換える。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`parseInt(str, 32)`が認識する文字は標準base-32の0–9, A–Vのみで、ULIDが採用するCrockford Base32固有のW, X, Y, Zを無効文字として扱う。

W/X/Y/Zがチャンク先頭に現れると`parseInt`が`NaN`を返して例外が発生し、`NotificationService#toXListId`を経由して伝播した後、本番環境では`trackPromise`がno-opであるためエラーログにも残らず通知が消滅していた。発生確率は訳23.4%

また、チャンク先頭以外にW/X/Y/Zが現れる場合も`parseInt`が途中で解析を停止して誤値を返すため、Redis StreamのIDが不正な値となりソート順が壊れる問題もあった。

Related: #17309

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
 `parseBigIntCrockford`は既存のCHARS定数(Crockford Base32)を使って`CHARS.indexOf`で各文字を変換する。タイムスタンプ部の`parseBase32`がすでに同方針で正しく実装されており、それと一貫した実装となっている                                                                      
   

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
