### PR TITLE
fix: include query string in HTTP Signature (request-target)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 -
 
 ### Server
--
+- Fix: HTTP Signaturesの`(request-target)`にクエリ文字列が含まれない問題を修正
 
 
 ## 2026.9.0

--- a/packages/backend/src/core/activitypub/ApRequestService.ts
+++ b/packages/backend/src/core/activitypub/ApRequestService.ts
@@ -121,7 +121,8 @@ export class ApRequestCreator {
 		for (const key of includeHeaders.map(x => x.toLowerCase())) {
 			if (key === '(request-target)') {
 				const url = new URL(request.url);
-				results.push(`(request-target): ${request.method.toLowerCase()} ${url.pathname}${url.search}`);
+				const query = url.search || (url.href.split('#', 1)[0].endsWith('?') ? '?' : '');
+				results.push(`(request-target): ${request.method.toLowerCase()} ${url.pathname}${query}`);
 			} else {
 				results.push(`${key}: ${request.headers[key]}`);
 			}

--- a/packages/backend/src/core/activitypub/ApRequestService.ts
+++ b/packages/backend/src/core/activitypub/ApRequestService.ts
@@ -120,7 +120,8 @@ export class ApRequestCreator {
 
 		for (const key of includeHeaders.map(x => x.toLowerCase())) {
 			if (key === '(request-target)') {
-				results.push(`(request-target): ${request.method.toLowerCase()} ${new URL(request.url).pathname}`);
+				const url = new URL(request.url);
+				results.push(`(request-target): ${request.method.toLowerCase()} ${url.pathname}${url.search}`);
 			} else {
 				results.push(`${key}: ${request.headers[key]}`);
 			}

--- a/packages/backend/test/unit/ap-request.ts
+++ b/packages/backend/test/unit/ap-request.ts
@@ -66,6 +66,57 @@ describe('ap-request', () => {
 		assert.deepStrictEqual(result, true);
 	});
 
+	test('createSignedGet includes query string in request-target', async () => {
+		const keypair = await genRsaKeyPair();
+		const key = { keyId: 'x', 'privateKeyPem': keypair.privateKey };
+		const url = 'https://example.com/users/alice?page=2';
+
+		const req = await ApRequestCreator.createSignedGet({ key, url, additionalHeaders: { 'User-Agent': 'UA' } });
+
+		assert.ok(req.signingString.split('\n').includes('(request-target): get /users/alice?page=2'));
+
+		const parsed = buildParsedSignature(req.signingString, req.signature, 'rsa-sha256');
+		assert.deepStrictEqual(httpSignature.verifySignature(parsed, keypair.publicKey), true);
+	});
+
+	test('createSignedPost includes query string in request-target', async () => {
+		const keypair = await genRsaKeyPair();
+		const key = { keyId: 'x', 'privateKeyPem': keypair.privateKey };
+		const url = 'https://example.com/inbox?token=abc';
+		const body = JSON.stringify({ a: 1 });
+
+		const req = await ApRequestCreator.createSignedPost({
+			key,
+			url,
+			body,
+			additionalHeaders: { 'User-Agent': 'UA' },
+		});
+
+		assert.ok(req.signingString.split('\n').includes('(request-target): post /inbox?token=abc'));
+
+		const parsed = buildParsedSignature(req.signingString, req.signature, 'rsa-sha256');
+		assert.deepStrictEqual(httpSignature.verifySignature(parsed, keypair.publicKey), true);
+	});
+
+	test('request-target omits hash and does not add empty query', async () => {
+		const keypair = await genRsaKeyPair();
+		const key = { keyId: 'x', 'privateKeyPem': keypair.privateKey };
+
+		const withHash = await ApRequestCreator.createSignedGet({
+			key,
+			url: 'https://example.com/users/alice?page=2#ignored',
+			additionalHeaders: { 'User-Agent': 'UA' },
+		});
+		assert.ok(withHash.signingString.split('\n').includes('(request-target): get /users/alice?page=2'));
+
+		const withoutQuery = await ApRequestCreator.createSignedGet({
+			key,
+			url: 'https://example.com/outbox',
+			additionalHeaders: { 'User-Agent': 'UA' },
+		});
+		assert.ok(withoutQuery.signingString.split('\n').includes('(request-target): get /outbox'));
+	});
+
 	test('rejects non matching domain', () => {
 		assert.doesNotThrow(() => assertActivityMatchesUrl(
 			'https://alice.example.com/abc',

--- a/packages/backend/test/unit/ap-request.ts
+++ b/packages/backend/test/unit/ap-request.ts
@@ -98,7 +98,7 @@ describe('ap-request', () => {
 		assert.deepStrictEqual(httpSignature.verifySignature(parsed, keypair.publicKey), true);
 	});
 
-	test('request-target omits hash and does not add empty query', async () => {
+	test('request-target omits hash and preserves empty query delimiter', async () => {
 		const keypair = await genRsaKeyPair();
 		const key = { keyId: 'x', 'privateKeyPem': keypair.privateKey };
 
@@ -108,6 +108,13 @@ describe('ap-request', () => {
 			additionalHeaders: { 'User-Agent': 'UA' },
 		});
 		assert.ok(withHash.signingString.split('\n').includes('(request-target): get /users/alice?page=2'));
+
+		const emptyQueryWithHash = await ApRequestCreator.createSignedGet({
+			key,
+			url: 'https://example.com/outbox?#ignored',
+			additionalHeaders: { 'User-Agent': 'UA' },
+		});
+		assert.ok(emptyQueryWithHash.signingString.split('\n').includes('(request-target): get /outbox?'));
 
 		const withoutQuery = await ApRequestCreator.createSignedGet({
 			key,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
Include the URL query string in the HTTP Signatures `(request-target)` pseudo-header when signing ActivityPub GET/POST requests.

`ApRequestCreator.#genSigningString` previously used only `URL.pathname`, so a request to `/users/alice?page=2` was signed as `/users/alice`.

## Why
Draft HTTP Signatures define `(request-target)` as the HTTP method plus the request-target (path **and** query). Implementations that verify the query string (including Mastodon) reject Misskey's signatures for URLs that have a query.

Fixes #17734

## Additional info (optional)
- Fragment identifiers are still omitted (`URL.search` does not include the hash).
- URLs without a query keep the previous `pathname`-only value (no trailing `?`).
- Unit tests: `NODE_ENV=test pnpm exec vitest --config vitest.config.unit.ts run test/unit/ap-request.ts` → 10 passed.

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
