### PR TITLE
fix: TOTP の認証失敗で 500 Internal Server Error が返ってくる

### DIFF
--- a/packages/backend/src/server/api/endpoints/i/2fa/key-done.ts
+++ b/packages/backend/src/server/api/endpoints/i/2fa/key-done.ts
@@ -26,6 +26,12 @@ export const meta = {
 			id: '0d7ec6d2-e652-443e-a7bf-9ee9a0cd77b0',
 		},
 
+		incorrectTotp: {
+			message: 'The one-time password is incorrect or has expired.',
+			code: 'INCORRECT_TOTP',
+			id: '57e56c36-e07e-49ab-97fb-7dc8a5b4cd50',
+		},
+
 		twoFactorNotEnabled: {
 			message: '2fa not enabled.',
 			code: 'TWO_FACTOR_NOT_ENABLED',
@@ -76,13 +82,13 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 
 			if (profile.twoFactorEnabled) {
 				if (token == null) {
-					throw new Error('authentication failed');
+					throw new ApiError(meta.errors.incorrectTotp);
 				}
 
 				try {
 					await this.userAuthService.twoFactorAuthenticate(profile, token);
 				} catch (_) {
-					throw new Error('authentication failed');
+					throw new ApiError(meta.errors.incorrectTotp);
 				}
 			}
 

--- a/packages/backend/src/server/api/endpoints/i/2fa/register-key.ts
+++ b/packages/backend/src/server/api/endpoints/i/2fa/register-key.ts
@@ -30,6 +30,12 @@ export const meta = {
 			id: '38769596-efe2-4faf-9bec-abbb3f2cd9ba',
 		},
 
+		incorrectTotp: {
+			message: 'The one-time password is incorrect or has expired.',
+			code: 'INCORRECT_TOTP',
+			id: '0606da0a-a3c3-4215-8b87-30ecb63475c1',
+		},
+
 		twoFactorNotEnabled: {
 			message: '2fa not enabled.',
 			code: 'TWO_FACTOR_NOT_ENABLED',
@@ -76,13 +82,13 @@ export default class extends Endpoint<typeof meta, typeof paramDef> {
 
 			if (profile.twoFactorEnabled) {
 				if (token == null) {
-					throw new Error('authentication failed');
+					throw new ApiError(meta.errors.incorrectTotp);
 				}
 
 				try {
 					await this.userAuthService.twoFactorAuthenticate(profile, token);
 				} catch (_) {
-					throw new Error('authentication failed');
+					throw new ApiError(meta.errors.incorrectTotp);
 				}
 			}
 


### PR DESCRIPTION
変更内容:
- パスキー登録フローの以下エンドポイントで、TOTP 未入力・誤入力時に通常の `Error` を投げて 500 になる問題を修正しました。
  - `packages/backend/src/server/api/endpoints/i/2fa/register-key.ts`
  - `packages/backend/src/server/api/endpoints/i/2fa/key-done.ts`
- `INCORRECT_TOTP` の `ApiError` を追加し、誤ったワンタイムパスワードの場合はクライアントエラーとして返るようにしました。
- コミット済みです:
  - `e582826fff fix(backend): return client error for invalid TOTP in passkey setup`

検証:
- 依存関係をインストールし、必要な workspace パッケージをビルドしました。
- `pnpm --filter backend typecheck` を実行し、成功しました。

Closes #17522
