### PR TITLE
fix(backend/build): bundle 外に @tensorflow/tfjs-node を出す

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Server
 - Enhance: リモートノートクリーニングジョブのスキップ処理のパフォーマンス改善
+- Fix: backend バンドルで `@tensorflow/tfjs-node` を external に含めず、起動時に `@mapbox/node-pre-gyp` の `find()` が backend の package.json を誤検出して `is not node-pre-gyp ready` エラーを永続的に吐く問題を修正
 
 
 ## 2026.5.4

--- a/packages/backend/rolldown.config.ts
+++ b/packages/backend/rolldown.config.ts
@@ -66,6 +66,7 @@ export default defineConfig((args) => {
 		'@nestjs/microservices/microservices-module',
 		'@nestjs/microservices',
 		/^@napi-rs\/.*/,
+		'@tensorflow/tfjs-node',
 		'mock-aws-s3',
 		'aws-sdk',
 		'nock',


### PR DESCRIPTION
## What

`packages/backend/rolldown.config.ts` の `externalModules` リストに `'@tensorflow/tfjs-node'` を 1 行追加します。

## Why

`@tensorflow/tfjs-node` はネイティブバインディングを持つパッケージで、`sharp` / `re2` / `@napi-rs/*` 等の既に external 化されている同性質のモジュールと同じ扱いをする必要があります。

backend bundle に取り込まれると、bundle 後の `__dirname` 解決により `@mapbox/node-pre-gyp` の `find()` が `@tensorflow/tfjs-node` の package.json を見失い、たまたまヒットする `packages/backend/package.json` を validate しようとして `is not node-pre-gyp ready` Error を永続的に吐きます。NSFW 判定機能(`sensitiveMediaDetection !== 'none'`)が有効なインスタンスで顕著（画像処理ごとに発生）。

詳細・スタックトレース・再現条件は #17500 に記載しています。

## Changes

- `packages/backend/rolldown.config.ts`: `externalModules` に `'@tensorflow/tfjs-node'` を追加（1 行）
- `CHANGELOG.md`: Unreleased > Server セクションに修正内容を記載

## 機能影響

なし。NSFW 判定機能は維持され、ログノイズが解消されます。

## 検証

実機（NSFW 判定有効、`sensitiveMediaDetection: all`）で本変更を反映後、`node-pre-gyp ready` Error の発生件数が 0 件となることを `journalctl` で確認しています（修正前: 5h で 350 件以上 → 修正後: 0 件）。

## 関連

- Closes #17500
- rolldown 導入: #17068
