### PR TITLE
fix: change bare activity.actor to getApId(activity.actor) in InboxPr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,8 @@
 - Fix: 連合が無効化されたサーバーで一部の設定項目が空欄で表示される問題を修正
 
 ### Server
-
-- Fix: support activity with `actor` as an id string or embedded object in inbox processor and ActivityPub inbox service
 - Enhance: メモリ使用量を削減
-- Enhance: 起動の高速化
+- Enhance: 起動の高速化  
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/1410)
 - Enhance: バックエンドの開発モード時の安定性向上
 - Enhance: バックエンドビルド・テスト時に使用する依存関係の整理（swc/esbuild→Rolldown, Jest→Vitest）
@@ -25,8 +23,9 @@
 - Fix: ID生成アルゴリズムにULIDを使用している場合にMisskeyが正しく動作しない問題を修正
 - Fix: リレー経由で届いたノートがリノートとして表示される問題を修正
 - Fix: robots.txtの内容を調整
-- Fix: 特定のユーザーに管理者権限を持つロールが複数ついている際に、取得できるユーザーIDが重複する問題を修正
+- Fix: 特定のユーザーに管理者権限を持つロールが複数ついている際に、取得できるユーザーIDが重複する問題を修正  
   (Cherry-picked from https://github.com/lqvp/misskey-tempura/commit/17ed4108cec4b6bd2fd989db5a9091db91fa37a7)
+- Fix: support activity with `actor` as an id string or embedded object in inbox processor and ActivityPub inbox service
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 - Fix: 連合が無効化されたサーバーで一部の設定項目が空欄で表示される問題を修正
 
 ### Server
+
+- Fix: support activity with `actor` as an id string or embedded object in inbox processor
 - Enhance: メモリ使用量を削減
-- Enhance: 起動の高速化  
+- Enhance: 起動の高速化
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/1410)
 - Enhance: バックエンドの開発モード時の安定性向上
 - Enhance: バックエンドビルド・テスト時に使用する依存関係の整理（swc/esbuild→Rolldown, Jest→Vitest）
@@ -23,7 +25,7 @@
 - Fix: ID生成アルゴリズムにULIDを使用している場合にMisskeyが正しく動作しない問題を修正
 - Fix: リレー経由で届いたノートがリノートとして表示される問題を修正
 - Fix: robots.txtの内容を調整
-- Fix: 特定のユーザーに管理者権限を持つロールが複数ついている際に、取得できるユーザーIDが重複する問題を修正  
+- Fix: 特定のユーザーに管理者権限を持つロールが複数ついている際に、取得できるユーザーIDが重複する問題を修正
   (Cherry-picked from https://github.com/lqvp/misskey-tempura/commit/17ed4108cec4b6bd2fd989db5a9091db91fa37a7)
 
 ## 2026.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Server
 
-- Fix: support activity with `actor` as an id string or embedded object in inbox processor
+- Fix: support activity with `actor` as an id string or embedded object in inbox processor and ActivityPub inbox service
 - Enhance: メモリ使用量を削減
 - Enhance: 起動の高速化
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/1410)

--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -259,7 +259,7 @@ export class ApInboxService {
 
 	@bindThis
 	private async add(actor: MiRemoteUser, activity: IAdd, resolver?: Resolver): Promise<string | void> {
-		if (actor.uri !== activity.actor) {
+		if (actor.uri !== getApId(activity.actor)) {
 			return 'invalid actor';
 		}
 
@@ -469,7 +469,7 @@ export class ApInboxService {
 
 	@bindThis
 	private async delete(actor: MiRemoteUser, activity: IDelete): Promise<string> {
-		if (actor.uri !== activity.actor) {
+		if (actor.uri !== getApId(activity.actor)) {
 			return 'invalid actor';
 		}
 
@@ -623,7 +623,7 @@ export class ApInboxService {
 
 	@bindThis
 	private async remove(actor: MiRemoteUser, activity: IRemove, resolver?: Resolver): Promise<string | void> {
-		if (actor.uri !== activity.actor) {
+		if (actor.uri !== getApId(activity.actor)) {
 			return 'invalid actor';
 		}
 
@@ -643,7 +643,7 @@ export class ApInboxService {
 
 	@bindThis
 	private async undo(actor: MiRemoteUser, activity: IUndo, resolver?: Resolver): Promise<string> {
-		if (actor.uri !== activity.actor) {
+		if (actor.uri !== getApId(activity.actor)) {
 			return 'invalid actor';
 		}
 
@@ -777,7 +777,7 @@ export class ApInboxService {
 
 	@bindThis
 	private async update(actor: MiRemoteUser, activity: IUpdate, resolver?: Resolver): Promise<string> {
-		if (actor.uri !== activity.actor) {
+		if (actor.uri !== getApId(activity.actor)) {
 			return 'skip: invalid actor';
 		}
 

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -115,9 +115,9 @@ export class InboxProcessorService implements OnApplicationShutdown {
 				// 対象が4xxならスキップ
 				if (err instanceof StatusError) {
 					if (!err.isRetryable) {
-						throw new Bull.UnrecoverableError(`skip: Ignored deleted actors on both ends ${activity.actor} - ${err.statusCode}`);
+						throw new Bull.UnrecoverableError(`skip: Ignored deleted actors on both ends ${getApId(activity.actor)} - ${err.statusCode}`);
 					}
-					throw new Error(`Error in actor ${activity.actor} - ${err.statusCode}`);
+					throw new Error(`Error in actor ${getApId(activity.actor)} - ${err.statusCode}`);
 				}
 			}
 		}
@@ -136,7 +136,7 @@ export class InboxProcessorService implements OnApplicationShutdown {
 		const httpSignatureValidated = httpSignature.verifySignature(signature, authUser.key.keyPem);
 
 		// また、signatureのsignerは、activity.actorと一致する必要がある
-		if (!httpSignatureValidated || authUser.user.uri !== activity.actor) {
+		if (!httpSignatureValidated || authUser.user.uri !== getApId(activity.actor)) {
 			// 一致しなくても、でもLD-Signatureがありそうならそっちも見る
 			const ldSignature = activity.signature;
 			if (ldSignature) {
@@ -187,8 +187,8 @@ export class InboxProcessorService implements OnApplicationShutdown {
 				//#endregion
 
 				// もう一度actorチェック
-				if (authUser.user.uri !== activity.actor) {
-					throw new Bull.UnrecoverableError(`skip: LD-Signature user(${authUser.user.uri}) !== activity.actor(${activity.actor})`);
+				if (authUser.user.uri !== getApId(activity.actor)) {
+					throw new Bull.UnrecoverableError(`skip: LD-Signature user(${authUser.user.uri}) !== activity.actor(${getApId(activity.actor)})`);
 				}
 
 				const ldHost = this.utilityService.extractDbHost(authUser.user.uri);


### PR DESCRIPTION
## What

Wrapped all uses of `activity.actor` as a string in InboxProcessorService with `getApId()`
Wrapped all uses of `activity.actor` as a string in ApInboxService with `getApId()`

## Why

Misskey silently rejects activities with an `actor` property that is an embedded object. `getApId()` will extract the id whether the property value is an embedded object or a URI.

Several uses of `activity.actor` in these modules already used the wrapper; this change covers the rest. I confirmed with each use that the wrapper was appropriate.

## Additional info (optional)

I was able to confirm that existing tests pass with this change. I manually tested with my own software, which includes `actor` as an embedded object, in a Docker Compose environment. Neither InboxProcessorService nor ApInboxService has a unit test suite.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
