### PR TITLE
fix(backend): `RoleService.getAdministratorIds` でユーザーIDが重複する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Fix: ID生成アルゴリズムにULIDを使用している場合にMisskeyが正しく動作しない問題を修正
 - Fix: リレー経由で届いたノートがリノートとして表示される問題を修正
 - Fix: robots.txtの内容を調整
+- Fix: 特定のユーザーに管理者権限を持つロールが複数ついている際に、取得できるユーザーIDが重複する問題を修正  
+  (Cherry-picked from https://github.com/lqvp/misskey-tempura/commit/17ed4108cec4b6bd2fd989db5a9091db91fa37a7)
 
 ## 2026.3.2
 

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -533,7 +533,8 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			roleId: In(administratorRoles.map(r => r.id)),
 		}) : [];
 		// TODO: isRootなアカウントも含める
-		return assigns.map(a => a.userId);
+		// Setを経由して重複を除去（ユーザIDは重複する可能性があるので）
+		return [...new Set(assigns.map(a => a.userId))].sort((x, y) => x.localeCompare(y));
 	}
 
 	@bindThis

--- a/packages/backend/src/core/SignupService.ts
+++ b/packages/backend/src/core/SignupService.ts
@@ -164,4 +164,3 @@ export class SignupService {
 		return { account, secret };
 	}
 }
-

--- a/packages/backend/test/unit/RoleService.ts
+++ b/packages/backend/test/unit/RoleService.ts
@@ -696,6 +696,19 @@ describe('RoleService', () => {
 			expect(adminIds).toHaveLength(0);
 		});
 
+		test('should not include duplicate user IDs if a user has multiple administrator roles', async () => {
+			const adminUser = await createUser();
+			const adminRole1 = await createRole({ name: 'admin1', isAdministrator: true });
+			const adminRole2 = await createRole({ name: 'admin2', isAdministrator: true });
+
+			await roleService.assign(adminUser.id, adminRole1.id);
+			await roleService.assign(adminUser.id, adminRole2.id);
+
+			const adminIds = await roleService.getAdministratorIds();
+
+			expect(adminIds).toEqual([adminUser.id]);
+		});
+
 		// TODO: rootユーザーは現在実装に含まれていないため、テストもそれに倣う
 		test('should not include the root user', async () => {
 			const rootUser = await createUser();


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
書いてある通り

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
現状呼び出し先での実働には問題ないが、間違ってはいるため

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
