### PR TITLE
fix(backend): 本番ビルドで @opentelemetry/instrumentation が解決できない問題を修正

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -71,6 +71,7 @@
 		"@opentelemetry/api": "1.9.1",
 		"@opentelemetry/core": "2.9.0",
 		"@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
+		"@opentelemetry/instrumentation": "0.219.0",
 		"@opentelemetry/instrumentation-pg": "0.72.0",
 		"@opentelemetry/resources": "2.9.0",
 		"@opentelemetry/sdk-trace-base": "2.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: 0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: 0.219.0
+        version: 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-pg':
         specifier: 0.72.0
         version: 0.72.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What

`packages/backend/package.json` の `dependencies` に `@opentelemetry/instrumentation@0.219.0` を直接追加しました。

- 追加バージョン `0.219.0` は現時点の `pnpm-lock.yaml` 上で `@fastify/otel@0.20.1` が解決している版と一致します。実体が二重にロードされて `@opentelemetry/api` の singleton 前提を壊さないよう、あえて同一版を pin しています。
- 変更ファイルは `packages/backend/package.json` と `pnpm-lock.yaml` の 2 ファイルのみ。

## Why

現状 backend の production build 済みイメージ (Docker image 等) を起動すると、`@opentelemetry/instrumentation` を解決できず起動に失敗します。

原因:

- `packages/backend/package.json` の `dependencies` には `@fastify/otel@0.20.1` があり、`@fastify/otel` は `@opentelemetry/instrumentation` を推移的に要求します。
- しかし backend の直接依存として `@opentelemetry/instrumentation` は宣言されていません。
- `packages/backend/rolldown.config.ts` は `/^@opentelemetry\/.*/` を external としているため、`@opentelemetry/instrumentation` はバンドルされずランタイム解決になり、解決起点はバンドル済みチャンク (`packages/backend/built/otel-*.js`) 側になります。
- pnpm は推移的依存を親パッケージの `node_modules/` に露出させない (isolated node_modules) ため、`packages/backend/node_modules/@opentelemetry/instrumentation` は存在せず、`require("@opentelemetry/instrumentation")` が `Cannot find module` で失敗します。

`pnpm dev` (watch モード) では rolldown の external ルールが `isWatchMode ? /^(?!@\/|\0)[^.\/](?!:[\/\\])/ : externalModules` に切り替わり、モジュール解決が `@fastify/otel` パッケージ位置を起点にできるため再現しません。**production build + pnpm** の組み合わせでのみ顕在化します。

関連 Issue: #17755 

## Additional info (optional)

- 動作確認:
  - パッチ適用前: production build で起動時に `Cannot find module '@opentelemetry/instrumentation'` が発生することを確認。
  - パッチ適用後: 同構成で backend が正常起動することを確認。
- CHANGELOG は更新していません。OpenTelemetry サポート自体が本リリース (2026.7.0-beta) で新規追加された機能で、まだリリース版に到達していないため。必要であれば別途追記します。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
