### PR TITLE
fix: RSS系ウィジェットにフィードURL検査機構を追加

### DIFF
--- a/packages/frontend-shared/js/url.ts
+++ b/packages/frontend-shared/js/url.ts
@@ -27,6 +27,14 @@ export function extractDomain(url: string) {
 	return match ? match[1] : null;
 }
 
+export function tryParseUrl(url: string | URL, base?: string | URL): URL | null {
+	try {
+		return new URL(url, base);
+	} catch {
+		return null;
+	}
+}
+
 export function maybeMakeRelative(urlStr: string, baseStr: string): string {
 	try {
 		const baseObj = new URL(baseStr);

--- a/packages/frontend/src/ui/_common_/statusbar-rss.vue
+++ b/packages/frontend/src/ui/_common_/statusbar-rss.vue
@@ -31,6 +31,7 @@ import { ref } from 'vue';
 import * as Misskey from 'misskey-js';
 import { useInterval } from '@@/js/use-interval.js';
 import { url as baseUrl } from '@@/js/config.js';
+import { tryParseUrl } from '@@/js/url.js';
 import MkMarqueeText from '@/components/MkMarqueeText.vue';
 import { shuffle } from '@/utility/shuffle.js';
 
@@ -56,8 +57,8 @@ const tick = () => {
 			}
 			items.value = feed.items.filter((item) => {
 				if (!item.link) return false;
-				const itemUrl = new URL(item.link, baseUrl);
-				return ['http:', 'https:'].includes(itemUrl.protocol);
+				const itemUrl = tryParseUrl(item.link, baseUrl);
+				return itemUrl != null && ['http:', 'https:'].includes(itemUrl.protocol);
 			});
 			fetching.value = false;
 			key.value++;

--- a/packages/frontend/src/widgets/WidgetRss.vue
+++ b/packages/frontend/src/widgets/WidgetRss.vue
@@ -24,10 +24,11 @@ import { ref, watch, computed } from 'vue';
 import * as Misskey from 'misskey-js';
 import { url as base } from '@@/js/config.js';
 import { useInterval } from '@@/js/use-interval.js';
+import { tryParseUrl } from '@@/js/url.js';
 import { useWidgetPropsManager } from './widget.js';
-import { i18n } from '@/i18n.js';
 import type { WidgetComponentEmits, WidgetComponentExpose, WidgetComponentProps } from './widget.js';
 import type { FormWithDefault, GetFormResultType } from '@/utility/form.js';
+import { i18n } from '@/i18n.js';
 import MkContainer from '@/components/MkContainer.vue';
 
 const name = 'rss';
@@ -83,8 +84,8 @@ const tick = () => {
 		.then((feed: Misskey.entities.FetchRssResponse) => {
 			rawItems.value = feed.items.filter((item) => {
 				if (!item.link) return false;
-				const itemUrl = new URL(item.link, base);
-				return ['http:', 'https:'].includes(itemUrl.protocol);
+				const itemUrl = tryParseUrl(item.link, base);
+				return itemUrl != null && ['http:', 'https:'].includes(itemUrl.protocol);
 			});
 			fetching.value = false;
 		});

--- a/packages/frontend/src/widgets/WidgetRssTicker.vue
+++ b/packages/frontend/src/widgets/WidgetRssTicker.vue
@@ -29,15 +29,16 @@ SPDX-License-Identifier: AGPL-3.0-only
 <script lang="ts" setup>
 import { ref, watch, computed } from 'vue';
 import * as Misskey from 'misskey-js';
+import { url as base } from '@@/js/config.js';
+import { useInterval } from '@@/js/use-interval.js';
+import { tryParseUrl } from '@@/js/url.js';
 import { useWidgetPropsManager } from './widget.js';
 import type { WidgetComponentEmits, WidgetComponentExpose, WidgetComponentProps } from './widget.js';
-import MkMarqueeText from '@/components/MkMarqueeText.vue';
 import type { FormWithDefault, GetFormResultType } from '@/utility/form.js';
+import MkMarqueeText from '@/components/MkMarqueeText.vue';
 import MkContainer from '@/components/MkContainer.vue';
 import { shuffle } from '@/utility/shuffle.js';
 import { i18n } from '@/i18n.js';
-import { url as base } from '@@/js/config.js';
-import { useInterval } from '@@/js/use-interval.js';
 
 const name = 'rssTicker';
 
@@ -123,8 +124,8 @@ const tick = () => {
 		.then((feed: Misskey.entities.FetchRssResponse) => {
 			rawItems.value = feed.items.filter((item) => {
 				if (!item.link) return false;
-				const itemUrl = new URL(item.link, base);
-				return ['http:', 'https:'].includes(itemUrl.protocol);
+				const itemUrl = tryParseUrl(item.link, base);
+				return itemUrl != null && ['http:', 'https:'].includes(itemUrl.protocol);
 			});
 			fetching.value = false;
 			key.value++;

--- a/packages/frontend/test/unit/url.test.ts
+++ b/packages/frontend/test/unit/url.test.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test } from 'vitest';
+import { tryParseUrl } from '@@/js/url.js';
+
+describe('tryParseUrl', () => {
+	test('parses an absolute URL', () => {
+		expect(tryParseUrl('https://example.com/path')?.href).toBe('https://example.com/path');
+	});
+
+	test('parses a relative URL against a base URL', () => {
+		expect(tryParseUrl('/path', 'https://example.com/base')?.href).toBe('https://example.com/path');
+	});
+
+	test('returns null for an invalid URL', () => {
+		expect(tryParseUrl('https://[invalid')).toBeNull();
+	});
+});


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

RSS系ウィジェットにて、サーバから取得したRSSフィードのURLをパースする箇所にtry - catchを設け、エラー落ちを抑止するようにします。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

https://github.com/misskey-dev/misskey/pull/17657#issuecomment-5139541138

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
