### PR TITLE
feat: Sentryバックエンドの自動計装を個別で無効化出来る仕組みを追加する

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -305,7 +305,7 @@ id: 'aidx'
 #  enableNodeProfiling: true
 #  # Specify Sentry integration names to disable individual auto-instrumentation.
 #  # The names are integration .name values, not factory function names.
-#  # To check enabled names, set options.debug: true and see
+#  # To check enabled names, set `options.debug: true` and see
 #  # "Integration installed: <name>" in the Sentry logs.
 #  #
 #  # As of 2026-07-05 / @sentry/node 10.59.0, useful names for Misskey include:

--- a/.config/example.yml
+++ b/.config/example.yml
@@ -303,6 +303,18 @@ id: 'aidx'
 
 #sentryForBackend:
 #  enableNodeProfiling: true
+#  # Specify Sentry integration names to disable individual auto-instrumentation.
+#  # The names are integration .name values, not factory function names.
+#  # To check enabled names, set options.debug: true and see
+#  # "Integration installed: <name>" in the Sentry logs.
+#  #
+#  # As of 2026-07-05 / @sentry/node 10.59.0, useful names for Misskey include:
+#  #   Postgres  ... DB queries (when pg is externalized)
+#  #   Redis     ... ioredis commands
+#  #   Fastify   ... inbound HTTP routes
+#  #   Http      ... inbound/outbound HTTP; disabling this can also affect request isolation
+#  #   NodeFetch ... fetch/undici requests
+#  disabledIntegrations: ['Postgres']
 #  options:
 #    dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Server
 - Enhance: センシティブメディアの判定を外部サービス ([sensitive-detector](https://github.com/misskey-dev/sensitive-detector)) に分離し、`nsfwjs` / `@tensorflow/tfjs(-node)` の同梱と NSFW 判定モデルを廃止 (#16804)
+- Enhance: Sentry バックエンドの自動計装を `sentryForBackend.disabledIntegrations` で個別に無効化できるように
 - Enhance: Node.js 22.23.0以降、24.17.0以降、26.4.0以降をサポートするように
 - Enhance: Docker Image の Node.js を 26.4.0 に、Debian を trixie (v13) に更新
 - Fix: `/stats` API のレスポンス型が正しくない問題を修正

--- a/packages/backend/src/config.ts
+++ b/packages/backend/src/config.ts
@@ -20,6 +20,12 @@ type RedisOptionsSource = Partial<RedisOptions> & {
 	prefix?: string;
 };
 
+type SentryBackendConfig = {
+	options: Partial<Sentry.NodeOptions>;
+	enableNodeProfiling: boolean;
+	disabledIntegrations?: string[];
+};
+
 /**
  * 設定ファイルの型
  */
@@ -64,7 +70,7 @@ type Source = {
 		index: string;
 		scope?: 'local' | 'global' | string[];
 	};
-	sentryForBackend?: { options: Partial<Sentry.NodeOptions>; enableNodeProfiling: boolean; };
+	sentryForBackend?: SentryBackendConfig;
 	sentryForFrontend?: {
 		options: Partial<SentryVue.BrowserOptions> & { dsn: string };
 		vueIntegration?: SentryVue.VueIntegrationOptions | null;
@@ -201,7 +207,7 @@ export type Config = {
 	redisForJobQueue: RedisOptions & RedisOptionsSource;
 	redisForTimelines: RedisOptions & RedisOptionsSource;
 	redisForReactions: RedisOptions & RedisOptionsSource;
-	sentryForBackend: { options: Partial<Sentry.NodeOptions>; enableNodeProfiling: boolean; } | undefined;
+	sentryForBackend: SentryBackendConfig | undefined;
 	sentryForFrontend: {
 		options: Partial<SentryVue.BrowserOptions> & { dsn: string };
 		vueIntegration?: SentryVue.VueIntegrationOptions | null;

--- a/packages/backend/src/core/telemetry/adapters/SentryTelemetryAdapter.ts
+++ b/packages/backend/src/core/telemetry/adapters/SentryTelemetryAdapter.ts
@@ -6,6 +6,34 @@
 import type { Config } from '@/config.js';
 import type { TelemetryAdapter, TelemetryCaptureMessageOptions } from './TelemetryAdapter.js';
 
+type SentryIntegrationsOption = NonNullable<import('@sentry/node').NodeOptions['integrations']>;
+type SentryIntegrationFactory = Extract<SentryIntegrationsOption, (integrations: any[]) => any[]>;
+type SentryIntegration = Parameters<SentryIntegrationFactory>[0][number];
+
+type BuildSentryIntegrationsOptions = {
+	disabledIntegrations?: string[];
+	enableNodeProfiling: boolean;
+	nodeProfilingIntegration?: () => SentryIntegration;
+	warn?: (message: string) => void;
+};
+
+export function buildSentryIntegrations(options: BuildSentryIntegrationsOptions): SentryIntegrationFactory {
+	return (defaults) => {
+		const disabledIntegrations = new Set(options.disabledIntegrations ?? []);
+		const defaultIntegrationNames = new Set(defaults.map((integration) => integration.name));
+		const unknownIntegrations = [...disabledIntegrations].filter((name) => !defaultIntegrationNames.has(name));
+
+		if (unknownIntegrations.length > 0) {
+			(options.warn ?? console.warn)(`Unknown Sentry integration configured in sentryForBackend.disabledIntegrations: ${unknownIntegrations.join(', ')}`);
+		}
+
+		return [
+			...defaults.filter((integration) => !disabledIntegrations.has(integration.name)),
+			...(options.enableNodeProfiling && options.nodeProfilingIntegration != null ? [options.nodeProfilingIntegration()] : []),
+		];
+	};
+}
+
 export class SentryTelemetryAdapter implements TelemetryAdapter {
 	private constructor(
 		private readonly Sentry: typeof import('@sentry/node'),
@@ -17,10 +45,6 @@ export class SentryTelemetryAdapter implements TelemetryAdapter {
 		const { nodeProfilingIntegration } = await import('@sentry/profiling-node');
 
 		Sentry.init({
-			integrations: [
-				...(config.enableNodeProfiling ? [nodeProfilingIntegration()] : []),
-			],
-
 			// Performance Monitoring
 			tracesSampleRate: 1.0, //  Capture 100% of the transactions
 
@@ -30,6 +54,12 @@ export class SentryTelemetryAdapter implements TelemetryAdapter {
 			maxBreadcrumbs: 0,
 
 			...config.options,
+
+			integrations: buildSentryIntegrations({
+				disabledIntegrations: config.disabledIntegrations,
+				enableNodeProfiling: config.enableNodeProfiling,
+				nodeProfilingIntegration,
+			}),
 		});
 
 		return new SentryTelemetryAdapter(Sentry);

--- a/packages/backend/test/unit/SentryTelemetryAdapter.ts
+++ b/packages/backend/test/unit/SentryTelemetryAdapter.ts
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import { buildSentryIntegrations } from '@/core/telemetry/adapters/SentryTelemetryAdapter.js';
+
+type TestIntegration = Parameters<ReturnType<typeof buildSentryIntegrations>>[0][number];
+
+function testIntegration(name: string): TestIntegration {
+	return { name };
+}
+
+describe('SentryTelemetryAdapter', () => {
+	test('removes disabled integrations from Sentry defaults', () => {
+		const integrations = buildSentryIntegrations({
+			disabledIntegrations: ['Postgres'],
+			enableNodeProfiling: false,
+		});
+
+		const result = integrations([
+			testIntegration('Http'),
+			testIntegration('Postgres'),
+			testIntegration('Redis'),
+		]);
+
+		expect(result.map((integration: TestIntegration) => integration.name)).toEqual(['Http', 'Redis']);
+	});
+
+	test('keeps profiling integration when enabled', () => {
+		const integrations = buildSentryIntegrations({
+			disabledIntegrations: [],
+			enableNodeProfiling: true,
+			nodeProfilingIntegration: () => testIntegration('ProfilingIntegration'),
+		});
+
+		const result = integrations([
+			testIntegration('Http'),
+		]);
+
+		expect(result.map((integration: TestIntegration) => integration.name)).toEqual(['Http', 'ProfilingIntegration']);
+	});
+
+	test('warns about unknown disabled integration names without removing defaults', () => {
+		const warn = vi.fn();
+		const integrations = buildSentryIntegrations({
+			disabledIntegrations: ['Unknown'],
+			enableNodeProfiling: false,
+			warn,
+		});
+
+		const result = integrations([
+			testIntegration('Http'),
+		]);
+
+		expect(result.map((integration: TestIntegration) => integration.name)).toEqual(['Http']);
+		expect(warn).toHaveBeenCalledWith('Unknown Sentry integration configured in sentryForBackend.disabledIntegrations: Unknown');
+	});
+});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

タイトルの通りです。
Sentryを有効化すると、自動的にpgやioredis、fetchなどにhookが追加されます。
それらを個別に無効化出来るオプションを追加します。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix #17672

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
