### PR TITLE
chore: git submodule update --initを削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
 
 COPY --link . ./
 
-RUN git submodule update --init
 RUN pnpm build
 RUN rm -rf .git/
 


### PR DESCRIPTION
## What

Dockerfileから`RUN git submodule update --init`を消す

## Why

Coolifyでのデプロイ時、ビルド時にgit操作をすることが想定外なためか、.gitフォルダが見当たらずに`git submodule update --init`でビルドに失敗する。

```log
> [native-builder 21/23] RUN git submodule update --init:
0.297 fatal: not a git repository (or any of the parent directories): .git
```

submodule周りのgit操作についてはビルド前のデプロイ環境側の仕事であるべきと考える。

## Additional info (optional)

[該当の行が初めて追加されたPR](https://github.com/misskey-dev/misskey/pull/7687)にて、GitHub CIが途中で落ちる事への対処としてDockerfileにも追記された。後にGitHub Actionsのオプション指定の方に切り替えたものの、Dockerfileには依然として残っており、それが今日まで続いていた。

## Checklist
- [v] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
