### PR TITLE
perf(frontend): Blurhash描画のworkerリスナー登録を必要なときのみ行うように (wip)

### DIFF
--- a/packages/frontend/src/components/MkBlurhash.vue
+++ b/packages/frontend/src/components/MkBlurhash.vue
@@ -78,6 +78,8 @@ const canvasWidth = ref(64);
 const canvasHeight = ref(64);
 const viewId = genId();
 const bitmapTmp = shallowRef<CanvasImageSource | undefined>();
+let isWorkerListenerRegistered = false;
+let isUnmounted = false;
 
 watch([() => props.width, () => props.height, canvas], () => {
 	const ratio = props.width / props.height;
@@ -137,7 +139,15 @@ async function draw() {
 	if (props.onlyAvgColor) return;
 
 	const work = await canvasPromise;
+	if (isUnmounted) return;
+
 	if (work instanceof WorkerMultiDispatch) {
+		// 実際にworkerへ描画を依頼するときまでリスナー登録しない
+		if (!isWorkerListenerRegistered) {
+			isWorkerListenerRegistered = true;
+			work.addListener(workerOnMessage);
+		}
+
 		work.postMessage(
 			{
 				id: viewId,
@@ -161,11 +171,7 @@ function workerOnMessage(event: MessageEvent) {
 	drawImage(event.data.bitmap as ImageBitmap);
 }
 
-canvasPromise.then(work => {
-	if (work instanceof WorkerMultiDispatch) {
-		work.addListener(workerOnMessage);
-	}
-
+canvasPromise.then(() => {
 	draw();
 });
 
@@ -177,10 +183,14 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
-	canvasPromise.then(work => {
-		if (work instanceof WorkerMultiDispatch) {
-			work.removeListener(workerOnMessage);
-		}
-	});
+	isUnmounted = true;
+
+	if (isWorkerListenerRegistered) {
+		canvasPromise.then(work => {
+			if (work instanceof WorkerMultiDispatch) {
+				work.removeListener(workerOnMessage);
+			}
+		});
+	}
 });
 </script>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
`drawAvgColor` や `blurhash` が `null` の場合など、実際にBlurhash描画を行わないコンポーネント上ではWorkerのリスナー登録を行わないように

（`drawAvgColor` は MkAvatar などで使用されているため頻繁に使われる）

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
