### PR TITLE
chore: set nodeMaxMemory to 4096 in renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,9 @@
 	extends: [
 		'config:recommended',
 	],
+	toolSettings: {
+		nodeMaxMemory: 4096,
+	},
 	timezone: 'Asia/Tokyo',
 	schedule: [
 		'* 0 * * *',


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

renovateが使うメモリの上限を引き上げます。
既にOSSプランを割り当ててもらっているので6GBまで使えるはず。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

https://github.com/misskey-dev/misskey/pull/17430 がOOMで落ちてるので

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
