### PR TITLE
feat(migration): add RecoverNotePinFavoriteIndexes migration for index management

### DIFF
--- a/packages/backend/migration/1781696230349-recover-note-pin-favorite-indexes.js
+++ b/packages/backend/migration/1781696230349-recover-note-pin-favorite-indexes.js
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+const isConcurrentIndexMigrationEnabled = process.env.MISSKEY_MIGRATION_CREATE_INDEX_CONCURRENTLY === '1';
+
+export class RecoverNotePinFavoriteIndexes1781696230349 {
+	name = 'RecoverNotePinFavoriteIndexes1781696230349';
+	transaction = isConcurrentIndexMigrationEnabled ? false : undefined;
+
+	async up(queryRunner) {
+		await this.ensureValidIndex(queryRunner, 'IDX_0e00498f180193423c992bc437', 'note_favorite', 'noteId');
+		await this.ensureValidIndex(queryRunner, 'IDX_68881008f7c3588ad7ecae471c', 'user_note_pining', 'noteId');
+	}
+
+	async down(queryRunner) {
+		// NoteIdIndexForPinAndFavorite1780059833698 で作成されるインデックスの補完なので、down でも存在する状態を維持する。
+		// The previous migration owns these indexes, so reverting this repair keeps them present.
+		await this.ensureValidIndex(queryRunner, 'IDX_0e00498f180193423c992bc437', 'note_favorite', 'noteId');
+		await this.ensureValidIndex(queryRunner, 'IDX_68881008f7c3588ad7ecae471c', 'user_note_pining', 'noteId');
+	}
+
+	async ensureValidIndex(queryRunner, indexName, tableName, columnName) {
+		if (isConcurrentIndexMigrationEnabled) {
+			const hasValidIndex = await queryRunner.query(`SELECT indisvalid FROM pg_index INNER JOIN pg_class ON pg_index.indexrelid = pg_class.oid WHERE pg_class.relname = '${indexName}'`);
+			if (hasValidIndex.length === 0 || hasValidIndex[0].indisvalid !== true) {
+				await queryRunner.query(`DROP INDEX IF EXISTS "${indexName}"`);
+				await queryRunner.query(`CREATE INDEX CONCURRENTLY "${indexName}" ON "${tableName}" ("${columnName}")`);
+			}
+		} else {
+			await queryRunner.query(`CREATE INDEX IF NOT EXISTS "${indexName}" ON "${tableName}" ("${columnName}")`);
+		}
+	}
+}


### PR DESCRIPTION

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

https://github.com/misskey-dev/misskey/pull/17511 のフォローアップです。
有効ではないindexが残ってしまっているケースにおいて、そのインデックスを検知して再作成するマイグレーションを追加します。

up/downで同じ処理を実行するようになっていますが、壊れたindexが無い場合はup/downともに何もしないようにするためです（IF NOT EXISTS）。indexのdropはNoteIdIndexForPinAndFavorite1780059833698に委ねます。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

https://github.com/misskey-dev/misskey/pull/17546#discussion_r3425736724 の指摘対応

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

同様の過去事例として下記があったので参考にしました。
https://github.com/misskey-dev/misskey/blob/e117456815507559d5b408d389261f4355d80d2b/packages/backend/migration/1745378064470-composite-note-index.js

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment ※indexを壊すのまではさすがに見れなかったがmigrate/revertが動くのは確認済み
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
