### PR TITLE
fix(backend): admin/queue/statsの権限をread:admin:queueに修正

### DIFF
--- a/packages/backend/src/server/api/endpoints/admin/queue/stats.ts
+++ b/packages/backend/src/server/api/endpoints/admin/queue/stats.ts
@@ -12,7 +12,7 @@ export const meta = {
 
 	requireCredential: true,
 	requireModerator: true,
-	kind: 'read:admin:emoji',
+	kind: 'read:admin:queue',
 
 	res: {
 		type: 'object',

--- a/packages/misskey-js/src/autogen/apiClientJSDoc.ts
+++ b/packages/misskey-js/src/autogen/apiClientJSDoc.ts
@@ -749,7 +749,7 @@ declare module '../api.js' {
     /**
      * No description provided.
      * 
-     * **Credential required**: *Yes* / **Permission**: *read:admin:emoji*
+     * **Credential required**: *Yes* / **Permission**: *read:admin:queue*
      */
     request<E extends 'admin/queue/stats', P extends Endpoints[E]['req']>(
       endpoint: E,

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -616,7 +616,7 @@ export type paths = {
          * admin/queue/stats
          * @description No description provided.
          *
-         *     **Credential required**: *Yes* / **Permission**: *read:admin:emoji*
+         *     **Credential required**: *Yes* / **Permission**: *read:admin:queue*
          */
         post: operations['admin___queue___stats'];
     };


### PR DESCRIPTION
## What
- `admin/queue/stats` エンドポイントの権限 (`kind`) が `read:admin:emoji` になっていた問題を `read:admin:queue` に修正しました。

## Why
- `admin/queue/stats` はキュー統計を扱う管理者用エンドポイントですが、`kind` が `read:admin:emoji` になっており、以下の問題がありました。
  - `read:admin:emoji` スコープを持つアプリが本来取得すべきでないキュー統計にアクセスできていた。
  - 逆に `read:admin:queue` スコープを持つアプリはアクセスできなかった。

## Additional info (optional)

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [] (If needed) Update CHANGELOG.md
- [] (If possible) Add tests