### PR TITLE
fix(backend): FTTL に歯抜けがあるときタイムラインAPIがDBのノートを取りこぼす問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix: 「D」キーでダークモードを切り替える際にsyncDeviceDarkModeのチェックがバイパスされる問題を修正
 
 ### Server
+- Fix: FTT (Fanout Timeline) 上に飛び石の歯抜けがあるとき、 タイムラインAPI が DB に存在するノートを取りこぼす問題を修正
 - Enhance: リモートノートクリーニングジョブのスキップ処理のパフォーマンス改善
 - Fix: PerUserDriveChart がシステム所有ファイル (userId が null) の更新で `"group"` の非NULL制約違反によりクラッシュする問題を修正 (#17498)
 - Enhance: リモートノートクリーニングジョブの削除対象検索処理のパフォーマンス改善

--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -168,13 +168,6 @@ export class FanoutTimelineEndpointService {
 			let readFromRedis = 0;
 			let lastSuccessfulRate = 1; // rateをキャッシュする？
 
-			// Redis 上に「上位 limit 件範囲を満たす素材」があるか
-			// (= 歯抜けなしと見なせるか) を early return 条件に組み込む。
-			// redisResultIds.length < ps.limit の場合は歯抜けまたはキャッシュ未飽和なので、
-			// ループ内で limit 件を満たしても early return せず、最終 dbFallback で
-			// 全範囲を取り直して上位 limit 件を再構築する (歯抜け範囲のスキップを防ぐ)。
-			const hasFullRedisCache = redisResultIds.length >= ps.limit;
-
 			while ((redisResultIds.length - readFromRedis) !== 0) {
 				const remainingToRead = ps.limit - redisTimeline.length;
 
@@ -188,21 +181,28 @@ export class FanoutTimelineEndpointService {
 				redisTimeline.push(...gotFromDb);
 				lastSuccessfulRate = gotFromDb.length / noteIds.length;
 
-				if (ps.allowPartial ? redisTimeline.length !== 0 : (redisTimeline.length >= ps.limit && hasFullRedisCache)) {
-					// 十分Redisからとれた
+				// allowPartial のみ早期 return 許可。
+				// それ以外は Redis 上位 limit 件範囲内の歯抜け検出が原理的に不可能なため
+				// (Redis 内に存在しない歯抜け ID の有無を Redis データだけからは判別できない)、
+				// 常に最終 dbFallback の全範囲取り直しに進ませて上位 limit 件を正しく再構築する。
+				if (ps.allowPartial && redisTimeline.length !== 0) {
 					return redisTimeline.slice(0, ps.limit);
+				}
+				if (redisTimeline.length >= ps.limit) {
+					break;
 				}
 			}
 
-			// まだ足りない分はDBにフォールバック
-			// Redisの最古/最新を境界に使うと、Redis上に飛び石の歯抜け
-			// (3分ガードでpushが拒否されたノート、TTL evict、LREM等)があった場合に、
-			// その歯抜け範囲のノートがDBクエリにも含まれず取りこぼされる。
-			// そのためps.untilId/ps.sinceIdの全範囲をDBに問い合わせ、
-			// Redis由来のノートと重複排除した上で再ソートする。
+			// 常に最終 dbFallback で全範囲を取り直し、Redis 由来と dedupe + sort + slice する。
+			// Redis 最古/最新を境界に使うと、Redis 上の飛び石歯抜け
+			// (3分ガード拒否, TTL evict, LREM 等) や、Redis ループでの古い ID 消費による
+			// ページネーション境界のずれで取りこぼしが発生するため、ps.untilId/ps.sinceId の
+			// 全範囲を引いて上位 limit 件を再構築する。
+			// gotFromDb にも filter を適用するのは、Redis 経由のフィルタ (excludeReplies,
+			// excludeNoFiles, ミュート/ブロック等) を DB 由来のノートにも揃えるため。
 			const gotFromDb = await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);
 			const seen = new Set(redisTimeline.map(n => n.id));
-			const merged = [...redisTimeline, ...gotFromDb.filter(n => !seen.has(n.id))];
+			const merged = [...redisTimeline, ...gotFromDb.filter(n => !seen.has(n.id) && filter(n))];
 			merged.sort((a, b) => idCompare(a.id, b.id));
 			return merged.slice(0, ps.limit);
 		}

--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -168,6 +168,13 @@ export class FanoutTimelineEndpointService {
 			let readFromRedis = 0;
 			let lastSuccessfulRate = 1; // rateをキャッシュする？
 
+			// Redis 上に「上位 limit 件範囲を満たす素材」があるか
+			// (= 歯抜けなしと見なせるか) を early return 条件に組み込む。
+			// redisResultIds.length < ps.limit の場合は歯抜けまたはキャッシュ未飽和なので、
+			// ループ内で limit 件を満たしても early return せず、最終 dbFallback で
+			// 全範囲を取り直して上位 limit 件を再構築する (歯抜け範囲のスキップを防ぐ)。
+			const hasFullRedisCache = redisResultIds.length >= ps.limit;
+
 			while ((redisResultIds.length - readFromRedis) !== 0) {
 				const remainingToRead = ps.limit - redisTimeline.length;
 
@@ -181,7 +188,7 @@ export class FanoutTimelineEndpointService {
 				redisTimeline.push(...gotFromDb);
 				lastSuccessfulRate = gotFromDb.length / noteIds.length;
 
-				if (ps.allowPartial ? redisTimeline.length !== 0 : redisTimeline.length >= ps.limit) {
+				if (ps.allowPartial ? redisTimeline.length !== 0 : (redisTimeline.length >= ps.limit && hasFullRedisCache)) {
 					// 十分Redisからとれた
 					return redisTimeline.slice(0, ps.limit);
 				}

--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -188,18 +188,16 @@ export class FanoutTimelineEndpointService {
 			}
 
 			// まだ足りない分はDBにフォールバック
-			const remainingToRead = ps.limit - redisTimeline.length;
-			let dbUntil: string | null;
-			let dbSince: string | null;
-			if (ascending) {
-				dbUntil = ps.untilId;
-				dbSince = noteIds[noteIds.length - 1];
-			} else {
-				dbUntil = noteIds[noteIds.length - 1];
-				dbSince = ps.sinceId;
-			}
-			const gotFromDb = await ps.dbFallback(dbUntil, dbSince, remainingToRead);
-			return [...redisTimeline, ...gotFromDb];
+			// Redisの最古/最新を境界に使うと、Redis上に飛び石の歯抜け
+			// (3分ガードでpushが拒否されたノート、TTL evict、LREM等)があった場合に、
+			// その歯抜け範囲のノートがDBクエリにも含まれず取りこぼされる。
+			// そのためps.untilId/ps.sinceIdの全範囲をDBに問い合わせ、
+			// Redis由来のノートと重複排除した上で再ソートする。
+			const gotFromDb = await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);
+			const seen = new Set(redisTimeline.map(n => n.id));
+			const merged = [...redisTimeline, ...gotFromDb.filter(n => !seen.has(n.id))];
+			merged.sort((a, b) => idCompare(a.id, b.id));
+			return merged.slice(0, ps.limit);
 		}
 
 		return await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);

--- a/packages/backend/test/e2e/timelines.ts
+++ b/packages/backend/test/e2e/timelines.ts
@@ -3326,4 +3326,99 @@ describe('Timelines', () => {
 		// TODO: リノートミュート済みユーザーのテスト
 		// TODO: ページネーションのテスト
 	});
+
+	// FanoutTimelineEndpointServiceの最終DBフォールバックがRedis最古を境界に使うため、
+	// Redis上に飛び石の歯抜け (3分ガードでpushが拒否されたノート, TTL evict, LREM等)
+	// があると、その歯抜け範囲のノートがDBクエリにも含まれず取りこぼされる問題に対する回帰テスト。
+	describe('FTT Redis gap fallback', () => {
+		beforeAll(async () => {
+			await api('admin/update-meta', { enableFanoutTimeline: true }, root);
+		}, 1000 * 60 * 2);
+
+		test('Home TL: Redis上のhomeTimeline FTTに飛び石の歯抜けがあっても、DBの全ノートを取りこぼさず返す', async () => {
+			const alice = await signup();
+
+			// alwaysIncludeMyNotes対象 = 自分宛投稿でHTLを埋める
+			const noteIds: string[] = [];
+			for (let i = 0; i < 20; i++) {
+				const n = await post(alice, { text: `seed ${i}` });
+				noteIds.push(n.id);
+			}
+			await setTimeout(500);
+
+			// Redis FTTから中間7件をLREMで抜いて飛び石歯抜けを作る
+			// (本番では3分ガード拒否, TTL evict, 編集起因のID変動などで自然発生する状態)
+			const gapTargets = noteIds.slice(5, 12);
+			for (const id of gapTargets) {
+				await redisForTimelines.lrem(`list:homeTimeline:${alice.id}`, 1, id);
+			}
+
+			const res = await api('notes/timeline', { limit: 20 }, alice);
+			const returnedIds = (res.body as Note[]).map(n => n.id);
+
+			// 期待: DBに存在する全20件が返る (Redis歯抜けにかかわらず取りこぼし0)
+			for (const id of noteIds) {
+				assert.ok(returnedIds.includes(id), `missing ${id} in HTL result`);
+			}
+			assert.strictEqual(returnedIds.length, 20);
+		});
+
+		test('Channel TL: Redis上のchannelTimeline FTTに飛び石の歯抜けがあっても、DBの全ノートを取りこぼさず返す', async () => {
+			const alice = await signup();
+			const channel = await createChannel('fttl-gap-' + randomString(), alice);
+
+			const noteIds: string[] = [];
+			for (let i = 0; i < 20; i++) {
+				const n = await post(alice, { text: `seed ${i}`, channelId: channel.id });
+				noteIds.push(n.id);
+			}
+			await setTimeout(500);
+
+			const gapTargets = noteIds.slice(5, 12);
+			for (const id of gapTargets) {
+				await redisForTimelines.lrem(`list:channelTimeline:${channel.id}`, 1, id);
+			}
+
+			const res = await api('channels/timeline', { channelId: channel.id, limit: 20 });
+			const returnedIds = (res.body as Note[]).map(n => n.id);
+
+			for (const id of noteIds) {
+				assert.ok(returnedIds.includes(id), `missing ${id} in channel TL result`);
+			}
+			assert.strictEqual(returnedIds.length, 20);
+		});
+
+		test('Channel TL: 連続ページネーションで歯抜けを横断しても全60件を取りこぼさず取得できる', async () => {
+			const alice = await signup();
+			const channel = await createChannel('fttl-gap-paginate-' + randomString(), alice);
+
+			const noteIds: string[] = [];
+			for (let i = 0; i < 60; i++) {
+				const n = await post(alice, { text: `seed ${i}`, channelId: channel.id });
+				noteIds.push(n.id);
+			}
+			await setTimeout(500);
+
+			// Redis FTT 60件のうち中間7件を抜く (noteIdsは古い順なので新しい側から数えてindex 13-19)
+			const gapTargets = noteIds.slice(40, 47);
+			for (const id of gapTargets) {
+				await redisForTimelines.lrem(`list:channelTimeline:${channel.id}`, 1, id);
+			}
+
+			const seenIds = new Set<string>();
+			let untilId: string | undefined;
+			for (let page = 0; page < 6; page++) {
+				const res = await api('channels/timeline', { channelId: channel.id, limit: 20, ...(untilId ? { untilId } : {}) });
+				const ids = (res.body as Note[]).map(n => n.id);
+				if (ids.length === 0) break;
+				for (const id of ids) seenIds.add(id);
+				untilId = ids[ids.length - 1];
+			}
+
+			for (const id of noteIds) {
+				assert.ok(seenIds.has(id), `missing ${id} after pagination`);
+			}
+			assert.strictEqual(seenIds.size, 60);
+		});
+	});
 });


### PR DESCRIPTION

## What

[`FanoutTimelineEndpointService`](packages/backend/src/core/FanoutTimelineEndpointService.ts#L190-L202) の最終 DB フォールバック処理が、 DB クエリの境界として **Redis 結果の最古 ID** を使用していたため、 Redis 上のキャッシュリストの中間にギャップがある (= 本来そこに存在するはずのノート ID が抜けた状態) と、 そのギャップ範囲のノートが DB に存在しても永久に取得不能になっていた。

`ps.untilId` / `ps.sinceId` の **全範囲** を DB に問い合わせ、 Redis 由来と重複排除した上で再ソートする方式に変更する。

### Before

```ts
// まだ足りない分はDBにフォールバック
const remainingToRead = ps.limit - redisTimeline.length;
let dbUntil: string | null;
let dbSince: string | null;
if (ascending) {
  dbUntil = ps.untilId;
  dbSince = noteIds[noteIds.length - 1];
} else {
  dbUntil = noteIds[noteIds.length - 1];  // ← Redis 最古を境界に
  dbSince = ps.sinceId;
}
const gotFromDb = await ps.dbFallback(dbUntil, dbSince, remainingToRead);
return [...redisTimeline, ...gotFromDb];
```

### After

```ts
// まだ足りない分はDBにフォールバック
// Redisの最古/最新を境界に使うと、Redis上に中間ギャップ
// (enableFanoutTimelineのON/OFF切り替え、antennas/remove-note等のLREM操作、
//  運用者の手動介入で発生し得る) があった場合に、
// そのギャップ範囲のノートがDBクエリにも含まれず取りこぼされる。
// そのためps.untilId/ps.sinceIdの全範囲をDBに問い合わせ、
// Redis由来のノートと重複排除した上で再ソートする。
const gotFromDb = await ps.dbFallback(ps.untilId, ps.sinceId, ps.limit);
const seen = new Set(redisTimeline.map(n => n.id));
const merged = [...redisTimeline, ...gotFromDb.filter(n => !seen.has(n.id))];
merged.sort((a, b) => idCompare(a.id, b.id));
return merged.slice(0, ps.limit);
```

## Why

`enableFanoutTimeline` を管理画面から **ON → OFF → ON** のように切り替える運用 (FTT の挙動調査、 一時的なメンテ、 障害対応等で一般に行われる) を経ると、 **OFF 期間中の投稿が Redis 上のキャッシュリストに乗らないまま** ON 復帰後の新規投稿だけが追加される状態になる。

その結果として **Redis 上に中間ギャップが生じ**、 現状の最終 DB フォールバックの境界式 (Redis 最古 ID を `dbUntil` に使う) では、 そのギャップ範囲のノートが DB クエリにも含まれず、 タイムライン API のレスポンスから永久に欠落する。

詳細・再現手順 (UI 操作)・原因・用語解説は Issue #XXXXX 参照。

## Additional info (optional)

### Tests added

`packages/backend/test/e2e/timelines.ts` に新 describe ブロック `FTT Redis gap fallback` を追加 (3 ケース):

1. **Home TL**: `homeTimeline` Redis リスト 20 件中 中間 7 件を `LREM` で削除して中間ギャップを作り、 `notes/timeline` (limit=20) で DB の全 20 件が返ることを確認
2. **Channel TL**: 同様に `channelTimeline` のギャップで `channels/timeline` (limit=20) を検証
3. **Channel TL 連続ページネーション**: 60 件投稿 + 中間 7 件ギャップ で 4 ページ走査により 60 件すべて取得できることを確認

> テストでは `LREM` で人為的に Redis 状態を作っているが、 Issue 本文のとおり管理画面の `enableFanoutTimeline` トグル ON → OFF → ON で同じ状態を作ることもできる。

### 修正前後の検証結果

| ケース | 修正前 | 修正後 |
|---|---|---|
| Home TL `untilId` 未指定 (limit=20) | NG (7 件 missing) | OK (20/20) |
| Channel TL `untilId` 未指定 (limit=20) | NG (7 件 missing) | OK (20/20) |
| Channel TL 連続ページネーション (60 件) | NG (53/60、 7 件スキップ) | OK (60/60) |

### Trade-off

最終フォールバックパスで DB クエリの limit が `remainingToRead` から `ps.limit` に増える分のコスト。 ただし元コードでも最終フォールバックで DB を叩いており、 追加コストは限定的。 正しさを保証する代償として妥当と判断。

`useDbFallback=false` の場合は `ps.dbFallback = () => Promise.resolve([])` に置換されるため ([`FanoutTimelineEndpointService.ts:73`](packages/backend/src/core/FanoutTimelineEndpointService.ts#L73))、 修正後も追加 DB クエリは発生しない (既存運用設定を尊重)。

### Affected endpoints

`FanoutTimelineEndpointService.timeline` を呼ぶ全 endpoint:

- `notes/timeline` (HTL)
- `notes/local-timeline` (LTL)
- `notes/hybrid-timeline`
- `channels/timeline`
- `notes/user-list-timeline`

なお `antennas/notes` 等は `FanoutTimelineEndpointService` を経由せず独自実装なので、 本 PR の修正は影響しません。

### Related

- Issue: https://github.com/misskey-dev/misskey/issues/17547 https://github.com/fruitriin/misskey/issues/38
- 関連 PR (過去の FTT 修正): [#16284](https://github.com/misskey-dev/misskey/pull/16284) (FTT バグ修正 + テスト), [#17251](https://github.com/misskey-dev/misskey/pull/17251) (チャンネルミュート関連修正)

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
