### PR TITLE
fix(backend): NSFW検出モデルが `file://` で読み込めない問題を修正 (tfjs-node external化後の tfjs-core 分裂)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Enhance: リモートノートクリーニングジョブのスキップ処理のパフォーマンス改善
 - Enhance: リモートノートクリーニングジョブの削除対象検索処理のパフォーマンス改善
 - Fix: backend バンドルで `@tensorflow/tfjs-node` を external に含めず、起動時に `@mapbox/node-pre-gyp` の `find()` が backend の package.json を誤検出して `is not node-pre-gyp ready` エラーを永続的に吐く問題を修正
+- Fix: センシティブメディア検出(NSFW)のモデルが `URL scheme "file" is not supported` エラーで読み込めず機能しない問題を修正 (bundle 内の `nsfwjs` と external な `@tensorflow/tfjs-node` で `@tensorflow/tfjs-core` インスタンスが分裂し `file://` IOHandler を共有できないため、`nsfwjs` と `@tensorflow/*` も external 化)
 - Fix: フォロワー限定投稿を指名投稿で引用した際に、引用した投稿の公開範囲が意図せず変更される問題を修正
 
 ## 2026.5.4

--- a/packages/backend/rolldown.config.ts
+++ b/packages/backend/rolldown.config.ts
@@ -66,7 +66,14 @@ export default defineConfig((args) => {
 		'@nestjs/microservices/microservices-module',
 		'@nestjs/microservices',
 		/^@napi-rs\/.*/,
-		'@tensorflow/tfjs-node',
+		// @tensorflow/tfjs-node はネイティブバインディングを持つため external 必須 (#17501)。
+		// あわせて nsfwjs と @tensorflow/* 全体を external にする。bundle 内の nsfwjs が
+		// 抱える @tensorflow/tfjs-core と、external な tfjs-node が使う tfjs-core が
+		// 別インスタンスに分裂すると、tfjs-node が登録する file:// IOHandler を nsfwjs 側が
+		// 共有できず、モデル読み込みが HTTP handler(node-fetch) にフォールバックして
+		// 「URL scheme "file" is not supported」で失敗するため。
+		/^@tensorflow\/.*/,
+		'nsfwjs',
 		'mock-aws-s3',
 		'aws-sdk',
 		'nock',


### PR DESCRIPTION
## What

`packages/backend/rolldown.config.ts` で `nsfwjs` と `@tensorflow/*` ファミリ全体を external 化します (これまでは `@tensorflow/tfjs-node` のみ external)。

Fixes #17527.

```diff
 		/^@napi-rs\/.*/,
-		'@tensorflow/tfjs-node',
+		/^@tensorflow\/.*/,
+		'nsfwjs',
```

## Why

#17501 で `@tensorflow/tfjs-node` をバンドル外に出して以降、センシティブメディア検出 (NSFW) が以下のエラーで壊れていました。

```
TypeError: node-fetch cannot load file:///.../packages/backend/nsfw-model/model.json. URL scheme "file" is not supported.
```

`@tensorflow/tfjs-node` は `file://` の `IOHandler` を **自身が参照する** `@tensorflow/tfjs-core` に登録します。しかし `nsfwjs` (とその依存の `@tensorflow/tfjs` → `@tensorflow/tfjs-core`) はバンドル内に残っていたため、実行時に **`tfjs-core` のインスタンスが 2 つに分裂** していました。`nsfwjs.load()` は `file://` router を持たないバンドル内 `tfjs-core` 上で動き、HTTP ハンドラ → `AiService` が差し込んだ `node-fetch` にフォールバックして `file://` が拒否されます。

`nsfwjs` と `@tensorflow/*` を external 化することで TF.js スタック全体が単一の dedupe 済み `@tensorflow/tfjs-core` (いずれも `4.22.0`) に解決され、`tfjs-node` が登録した `file://` IOHandler が共有されます。根本原因の詳細は #17527 を参照してください。

バンドルへの影響はありません。`packages/backend/src` 内でのこれらのモジュールの参照は `import type` (ビルド時に消去) と `await import(...)` (動的) のみで、バンドルが静的に import している箇所は無いため、これらは既に external な `@tensorflow/tfjs-node` と同様に `node_modules` から解決される実行時 `require` になるだけです。

## Additional info (optional)

稼働中の `2026.5.4` インスタンス (Node 22.22.2 / `develop` + #17068 + #17501 ビルド) で検証しました。

```
[1] external な @tensorflow/tfjs-node  loadLayersModel(file://) => OK (318 layers)
[2] external な nsfwjs (node_modules)  .load(file://)           => OK
[3] tfjs-core 4.22.0 / tfjs 4.22.0 / tfjs-node 4.22.0 (一致 → 単一インスタンスに dedupe)
```

[2] は修正後の解決経路 (`nsfwjs` を external 解決 → 単一 `tfjs-core` を共有) をそのまま再現し、`file://` でのモデル読み込みが復活することを確認しています。ローカルでのフルバンドル再ビルドは未実施ですが、バンドルビルド自体は CI で検証され、本変更は既存の `externalModules` 配列にエントリを追加するのみ (`@sentry` / `@napi-rs` / `slacc` で既に使われている `RegExp` 形式と同じ) です。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment (稼働中インスタンスで externalize 後のモデル読み込み経路を実証。Additional info 参照)
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
