### PR TITLE
fix: ensure color output for child processes in Windows environment

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -31,6 +31,9 @@ let shutdownPromise = null;
  */
 function spawnChildProcess(command, args, options) {
 	const isWindows = process.platform === 'win32';
+	const shouldForceColor = (process.stdout.isTTY || process.stderr.isTTY)
+		&& process.env.FORCE_COLOR == null
+		&& process.env.NO_COLOR == null;
 	const pnpmPath = _dirname + '/../node_modules/pnpm/bin/pnpm.mjs';
 	const windowsCommand = [process.execPath, pnpmPath, ...args]
 		.map(argument => `"${argument}"`)
@@ -45,6 +48,7 @@ function spawnChildProcess(command, args, options) {
 		// Ctrl+C, allowing only this supervisor to coordinate the shutdown.
 		windowsVerbatimArguments: true,
 		windowsHide: false,
+		env: shouldForceColor ? { FORCE_COLOR: '1' } : undefined,
 		stdout: 'pipe',
 		stderr: 'pipe',
 		buffer: false,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

https://github.com/misskey-dev/misskey/pull/17690 のフォローアップです
Windowsでpnpm devしたとき文字色がつかないのを直します

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

fix https://github.com/misskey-dev/misskey/pull/17690#issuecomment-4942318859

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
