### PR TITLE
fix: 高解像度スマートフォン環境下でヘッダーのアバターアイコンが表示されなくなる

### DIFF
--- a/packages/frontend/src/components/global/MkPageHeader.vue
+++ b/packages/frontend/src/components/global/MkPageHeader.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 <template>
 <div v-if="show" ref="el" :class="[$style.root]">
 	<div :class="[$style.upper, { [$style.slim]: narrow, [$style.thin]: thin_ }]">
-		<div v-if="!thin_ && narrow && props.displayMyAvatar && $i" class="_button" @click="openAccountMenu">
+		<div v-if="shouldDisplayMyAvatar" class="_button" @click="openAccountMenu">
 			<MkAvatar :class="$style.avatar" :user="$i"/>
 		</div>
 		<div v-else-if="!thin_ && narrow && !hideTitle" :class="$style.buttons"></div>
@@ -64,6 +64,7 @@ import XTabs from './MkPageHeader.tabs.vue';
 import { getAccountMenu } from '@/accounts.js';
 import { $i } from '@/i.js';
 import { DI } from '@/di.js';
+import { deviceKind } from '@/utility/device-kind.js';
 import * as os from '@/os.js';
 
 const props = withDefaults(defineProps<PageHeaderProps>(), {
@@ -80,6 +81,7 @@ const pageMetadata = computed(() => props.overridePageMetadata ?? injectedPageMe
 
 const hideTitle = computed(() => inject('shouldOmitHeaderTitle', false) || props.hideTitle || (props.canOmitTitle && props.tabs.length > 0));
 const thin_ = props.thin || inject('shouldHeaderThin', false);
+const shouldDisplayMyAvatar = computed(() => !thin_ && props.displayMyAvatar && $i && (narrow.value || deviceKind === 'smartphone'));
 
 const el = useTemplateRef('el');
 const narrow = ref(false);


### PR DESCRIPTION
- Updated `packages/frontend/src/components/global/MkPageHeader.vue`
- The timeline header avatar now remains visible when the configured device type is `smartphone`, even if the page/header width is above the previous narrow threshold.
- Kept the existing narrow-width behavior unchanged for non-smartphone layouts.

Verification:
- Ran `pnpm --filter frontend exec eslint --quiet src/components/global/MkPageHeader.vue` successfully.
- Ran `git diff --check` successfully.
- Attempted `pnpm --filter frontend typecheck`; it failed due existing workspace/module resolution issues such as missing `misskey-js` and `i18n` type declarations, not due this file’s linting.

Fixes #17588
