### PR TITLE
fix(frontend): StreamingTimelineのインスタンスが保持された状態でページを行き来するとアニメーションが再度再生される問題を修正

### DIFF
--- a/packages/frontend/src/components/MkStreamingTimelineItem.vue
+++ b/packages/frontend/src/components/MkStreamingTimelineItem.vue
@@ -52,8 +52,8 @@ const innerEl = useTemplateRef('innerEl');
 
 const animating = ref(false);
 
-watch(() => props.animatingIn === true || props.animatingOut === true, (shouldAnimate) => {
-	if (shouldAnimate) animating.value = true;
+watch([() => props.animatingIn, () => props.animatingOut], ([animatingIn, animatingOut]) => {
+	if (animatingIn === true || animatingOut === true) animating.value = true;
 }, { immediate: true });
 
 function onAnimationEnd() {

--- a/packages/frontend/src/components/MkStreamingTimelineItem.vue
+++ b/packages/frontend/src/components/MkStreamingTimelineItem.vue
@@ -7,12 +7,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 	<div
 		ref="rootEl"
 		:class="[$style.root, {
-			[$style.enter]: animatingIn,
+			[$style.enter]: animatingIn && animating && !animatingOut,
 			[$style.leave]: animatingOut,
 			[$style.animating]: animating,
 		}]"
-		@animationstart="animating = true"
-		@animationend="animating = false"
+		@animationend.self="onAnimationEnd"
+		@animationcancel.self="onAnimationEnd"
 	>
 		<div ref="innerEl">
 			<slot></slot>
@@ -40,7 +40,7 @@ if (!supportsInterpolateSize) {
 </script>
 
 <script setup lang="ts">
-import { useTemplateRef, onMounted, onBeforeUnmount, ref } from 'vue';
+import { useTemplateRef, onMounted, onBeforeUnmount, ref, watch } from 'vue';
 
 const props = defineProps<{
 	animatingIn?: boolean;
@@ -51,6 +51,16 @@ const rootEl = useTemplateRef('rootEl');
 const innerEl = useTemplateRef('innerEl');
 
 const animating = ref(false);
+
+watch(() => props.animatingIn === true || props.animatingOut === true, (shouldAnimate) => {
+	if (shouldAnimate) animating.value = true;
+}, { immediate: true });
+
+function onAnimationEnd() {
+	// 削除アニメーション中（enterから差し替わった場合を含む）は、要素が消えるまで再生中扱いのままにする
+	if (props.animatingOut === true) return;
+	animating.value = false;
+}
 
 onMounted(() => {
 	if (resizeObserver != null && rootEl.value != null && innerEl.value != null) {


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #17774

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md ※同一バージョン
- [ ] (If possible) Add tests
