### PR TITLE
fix(backend): Acquire lock of Announce object in announceNote even if it is from a relay actor

### DIFF
--- a/packages/backend/src/core/activitypub/ApInboxService.ts
+++ b/packages/backend/src/core/activitypub/ApInboxService.ts
@@ -313,7 +313,8 @@ export class ApInboxService {
 		// アナウンス先が許可されているかチェック
 		if (!this.utilityService.isFederationAllowedUri(uri)) return;
 
-		const unlock = await acquireApObjectLock(this.redisClient, uri);
+		const activityUri = getApId(activity);
+		const unlock = await acquireApObjectLock(this.redisClient, activityUri);
 
 		try {
 			// 既に同じURIを持つものが登録されていないかチェック


### PR DESCRIPTION
## What
In `announceNote`, acquire lock of `Announce` activity even if it came from a relay actor.

## Why
- Locking `activity` object (instead of `target`) is the correct one because `announceNote` operates on the `Announce` activity.
- Following call to `resolveNote` tries to acquire lock of the target activity, which will always fail for relays currently.

## Additional info (optional)
Tested on mitir.social

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
