### PR TITLE
fix(gh): リリースPRがあるとpush/PRで2回ワークフローが実行される問題を修正

### DIFF
--- a/.github/workflows/api-misskey-js.yml
+++ b/.github/workflows/api-misskey-js.yml
@@ -6,6 +6,8 @@ on:
       - packages/misskey-js/**
       - .github/workflows/api-misskey-js.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/misskey-js/**
       - .github/workflows/api-misskey-js.yml

--- a/.github/workflows/check-spdx-license-id.yml
+++ b/.github/workflows/check-spdx-license-id.yml
@@ -6,6 +6,8 @@ on:
       - master
       - develop
   pull_request:
+    branches-ignore:
+      - master
 
 jobs:
   check-spdx-license-id:

--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -7,6 +7,8 @@ on:
       - master
       - develop
   pull_request:
+    branches-ignore:
+      - master
 
 jobs:
   dockle:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ on:
       - .github/workflows/lint.yml
       - package.json
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/backend/**
       - packages/frontend/**

--- a/.github/workflows/locale.yml
+++ b/.github/workflows/locale.yml
@@ -7,6 +7,8 @@ on:
       - locales/**
       - .github/workflows/locale.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/i18n/**
       - locales/**

--- a/.github/workflows/packages-private.yml
+++ b/.github/workflows/packages-private.yml
@@ -13,6 +13,8 @@ on:
       - pnpm-lock.yaml
       - .github/workflows/packages-private.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages-private/**
       - packages/shared/eslint.config.js

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -12,6 +12,8 @@ on:
       - .github/workflows/test-backend.yml
       - .github/misskey/test.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/backend/**
       # for permissions

--- a/.github/workflows/test-federation.yml
+++ b/.github/workflows/test-federation.yml
@@ -10,6 +10,8 @@ on:
       - packages/misskey-js/**
       - .github/workflows/test-federation.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/backend/**
       - packages/misskey-js/**

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -14,6 +14,8 @@ on:
       - .github/workflows/test-frontend.yml
       - .github/misskey/test.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/frontend/**
       # for permissions

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -6,6 +6,8 @@ on:
       - master
       - develop
   pull_request:
+    branches-ignore:
+      - master
 
 env:
   NODE_ENV: production

--- a/.github/workflows/validate-api-json.yml
+++ b/.github/workflows/validate-api-json.yml
@@ -9,6 +9,8 @@ on:
       - packages/backend/**
       - .github/workflows/validate-api-json.yml
   pull_request:
+    branches-ignore:
+      - master
     paths:
       - packages/backend/**
       - .github/workflows/validate-api-json.yml


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
master 行きのPRではCIを発動しないように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
2回実行されている

<img width="613" height="368" alt="image" src="https://github.com/user-attachments/assets/95225b9e-02dc-4c90-adbb-0c0371afa923" />

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->
リリースPRのマージ時にはCIが失敗していないかどうかの確認が入るが、これは先頭のコミットのCIに失敗がないかどうかを見ているだけなのでいけるはず？

https://github.com/misskey-dev/release-manager-actions/blob/v2/.github/workflows/merge.yml

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
