### PR TITLE
fix(frontend): add antenna handling in antenna-column component

### DIFF
--- a/packages/frontend/src/ui/deck/antenna-column.vue
+++ b/packages/frontend/src/ui/deck/antenna-column.vue
@@ -14,8 +14,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { onMounted, ref, useTemplateRef, watch, defineAsyncComponent } from 'vue';
+import { onMounted, ref, useTemplateRef, watch, defineAsyncComponent, provide } from 'vue';
 import XColumn from './column.vue';
+import type * as Misskey from 'misskey-js';
 import type { entities as MisskeyEntities } from 'misskey-js';
 import type { Column } from '@/deck.js';
 import type { MenuItem } from '@/types/menu.js';
@@ -35,6 +36,14 @@ const props = defineProps<{
 
 const timeline = useTemplateRef('timeline');
 const soundSetting = ref<SoundStore>(props.column.soundSetting ?? { type: null, volume: 1 });
+const antenna = ref<Misskey.entities.Antenna | null>(null);
+
+provide('currentAntenna', antenna);
+
+watch(() => props.column.antennaId, async (antennaId) => {
+	if (antennaId == null) return;
+	antenna.value = await misskeyApi('antennas/show', { antennaId });
+}, { immediate: true });
 
 onMounted(() => {
 	if (props.column.antennaId == null) {
@@ -84,11 +93,12 @@ async function setAntenna() {
 		return;
 	}
 
-	const antenna = antennas.find(x => x.id === antennaIdOrOperation)!;
+	const selectedAntenna = antennas.find(x => x.id === antennaIdOrOperation);
+	if (selectedAntenna == null) return;
 
 	updateColumn(props.column.id, {
-		antennaId: antenna.id,
-		timelineNameCache: antenna.name,
+		antennaId: selectedAntenna.id,
+		timelineNameCache: selectedAntenna.name,
 	});
 }
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

カラム表示時にアンテナ情報をprovideするようにします。
antenna-timeline.vueはアンテナ情報をprovideしていたので問題が起こっていませんでしたが、antenna-column.vueではprovideしておらず、アンテナTL以外での表示とみなされていたためメニュー項目が出ていなかったようです。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix https://github.com/misskey-dev/misskey/issues/17552

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ※同一バージョンのため記載なし
- [ ] (If possible) Add tests
