### PR TITLE
fix(frontend): ディレクティブのイベントリスナーがマウント解除後も残る問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix: デバイスタイプをスマートフォンに固定している状態で画面幅が広いとき、画面左上のアイコンが表示されない問題を修正
 - Fix: チャットでIMEの変換を確定するEnterでメッセージが送信されてしまうことがある問題を修正
 - Fix: 自分へのメンションに対する色分けで、判定が大文字/小文字を区別していた問題を修正
+- Fix: いくつかのイベントリスナーが正しく解除されない問題を修正（メモリ使用量の改善）
 
 ### Server
 - Enhance: センシティブメディアの判定を外部サービス ([sensitive-detector](https://github.com/misskey-dev/sensitive-detector)) に分離し、`nsfwjs` / `@tensorflow/tfjs(-node)` の同梱と NSFW 判定モデルを廃止 (#16804)

--- a/packages/frontend/src/composables/use-tooltip.ts
+++ b/packages/frontend/src/composables/use-tooltip.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { ref, watch, onUnmounted } from 'vue';
+import { ref, watch, onBeforeUnmount } from 'vue';
 import type { Ref } from 'vue';
 
 export function useTooltip(
@@ -100,7 +100,15 @@ export function useTooltip(
 		flush: 'post',
 	});
 
-	onUnmounted(() => {
+	onBeforeUnmount(() => {
 		close();
+		if (elRef.value) {
+			const el = elRef.value instanceof Element ? elRef.value : elRef.value.$el;
+			el.removeEventListener('mouseover', onMouseover);
+			el.removeEventListener('mouseleave', onMouseleave);
+			el.removeEventListener('touchstart', onTouchstart);
+			el.removeEventListener('touchend', onTouchend);
+			el.removeEventListener('click', close);
+		}
 	});
 }

--- a/packages/frontend/src/directives/appear.ts
+++ b/packages/frontend/src/directives/appear.ts
@@ -7,9 +7,7 @@ import { throttle } from 'throttle-debounce';
 import type { Directive } from 'vue';
 import type { Awaitable } from '@/types/misc.js';
 
-interface HTMLElementWithObserver extends HTMLElement {
-	_observer_?: IntersectionObserver;
-}
+const observers = new WeakMap<HTMLElement, IntersectionObserver>();
 
 export const appearDirective = {
 	mounted(src, binding) {
@@ -23,13 +21,16 @@ export const appearDirective = {
 		});
 
 		const observer = new IntersectionObserver(check);
-
 		observer.observe(src);
 
-		src._observer_ = observer;
+		observers.set(src, observer);
 	},
 
-	unmounted(src) {
-		if (src._observer_) src._observer_.disconnect();
+	beforeUnmount(src) {
+		const observer = observers.get(src);
+		if (observer) {
+			observer.disconnect();
+			observers.delete(src);
+		}
 	},
-} as Directive<HTMLElementWithObserver, (() => Awaitable<void>) | null | undefined>;
+} as Directive<HTMLElement, (() => Awaitable<void>) | null | undefined>;

--- a/packages/frontend/src/directives/click-anime.ts
+++ b/packages/frontend/src/directives/click-anime.ts
@@ -6,13 +6,7 @@
 import type { Directive } from 'vue';
 import { prefer } from '@/preferences.js';
 
-type ClickAnimeDirectiveState = {
-	mousedownHandler: (ev: MouseEvent) => void;
-	clickHandler: (ev: MouseEvent) => void;
-	animationendHandler: (ev: AnimationEvent) => void;
-};
-
-const states = new WeakMap<HTMLElement, ClickAnimeDirectiveState>();
+const abortControllers = new WeakMap<HTMLElement, AbortController>();
 
 export const clickAnimeDirective = {
 	mounted(el) {
@@ -22,9 +16,12 @@ export const clickAnimeDirective = {
 
 		if (target == null) return;
 
+		const abortController = new AbortController();
+		abortControllers.set(el, abortController);
+
 		target.classList.add('_anime_bounce_standBy');
 
-		const mousedownHandler = () => {
+		el.addEventListener('mousedown', () => {
 			target.classList.remove('_anime_bounce');
 
 			target.classList.add('_anime_bounce_standBy');
@@ -33,38 +30,26 @@ export const clickAnimeDirective = {
 			target.addEventListener('mouseleave', () => {
 				target.classList.remove('_anime_bounce_ready');
 			});
-		};
+		}, { signal: abortController.signal });
 
-		const clickHandler = () => {
+		el.addEventListener('click', () => {
 			target.classList.add('_anime_bounce');
 			target.classList.remove('_anime_bounce_ready');
-		};
+		}, { signal: abortController.signal });
 
-		const animationendHandler = () => {
+		el.addEventListener('animationend', () => {
 			target.classList.remove('_anime_bounce');
 			target.classList.add('_anime_bounce_standBy');
-		};
-
-		el.addEventListener('mousedown', mousedownHandler);
-		el.addEventListener('click', clickHandler);
-		el.addEventListener('animationend', animationendHandler);
-
-		states.set(el, {
-			mousedownHandler,
-			clickHandler,
-			animationendHandler,
-		});
+		}, { signal: abortController.signal });
 	},
 
 	beforeUnmount(el) {
 		if (!prefer.s.animation) return;
 
-		const state = states.get(el);
-		if (state == null) return;
-
-		el.removeEventListener('mousedown', state.mousedownHandler);
-		el.removeEventListener('click', state.clickHandler);
-		el.removeEventListener('animationend', state.animationendHandler);
-		states.delete(el);
+		const abortController = abortControllers.get(el);
+		if (abortController) {
+			abortController.abort();
+			abortControllers.delete(el);
+		}
 	},
 } as Directive<HTMLElement>;

--- a/packages/frontend/src/directives/click-anime.ts
+++ b/packages/frontend/src/directives/click-anime.ts
@@ -6,6 +6,14 @@
 import type { Directive } from 'vue';
 import { prefer } from '@/preferences.js';
 
+type ClickAnimeDirectiveState = {
+	mousedownHandler: (ev: MouseEvent) => void;
+	clickHandler: (ev: MouseEvent) => void;
+	animationendHandler: (ev: AnimationEvent) => void;
+};
+
+const states = new WeakMap<HTMLElement, ClickAnimeDirectiveState>();
+
 export const clickAnimeDirective = {
 	mounted(el) {
 		if (!prefer.s.animation) return;
@@ -16,7 +24,7 @@ export const clickAnimeDirective = {
 
 		target.classList.add('_anime_bounce_standBy');
 
-		el.addEventListener('mousedown', () => {
+		const mousedownHandler = () => {
 			target.classList.remove('_anime_bounce');
 
 			target.classList.add('_anime_bounce_standBy');
@@ -25,16 +33,38 @@ export const clickAnimeDirective = {
 			target.addEventListener('mouseleave', () => {
 				target.classList.remove('_anime_bounce_ready');
 			});
-		});
+		};
 
-		el.addEventListener('click', () => {
+		const clickHandler = () => {
 			target.classList.add('_anime_bounce');
 			target.classList.remove('_anime_bounce_ready');
-		});
+		};
 
-		el.addEventListener('animationend', () => {
+		const animationendHandler = () => {
 			target.classList.remove('_anime_bounce');
 			target.classList.add('_anime_bounce_standBy');
+		};
+
+		el.addEventListener('mousedown', mousedownHandler);
+		el.addEventListener('click', clickHandler);
+		el.addEventListener('animationend', animationendHandler);
+
+		states.set(el, {
+			mousedownHandler,
+			clickHandler,
+			animationendHandler,
 		});
+	},
+
+	beforeUnmount(el) {
+		if (!prefer.s.animation) return;
+
+		const state = states.get(el);
+		if (state == null) return;
+
+		el.removeEventListener('mousedown', state.mousedownHandler);
+		el.removeEventListener('click', state.clickHandler);
+		el.removeEventListener('animationend', state.animationendHandler);
+		states.delete(el);
 	},
 } as Directive<HTMLElement>;

--- a/packages/frontend/src/directives/follow-append.ts
+++ b/packages/frontend/src/directives/follow-append.ts
@@ -6,9 +6,11 @@
 import type { Directive } from 'vue';
 import { getScrollContainer, getScrollPosition } from '@@/js/scroll.js';
 
-interface HTMLElementWithRO extends HTMLElement {
-	_ro_?: ResizeObserver;
-}
+const states = new WeakMap<HTMLElement, {
+	observer: ResizeObserver;
+	scrollHandlerTarget: HTMLElement;
+	scrollHandler: (ev: Event) => void;
+}>();
 
 export const followAppendDirective = {
 	mounted(src, binding) {
@@ -17,15 +19,16 @@ export const followAppendDirective = {
 		let isBottom = true;
 
 		const container = getScrollContainer(src)!;
-		container.addEventListener('scroll', () => {
+		const scrollHandler = () => {
 			const pos = getScrollPosition(container);
 			const viewHeight = container.clientHeight;
 			const height = container.scrollHeight;
 			isBottom = (pos + viewHeight > height - 32);
-		}, { passive: true });
+		};
+		container.addEventListener('scroll', scrollHandler, { passive: true });
 		container.scrollTop = container.scrollHeight;
 
-		const ro = new ResizeObserver((entries, observer) => {
+		const ro = new ResizeObserver(() => {
 			if (isBottom) {
 				const height = container.scrollHeight;
 				container.scrollTop = height;
@@ -34,11 +37,19 @@ export const followAppendDirective = {
 
 		ro.observe(src);
 
-		// TODO: 新たにプロパティを作るのをやめMapを使う
-		src._ro_ = ro;
+		states.set(src, {
+			observer: ro,
+			scrollHandlerTarget: container,
+			scrollHandler,
+		});
 	},
 
-	unmounted(src) {
-		if (src._ro_) src._ro_.unobserve(src);
+	beforeUnmount(src) {
+		const state = states.get(src);
+		if (!state) return;
+
+		state.observer.disconnect();
+		state.scrollHandlerTarget.removeEventListener('scroll', state.scrollHandler);
+		states.delete(src);
 	},
-} as Directive<HTMLElementWithRO, boolean>;
+} as Directive<HTMLElement, boolean>;

--- a/packages/frontend/src/directives/follow-append.ts
+++ b/packages/frontend/src/directives/follow-append.ts
@@ -8,13 +8,14 @@ import { getScrollContainer, getScrollPosition } from '@@/js/scroll.js';
 
 const states = new WeakMap<HTMLElement, {
 	observer: ResizeObserver;
-	scrollHandlerTarget: HTMLElement;
-	scrollHandler: (ev: Event) => void;
+	abortController: AbortController;
 }>();
 
 export const followAppendDirective = {
 	mounted(src, binding) {
 		if (binding.value === false) return;
+
+		const abortController = new AbortController();
 
 		let isBottom = true;
 
@@ -25,7 +26,7 @@ export const followAppendDirective = {
 			const height = container.scrollHeight;
 			isBottom = (pos + viewHeight > height - 32);
 		};
-		container.addEventListener('scroll', scrollHandler, { passive: true });
+		container.addEventListener('scroll', scrollHandler, { passive: true, signal: abortController.signal });
 		container.scrollTop = container.scrollHeight;
 
 		const ro = new ResizeObserver(() => {
@@ -39,8 +40,7 @@ export const followAppendDirective = {
 
 		states.set(src, {
 			observer: ro,
-			scrollHandlerTarget: container,
-			scrollHandler,
+			abortController,
 		});
 	},
 
@@ -49,7 +49,7 @@ export const followAppendDirective = {
 		if (!state) return;
 
 		state.observer.disconnect();
-		state.scrollHandlerTarget.removeEventListener('scroll', state.scrollHandler);
+		state.abortController.abort();
 		states.delete(src);
 	},
 } as Directive<HTMLElement, boolean>;

--- a/packages/frontend/src/directives/follow-append.ts
+++ b/packages/frontend/src/directives/follow-append.ts
@@ -20,13 +20,12 @@ export const followAppendDirective = {
 		let isBottom = true;
 
 		const container = getScrollContainer(src)!;
-		const scrollHandler = () => {
+		container.addEventListener('scroll', () => {
 			const pos = getScrollPosition(container);
 			const viewHeight = container.clientHeight;
 			const height = container.scrollHeight;
 			isBottom = (pos + viewHeight > height - 32);
-		};
-		container.addEventListener('scroll', scrollHandler, { passive: true, signal: abortController.signal });
+		}, { passive: true, signal: abortController.signal });
 		container.scrollTop = container.scrollHeight;
 
 		const ro = new ResizeObserver(() => {

--- a/packages/frontend/src/directives/hotkey.ts
+++ b/packages/frontend/src/directives/hotkey.ts
@@ -7,38 +7,28 @@ import type { Directive } from 'vue';
 import { makeHotkey } from '@/utility/hotkey.js';
 import type { Keymap } from '@/utility/hotkey.js';
 
-const states = new WeakMap<HTMLElement, {
-	isGlobal: boolean;
-	keyHandler: (ev: KeyboardEvent) => void;
-}>();
+const abortControllers = new WeakMap<HTMLElement, AbortController>();
 
 export const hotkeyDirective = {
 	mounted(el, binding) {
 		const isGlobal = (binding.modifiers.global === true);
 		const keyHandler = makeHotkey(binding.value);
+		const abortController = new AbortController();
 
 		if (isGlobal) {
-			window.document.addEventListener('keydown', keyHandler, { passive: false });
+			window.document.addEventListener('keydown', keyHandler, { passive: false, signal: abortController.signal });
 		} else {
-			el.addEventListener('keydown', keyHandler, { passive: false });
+			el.addEventListener('keydown', keyHandler, { passive: false, signal: abortController.signal });
 		}
 
-		states.set(el, {
-			isGlobal,
-			keyHandler,
-		});
+		abortControllers.set(el, abortController);
 	},
 
 	beforeUnmount(el) {
-		const state = states.get(el);
-		if (!state) return;
-
-		if (state.isGlobal) {
-			window.document.removeEventListener('keydown', state.keyHandler);
-		} else {
-			el.removeEventListener('keydown', state.keyHandler);
+		const abortController = abortControllers.get(el);
+		if (abortController) {
+			abortController.abort();
+			abortControllers.delete(el);
 		}
-
-		states.delete(el);
 	},
 } as Directive<HTMLElement, Keymap>;

--- a/packages/frontend/src/directives/hotkey.ts
+++ b/packages/frontend/src/directives/hotkey.ts
@@ -7,30 +7,38 @@ import type { Directive } from 'vue';
 import { makeHotkey } from '@/utility/hotkey.js';
 import type { Keymap } from '@/utility/hotkey.js';
 
-interface HTMLElementWithHotkey extends HTMLElement {
-	_hotkey_global?: boolean;
-	_keyHandler?: (ev: KeyboardEvent) => void;
-}
+const states = new WeakMap<HTMLElement, {
+	isGlobal: boolean;
+	keyHandler: (ev: KeyboardEvent) => void;
+}>();
 
 export const hotkeyDirective = {
 	mounted(el, binding) {
-		el._hotkey_global = binding.modifiers.global === true;
+		const isGlobal = (binding.modifiers.global === true);
+		const keyHandler = makeHotkey(binding.value);
 
-		el._keyHandler = makeHotkey(binding.value);
-
-		if (el._hotkey_global) {
-			window.document.addEventListener('keydown', el._keyHandler, { passive: false });
+		if (isGlobal) {
+			window.document.addEventListener('keydown', keyHandler, { passive: false });
 		} else {
-			el.addEventListener('keydown', el._keyHandler, { passive: false });
+			el.addEventListener('keydown', keyHandler, { passive: false });
 		}
+
+		states.set(el, {
+			isGlobal,
+			keyHandler,
+		});
 	},
 
-	unmounted(el) {
-		if (el._keyHandler == null) return;
-		if (el._hotkey_global) {
-			window.document.removeEventListener('keydown', el._keyHandler);
+	beforeUnmount(el) {
+		const state = states.get(el);
+		if (!state) return;
+
+		if (state.isGlobal) {
+			window.document.removeEventListener('keydown', state.keyHandler);
 		} else {
-			el.removeEventListener('keydown', el._keyHandler);
+			el.removeEventListener('keydown', state.keyHandler);
 		}
+
+		states.delete(el);
 	},
-} as Directive<HTMLElementWithHotkey, Keymap>;
+} as Directive<HTMLElement, Keymap>;

--- a/packages/frontend/src/directives/ripple.ts
+++ b/packages/frontend/src/directives/ripple.ts
@@ -9,6 +9,7 @@ import { prefer } from '@/preferences.js';
 import { popup } from '@/os.js';
 
 const handlers = new WeakMap<HTMLElement, (ev: MouseEvent) => void>();
+const abortControllers = new WeakMap<HTMLElement, AbortController>();
 
 export const rippleDirective = {
 	mounted(el, binding) {
@@ -16,7 +17,9 @@ export const rippleDirective = {
 		if (binding.value === false) return;
 		if (!prefer.s.animation) return;
 
-		const clickHandler = () => {
+		const abortController = new AbortController();
+
+		el.addEventListener('click', () => {
 			const rect = el.getBoundingClientRect();
 
 			const x = rect.left + (el.offsetWidth / 2);
@@ -25,17 +28,16 @@ export const rippleDirective = {
 			const { dispose } = popup(MkRippleEffect, { x, y }, {
 				end: () => dispose(),
 			});
-		};
+		}, { passive: true, signal: abortController.signal });
 
-		el.addEventListener('click', clickHandler, { passive: true });
-		handlers.set(el, clickHandler);
+		abortControllers.set(el, abortController);
 	},
 
 	beforeUnmount(el) {
-		const clickHandler = handlers.get(el);
-		if (clickHandler) {
-			el.removeEventListener('click', clickHandler);
-			handlers.delete(el);
+		const abortController = abortControllers.get(el);
+		if (abortController) {
+			abortController.abort();
+			abortControllers.delete(el);
 		}
 	},
 } as Directive<HTMLElement, boolean | null | undefined>;

--- a/packages/frontend/src/directives/ripple.ts
+++ b/packages/frontend/src/directives/ripple.ts
@@ -8,13 +8,15 @@ import MkRippleEffect from '@/components/MkRippleEffect.vue';
 import { prefer } from '@/preferences.js';
 import { popup } from '@/os.js';
 
+const handlers = new WeakMap<HTMLElement, (ev: MouseEvent) => void>();
+
 export const rippleDirective = {
 	mounted(el, binding) {
 		// 明示的に false であればバインドしない
 		if (binding.value === false) return;
 		if (!prefer.s.animation) return;
 
-		el.addEventListener('click', () => {
+		const clickHandler = () => {
 			const rect = el.getBoundingClientRect();
 
 			const x = rect.left + (el.offsetWidth / 2);
@@ -23,6 +25,17 @@ export const rippleDirective = {
 			const { dispose } = popup(MkRippleEffect, { x, y }, {
 				end: () => dispose(),
 			});
-		});
+		};
+
+		el.addEventListener('click', clickHandler, { passive: true });
+		handlers.set(el, clickHandler);
 	},
-} as Directive<HTMLElement, boolean | undefined>;
+
+	beforeUnmount(el) {
+		const clickHandler = handlers.get(el);
+		if (clickHandler) {
+			el.removeEventListener('click', clickHandler);
+			handlers.delete(el);
+		}
+	},
+} as Directive<HTMLElement, boolean | null | undefined>;

--- a/packages/frontend/src/directives/tooltip.ts
+++ b/packages/frontend/src/directives/tooltip.ts
@@ -29,9 +29,7 @@ type TooltipDirectiveState = {
 	hoverEndHandler?: (ev: Event) => void;
 };
 
-interface TooltipDirectiveElement extends HTMLElement {
-	_tooltipDirective_?: TooltipDirectiveState;
-}
+const states = new WeakMap<HTMLElement, TooltipDirectiveState>();
 
 type TooltipDirectiveModifiers = 'left' | 'right' | 'top' | 'bottom' | 'mfm' | 'noDelay';
 type TooltipDirectiveArg = 'dialog';
@@ -40,24 +38,24 @@ export const tooltipDirective = {
 	mounted(el, binding) {
 		const delay = binding.modifiers.noDelay ? 0 : 100;
 
-		const self = el._tooltipDirective_ = {} as TooltipDirectiveState;
+		const state = {
+			text: binding.value,
+			_close: null,
+			showTimer: null,
+			hideTimer: null,
+			checkTimer: null,
+		} as TooltipDirectiveState;
 
-		self.text = binding.value;
-		self._close = null;
-		self.showTimer = null;
-		self.hideTimer = null;
-		self.checkTimer = null;
-
-		self.close = () => {
-			if (self._close) {
-				if (self.checkTimer) window.clearInterval(self.checkTimer);
-				self._close();
-				self._close = null;
+		state.close = () => {
+			if (state._close) {
+				if (state.checkTimer) window.clearInterval(state.checkTimer);
+				state._close();
+				state._close = null;
 			}
 		};
 
 		if (binding.arg === 'dialog') {
-			self.dialogClickHandler = (ev) => {
+			state.dialogClickHandler = (ev) => {
 				if (binding.value == null) return;
 				ev.preventDefault();
 				ev.stopPropagation();
@@ -67,18 +65,18 @@ export const tooltipDirective = {
 				});
 				return false;
 			};
-			el.addEventListener('click', self.dialogClickHandler);
+			el.addEventListener('click', state.dialogClickHandler);
 		}
 
-		self.show = () => {
+		state.show = () => {
 			if (!window.document.body.contains(el)) return;
-			if (self._close) return;
-			if (self.text == null) return;
+			if (state._close) return;
+			if (state.text == null) return;
 
 			const showing = ref(true);
 			const { dispose } = popup(defineAsyncComponent(() => import('@/components/MkTooltip.vue')), {
 				showing,
-				text: self.text,
+				text: state.text,
 				asMfm: binding.modifiers.mfm,
 				direction: binding.modifiers.left ? 'left' : binding.modifiers.right ? 'right' : binding.modifiers.top ? 'top' : binding.modifiers.bottom ? 'bottom' : 'top',
 				anchorElement: el,
@@ -86,57 +84,64 @@ export const tooltipDirective = {
 				closed: () => dispose(),
 			});
 
-			self._close = () => {
+			state._close = () => {
 				showing.value = false;
 			};
 		};
 
-		self.selectstartHandler = (ev) => {
+		state.selectstartHandler = (ev) => {
 			ev.preventDefault();
 		};
 
-		self.hoverStartHandler = (ev) => {
-			if (self.showTimer) window.clearTimeout(self.showTimer);
-			if (self.hideTimer) window.clearTimeout(self.hideTimer);
+		state.hoverStartHandler = (ev) => {
+			if (state.showTimer) window.clearTimeout(state.showTimer);
+			if (state.hideTimer) window.clearTimeout(state.hideTimer);
 			if (delay === 0) {
-				self.show();
+				state.show();
 			} else {
-				self.showTimer = window.setTimeout(self.show, delay);
+				state.showTimer = window.setTimeout(state.show, delay);
 			}
 		};
 
-		self.hoverEndHandler = (ev) => {
-			if (self.showTimer) window.clearTimeout(self.showTimer);
-			if (self.hideTimer) window.clearTimeout(self.hideTimer);
+		state.hoverEndHandler = (ev) => {
+			if (state.showTimer) window.clearTimeout(state.showTimer);
+			if (state.hideTimer) window.clearTimeout(state.hideTimer);
 			if (delay === 0) {
-				self.close();
+				state.close();
 			} else {
-				self.hideTimer = window.setTimeout(self.close, delay);
+				state.hideTimer = window.setTimeout(state.close, delay);
 			}
 		};
 
-		el.addEventListener(start, self.hoverStartHandler, { passive: true });
-		el.addEventListener(end, self.hoverEndHandler, { passive: true });
-		el.addEventListener('click', self.close, { passive: true });
-		el.addEventListener('selectstart', self.selectstartHandler);
+		el.addEventListener(start, state.hoverStartHandler, { passive: true });
+		el.addEventListener(end, state.hoverEndHandler, { passive: true });
+		el.addEventListener('click', state.close, { passive: true });
+		el.addEventListener('selectstart', state.selectstartHandler);
+
+		states.set(el, state);
 	},
 
 	updated(el, binding) {
-		const self = el._tooltipDirective_;
-		if (self == null) return;
-		self.text = binding.value as string;
+		const state = states.get(el);
+		if (!state) return;
+		state.text = binding.value;
 	},
 
 	beforeUnmount(el) {
-		const self = el._tooltipDirective_;
-		if (self == null) return;
-		if (self.showTimer) window.clearTimeout(self.showTimer);
-		if (self.hideTimer) window.clearTimeout(self.hideTimer);
-		if (self.checkTimer) window.clearTimeout(self.checkTimer);
-		if (self.dialogClickHandler) el.removeEventListener('click', self.dialogClickHandler);
-		if (self.selectstartHandler) el.removeEventListener('selectstart', self.selectstartHandler);
-		if (self.hoverStartHandler) el.removeEventListener(start, self.hoverStartHandler);
-		if (self.hoverEndHandler) el.removeEventListener(end, self.hoverEndHandler);
-		self.close();
+		const state = states.get(el);
+		if (!state) return;
+
+		if (state.showTimer) window.clearTimeout(state.showTimer);
+		if (state.hideTimer) window.clearTimeout(state.hideTimer);
+		if (state.checkTimer) window.clearInterval(state.checkTimer);
+
+		state.close();
+
+		if (state.dialogClickHandler) el.removeEventListener('click', state.dialogClickHandler);
+		if (state.hoverStartHandler) el.removeEventListener(start, state.hoverStartHandler);
+		if (state.hoverEndHandler) el.removeEventListener(end, state.hoverEndHandler);
+		if (state.selectstartHandler) el.removeEventListener('selectstart', state.selectstartHandler);
+
+		states.delete(el);
 	},
-} as Directive<TooltipDirectiveElement, string | null | undefined, TooltipDirectiveModifiers, TooltipDirectiveArg>;
+} as Directive<HTMLElement, string | null | undefined, TooltipDirectiveModifiers, TooltipDirectiveArg>;

--- a/packages/frontend/src/directives/tooltip.ts
+++ b/packages/frontend/src/directives/tooltip.ts
@@ -115,10 +115,8 @@ export const tooltipDirective = {
 			}
 		};
 
-		el.addEventListener('mouseover', self.hoverStartHandler, { passive: true });
-		el.addEventListener('mouseleave', self.hoverEndHandler, { passive: true });
-		el.addEventListener('touchstart', self.hoverStartHandler, { passive: true });
-		el.addEventListener('touchend', self.hoverEndHandler, { passive: true });
+		el.addEventListener(start, self.hoverStartHandler, { passive: true });
+		el.addEventListener(end, self.hoverEndHandler, { passive: true });
 		el.addEventListener('click', self.close, { passive: true });
 		el.addEventListener('selectstart', self.selectstartHandler);
 	},
@@ -137,14 +135,8 @@ export const tooltipDirective = {
 		if (self.checkTimer) window.clearTimeout(self.checkTimer);
 		if (self.dialogClickHandler) el.removeEventListener('click', self.dialogClickHandler);
 		if (self.selectstartHandler) el.removeEventListener('selectstart', self.selectstartHandler);
-		if (self.hoverStartHandler) {
-			el.removeEventListener('mouseover', self.hoverStartHandler);
-			el.removeEventListener('touchstart', self.hoverStartHandler);
-		}
-		if (self.hoverEndHandler) {
-			el.removeEventListener('mouseleave', self.hoverEndHandler);
-			el.removeEventListener('touchend', self.hoverEndHandler);
-		}
+		if (self.hoverStartHandler) el.removeEventListener(start, self.hoverStartHandler);
+		if (self.hoverEndHandler) el.removeEventListener(end, self.hoverEndHandler);
 		self.close();
 	},
 } as Directive<TooltipDirectiveElement, string | null | undefined, TooltipDirectiveModifiers, TooltipDirectiveArg>;

--- a/packages/frontend/src/directives/tooltip.ts
+++ b/packages/frontend/src/directives/tooltip.ts
@@ -17,11 +17,16 @@ const end = isTouchUsing ? 'touchend' : 'mouseleave';
 type TooltipDirectiveState = {
 	text: string | null | undefined;
 	_close: null | (() => void);
+	show: () => void;
+	close: () => void;
+
 	showTimer: number | null;
 	hideTimer: number | null;
 	checkTimer: number | null;
-	show: () => void;
-	close: () => void;
+	dialogClickHandler?: (ev: MouseEvent) => void;
+	selectstartHandler?: (ev: Event) => void;
+	hoverStartHandler?: (ev: Event) => void;
+	hoverEndHandler?: (ev: Event) => void;
 };
 
 interface TooltipDirectiveElement extends HTMLElement {
@@ -52,7 +57,7 @@ export const tooltipDirective = {
 		};
 
 		if (binding.arg === 'dialog') {
-			el.addEventListener('click', (ev) => {
+			self.dialogClickHandler = (ev) => {
 				if (binding.value == null) return;
 				ev.preventDefault();
 				ev.stopPropagation();
@@ -61,7 +66,8 @@ export const tooltipDirective = {
 					text: binding.value,
 				});
 				return false;
-			});
+			};
+			el.addEventListener('click', self.dialogClickHandler);
 		}
 
 		self.show = () => {
@@ -85,11 +91,11 @@ export const tooltipDirective = {
 			};
 		};
 
-		el.addEventListener('selectstart', ev => {
+		self.selectstartHandler = (ev) => {
 			ev.preventDefault();
-		});
+		};
 
-		el.addEventListener(start, (ev) => {
+		self.hoverStartHandler = (ev) => {
 			if (self.showTimer) window.clearTimeout(self.showTimer);
 			if (self.hideTimer) window.clearTimeout(self.hideTimer);
 			if (delay === 0) {
@@ -97,9 +103,9 @@ export const tooltipDirective = {
 			} else {
 				self.showTimer = window.setTimeout(self.show, delay);
 			}
-		}, { passive: true });
+		};
 
-		el.addEventListener(end, () => {
+		self.hoverEndHandler = (ev) => {
 			if (self.showTimer) window.clearTimeout(self.showTimer);
 			if (self.hideTimer) window.clearTimeout(self.hideTimer);
 			if (delay === 0) {
@@ -107,12 +113,14 @@ export const tooltipDirective = {
 			} else {
 				self.hideTimer = window.setTimeout(self.close, delay);
 			}
-		}, { passive: true });
+		};
 
-		el.addEventListener('click', () => {
-			if (self.showTimer) window.clearTimeout(self.showTimer);
-			self.close();
-		});
+		el.addEventListener('mouseover', self.hoverStartHandler, { passive: true });
+		el.addEventListener('mouseleave', self.hoverEndHandler, { passive: true });
+		el.addEventListener('touchstart', self.hoverStartHandler, { passive: true });
+		el.addEventListener('touchend', self.hoverEndHandler, { passive: true });
+		el.addEventListener('click', self.close, { passive: true });
+		el.addEventListener('selectstart', self.selectstartHandler);
 	},
 
 	updated(el, binding) {
@@ -121,12 +129,22 @@ export const tooltipDirective = {
 		self.text = binding.value as string;
 	},
 
-	unmounted(el) {
+	beforeUnmount(el) {
 		const self = el._tooltipDirective_;
 		if (self == null) return;
 		if (self.showTimer) window.clearTimeout(self.showTimer);
 		if (self.hideTimer) window.clearTimeout(self.hideTimer);
 		if (self.checkTimer) window.clearTimeout(self.checkTimer);
+		if (self.dialogClickHandler) el.removeEventListener('click', self.dialogClickHandler);
+		if (self.selectstartHandler) el.removeEventListener('selectstart', self.selectstartHandler);
+		if (self.hoverStartHandler) {
+			el.removeEventListener('mouseover', self.hoverStartHandler);
+			el.removeEventListener('touchstart', self.hoverStartHandler);
+		}
+		if (self.hoverEndHandler) {
+			el.removeEventListener('mouseleave', self.hoverEndHandler);
+			el.removeEventListener('touchend', self.hoverEndHandler);
+		}
 		self.close();
 	},
 } as Directive<TooltipDirectiveElement, string | null | undefined, TooltipDirectiveModifiers, TooltipDirectiveArg>;

--- a/packages/frontend/src/directives/tooltip.ts
+++ b/packages/frontend/src/directives/tooltip.ts
@@ -20,13 +20,9 @@ type TooltipDirectiveState = {
 	show: () => void;
 	close: () => void;
 
+	abortController: AbortController;
 	showTimer: number | null;
 	hideTimer: number | null;
-	checkTimer: number | null;
-	dialogClickHandler?: (ev: MouseEvent) => void;
-	selectstartHandler?: (ev: Event) => void;
-	hoverStartHandler?: (ev: Event) => void;
-	hoverEndHandler?: (ev: Event) => void;
 };
 
 const states = new WeakMap<HTMLElement, TooltipDirectiveState>();
@@ -41,31 +37,30 @@ export const tooltipDirective = {
 		const state = {
 			text: binding.value,
 			_close: null,
+			abortController: new AbortController(),
 			showTimer: null,
 			hideTimer: null,
-			checkTimer: null,
 		} as TooltipDirectiveState;
 
 		state.close = () => {
 			if (state._close) {
-				if (state.checkTimer) window.clearInterval(state.checkTimer);
 				state._close();
 				state._close = null;
 			}
 		};
 
 		if (binding.arg === 'dialog') {
-			state.dialogClickHandler = (ev) => {
-				if (binding.value == null) return;
+			el.addEventListener('click', (ev) => {
+				const text = state.text ?? undefined;
+				if (text == null) return;
 				ev.preventDefault();
 				ev.stopPropagation();
 				alert({
 					type: 'info',
-					text: binding.value,
+					text,
 				});
 				return false;
-			};
-			el.addEventListener('click', state.dialogClickHandler);
+			}, { signal: state.abortController.signal });
 		}
 
 		state.show = () => {
@@ -89,11 +84,11 @@ export const tooltipDirective = {
 			};
 		};
 
-		state.selectstartHandler = (ev) => {
+		el.addEventListener('selectstart', (ev) => {
 			ev.preventDefault();
-		};
+		}, { signal: state.abortController.signal });
 
-		state.hoverStartHandler = (ev) => {
+		el.addEventListener(start, () => {
 			if (state.showTimer) window.clearTimeout(state.showTimer);
 			if (state.hideTimer) window.clearTimeout(state.hideTimer);
 			if (delay === 0) {
@@ -101,9 +96,9 @@ export const tooltipDirective = {
 			} else {
 				state.showTimer = window.setTimeout(state.show, delay);
 			}
-		};
+		}, { passive: true, signal: state.abortController.signal });
 
-		state.hoverEndHandler = (ev) => {
+		el.addEventListener(end, () => {
 			if (state.showTimer) window.clearTimeout(state.showTimer);
 			if (state.hideTimer) window.clearTimeout(state.hideTimer);
 			if (delay === 0) {
@@ -111,12 +106,12 @@ export const tooltipDirective = {
 			} else {
 				state.hideTimer = window.setTimeout(state.close, delay);
 			}
-		};
+		}, { passive: true, signal: state.abortController.signal });
 
-		el.addEventListener(start, state.hoverStartHandler, { passive: true });
-		el.addEventListener(end, state.hoverEndHandler, { passive: true });
-		el.addEventListener('click', state.close, { passive: true });
-		el.addEventListener('selectstart', state.selectstartHandler);
+		el.addEventListener('click', () => {
+			if (state.showTimer) window.clearTimeout(state.showTimer);
+			state.close();
+		}, { passive: true, signal: state.abortController.signal });
 
 		states.set(el, state);
 	},
@@ -133,14 +128,9 @@ export const tooltipDirective = {
 
 		if (state.showTimer) window.clearTimeout(state.showTimer);
 		if (state.hideTimer) window.clearTimeout(state.hideTimer);
-		if (state.checkTimer) window.clearInterval(state.checkTimer);
 
 		state.close();
-
-		if (state.dialogClickHandler) el.removeEventListener('click', state.dialogClickHandler);
-		if (state.hoverStartHandler) el.removeEventListener(start, state.hoverStartHandler);
-		if (state.hoverEndHandler) el.removeEventListener(end, state.hoverEndHandler);
-		if (state.selectstartHandler) el.removeEventListener('selectstart', state.selectstartHandler);
+		state.abortController.abort();
 
 		states.delete(el);
 	},

--- a/packages/frontend/src/directives/user-preview.ts
+++ b/packages/frontend/src/directives/user-preview.ts
@@ -113,8 +113,7 @@ export const userPreviewDirective = {
 		if (binding.value == null) return;
 		if (isTouchUsing) return;
 
-		// TODO: 新たにプロパティを作るのをやめMapを使う
-		// ただメモリ的には↓の方が省メモリかもしれないので検討中
+		// メモリ的にはWeakMapを使わずに要素にプロパティを生やしたほうが省メモリかもしれないので検討中
 		const preview = new UserPreview(el, binding.value);
 		states.set(el, preview);
 	},

--- a/packages/frontend/src/directives/user-preview.ts
+++ b/packages/frontend/src/directives/user-preview.ts
@@ -106,11 +106,7 @@ export class UserPreview {
 	}
 }
 
-interface UserPreviewDirectiveElement extends HTMLElement {
-	_userPreviewDirective_?: {
-		preview: UserPreview;
-	};
-}
+const states = new WeakMap<HTMLElement, UserPreview>();
 
 export const userPreviewDirective = {
 	mounted(el, binding) {
@@ -119,16 +115,16 @@ export const userPreviewDirective = {
 
 		// TODO: 新たにプロパティを作るのをやめMapを使う
 		// ただメモリ的には↓の方が省メモリかもしれないので検討中
-		el._userPreviewDirective_ = {
-			preview: new UserPreview(el, binding.value),
-		};
+		const preview = new UserPreview(el, binding.value);
+		states.set(el, preview);
 	},
 
 	unmounted(el, binding) {
 		if (binding.value == null) return;
-
-		const self = el._userPreviewDirective_;
-		if (self == null) return;
-		self.preview.detach();
+		const preview = states.get(el);
+		if (preview) {
+			preview.detach();
+			states.delete(el);
+		}
 	},
-} as Directive<UserPreviewDirectiveElement, string | Misskey.entities.UserDetailed | null | undefined>;
+} as Directive<HTMLElement, string | Misskey.entities.UserDetailed | null | undefined>;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- イベントリスナーが解除されずtooltipの要素が内部メモリに残っていることを発見したのでその修正
- 他のディレクティブでもイベントリスナーの解除が行われていないのをちらほら見かけたので同様に修正
- 要素に直接プロパティを生やすのではなくWeakMapで管理するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
performance

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
