### PR TITLE
fix: CIがFFmpegのインストールで落ちる問題を修正

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -81,11 +81,11 @@ jobs:
       run: |
         for i in {1..3}; do
           echo "Attempt $i: Installing FFmpeg..."
-          curl -s -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -o ffmpeg.tar.xz && \
+          curl -f -s -L https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz -o ffmpeg.tar.xz && \
           tar -xf ffmpeg.tar.xz && \
-          mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
-          mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
-          rm -rf ffmpeg.tar.xz ffmpeg-*-static/ && \
+          mv ffmpeg-master-latest-linux64-gpl/bin/ffmpeg /usr/local/bin/ && \
+          mv ffmpeg-master-latest-linux64-gpl/bin/ffprobe /usr/local/bin/ && \
+          rm -rf ffmpeg.tar.xz ffmpeg-master-latest-linux64-gpl/ && \
           break || sleep 10
           if [ $i -eq 3 ]; then
             echo "Failed to install FFmpeg after 3 attempts"

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -56,11 +56,11 @@ jobs:
         run: |
           for i in {1..3}; do
             echo "Attempt $i: Installing FFmpeg..."
-            curl -s -L https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -o ffmpeg.tar.xz && \
+            curl -f -s -L https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-linux64-gpl.tar.xz -o ffmpeg.tar.xz && \
             tar -xf ffmpeg.tar.xz && \
-            mv ffmpeg-*-static/ffmpeg /usr/local/bin/ && \
-            mv ffmpeg-*-static/ffprobe /usr/local/bin/ && \
-            rm -rf ffmpeg.tar.xz ffmpeg-*-static/ && \
+            mv ffmpeg-master-latest-linux64-gpl/bin/ffmpeg /usr/local/bin/ && \
+            mv ffmpeg-master-latest-linux64-gpl/bin/ffprobe /usr/local/bin/ && \
+            rm -rf ffmpeg.tar.xz ffmpeg-master-latest-linux64-gpl/ && \
             break || sleep 10
             if [ $i -eq 3 ]; then
               echo "Failed to install FFmpeg after 3 attempts"


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

FFmpegのfetch先を不安定なjohnvansickle.comからgithub.com/BtbN/FFmpeg-Buildsに変更.
これによりFFmpegのインストールエラーによりCIが落ちる問題を解消できる.
related: https://github.com/misskey-dev/misskey/issues/17610

## Why

johnvansickle.comが不安定であり, FFmpegのバイナリのfetchによく失敗しCIが落ちるため
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)

fetch先を差し替えた上で失敗するCIを実行
* [Unit tests (backend) (.node-version)](https://github.com/jj1guj/jiskey/actions/runs/28066620762/job/83092247149#logs)
* [Unit tests (backend) (.github/min.node-version)](https://github.com/jj1guj/jiskey/actions/runs/28066620762/job/83092247241#logs)
* [Federation test (.node-version)](https://github.com/jj1guj/jiskey/actions/runs/28066664146/job/83092381697#logs)
* [Federation test (.github/min.node-version)](https://github.com/jj1guj/jiskey/actions/runs/28066664146/job/83092381627#logs)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
