### PR TITLE
enhance(frontend): サイドバーの折りたたみアニメーションを改善しUIの押下フィードバックを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Unreleased
+
+### General
+-
+
+### Client
+- Enhance: UIアニメーションとボタンの押下フィードバックを改善
+  - `transition: all` を特定プロパティに限定 (MkButton, MkSwitch, MkSwitch.button)
+  - ボタンの `:active` 時に scale(0.98) の押下フィードバックを追加 (MkButton, MkPostForm, MkFollowButton)
+  - MkRadios の `scale(0)` を `scale(0.5)` に変更してサブピixel描画の問題を修正
+  - MkModal: `ease-in` → `ease-out`, `scale(0.9)` → `scale(0.95)`
+  - MkTooltip: 200ms → 150ms でよりスナッピーに
+  - スピナー: 400ms → 600ms で知覚パフォーマンスを向上
+  - 通知の退出方向を入場方向に合わせて空間的一貫性を修正
+  - MkSwiper: ジェスチャー中のトランジションを削除して中断可能性を向上
+  - ナビバー: サイドバーの折りたたみをCSS widthトランジションでスムーズに
+
+### Server
+-
+
 ## 2026.7.0
 
 ### Note

--- a/packages/frontend/src/components/MkButton.vue
+++ b/packages/frontend/src/components/MkButton.vue
@@ -121,7 +121,7 @@ function onMousedown(evt: MouseEvent): void {
 		ripple.style.transform = 'scale(' + (scale / 2) + ')';
 	}, 1);
 	window.setTimeout(() => {
-		ripple.style.transition = 'all 1s ease';
+		ripple.style.transition = 'opacity 1s ease';
 		ripple.style.opacity = '0';
 	}, 1000);
 	window.setTimeout(() => {
@@ -159,6 +159,7 @@ function onMousedown(evt: MouseEvent): void {
 
 	&:not(:disabled):active {
 		background: var(--MI_THEME-buttonHoverBg);
+		transform: scale(0.98);
 	}
 
 	&.iconOnly {
@@ -312,7 +313,7 @@ function onMousedown(evt: MouseEvent): void {
 	background: rgba(0, 0, 0, 0.1);
 	opacity: 1;
 	transform: scale(1);
-	transition: all 0.5s cubic-bezier(0,.5,0,1);
+	transition: transform 0.5s cubic-bezier(0,.5,0,1), opacity 0.5s cubic-bezier(0,.5,0,1);
 }
 
 .content {

--- a/packages/frontend/src/components/MkFollowButton.vue
+++ b/packages/frontend/src/components/MkFollowButton.vue
@@ -220,7 +220,7 @@ onBeforeUnmount(() => {
 	}
 
 	&:active {
-		//background: mix($primary, #fff, 40);
+		transform: scale(0.98);
 	}
 
 	&.active {

--- a/packages/frontend/src/components/MkModal.vue
+++ b/packages/frontend/src/components/MkModal.vue
@@ -364,7 +364,7 @@ defineExpose({
 
 	> .content {
     transform: translateY(0px);
-		transition: opacity 0.3s ease-in, transform 0.3s cubic-bezier(.5,-0.5,1,.5) !important;
+		transition: opacity 0.3s ease-out, transform 0.3s cubic-bezier(.5,-0.5,1,.5) !important;
 	}
 }
 .transition_send_enterFrom,
@@ -401,7 +401,7 @@ defineExpose({
 		pointer-events: none;
 		opacity: 0;
 		transform-origin: var(--transformOrigin);
-		transform: scale(0.9);
+		transform: scale(0.95);
 	}
 }
 
@@ -426,7 +426,7 @@ defineExpose({
 		pointer-events: none;
 		opacity: 0;
 		transform-origin: var(--transformOrigin);
-		transform: scale(0.9);
+		transform: scale(0.95);
 	}
 }
 

--- a/packages/frontend/src/components/MkPostForm.vue
+++ b/packages/frontend/src/components/MkPostForm.vue
@@ -1583,7 +1583,8 @@ defineExpose({
 
 	&:not(:disabled):active {
 		> .submitInner {
-			background: linear-gradient(90deg, hsl(from var(--MI_THEME-accent) h s calc(l + 5)), hsl(from var(--MI_THEME-accent) h s calc(l + 5)));
+			background: linear-gradient(90deg, hsl(from var(--MI_THEME-accent) h s calc(l + 10)), hsl(from var(--MI_THEME-accent) h s calc(l + 10)));
+			transform: scale(0.98);
 		}
 	}
 }

--- a/packages/frontend/src/components/MkRadios.vue
+++ b/packages/frontend/src/components/MkRadios.vue
@@ -202,7 +202,7 @@ function toggle(o: MkRadiosOption): void {
 		left: 3px;
 		border-radius: 100%;
 		opacity: 0;
-		transform: scale(0);
+		transform: scale(0.5);
 		transition: 0.4s cubic-bezier(0.25, 0.8, 0.25, 1);
 	}
 }

--- a/packages/frontend/src/components/MkSwiper.vue
+++ b/packages/frontend/src/components/MkSwiper.vue
@@ -246,6 +246,6 @@ watch(tabModel, (newTab, oldTab) => {
 }
 
 .swiping {
-	transition: transform .2s ease-out;
+	transition: none;
 }
 </style>

--- a/packages/frontend/src/components/MkSwitch.button.vue
+++ b/packages/frontend/src/components/MkSwitch.button.vue
@@ -77,7 +77,7 @@ const toggle = () => {
 	width: calc(var(--height) - 6px);
 	height: calc(var(--height) - 6px);
 	border-radius: 999px;
-	transition: all 0.2s ease;
+	transition: left 0.2s ease, background-color 0.2s ease;
 
 	&:not(.knobChecked) {
 		left: 3px;

--- a/packages/frontend/src/components/MkSwitch.vue
+++ b/packages/frontend/src/components/MkSwitch.vue
@@ -58,7 +58,7 @@ const toggle = () => {
 .root {
 	position: relative;
 	display: flex;
-	transition: all 0.2s ease;
+	transition: opacity 0.2s ease;
 	user-select: none;
 
 	&:hover {

--- a/packages/frontend/src/components/MkTooltip.vue
+++ b/packages/frontend/src/components/MkTooltip.vue
@@ -96,7 +96,7 @@ onUnmounted(() => {
 .transition_tooltip_leaveActive {
 	opacity: 1;
 	transform: scale(1);
-	transition: transform 200ms cubic-bezier(0.23, 1, 0.32, 1), opacity 200ms cubic-bezier(0.23, 1, 0.32, 1);
+	transition: transform 150ms cubic-bezier(0.23, 1, 0.32, 1), opacity 150ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .transition_tooltip_enterFrom,
 .transition_tooltip_leaveTo {

--- a/packages/frontend/src/ui/_common_/common.vue
+++ b/packages/frontend/src/ui/_common_/common.vue
@@ -228,7 +228,17 @@ if ($i) {
 }
 .transition_notification_leaveTo {
 	opacity: 0;
-	transform: translateX(-250px);
+	transform: translateX(250px);
+}
+// 左側配置の通知は左方向に出退場させる (空間的一貫性)
+.notificationsPosition_leftTop,
+.notificationsPosition_leftBottom {
+	.transition_notification_enterFrom {
+		transform: translateX(-250px);
+	}
+	.transition_notification_leaveTo {
+		transform: translateX(-250px);
+	}
 }
 
 .menuDrawerBg {
@@ -397,7 +407,7 @@ if ($i) {
 		border-top-color: var(--MI_THEME-accent);
 		border-left-color: var(--MI_THEME-accent);
 		border-radius: 50%;
-		animation: progress-spinner 400ms linear infinite;
+		animation: progress-spinner 600ms linear infinite;
 	}
 }
 

--- a/packages/frontend/src/ui/_common_/navbar.vue
+++ b/packages/frontend/src/ui/_common_/navbar.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<div :class="[$style.root, { [$style.iconOnly]: iconOnly }]">
+<div :class="[$style.root, { [$style.iconOnly]: iconOnly, [$style.noAnim]: !prefer.s.animation }]">
 	<div :class="$style.body">
 		<div :class="$style.top">
 			<button v-tooltip.noDelay.right="instance.name ?? i18n.ts.instance" class="_button" :class="$style.instance" @click="openInstanceMenu">
@@ -152,13 +152,7 @@ watch(store.r.menuDisplay, () => {
 });
 
 function toggleIconOnly() {
-	if (window.document.startViewTransition && prefer.s.animation) {
-		window.document.startViewTransition(() => {
-			store.set('menuDisplay', iconOnly.value ? 'sideFull' : 'sideIcon');
-		});
-	} else {
-		store.set('menuDisplay', iconOnly.value ? 'sideFull' : 'sideIcon');
-	}
+	store.set('menuDisplay', iconOnly.value ? 'sideFull' : 'sideIcon');
 }
 
 function toggleRealtimeMode(ev: PointerEvent) {
@@ -209,6 +203,20 @@ function menuEdit() {
 	flex: 0 0 var(--nav-width);
 	width: var(--nav-width);
 	box-sizing: border-box;
+	transition: flex-basis 0.25s ease, width 0.25s ease;
+	will-change: width, flex-basis;
+}
+
+.root.noAnim {
+	transition: none;
+
+	.body {
+		transition: none;
+	}
+
+	.subButtons {
+		transition: none;
+	}
 }
 
 .body {
@@ -221,6 +229,7 @@ function menuEdit() {
 	overscroll-behavior: contain;
 	background: var(--MI_THEME-navBg);
 	contain: strict;
+	transition: width 0.25s ease;
 
 	/* 画面が縦に長い、設置している項目数が少ないなどの環境においても確実にbottomを最下部に表示するため */
 	display: flex;
@@ -331,6 +340,7 @@ function menuEdit() {
 	bottom: 80px;
 	z-index: 1001;
 	box-sizing: border-box;
+	transition: left 0.25s ease;
 }
 
 .subButton {


### PR DESCRIPTION
## What

- ナビバーのサイドバー折りたたみアニメーションをスムーズに改善 (instant snap / startViewTransition cross-fade → CSS width/flex-basis transition)
- `transition: all` を特定プロパティに限定 (MkButton, MkSwitch, MkSwitch.button)
- ボタンの `:active` 時に scale(0.98) の押下フィードバックを追加 (MkButton, MkPostForm, MkFollowButton)
- MkRadios: `scale(0)` → `scale(0.5)` でサブピクセル描画の問題を修正
- MkModal: `ease-in` → `ease-out`, `scale(0.9)` → `scale(0.95)`
- MkTooltip: 200ms → 150ms でスナッピーに
- スピナー: 400ms → 600ms で知覚パフォーマンスを向上
- 通知の退出方向を入場方向に合わせて空間的一貫性を修正
- MkSwiper: ジェスチャー中のトランジションを削除して中断可能性を向上

## Why

- サイドバーの折りたたみが瞬時に切り替わる（または startViewTransition のcross-fade）ため、スムーズなアニメーションがなかった
- ボタンに押下フィードバックがないため、タッチした感覚がなかった
- `transition: all` は不要なプロパティまでアニメーションしてパフォーマンスに悪影響がある
- 通知が入場と違う方向から退出するのが不自然だった

## Additional info (optional)

- アニメーション無効設定 (`prefer.s.animation`) には `.noAnim` クラスで対応済み
- typecheck / eslint 通過済み

## Checklist
- [x] [コントリビューションガイド](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)を読んだ
- [x] ローカル環境で動作確認した
- [ ] (必要なら) Storybookストーリーを追加した
- [x] CHANGELOG.mdを更新した
- [ ] (可能なら) テストを追加した