### PR TITLE
refactor: linearlize findMaxPrefixLength for performance

### DIFF
--- a/packages/backend/src/logging/LogNormalizer.ts
+++ b/packages/backend/src/logging/LogNormalizer.ts
@@ -132,24 +132,29 @@ function normalizeString(value: string, maxBytes: number): string {
 	return value.slice(0, end) + suffix;
 }
 
-/** 指定した後置文字列を含めて上限に収まる接頭辞の長さを二分探索します。 */
-function findMaxPrefixLength(value: string, suffix: string, maxBytes: number): number {
-	let lower = 0;
-	let upper = value.length;
-	while (lower < upper) {
-		const middle = Math.ceil((lower + upper) / 2);
-		if (byteLength(value.slice(0, middle) + suffix) <= maxBytes) {
-			lower = middle;
-		} else {
-			upper = middle - 1;
-		}
+function charUtf8Len(codePoint: number): number {
+	return codePoint < 0x80 ? 1
+		: codePoint < 0x800 ? 2
+		: codePoint < 0x10000 ? 3
+		: 4;
+}
+
+function charUtf16Len(codePoint: number): number {
+	return codePoint < 0x10000 ? 1 : 2;
+}
+
+function findMaxPrefixLength(value: string, suffix: string, maxBytes: number) {
+	let usedBytes = byteLength(suffix);
+	let prefixLength = 0;
+	while (prefixLength < value.length) {
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- similar to for-of, but for-of requires additional allocations
+		const cp = value.codePointAt(prefixLength)!;
+		const charBytes = charUtf8Len(cp);
+		if (usedBytes + charBytes > maxBytes) break;
+		usedBytes += charBytes;
+		prefixLength += charUtf16Len(cp);
 	}
-	// UTF-16のサロゲート対を途中で切らないよう、必要なら1文字戻します。
-	if (lower > 0 && lower < value.length) {
-		const code = value.charCodeAt(lower - 1);
-		if (code >= 0xd800 && code <= 0xdbff) lower--;
-	}
-	return lower;
+	return prefixLength;
 }
 
 /** 特殊な値に対しても、エラー判定で例外を発生させないようにします。 */


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Remaining part of #17832 

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
パフォーマンス。`O(max(maxStringBytes, value.length))`なので特に`maxStringBytes`より大きなデータの処理で有利 (元は`O(log(value.length) * value.length)`。コード上は`O(log(value.length))`で、中の`byteLength`と`string.slice`が`O(middle)`のはずで`middle ~= value.length`のはず)

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
ベンチマークしてこの方が早いことは確認済 https://gist.github.com/anatawa12/d9279265e91aea550ca1e75933a495e2

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
