### PR TITLE
fix(test): setup.sh で $1.config.json の生成条件が $1.default.yml を参照していたのを修正

### DIFF
--- a/packages/backend/test-federation/.gitignore
+++ b/packages/backend/test-federation/.gitignore
@@ -4,3 +4,4 @@ volumes
 docker.env
 *.test.conf
 *.test.default.yml
+*.test.config.json

--- a/packages/backend/test-federation/setup.sh
+++ b/packages/backend/test-federation/setup.sh
@@ -28,7 +28,7 @@ function generate {
     -days 500
   if [ ! -f .config/docker.env ]; then cp .config/example.docker.env .config/docker.env; fi
   if [ ! -f .config/$1.conf ]; then sed "s/\${HOST}/$1/g" .config/example.conf > .config/$1.conf; fi
-  if [ ! -f .config/$1.default.yml ]; then sed "s/\${HOST}/$1/g" .config/example.config.json > .config/$1.config.json; fi
+  if [ ! -f .config/$1.config.json ]; then sed "s/\${HOST}/$1/g" .config/example.config.json > .config/$1.config.json; fi
 }
 
 generate a.test


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`test-federation/setup.sh` の `generate` 関数内で、`.config/$1.config.json` の生成条件が誤って `.config/$1.default.yml` の存在チェックになっていたのを修正しました。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
`.config/$1.config.json` が既に存在していても存在していなくても正しく判定されない問題の修正しました

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
