### PR TITLE
fix(backend): 同名の新規ハッシュタグが複数同時に作成されたとき、DBで発生した競合を適切にハンドリング

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Enhance: Node.js 22.23.0以降、24.17.0以降、26.4.0以降をサポートするように
 - Enhance: Docker Image の Node.js を 26.4.0 に、Debian を trixie (v13) に更新
 - Fix: `/stats` API のレスポンス型が正しくない問題を修正
+- Fix: ハッシュタグに関連するデータを更新する際のエラーハンドリングを修正
 
 ## 2026.6.0
 

--- a/packages/backend/src/core/HashtagService.ts
+++ b/packages/backend/src/core/HashtagService.ts
@@ -116,8 +116,11 @@ export class HashtagService {
 		}
 
 		await this.hashtagsRepository.manager.transaction(async transactionalEntityManager => {
-			const index = await transactionalEntityManager
-				.createQueryBuilder(MiHashtag, 'tag')
+			const transactionalHashtagRepository = transactionalEntityManager
+				.getRepository(MiHashtag);
+
+			const index = await transactionalHashtagRepository
+				.createQueryBuilder()
 				.setLock('pessimistic_write')
 				.where('name = :name', { name: tag })
 				.getOne();
@@ -173,8 +176,7 @@ export class HashtagService {
 			}
 
 			if (Object.keys(set).length > 0) {
-				await transactionalEntityManager
-					.getRepository(MiHashtag)
+				await transactionalHashtagRepository
 					.createQueryBuilder()
 					.update()
 					.where('id = :id', { id: index.id })

--- a/packages/backend/src/core/HashtagService.ts
+++ b/packages/backend/src/core/HashtagService.ts
@@ -9,12 +9,16 @@ import { DI } from '@/di-symbols.js';
 import type { MiUser } from '@/models/User.js';
 import { normalizeForSearch } from '@/misc/normalize-for-search.js';
 import { IdService } from '@/core/IdService.js';
-import type { MiHashtag } from '@/models/Hashtag.js';
+import { MiHashtag } from '@/models/Hashtag.js';
 import type { HashtagsRepository, MiMeta } from '@/models/_.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { bindThis } from '@/decorators.js';
 import { FeaturedService } from '@/core/FeaturedService.js';
 import { UtilityService } from '@/core/UtilityService.js';
+import { isDuplicateKeyValueError } from '@/misc/is-duplicate-key-value-error.js';
+import Logger from '../logger.js';
+
+const logger = new Logger('hashtag/create');
 
 @Injectable()
 export class HashtagService {
@@ -60,19 +64,71 @@ export class HashtagService {
 		// TODO: サンプリング
 		this.updateHashtagsRanking(tag, user.id);
 
-		const index = await this.hashtagsRepository.findOneBy({ name: tag });
+		{
+			const index = await this.hashtagsRepository.findOneBy({ name: tag });
 
-		if (index == null && !inc) return;
+			if (index == null && inc) {
+				try {
+					if (isUserAttached) {
+						await this.hashtagsRepository.insert({
+							id: this.idService.gen(),
+							name: tag,
+							mentionedUserIds: [],
+							mentionedUsersCount: 0,
+							mentionedLocalUserIds: [],
+							mentionedLocalUsersCount: 0,
+							mentionedRemoteUserIds: [],
+							mentionedRemoteUsersCount: 0,
+							attachedUserIds: [user.id],
+							attachedUsersCount: 1,
+							attachedLocalUserIds: this.userEntityService.isLocalUser(user) ? [user.id] : [],
+							attachedLocalUsersCount: this.userEntityService.isLocalUser(user) ? 1 : 0,
+							attachedRemoteUserIds: this.userEntityService.isRemoteUser(user) ? [user.id] : [],
+							attachedRemoteUsersCount: this.userEntityService.isRemoteUser(user) ? 1 : 0,
+						} as MiHashtag);
+					} else {
+						await this.hashtagsRepository.insert({
+							id: this.idService.gen(),
+							name: tag,
+							mentionedUserIds: [user.id],
+							mentionedUsersCount: 1,
+							mentionedLocalUserIds: this.userEntityService.isLocalUser(user) ? [user.id] : [],
+							mentionedLocalUsersCount: this.userEntityService.isLocalUser(user) ? 1 : 0,
+							mentionedRemoteUserIds: this.userEntityService.isRemoteUser(user) ? [user.id] : [],
+							mentionedRemoteUsersCount: this.userEntityService.isRemoteUser(user) ? 1 : 0,
+							attachedUserIds: [],
+							attachedUsersCount: 0,
+							attachedLocalUserIds: [],
+							attachedLocalUsersCount: 0,
+							attachedRemoteUserIds: [],
+							attachedRemoteUsersCount: 0,
+						} as MiHashtag);
+					}
+					return;
+				} catch (err) {
+					if (isDuplicateKeyValueError(err)) {
+						logger.info(`Duplicate insertion detected. Falling back to update. #${tag}`);
+					} else {
+						throw err;
+					}
+				}
+			}
+		}
 
-		if (index != null) {
-			const q = this.hashtagsRepository.createQueryBuilder('tag').update()
-				.where('name = :name', { name: tag });
+		await this.hashtagsRepository.manager.transaction(async transactionalEntityManager => {
+			const index = await transactionalEntityManager
+				.createQueryBuilder(MiHashtag, 'tag')
+				.setLock('pessimistic_write')
+				.where('name = :name', { name: tag })
+				.getOne();
+
+			if (index == null) return;
 
 			const set = {} as any;
 
 			if (isUserAttached) {
 				if (inc) {
-				// 自分が初めてこのタグを使ったなら
+					// 自分が初めてこのタグを使ったなら
 					if (!index.attachedUserIds.some(id => id === user.id)) {
 						set.attachedUserIds = () => `array_append("attachedUserIds", '${user.id}')`;
 						set.attachedUsersCount = () => '"attachedUsersCount" + 1';
@@ -117,46 +173,15 @@ export class HashtagService {
 			}
 
 			if (Object.keys(set).length > 0) {
-				q.set(set);
-				q.execute();
+				await transactionalEntityManager
+					.getRepository(MiHashtag)
+					.createQueryBuilder()
+					.update()
+					.where('id = :id', { id: index.id })
+					.set(set)
+					.execute();
 			}
-		} else {
-			if (isUserAttached) {
-				this.hashtagsRepository.insert({
-					id: this.idService.gen(),
-					name: tag,
-					mentionedUserIds: [],
-					mentionedUsersCount: 0,
-					mentionedLocalUserIds: [],
-					mentionedLocalUsersCount: 0,
-					mentionedRemoteUserIds: [],
-					mentionedRemoteUsersCount: 0,
-					attachedUserIds: [user.id],
-					attachedUsersCount: 1,
-					attachedLocalUserIds: this.userEntityService.isLocalUser(user) ? [user.id] : [],
-					attachedLocalUsersCount: this.userEntityService.isLocalUser(user) ? 1 : 0,
-					attachedRemoteUserIds: this.userEntityService.isRemoteUser(user) ? [user.id] : [],
-					attachedRemoteUsersCount: this.userEntityService.isRemoteUser(user) ? 1 : 0,
-				} as MiHashtag);
-			} else {
-				this.hashtagsRepository.insert({
-					id: this.idService.gen(),
-					name: tag,
-					mentionedUserIds: [user.id],
-					mentionedUsersCount: 1,
-					mentionedLocalUserIds: this.userEntityService.isLocalUser(user) ? [user.id] : [],
-					mentionedLocalUsersCount: this.userEntityService.isLocalUser(user) ? 1 : 0,
-					mentionedRemoteUserIds: this.userEntityService.isRemoteUser(user) ? [user.id] : [],
-					mentionedRemoteUsersCount: this.userEntityService.isRemoteUser(user) ? 1 : 0,
-					attachedUserIds: [],
-					attachedUsersCount: 0,
-					attachedLocalUserIds: [],
-					attachedLocalUsersCount: 0,
-					attachedRemoteUserIds: [],
-					attachedRemoteUsersCount: 0,
-				} as MiHashtag);
-			}
-		}
+		});
 	}
 
 	@bindThis

--- a/packages/backend/src/core/HashtagService.ts
+++ b/packages/backend/src/core/HashtagService.ts
@@ -5,6 +5,7 @@
 
 import { Inject, Injectable } from '@nestjs/common';
 import * as Redis from 'ioredis';
+import { DataSource } from 'typeorm';
 import { DI } from '@/di-symbols.js';
 import type { MiUser } from '@/models/User.js';
 import { normalizeForSearch } from '@/misc/normalize-for-search.js';
@@ -23,6 +24,9 @@ const logger = new Logger('hashtag/create');
 @Injectable()
 export class HashtagService {
 	constructor(
+		@Inject(DI.db)
+		private db: DataSource,
+
 		@Inject(DI.meta)
 		private meta: MiMeta,
 
@@ -115,7 +119,7 @@ export class HashtagService {
 			}
 		}
 
-		await this.hashtagsRepository.manager.transaction(async transactionalEntityManager => {
+		await this.db.transaction(async transactionalEntityManager => {
 			const transactionalHashtagRepository = transactionalEntityManager
 				.getRepository(MiHashtag);
 

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -8,9 +8,9 @@ process.env.NODE_ENV = 'test';
 import * as assert from 'assert';
 import { describe, beforeAll, test } from 'vitest';
 import { WebSocket } from 'ws';
-import { MiFollowing } from '@/models/Following.js';
-import { api, createAppToken, initTestDb, port, post, signup, waitFire } from '../utils.js';
+import { api, connectStream, createAppToken, initTestDb, port, post, signup, waitFire } from '../utils.js';
 import type * as misskey from 'misskey-js';
+import { MiFollowing } from '@/models/Following.js';
 
 describe('Streaming', () => {
 	let Followings: any;
@@ -744,164 +744,83 @@ describe('Streaming', () => {
 			assert.strictEqual(fired, true);
 		});
 
-		// XXX: QueryFailedError: duplicate key value violates unique constraint "IDX_347fec870eafea7b26c8a73bac"
-		/*
 		describe('Hashtag Timeline', () => {
-			test('指定したハッシュタグの投稿が流れる', () => new Promise<void>(async done => {
-				const ws = await connectStream(chitose, 'hashtag', ({ type, body }) => {
-					if (type === 'note') {
-						assert.deepStrictEqual(body.text, '#foo');
-						ws.close();
-						done();
-					}
-				}, {
-					q: [
-						['foo'],
-					],
-				});
+			test('指定したハッシュタグの投稿が流れる', async () => {
+				const fired = await waitFire(
+					chitose, 'hashtag',
+					() => api('notes/create', { text: '#foo' }, chitose),
+					msg => msg.type === 'note' && msg.body.text === '#foo',
+					{ q: [['foo']] },
+				);
 
-				post(chitose, {
-					text: '#foo',
-				});
-			}));
+				assert.strictEqual(fired, true);
+			});
 
-			test('指定したハッシュタグの投稿が流れる (AND)', () => new Promise<void>(async done => {
-				let fooCount = 0;
-				let barCount = 0;
-				let fooBarCount = 0;
+			test('指定したハッシュタグの投稿が流れる (AND)', async () => {
+				const received: string[] = [];
+				const ws = await connectStream(chitose, 'hashtag', (msg) => {
+					if (msg.type === 'note') received.push(msg.body.text);
+				}, { q: [['foo', 'bar']] });
 
-				const ws = await connectStream(chitose, 'hashtag', ({ type, body }) => {
-					if (type === 'note') {
-						if (body.text === '#foo') fooCount++;
-						if (body.text === '#bar') barCount++;
-						if (body.text === '#foo #bar') fooBarCount++;
-					}
-				}, {
-					q: [
-						['foo', 'bar'],
-					],
-				});
+				await Promise.all([
+					await api('notes/create', { text: '#foo' }, chitose),
+					await api('notes/create', { text: '#bar' }, chitose),
+					await api('notes/create', { text: '#foo #bar' }, chitose),
+				]);
 
-				post(chitose, {
-					text: '#foo',
-				});
-
-				post(chitose, {
-					text: '#bar',
-				});
-
-				post(chitose, {
-					text: '#foo #bar',
-				});
-
-				setTimeout(() => {
-					assert.strictEqual(fooCount, 0);
-					assert.strictEqual(barCount, 0);
-					assert.strictEqual(fooBarCount, 1);
+				await new Promise(r => setTimeout(r, 1000));
 					ws.close();
-					done();
-				}, 3000);
-			}));
 
-			test('指定したハッシュタグの投稿が流れる (OR)', () => new Promise<void>(async done => {
-				let fooCount = 0;
-				let barCount = 0;
-				let fooBarCount = 0;
-				let piyoCount = 0;
+				assert.strictEqual(received.includes('#foo'), false);
+				assert.strictEqual(received.includes('#bar'), false);
+				assert.strictEqual(received.includes('#foo #bar'), true);
+			});
 
-				const ws = await connectStream(chitose, 'hashtag', ({ type, body }) => {
-					if (type === 'note') {
-						if (body.text === '#foo') fooCount++;
-						if (body.text === '#bar') barCount++;
-						if (body.text === '#foo #bar') fooBarCount++;
-						if (body.text === '#piyo') piyoCount++;
-					}
-				}, {
-					q: [
-						['foo'],
-						['bar'],
-					],
-				});
+			test('指定したハッシュタグの投稿が流れる (OR)', async () => {
+				const received: string[] = [];
+				const ws = await connectStream(chitose, 'hashtag', (msg) => {
+					if (msg.type === 'note') received.push(msg.body.text);
+				}, { q: [['foo'], ['bar']] });
 
-				post(chitose, {
-					text: '#foo',
-				});
+				await Promise.all([
+					await api('notes/create', { text: '#foo' }, chitose),
+					await api('notes/create', { text: '#bar' }, chitose),
+					await api('notes/create', { text: '#foo #bar' }, chitose),
+					await api('notes/create', { text: '#piyo' }, chitose),
+				]);
 
-				post(chitose, {
-					text: '#bar',
-				});
+				await new Promise(r => setTimeout(r, 1000));
+				ws.close();
 
-				post(chitose, {
-					text: '#foo #bar',
-				});
+				assert.strictEqual(received.includes('#foo'), true);
+				assert.strictEqual(received.includes('#bar'), true);
+				assert.strictEqual(received.includes('#foo #bar'), true);
+				assert.strictEqual(received.includes('#piyo'), false);
+			});
 
-				post(chitose, {
-					text: '#piyo',
-				});
+			test('指定したハッシュタグの投稿が流れる (AND + OR)', async () => {
+				const received: string[] = [];
+				const ws = await connectStream(chitose, 'hashtag', (msg) => {
+					if (msg.type === 'note') received.push(msg.body.text);
+				}, { q: [['foo', 'bar'], ['piyo']] });
 
-				setTimeout(() => {
-					assert.strictEqual(fooCount, 1);
-					assert.strictEqual(barCount, 1);
-					assert.strictEqual(fooBarCount, 1);
-					assert.strictEqual(piyoCount, 0);
+				await Promise.all([
+					api('notes/create', { text: '#foo' }, chitose),
+					api('notes/create', { text: '#bar' }, chitose),
+					api('notes/create', { text: '#foo #bar' }, chitose),
+					api('notes/create', { text: '#piyo' }, chitose),
+					api('notes/create', { text: '#waaa' }, chitose),
+				]);
+
+				await new Promise(r => setTimeout(r, 1000));
 					ws.close();
-					done();
-				}, 3000);
-			}));
 
-			test('指定したハッシュタグの投稿が流れる (AND + OR)', () => new Promise<void>(async done => {
-				let fooCount = 0;
-				let barCount = 0;
-				let fooBarCount = 0;
-				let piyoCount = 0;
-				let waaaCount = 0;
-
-				const ws = await connectStream(chitose, 'hashtag', ({ type, body }) => {
-					if (type === 'note') {
-						if (body.text === '#foo') fooCount++;
-						if (body.text === '#bar') barCount++;
-						if (body.text === '#foo #bar') fooBarCount++;
-						if (body.text === '#piyo') piyoCount++;
-						if (body.text === '#waaa') waaaCount++;
-					}
-				}, {
-					q: [
-						['foo', 'bar'],
-						['piyo'],
-					],
-				});
-
-				post(chitose, {
-					text: '#foo',
-				});
-
-				post(chitose, {
-					text: '#bar',
-				});
-
-				post(chitose, {
-					text: '#foo #bar',
-				});
-
-				post(chitose, {
-					text: '#piyo',
-				});
-
-				post(chitose, {
-					text: '#waaa',
-				});
-
-				setTimeout(() => {
-					assert.strictEqual(fooCount, 0);
-					assert.strictEqual(barCount, 0);
-					assert.strictEqual(fooBarCount, 1);
-					assert.strictEqual(piyoCount, 1);
-					assert.strictEqual(waaaCount, 0);
-					ws.close();
-					done();
-				}, 3000);
-			}));
+				assert.strictEqual(received.includes('#foo'), false);
+				assert.strictEqual(received.includes('#bar'), false);
+				assert.strictEqual(received.includes('#foo #bar'), true);
+				assert.strictEqual(received.includes('#piyo'), true);
+				assert.strictEqual(received.includes('#waaa'), false);
+			});
 		});
-		*/
 	});
 });

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -769,7 +769,7 @@ describe('Streaming', () => {
 				]);
 
 				await new Promise(r => setTimeout(r, 1000));
-					ws.close();
+				ws.close();
 
 				assert.strictEqual(received.includes('#foo'), false);
 				assert.strictEqual(received.includes('#bar'), false);
@@ -813,7 +813,7 @@ describe('Streaming', () => {
 				]);
 
 				await new Promise(r => setTimeout(r, 1000));
-					ws.close();
+				ws.close();
 
 				assert.strictEqual(received.includes('#foo'), false);
 				assert.strictEqual(received.includes('#bar'), false);


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

同名の新規ハッシュタグが複数同時に作成されたとき、 `HashtagService.updateHashtag` で下記の現象が発生することがあります。

1. `findOneBy()` で null が返ってくる
2. 別の非同期タスクにより該当レコードが作成される
3. <plain>1.</plain> で null だったので `hashtagsRepository.insert` が呼ばれる

このような場合にユニーク制約違反に起因するエラーが発生しますが、 `hashtagsRepository.insert()` は await されていないため、 unhandled rejection になります。
また、本来更新されるべきレコードが更新されないままになります。

そこで、 `hashtagsRepository.insert()` のエラー処理を追加し、すでにレコードが作成されていた場合はレコードの更新にフォールバックするようにします。

レコードの更新処理においては、更新の競合が発生しないように排他制御を行います。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

Fix #17639

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

- flaky としてコメントアウトされていた Hashtag Timeline の E2E テストを復活させました

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
