### PR TITLE
perf(frontend): ワードミュートの正規表現・前処理結果をキャッシュし判定を高速化

### DIFF
--- a/packages/frontend/src/composables/use-note.ts
+++ b/packages/frontend/src/composables/use-note.ts
@@ -37,6 +37,7 @@ import { notePage } from '@/filters/note.js';
 import type { DI as DIType } from '@/di.js';
 import type { ExtractInjectedType } from '@/types/misc.js';
 import type { MenuItem } from '@/types/menu.js';
+import type { WordMuteResult } from '@/utility/check-word-mute.js';
 
 export interface UseNoteProps {
 	note: Misskey.entities.Note;
@@ -66,7 +67,7 @@ export function checkNoteWordMute(
 	noteToCheck: Misskey.entities.Note,
 	user: typeof $i,
 	mutedWords: Array<string | string[]> | null,
-): Array<string | string[]> | false {
+): WordMuteResult {
 	if (mutedWords != null) {
 		const result = checkWordMute(noteToCheck, user, mutedWords);
 		if (Array.isArray(result)) return result;

--- a/packages/frontend/src/utility/check-word-mute.ts
+++ b/packages/frontend/src/utility/check-word-mute.ts
@@ -4,35 +4,66 @@
  */
 import * as Misskey from 'misskey-js';
 
-export function checkWordMute(note: Misskey.entities.Note, me: Misskey.entities.UserLite | null | undefined, mutedWords: Array<string | string[]>): Array<string | string[]> | false {
+export type WordMuteResult = Array<string | string[]> | false;
+
+// ミュートワードの判定はタイムラインのノートごとに繰り返し実行されるため、
+// フィルタ単位の前処理(正規表現のコンパイル・空キーワードの除去)をキャッシュする
+// keywordsCacheはWeakMapによりフィルタ配列がGCされるとキャッシュも破棄される
+const regexCache = new Map<string, RegExp | null>();
+const keywordsCache = new WeakMap<string[], string[]>();
+
+function getCompiledRegex(filter: string): RegExp | null {
+	let regex = regexCache.get(filter);
+	if (regex === undefined) {
+		const parts = filter.match(/^\/(.+)\/(.*)$/);
+		if (parts == null) {
+			// This should never happen due to input sanitisation.
+			regex = null;
+		} else {
+			try {
+				regex = new RegExp(parts[1], parts[2]);
+			} catch (_) {
+				// This should never happen due to input sanitisation.
+				regex = null;
+			}
+		}
+		regexCache.set(filter, regex);
+	}
+	return regex;
+}
+
+function getCleanedKeywords(filter: string[]): string[] {
+	let keywords = keywordsCache.get(filter);
+	if (keywords === undefined) {
+		keywords = filter.filter(keyword => keyword !== '');
+		keywordsCache.set(filter, keywords);
+	}
+	return keywords;
+}
+
+export function checkWordMute(note: Misskey.entities.Note, me: Misskey.entities.UserLite | null | undefined, mutedWords: Array<string | string[]>): WordMuteResult {
 	// 自分自身
 	if (me && (note.userId === me.id)) return false;
 
-	if (mutedWords.length > 0) {
-		const text = ((note.cw ?? '') + '\n' + (note.text ?? '')).trim();
+	if (mutedWords.length === 0) return false;
 
-		if (text === '') return false;
+	const text = ((note.cw ?? '') + '\n' + (note.text ?? '')).trim();
 
+	if (text !== '') {
 		const matched = mutedWords.filter(filter => {
 			if (Array.isArray(filter)) {
-				// Clean up
-				const filteredFilter = filter.filter(keyword => keyword !== '');
-				if (filteredFilter.length === 0) return false;
+				const keywords = getCleanedKeywords(filter);
+				if (keywords.length === 0) return false;
 
-				return filteredFilter.every(keyword => text.includes(keyword));
+				return keywords.every(keyword => text.includes(keyword));
 			} else {
 				// represents RegExp
-				const regexp = filter.match(/^\/(.+)\/(.*)$/);
+				const regex = getCompiledRegex(filter);
+				if (regex == null) return false;
 
-				// This should never happen due to input sanitisation.
-				if (!regexp) return false;
-
-				try {
-					return new RegExp(regexp[1], regexp[2]).test(text);
-				} catch (_) {
-					// This should never happen due to input sanitisation.
-					return false;
-				}
+				// gフラグ等が付いているとtestでlastIndexが進み、共有インスタンスでは結果が変わってしまうためリセットする
+				regex.lastIndex = 0;
+				return regex.test(text);
 			}
 		});
 


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
ワードミュート判定時に毎回文字列から正規表現をコンパイルしたり、空文字の削除などの前処理が行われていたが、この結果をキャッシュするように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
判定の高速化

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
