### PR TITLE
fix(frontend): correctly detect isMe in mention

### DIFF
--- a/packages/frontend/src/components/MkMention.vue
+++ b/packages/frontend/src/components/MkMention.vue
@@ -33,7 +33,7 @@ const canonical = props.host === localHost ? `@${props.username}` : `@${props.us
 const url = `/${canonical}`;
 
 const isMe = $i && (
-	`@${props.username}@${toUnicode(props.host)}` === `@${$i.username}@${toUnicode(localHost)}`.toLowerCase()
+	`@${props.username}@${toUnicode(props.host)}`.toLowerCase() === `@${$i.username}@${toUnicode(localHost)}`.toLowerCase()
 );
 
 const avatarUrl = computed(() => prefer.s.disableShowingAnimatedImages || prefer.s.dataSaver.avatar


### PR DESCRIPTION
## What
Mentions are supposed to be differently formatted when the mention is of the logged in user that is reading the note. This is done using the `isMe` variable. This was not working because in the comparison only one part was converted to lower case.

previous behaviour (not working with upper case):
<img width="548" height="125" alt="grafik" src="https://github.com/user-attachments/assets/c34e3f58-520c-43ba-a2b2-f71b6a54b23e" />

As you can see only the lower case spelling is slightly highlighted with a different colour. The upper case spelling is shown in the same colour as all other mentions.

## Why
The intention seems obvious from the code but it only works when the mentioned user name in the note is written in lower case.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
