### PR TITLE
fix(backend/test): e2e testの固定待ち時間をポーリングに変更

### DIFF
--- a/packages/backend/test/e2e/move.ts
+++ b/packages/backend/test/e2e/move.ts
@@ -7,15 +7,19 @@ import { INestApplicationContext } from '@nestjs/common';
 
 process.env.NODE_ENV = 'test';
 
-import { setTimeout } from 'node:timers/promises';
 import * as assert from 'assert';
-import { afterAll, beforeAll, afterEach, describe, test } from 'vitest';
+import { afterAll, beforeAll, afterEach, describe, test, vi } from 'vitest';
 import { loadConfig } from '@/config.js';
 import { MiRepository, MiUser, UsersRepository, miRepository } from '@/models/_.js';
 import { secureRndstr } from '@/misc/secure-rndstr.js';
 import { jobQueue } from '@/boot/common.js';
 import { api, castAsError, initTestDb, signup, successfulApiCall, uploadFile } from '../utils.js';
 import type * as misskey from 'misskey-js';
+
+// i/move 呼び出しで大部分が同期的に完了する後続ジョブ (フォロー解除/ブロック・ミュート引き継ぎ/リスト更新等) を待つ
+const waitForMoveJobOptions = { timeout: 5000, interval: 50 };
+// AccountMoveService がテスト環境向けに 10000ms に短縮している遅延アンフォロージョブを待つ (安全マージンを載せた上限)
+const waitForDelayedUnfollowJobOptions = { timeout: 15000, interval: 100 };
 
 describe('Account Move', () => {
 	let jq: INestApplicationContext;
@@ -273,53 +277,63 @@ describe('Account Move', () => {
 
 			assert.strictEqual(move.status, 200);
 
-			await setTimeout(1000 * 3); // wait for jobs to finish
-
 			// Unfollow delayed?
-			const aliceFollowings = await api('users/following', {
-				userId: alice.id,
-			}, alice);
-			assert.strictEqual(aliceFollowings.status, 200);
-			assert.ok(aliceFollowings);
-			assert.strictEqual(aliceFollowings.body.length, 3);
+			await vi.waitFor(async () => {
+				const aliceFollowings = await api('users/following', {
+					userId: alice.id,
+				}, alice);
+				assert.strictEqual(aliceFollowings.status, 200);
+				assert.ok(aliceFollowings);
+				assert.strictEqual(aliceFollowings.body.length, 3);
+			}, waitForMoveJobOptions);
 
-			const carolFollowings = await api('users/following', {
-				userId: carol.id,
-			}, carol);
-			assert.strictEqual(carolFollowings.status, 200);
-			assert.ok(carolFollowings);
-			assert.strictEqual(carolFollowings.body.length, 2);
-			assert.strictEqual(carolFollowings.body[0].followeeId, bob.id);
-			assert.strictEqual(carolFollowings.body[1].followeeId, alice.id);
+			await vi.waitFor(async () => {
+				const carolFollowings = await api('users/following', {
+					userId: carol.id,
+				}, carol);
+				assert.strictEqual(carolFollowings.status, 200);
+				assert.ok(carolFollowings);
+				assert.strictEqual(carolFollowings.body.length, 2);
+				assert.strictEqual(carolFollowings.body[0].followeeId, bob.id);
+				assert.strictEqual(carolFollowings.body[1].followeeId, alice.id);
+			}, waitForMoveJobOptions);
 
-			const blockings = await api('blocking/list', {}, dave);
-			assert.strictEqual(blockings.status, 200);
-			assert.ok(blockings);
-			assert.strictEqual(blockings.body.length, 2);
-			assert.strictEqual(blockings.body[0].blockeeId, bob.id);
-			assert.strictEqual(blockings.body[1].blockeeId, alice.id);
+			await vi.waitFor(async () => {
+				const blockings = await api('blocking/list', {}, dave);
+				assert.strictEqual(blockings.status, 200);
+				assert.ok(blockings);
+				assert.strictEqual(blockings.body.length, 2);
+				assert.strictEqual(blockings.body[0].blockeeId, bob.id);
+				assert.strictEqual(blockings.body[1].blockeeId, alice.id);
+			}, waitForMoveJobOptions);
 
-			const mutings = await api('mute/list', {}, dave);
-			assert.strictEqual(mutings.status, 200);
-			assert.ok(mutings);
-			assert.strictEqual(mutings.body.length, 2);
-			assert.strictEqual(mutings.body[0].muteeId, bob.id);
-			assert.strictEqual(mutings.body[1].muteeId, alice.id);
+			await vi.waitFor(async () => {
+				const mutings = await api('mute/list', {}, dave);
+				assert.strictEqual(mutings.status, 200);
+				assert.ok(mutings);
+				assert.strictEqual(mutings.body.length, 2);
+				assert.strictEqual(mutings.body[0].muteeId, bob.id);
+				assert.strictEqual(mutings.body[1].muteeId, alice.id);
+			}, waitForMoveJobOptions);
 
-			const rootLists = await api('users/lists/list', {}, root);
-			assert.strictEqual(rootLists.status, 200);
-			assert.ok(rootLists);
-			assert.ok(rootLists.body[0].userIds);
-			assert.strictEqual(rootLists.body[0].userIds.length, 2);
-			assert.ok(rootLists.body[0].userIds.find((id: string) => id === bob.id));
-			assert.ok(rootLists.body[0].userIds.find((id: string) => id === alice.id));
+			await vi.waitFor(async () => {
+				const rootLists = await api('users/lists/list', {}, root);
+				assert.strictEqual(rootLists.status, 200);
+				assert.ok(rootLists);
+				assert.ok(rootLists.body[0].userIds);
+				assert.strictEqual(rootLists.body[0].userIds.length, 2);
+				assert.ok(rootLists.body[0].userIds.find((id: string) => id === bob.id));
+				assert.ok(rootLists.body[0].userIds.find((id: string) => id === alice.id));
+			}, waitForMoveJobOptions);
 
-			const eveLists = await api('users/lists/list', {}, eve);
-			assert.strictEqual(eveLists.status, 200);
-			assert.ok(eveLists);
-			assert.ok(eveLists.body[0].userIds);
-			assert.strictEqual(eveLists.body[0].userIds.length, 1);
-			assert.ok(eveLists.body[0].userIds.find((id: string) => id === bob.id));
+			await vi.waitFor(async () => {
+				const eveLists = await api('users/lists/list', {}, eve);
+				assert.strictEqual(eveLists.status, 200);
+				assert.ok(eveLists);
+				assert.ok(eveLists.body[0].userIds);
+				assert.strictEqual(eveLists.body[0].userIds.length, 1);
+				assert.ok(eveLists.body[0].userIds.find((id: string) => id === bob.id));
+			}, waitForMoveJobOptions);
 		});
 
 		test('A locked account automatically accept the follow request if it had already accepted the old account.', async () => {
@@ -340,14 +354,14 @@ describe('Account Move', () => {
 		});
 
 		test('Unfollowed after 10 sec (24 hours in production).', async () => {
-			await setTimeout(1000 * 8);
+			await vi.waitFor(async () => {
+				const following = await api('users/following', {
+					userId: alice.id,
+				}, alice);
 
-			const following = await api('users/following', {
-				userId: alice.id,
-			}, alice);
-
-			assert.strictEqual(following.status, 200);
-			assert.strictEqual(following.body.length, 0);
+				assert.strictEqual(following.status, 200);
+				assert.strictEqual(following.body.length, 0);
+			}, waitForDelayedUnfollowJobOptions);
 		});
 
 		test('Unable to move if the destination account has already moved.', async () => {

--- a/packages/backend/test/e2e/timelines.ts
+++ b/packages/backend/test/e2e/timelines.ts
@@ -9,7 +9,7 @@
 // pnpm jest -- e2e/timelines.ts
 
 import * as assert from 'assert';
-import { describe, beforeAll, test } from 'vitest';
+import { describe, beforeAll, test, vi } from 'vitest';
 import { setTimeout } from 'node:timers/promises';
 import { entities } from 'misskey-js';
 import { Redis } from 'ioredis';
@@ -20,6 +20,8 @@ import { loadConfig } from '@/config.js';
 function genHost() {
 	return randomString() + '.example.com';
 }
+
+const waitForPushToTlOptions = { timeout: 3000, interval: 25 };
 
 let redisForTimelines: Redis;
 let root: SignupResponse;
@@ -108,52 +110,49 @@ describe('Timelines', () => {
 
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'followers' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーのノートが含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi' });
 				const carolNote = await post(carol, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーの visibility: followers なノートが含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'followers' });
 				const carolNote = await post(carol, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしているユーザーの他人への返信が含まれない', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -172,16 +171,15 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: true でフォローしているユーザーの他人へのDM返信が含まれない', async () => {
@@ -189,7 +187,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id, visibility: 'specified', visibleUserIds: [carolNote.id] });
 
@@ -207,7 +204,6 @@ describe('Timelines', () => {
 				await api('following/create', { userId: carol.id }, bob);
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -228,17 +224,16 @@ describe('Timelines', () => {
 				await api('following/create', { userId: carol.id }, alice);
 				await api('following/create', { userId: carol.id }, bob);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === carolNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === carolNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: true でフォローしているユーザーの自分の visibility: followers な投稿への返信が含まれる', async () => {
@@ -249,16 +244,15 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/create', { userId: alice.id }, bob);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: true でフォローしているユーザーの行った別のフォローしているユーザーの投稿への visibility: specified な返信が含まれない', async () => {
@@ -267,32 +261,30 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/create', { userId: carol.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id, visibility: 'specified', visibleUserIds: [carolNote.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしているユーザーのそのユーザー自身への返信が含まれる', async () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: bobNote1.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしているユーザーからの自分への返信が含まれる', async () => {
@@ -301,16 +293,15 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('自分の他人への返信が含まれる', async () => {
@@ -321,54 +312,51 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'hi' });
 				const aliceNote = await post(alice, { text: 'hi', replyId: bobNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーの他人の投稿のリノートが含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { renoteId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withRenotes: false] フォローしているユーザーの投稿が含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi' });
 				const carolNote = await post(carol, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', {
+						limit: 100,
+						withRenotes: false,
+					}, alice);
 
-				const res = await api('notes/timeline', {
-					limit: 100,
-					withRenotes: false,
-				}, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withRenotes: false] フォローしているユーザーのファイルのみの投稿が含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const [bobFile, carolFile] = await Promise.all([
 					uploadUrl(bob, 'https://raw.githubusercontent.com/misskey-dev/assets/main/public/icon.png'),
 					uploadUrl(carol, 'https://raw.githubusercontent.com/misskey-dev/assets/main/public/icon.png'),
@@ -376,22 +364,21 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { fileIds: [bobFile.id] });
 				const carolNote = await post(carol, { fileIds: [carolFile.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', {
+						limit: 100,
+						withRenotes: false,
+					}, alice);
 
-				const res = await api('notes/timeline', {
-					limit: 100,
-					withRenotes: false,
-				}, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withRenotes: false] フォローしているユーザーの他人の投稿のリノートが含まれない', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { renoteId: carolNote.id });
 
@@ -409,25 +396,23 @@ describe('Timelines', () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', renoteId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', {
+						withRenotes: false,
+					}, alice);
 
-				const res = await api('notes/timeline', {
-					withRenotes: false,
-				}, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーの他人への visibility: specified なノートが含まれない', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [carol.id] });
 
 				await waitForPushToTl();
@@ -442,7 +427,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', renoteId: carolNote.id });
 
@@ -460,7 +444,6 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -477,7 +460,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', renoteId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -496,7 +478,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', replyId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -518,11 +499,11 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているリモートユーザーの visibility: home なノートが含まれる', async () => {
@@ -533,18 +514,17 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withFiles: true] フォローしているユーザーのファイル付きノートのみ含まれる', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const [bobFile, carolFile] = await Promise.all([
 					uploadUrl(bob, 'https://raw.githubusercontent.com/misskey-dev/assets/main/public/icon.png'),
 					uploadUrl(carol, 'https://raw.githubusercontent.com/misskey-dev/assets/main/public/icon.png'),
@@ -554,14 +534,14 @@ describe('Timelines', () => {
 				const carolNote1 = await post(carol, { text: 'hi' });
 				const carolNote2 = await post(carol, { fileIds: [carolFile.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100, withFiles: true }, alice);
 
-				const res = await api('notes/timeline', { limit: 100, withFiles: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === carolNote2.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === carolNote2.id), false);
+				}, waitForPushToTlOptions);
 			}, 1000 * 30);
 
 			test('フォローしているユーザーのチャンネル投稿が含まれない', async () => {
@@ -569,7 +549,6 @@ describe('Timelines', () => {
 
 				const channel = await api('channels/create', { name: 'channel' }, bob).then(x => x.body);
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', channelId: channel.id });
 
 				await waitForPushToTl();
@@ -584,27 +563,26 @@ describe('Timelines', () => {
 
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'specified' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーの自身を visibleUserIds に指定した visibility: specified なノートが含まれる', async () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [alice.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしていないユーザーの自身を visibleUserIds に指定した visibility: specified なノートが含まれない', async () => {
@@ -623,7 +601,6 @@ describe('Timelines', () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [carol.id] });
 
 				await waitForPushToTl();
@@ -641,12 +618,12 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [alice.id] });
 				const aliceNote = await post(alice, { text: 'ok', visibility: 'specified', visibleUserIds: [bob.id], replyId: bobNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'ok');
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'ok');
+				}, waitForPushToTlOptions);
 			});
 
 			/* TODO
@@ -654,10 +631,11 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'specified', visibleUserIds: [bob.id] });
 				const bobNote = await post(bob, { text: 'ok', visibility: 'specified', visibleUserIds: [alice.id], replyId: aliceNote.id });
-				await waitForPushToTl();
-				const res = await api('notes/timeline', { limit: 100 }, alice);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id).text, 'ok');
+				await vi.waitFor(async () => {
+					const res = await api('notes/timeline', { limit: 100 }, alice);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id).text, 'ok');
+				}, waitForPushToTlOptions);
 			});
 			*/
 
@@ -700,11 +678,11 @@ describe('Timelines', () => {
 					const aliceNote = await post(alice, { text: 'hi' });
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('チャンネル未フォロー　＋　ユーザフォロー　＝　TLに流れない', async () => {
@@ -733,11 +711,11 @@ describe('Timelines', () => {
 					const aliceNote = await post(alice, { text: 'hi' });
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('チャンネル未フォロー　＋　ユーザ未フォロー　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -851,11 +829,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　ユーザフォロー　＝　TLに流れる', async () => {
@@ -869,11 +847,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　ユーザ未フォロー　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -960,19 +938,19 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'I\'m Bob.' });
 				const carolNote = await post(carol, { text: 'I\'m Carol.' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					if (enableFanoutTimeline) {
+						// NOTE: notes/timeline だと DB へのフォールバックが効くので Redis を直接見て確かめる
+						assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 1);
 
-				if (enableFanoutTimeline) {
-					// NOTE: notes/timeline だと DB へのフォールバックが効くので Redis を直接見て確かめる
-					assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 1);
-
-					const bobHTL = await redisForTimelines.lrange(`list:homeTimeline:${bob.id}`, 0, -1);
-					assert.strictEqual(bobHTL.includes(aliceNote.id), true);
-					assert.strictEqual(bobHTL.includes(bobNote.id), true);
-					assert.strictEqual(bobHTL.includes(carolNote.id), false);
-				} else {
-					assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 0);
-				}
+						const bobHTL = await redisForTimelines.lrange(`list:homeTimeline:${bob.id}`, 0, -1);
+						assert.strictEqual(bobHTL.includes(aliceNote.id), true);
+						assert.strictEqual(bobHTL.includes(bobNote.id), true);
+						assert.strictEqual(bobHTL.includes(carolNote.id), false);
+					} else {
+						assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 0);
+					}
+				}, waitForPushToTlOptions);
 			});
 
 			test('FTT: リモートユーザーの HTL にはプッシュされない', async () => {
@@ -985,10 +963,10 @@ describe('Timelines', () => {
 				await post(alice, { text: 'I\'m Alice.' });
 				await post(bob, { text: 'I\'m Bob.' });
 
-				await waitForPushToTl();
-
-				// NOTE: notes/timeline だと DB へのフォールバックが効くので Redis を直接見て確かめる
-				assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 0);
+				await vi.waitFor(async () => {
+					// NOTE: notes/timeline だと DB へのフォールバックが効くので Redis を直接見て確かめる
+					assert.strictEqual(await redisForTimelines.exists(`list:homeTimeline:${bob.id}`), 0);
+				}, waitForPushToTlOptions);
 			});
 
 			describe('凍結', () => {
@@ -1004,7 +982,13 @@ describe('Timelines', () => {
 					bobNote = await post(bob, { text: 'yo' });
 					carolNote = await post(carol, { text: 'kon\'nichiwa' });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
+
+						assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					}, waitForPushToTlOptions);
 
 					await api('admin/suspend-user', { userId: carol.id }, root);
 					await setTimeout(100);
@@ -1045,7 +1029,15 @@ describe('Timelines', () => {
 					bobRenote = await post(bob, { renoteId: carolNote.id });
 					carolRenote = await post(carol, { renoteId: bobNote.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
+
+						assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === carolRenote.id), true);
+					}, waitForPushToTlOptions);
 
 					await api('admin/suspend-user', { userId: carol.id }, root);
 					await setTimeout(100);
@@ -1088,7 +1080,13 @@ describe('Timelines', () => {
 					bobNote = await post(bob, { text: 'yo' });
 					carolNote = await post(carol, { text: 'kon\'nichiwa' });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/timeline', { limit: 100 }, alice);
+
+						assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					}, waitForPushToTlOptions);
 
 					await api('admin/suspend-user', { userId: carol.id }, root);
 					await setTimeout(100);
@@ -1122,12 +1120,12 @@ describe('Timelines', () => {
 				const carolNote = await post(carol, { text: 'hi', visibility: 'home' });
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('他人の他人への返信が含まれない', async () => {
@@ -1136,12 +1134,12 @@ describe('Timelines', () => {
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('他人のその人自身への返信が含まれる', async () => {
@@ -1150,12 +1148,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: bobNote1.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('チャンネル投稿が含まれない', async () => {
@@ -1188,32 +1186,30 @@ describe('Timelines', () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('following/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi', visibility: 'home' });
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('ミュートしているユーザーのノートが含まれない', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているユーザーが行ったミュートしているユーザーのリノートが含まれない', async () => {
@@ -1221,7 +1217,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', renoteId: carolNote.id });
 
@@ -1239,7 +1234,6 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -1255,7 +1249,6 @@ describe('Timelines', () => {
 				const [alice, bob, carol, dave] = await Promise.all([signup(), signup(), signup(), signup()]);
 
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', renoteId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -1273,7 +1266,6 @@ describe('Timelines', () => {
 				const [alice, bob, carol, dave] = await Promise.all([signup(), signup(), signup(), signup()]);
 
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', replyId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -1293,16 +1285,15 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしていないユーザーからの自分への返信が含まれる', async () => {
@@ -1310,16 +1301,15 @@ describe('Timelines', () => {
 
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withReplies: true] 他人の他人への返信が含まれる', async () => {
@@ -1328,11 +1318,11 @@ describe('Timelines', () => {
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100, withReplies: true }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100, withReplies: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withFiles: true] ファイル付きノートのみ含まれる', async () => {
@@ -1342,12 +1332,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { fileIds: [file.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100, withFiles: true }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100, withFiles: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			}, 1000 * 10);
 
 			describe('Channel', () => {
@@ -1492,11 +1482,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　ユーザ未フォロー　＝　TLに流れる', async () => {
@@ -1509,11 +1499,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　ユーザフォロー　＝　TLに流れる', async () => {
@@ -1526,11 +1516,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　ユーザフォロー　＝　TLに流れる', async () => {
@@ -1544,11 +1534,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　ユーザ未フォロー　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -1631,11 +1621,11 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('ローカルユーザーの visibility: home なノートが含まれない', async () => {
@@ -1654,14 +1644,13 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしているユーザーからの自分への返信が含まれる', async () => {
@@ -1671,16 +1660,15 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: true でフォローしているユーザーの他人の visibility: followers な投稿への返信が含まれない', async () => {
@@ -1689,7 +1677,6 @@ describe('Timelines', () => {
 				await api('following/create', { userId: carol.id }, bob);
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -1711,17 +1698,16 @@ describe('Timelines', () => {
 				await api('following/create', { userId: carol.id }, alice);
 				await api('following/create', { userId: carol.id }, bob);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some((note: any) => note.id === carolNote.id), true);
-				assert.strictEqual(res.body.find((note: any) => note.id === carolNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === carolNote.id), true);
+					assert.strictEqual(res.body.find((note: any) => note.id === carolNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: true でフォローしているユーザーの自分の visibility: followers な投稿への返信が含まれる', async () => {
@@ -1733,16 +1719,15 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				await api('following/create', { userId: alice.id }, bob);
 				await api('following/update', { userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'followers' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('他人の他人への返信が含まれない', async () => {
@@ -1751,12 +1736,12 @@ describe('Timelines', () => {
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
-				assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
+					assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('リモートユーザーのノートが含まれない', async () => {
@@ -1779,11 +1764,11 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしているリモートユーザーの visibility: home なノートが含まれる', async () => {
@@ -1794,11 +1779,11 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でフォローしていないユーザーからの自分への返信が含まれる', async () => {
@@ -1807,16 +1792,15 @@ describe('Timelines', () => {
 
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/local-timeline', { limit: 100 }, alice);
 
-				const res = await api('notes/local-timeline', { limit: 100 }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withReplies: true] 他人の他人への返信が含まれる', async () => {
@@ -1825,11 +1809,11 @@ describe('Timelines', () => {
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100, withReplies: true }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100, withReplies: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withFiles: true] ファイル付きノートのみ含まれる', async () => {
@@ -1839,12 +1823,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { fileIds: [file.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/hybrid-timeline', { limit: 100, withFiles: true }, alice);
 
-				const res = await api('notes/hybrid-timeline', { limit: 100, withFiles: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			}, 1000 * 10);
 
 			describe('Channel', () => {
@@ -1872,11 +1856,11 @@ describe('Timelines', () => {
 					const aliceNote = await post(alice, { text: 'hi' });
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('チャンネル未フォロー　＋　ユーザフォロー　＝　TLに流れない', async () => {
@@ -1905,11 +1889,11 @@ describe('Timelines', () => {
 					const aliceNote = await post(alice, { text: 'hi' });
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('チャンネル未フォロー　＋　ユーザ未フォロー　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -1989,11 +1973,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　ユーザ未フォロー　＝　TLに流れる', async () => {
@@ -2006,11 +1990,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　ユーザフォロー　＝　TLに流れる', async () => {
@@ -2023,11 +2007,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　ユーザフォロー　＝　TLに流れる', async () => {
@@ -2041,11 +2025,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
-					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　ユーザ未フォロー　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -2139,11 +2123,17 @@ describe('Timelines', () => {
 					carolNote = await post(carol, { text: 'kon\'nichiwa' });
 					daveNote = await post(dave, { text: 'hello' });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
+
+						assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === carolNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === daveNote.id), true);
+					}, waitForPushToTlOptions);
 
 					await api('admin/suspend-user', { userId: carol.id }, root);
 					await api('admin/suspend-user', { userId: dave.id }, root);
-					await setTimeout(250);
 				});
 
 				test('凍結後に凍結されたユーザーのノートは見えなくなる', async () => {
@@ -2158,7 +2148,6 @@ describe('Timelines', () => {
 				test('凍結解除後に凍結されていたユーザーのノートは見えるようになる', async () => {
 					await api('admin/unsuspend-user', { userId: carol.id }, root);
 					await api('admin/unsuspend-user', { userId: dave.id }, root);
-					await setTimeout(250);
 
 					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
@@ -2186,11 +2175,15 @@ describe('Timelines', () => {
 					carolNote = await post(carol, { text: 'kon\'nichiwa' });
 					elleNote = await post(elle, { text: 'hi there' });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
+
+						assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+						assert.strictEqual(res.body.some(note => note.id === elleNote.id), true);
+					}, waitForPushToTlOptions);
 
 					await api('admin/suspend-user', { userId: carol.id }, root);
 					await api('admin/suspend-user', { userId: elle.id }, root);
-					await setTimeout(250);
 				});
 
 				test('凍結後に凍結されたユーザーのノートは見えなくなる', async () => {
@@ -2204,7 +2197,6 @@ describe('Timelines', () => {
 				test('凍結解除後に凍結されていたユーザーのノートは見えるようになる', async () => {
 					await api('admin/unsuspend-user', { userId: carol.id }, root);
 					await api('admin/unsuspend-user', { userId: elle.id }, root);
-					await setTimeout(250);
 
 					const res = await api('notes/hybrid-timeline', { limit: 100 }, alice);
 
@@ -2221,14 +2213,13 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているフォローしていないユーザーの visibility: home なノートが含まれる', async () => {
@@ -2236,14 +2227,13 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているフォローしていないユーザーの visibility: followers なノートが含まれない', async () => {
@@ -2251,7 +2241,6 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'followers' });
 
 				await waitForPushToTl();
@@ -2266,7 +2255,6 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -2282,16 +2270,15 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: bobNote1.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でリスインしているフォローしていないユーザーからの自分への返信が含まれる', async () => {
@@ -2300,15 +2287,14 @@ describe('Timelines', () => {
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
 				await api('users/lists/update-membership', { listId: list.id, userId: bob.id, withReplies: false }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: aliceNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('withReplies: false でリスインしているフォローしていないユーザーの他人への返信が含まれない', async () => {
@@ -2317,7 +2303,6 @@ describe('Timelines', () => {
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
 				await api('users/lists/update-membership', { listId: list.id, userId: bob.id, withReplies: false }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
@@ -2334,15 +2319,14 @@ describe('Timelines', () => {
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
 				await api('users/lists/update-membership', { listId: list.id, userId: bob.id, withReplies: true }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているフォローしているユーザーの visibility: home なノートが含まれる', async () => {
@@ -2351,14 +2335,13 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているフォローしているユーザーの visibility: followers なノートが含まれる', async () => {
@@ -2367,15 +2350,14 @@ describe('Timelines', () => {
 				await api('following/create', { userId: bob.id }, alice);
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'followers' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしている自分の visibility: followers なノートが含まれる', async () => {
@@ -2383,15 +2365,14 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: alice.id }, alice);
-				await setTimeout(250);
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'followers' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているユーザーのチャンネルノートが含まれない', async () => {
@@ -2400,7 +2381,6 @@ describe('Timelines', () => {
 				const channel = await api('channels/create', { name: 'channel' }, bob).then(x => x.body);
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', channelId: channel.id });
 
 				await waitForPushToTl();
@@ -2419,12 +2399,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { fileIds: [file.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id, withFiles: true }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id, withFiles: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			}, 1000 * 10);
 
 			test('リスインしているユーザーの自身宛ての visibility: specified なノートが含まれる', async () => {
@@ -2432,15 +2412,14 @@ describe('Timelines', () => {
 
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [alice.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
 
-				const res = await api('notes/user-list-timeline', { listId: list.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('リスインしているユーザーの自身宛てではない visibility: specified なノートが含まれない', async () => {
@@ -2449,7 +2428,6 @@ describe('Timelines', () => {
 				const list = await api('users/lists/create', { name: 'list' }, alice).then(res => res.body);
 				await api('users/lists/push', { listId: list.id, userId: bob.id }, alice);
 				await api('users/lists/push', { listId: list.id, userId: carol.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'specified', visibleUserIds: [carol.id] });
 
 				await waitForPushToTl();
@@ -2657,11 +2635,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/user-list-timeline', { limit: 100, listId: list.id }, alice);
 
-					const res = await api('notes/user-list-timeline', { limit: 100, listId: list.id }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルフォロー　＋　リスインしてる　＝　TLに流れる', async () => {
@@ -2677,11 +2655,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('notes/user-list-timeline', { limit: 100, listId: list.id }, alice);
 
-					const res = await api('notes/user-list-timeline', { limit: 100, listId: list.id }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネル未フォロー　＋　リスインしてない　＋　チャンネルミュート　＝　TLに流れない', async () => {
@@ -2772,11 +2750,11 @@ describe('Timelines', () => {
 
 				const bobNote = await post(bob, { text: 'hi' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id }, alice);
 
-				const res = await api('users/notes', { userId: bob.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('フォローしていないユーザーの visibility: followers なノートが含まれない', async () => {
@@ -2795,15 +2773,14 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('following/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote = await post(bob, { text: 'hi', visibility: 'followers' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id }, alice);
 
-				const res = await api('users/notes', { userId: bob.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('自身の visibility: followers なノートが含まれる', async () => {
@@ -2811,12 +2788,12 @@ describe('Timelines', () => {
 
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'followers' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: alice.id }, alice);
 
-				const res = await api('users/notes', { userId: alice.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
-				assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.find(note => note.id === aliceNote.id)?.text, 'hi');
+				}, waitForPushToTlOptions);
 			});
 
 			test('チャンネル投稿が含まれない', async () => {
@@ -2841,12 +2818,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id }, alice);
 
-				const res = await api('users/notes', { userId: bob.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withReplies: true] 他人への返信が含まれる', async () => {
@@ -2856,12 +2833,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: carolNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id, withReplies: true }, alice);
 
-				const res = await api('users/notes', { userId: bob.id, withReplies: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withReplies: true] 他人への visibility: specified な返信が含まれない', async () => {
@@ -2871,12 +2848,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: carolNote.id, visibility: 'specified' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id, withReplies: true }, alice);
 
-				const res = await api('users/notes', { userId: bob.id, withReplies: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), false);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withFiles: true] ファイル付きノートのみ含まれる', async () => {
@@ -2886,12 +2863,12 @@ describe('Timelines', () => {
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { fileIds: [file.id] });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id, withFiles: true }, alice);
 
-				const res = await api('users/notes', { userId: bob.id, withFiles: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), false);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+				}, waitForPushToTlOptions);
 			}, 1000 * 10);
 
 			test('[withChannelNotes: true] チャンネル投稿が含まれる', async () => {
@@ -2900,11 +2877,11 @@ describe('Timelines', () => {
 				const channel = await api('channels/create', { name: 'channel' }, bob).then(x => x.body);
 				const bobNote = await post(bob, { text: 'hi', channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
 
-				const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('[withChannelNotes: true] 他人が取得した場合センシティブチャンネル投稿が含まれない', async () => {
@@ -2926,18 +2903,17 @@ describe('Timelines', () => {
 				const channel = await api('channels/create', { name: 'channel', isSensitive: true }, bob).then(x => x.body);
 				const bobNote = await post(bob, { text: 'hi', channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, bob);
 
-				const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, bob);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('ミュートしているユーザーに関連する投稿が含まれない', async () => {
 				const [alice, bob, carol] = await Promise.all([signup(), signup(), signup()]);
 
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'hi', renoteId: carolNote.id });
 
@@ -2952,7 +2928,6 @@ describe('Timelines', () => {
 				const [alice, bob, carol, dave] = await Promise.all([signup(), signup(), signup(), signup()]);
 
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', renoteId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -2969,7 +2944,6 @@ describe('Timelines', () => {
 
 				await api('following/create', { userId: bob.id }, alice);
 				await api('mute/create', { userId: carol.id }, alice);
-				await setTimeout(250);
 				const carolNote = await post(carol, { text: 'hi' });
 				const daveNote = await post(dave, { text: 'quote hi', replyId: carolNote.id });
 				const bobNote = await post(bob, { renoteId: daveNote.id });
@@ -2985,22 +2959,21 @@ describe('Timelines', () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 
 				await api('mute/create', { userId: bob.id }, alice);
-				await setTimeout(250);
 				const bobNote1 = await post(bob, { text: 'hi' });
 				const bobNote2 = await post(bob, { text: 'hi', replyId: bobNote1.id });
 				const bobNote3 = await post(bob, { text: 'hi', renoteId: bobNote1.id });
 				const bobNote4 = await post(bob, { renoteId: bobNote2.id });
 				const bobNote5 = await post(bob, { renoteId: bobNote3.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: bob.id }, alice);
 
-				const res = await api('users/notes', { userId: bob.id }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote3.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote4.id), true);
-				assert.strictEqual(res.body.some(note => note.id === bobNote5.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote1.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote2.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote3.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote4.id), true);
+					assert.strictEqual(res.body.some(note => note.id === bobNote5.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('自身の visibility: specified なノートが含まれる', async () => {
@@ -3008,11 +2981,11 @@ describe('Timelines', () => {
 
 				const aliceNote = await post(alice, { text: 'hi', visibility: 'specified' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('users/notes', { userId: alice.id, withReplies: true }, alice);
 
-				const res = await api('users/notes', { userId: alice.id, withReplies: true }, alice);
-
-				assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some(note => note.id === aliceNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('visibleUserIds に指定されてない visibility: specified なノートが含まれない', async () => {
@@ -3063,11 +3036,11 @@ describe('Timelines', () => {
 					const aliceNote = await post(alice, { text: 'hi' });
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
 
-					const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('チャンネルミュート　＝　TLに流れない', async () => {
@@ -3095,11 +3068,11 @@ describe('Timelines', () => {
 					const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 					const bobRenote = await renote(bobNote.id, bob);
 
-					await waitForPushToTl();
+					await vi.waitFor(async () => {
+						const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
 
-					const res = await api('users/notes', { userId: bob.id, withChannelNotes: true }, alice);
-
-					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+						assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					}, waitForPushToTlOptions);
 				});
 
 				test('[チャンネル外リノート] チャンネルミュート　＝　TLに流れない', async () => {
@@ -3130,12 +3103,12 @@ describe('Timelines', () => {
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), false);
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), false);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルとは別チャンネルのノートは含まれない', async() => {
@@ -3164,11 +3137,11 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 				const bobRenote = await post(bob, { channelId: channel.id, renoteId: bobNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルとは別チャンネルからのリノートが含まれる', async() => {
@@ -3181,11 +3154,11 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'ok', channelId: channel2.id });
 				const bobRenote = await post(bob, { channelId: channel.id, renoteId: bobNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルに自分の他人への返信が含まれる', async () => {
@@ -3196,11 +3169,11 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 				const aliceNote = await post(alice, { text: 'hi', replyId: bobNote.id, channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルに他人の自分への返信が含まれる', async () => {
@@ -3211,11 +3184,11 @@ describe('Timelines', () => {
 				const aliceNote = await post(alice, { text: 'hi', channelId: channel.id });
 				const bobNote = await post(bob, { text: 'ok', replyId: aliceNote.id, channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルにミュートしているユーザのノートは含まれない', async () => {
@@ -3263,12 +3236,12 @@ describe('Timelines', () => {
 				const aliceNote = await post(alice, { text: 'hi' });
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), false);
-				assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === aliceNote.id), false);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobNote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルをミュートしていても、同チャンネルのリノートが含まれる', async () => {
@@ -3281,11 +3254,11 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 				const bobRenote = await post(bob, { channelId: channel.id, renoteId: bobNote.id });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルをミュートしていても、同チャンネルのリプライが含まれる', async () => {
@@ -3298,11 +3271,11 @@ describe('Timelines', () => {
 				const bobNote = await post(bob, { text: 'ok', channelId: channel.id });
 				const bobRenote = await post(bob, { channelId: channel.id, replyId: bobNote.id, text: 'ho' });
 
-				await waitForPushToTl();
+				await vi.waitFor(async () => {
+					const res = await api('channels/timeline', { channelId: channel.id }, alice);
 
-				const res = await api('channels/timeline', { channelId: channel.id }, alice);
-
-				assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+					assert.strictEqual(res.body.some((note: any) => note.id === bobRenote.id), true);
+				}, waitForPushToTlOptions);
 			});
 
 			test('閲覧中チャンネルとは別チャンネルをミュートしているとき、そのチャンネルからのリノートは含まれない', async() => {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
- 固定待ち時間の間に十分処理が終わる場合の高速化
- 固定待ち時間の間に処理が終わらなかった場合にテストが落ちるのを修正

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
