### PR TITLE
fix(backend): resyncCharts が statement timeout で失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Fix: ノートの詳細表示で削除された引用元が表示されない問題を修正
 
 ### Server
+- Fix: チャートの日次補正 (resyncCharts) が大規模テーブルの集計で statement timeout に達して毎回失敗し、ノート・ユーザー総数が実際の値から乖離し続ける問題を修正
 - Feat: OpenTelemetryサポート
   - 詳細な設定はconfigファイルを参照してください。
   - Sentryとの併用も可能です。Sentry併用時は、PostgreSQL Query と Redis command は Sentry で計装されます。

--- a/packages/backend/src/core/chart/charts/notes.ts
+++ b/packages/backend/src/core/chart/charts/notes.ts
@@ -6,12 +6,11 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { Not, IsNull, DataSource } from 'typeorm';
 import * as Redis from 'ioredis';
-import type { NotesRepository } from '@/models/_.js';
-import type { MiNote } from '@/models/Note.js';
+import { MiNote } from '@/models/Note.js';
 import { DI } from '@/di-symbols.js';
 import { bindThis } from '@/decorators.js';
 import { acquireChartInsertLock } from '@/misc/distributed-lock.js';
-import Chart from '../core.js';
+import Chart, { resyncQueryWithExtendedTimeout } from '../core.js';
 import { ChartLoggerService } from '../ChartLoggerService.js';
 import { name, schema } from './entities/notes.js';
 import type { KVs } from '../core.js';
@@ -28,18 +27,16 @@ export default class NotesChart extends Chart<typeof schema> { // eslint-disable
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 
-		@Inject(DI.notesRepository)
-		private notesRepository: NotesRepository,
-
 		private chartLoggerService: ChartLoggerService,
 	) {
 		super(db, (k) => acquireChartInsertLock(redisClient, k), chartLoggerService.logger, name, schema);
 	}
 
 	protected async tickMajor(): Promise<Partial<KVs<typeof schema>>> {
-		const [localCount, remoteCount] = await Promise.all([
-			this.notesRepository.countBy({ userHost: IsNull() }),
-			this.notesRepository.countBy({ userHost: Not(IsNull()) }),
+		// note テーブルの全件 count はデフォルトの statement_timeout (10秒) を超過しうるため延長する
+		const [localCount, remoteCount] = await resyncQueryWithExtendedTimeout(this.db, async em => [
+			await em.countBy(MiNote, { userHost: IsNull() }),
+			await em.countBy(MiNote, { userHost: Not(IsNull()) }),
 		]);
 
 		return {

--- a/packages/backend/src/core/chart/charts/users.ts
+++ b/packages/backend/src/core/chart/charts/users.ts
@@ -6,13 +6,12 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { Not, IsNull, DataSource } from 'typeorm';
 import * as Redis from 'ioredis';
-import type { MiUser } from '@/models/User.js';
+import { MiUser } from '@/models/User.js';
 import { DI } from '@/di-symbols.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
-import type { UsersRepository } from '@/models/_.js';
 import { bindThis } from '@/decorators.js';
 import { acquireChartInsertLock } from '@/misc/distributed-lock.js';
-import Chart from '../core.js';
+import Chart, { resyncQueryWithExtendedTimeout } from '../core.js';
 import { ChartLoggerService } from '../ChartLoggerService.js';
 import { name, schema } from './entities/users.js';
 import type { KVs } from '../core.js';
@@ -29,9 +28,6 @@ export default class UsersChart extends Chart<typeof schema> { // eslint-disable
 		@Inject(DI.redis)
 		private redisClient: Redis.Redis,
 
-		@Inject(DI.usersRepository)
-		private usersRepository: UsersRepository,
-
 		private userEntityService: UserEntityService,
 		private chartLoggerService: ChartLoggerService,
 	) {
@@ -39,9 +35,10 @@ export default class UsersChart extends Chart<typeof schema> { // eslint-disable
 	}
 
 	protected async tickMajor(): Promise<Partial<KVs<typeof schema>>> {
-		const [localCount, remoteCount] = await Promise.all([
-			this.usersRepository.countBy({ host: IsNull() }),
-			this.usersRepository.countBy({ host: Not(IsNull()) }),
+		// 大規模インスタンスでは user テーブルの全件 count も statement_timeout (10秒) を超過しうるため延長する
+		const [localCount, remoteCount] = await resyncQueryWithExtendedTimeout(this.db, async em => [
+			await em.countBy(MiUser, { host: IsNull() }),
+			await em.countBy(MiUser, { host: Not(IsNull()) }),
 		]);
 
 		return {

--- a/packages/backend/src/core/chart/core.ts
+++ b/packages/backend/src/core/chart/core.ts
@@ -15,11 +15,24 @@ import { dateUTC, isTimeSame, isTimeBefore, subtractTime, addTime } from '@/misc
 import type Logger from '@/logger.js';
 import { bindThis } from '@/decorators.js';
 import { MiRepository, miRepository } from '@/models/_.js';
-import type { DataSource, Repository } from 'typeorm';
+import type { DataSource, EntityManager, Repository } from 'typeorm';
 
 const COLUMN_PREFIX = '___' as const;
 const UNIQUE_TEMP_COLUMN_PREFIX = 'unique_temp___' as const;
 const COLUMN_DELIMITER = '_' as const;
+
+/**
+ * resync (tickMajor) の実カウント専用ヘルパー。
+ * 巨大テーブルの count はアプリ既定の statement_timeout (10秒) を超過して失敗するため、
+ * トランザクション内の SET LOCAL でこの実行だけ制限を延長する。
+ * SET LOCAL はトランザクション内でのみ有効なので、通常クエリのタイムアウトには影響しない。
+ */
+export async function resyncQueryWithExtendedTimeout<T>(db: DataSource, queries: (em: EntityManager) => Promise<T>): Promise<T> {
+	return await db.transaction(async em => {
+		await em.query('SET LOCAL statement_timeout = \'10min\'');
+		return await queries(em);
+	});
+}
 
 type Schema = Record<string, {
 	uniqueIncrement?: boolean;

--- a/packages/backend/src/queue/processors/ResyncChartsProcessorService.ts
+++ b/packages/backend/src/queue/processors/ResyncChartsProcessorService.ts
@@ -32,9 +32,27 @@ export class ResyncChartsProcessorService {
 		// DBへの同時接続を避けるためにPromise.allを使わずひとつずつ実行する
 		// TODO: ユーザーごとのチャートも更新する
 		// TODO: インスタンスごとのチャートも更新する
-		await this.driveChart.resync();
-		await this.notesChart.resync();
-		await this.usersChart.resync();
+		// 1つのチャートの失敗が残りのチャートの補正を道連れにしないよう、チャートごとに捕捉する
+		const charts = [
+			['drive', () => this.driveChart.resync()],
+			['notes', () => this.notesChart.resync()],
+			['users', () => this.usersChart.resync()],
+		] as const;
+
+		const failed: string[] = [];
+		for (const [chartName, resync] of charts) {
+			try {
+				await resync();
+			} catch (err) {
+				this.logger.error(`Failed to resync ${chartName} chart: ${err}`);
+				failed.push(chartName);
+			}
+		}
+
+		if (failed.length > 0) {
+			// ジョブとしては失敗扱いにして Bull の記録に残す
+			throw new Error(`Failed to resync charts: ${failed.join(', ')}`);
+		}
 
 		this.logger.succ('All charts successfully resynced.');
 	}


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

resyncのチャート集計クエリのタイムアウトを10分に延長する

どれかが失敗するとそれがエラーをthrowして後続の resyncを行わずに終了してしまうのを併せて修正



## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
Fix #17777


## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
